### PR TITLE
Swap all mentions of the hybridlogic/flocker repository for ClusterHQ/flocker

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,7 +38,7 @@ Talk to us
 Have questions or need help?
 Besides filing a `GitHub issue`_ with feature requests or bug reports you can also join us on the ``#clusterhq`` channel on the ``irc.freenode.net`` IRC network.
 
-.. _GitHub issue: https://github.com/clusterhq/flocker/issues
+.. _GitHub issue: https://github.com/ClusterHQ/flocker/issues
 
 
 Development environment

--- a/flocker.spec.in
+++ b/flocker.spec.in
@@ -23,7 +23,7 @@ BuildRequires:  python-ipaddr = 2.1.10
 BuildRequires:  python-netifaces >= 0.8.0
 BuildRequires:  python-treq = 0.2.1
 BuildRequires:  python-nomenclature >= 0.1.0
-# See https://github.com/clusterhq/flocker/issues/85
+# See https://github.com/ClusterHQ/flocker/issues/85
 BuildRequires:  docker-io
 
 Requires:       python

--- a/flocker/node/functional/test_gear.py
+++ b/flocker/node/functional/test_gear.py
@@ -70,7 +70,7 @@ class GearClientTests(TestCase):
 
         def check_if_started():
             # Replace with ``GearClient.list`` as part of
-            # https://github.com/clusterhq/flocker/issues/32
+            # https://github.com/ClusterHQ/flocker/issues/32
             responded = request(
                 b"GET", b"http://127.0.0.1:%d/containers" % (GEAR_PORT,),
                 persistent=False)

--- a/flocker/route/functional/iptables.py
+++ b/flocker/route/functional/iptables.py
@@ -37,7 +37,7 @@ class _Namespace(object):
 
     :ivar ADDRESSES: List of :py:class:`IPAddress`es in the created namespace.
     """
-    # https://github.com/clusterhq/flocker/issues/135
+    # https://github.com/ClusterHQ/flocker/issues/135
     # Don't hardcode addresses in the created namespace
     ADDRESSES = [IPAddress('127.0.0.1'), IPAddress('10.0.0.1')]
 

--- a/flocker/route/functional/test_iptables_create.py
+++ b/flocker/route/functional/test_iptables_create.py
@@ -122,7 +122,7 @@ class CreateTests(TestCase):
         self.namespace = create_network_namespace()
         self.addCleanup(self.namespace.restore)
 
-        # https://github.com/clusterhq/flocker/issues/135
+        # https://github.com/ClusterHQ/flocker/issues/135
         # Don't hardcode addresses in the created namespace
         self.server_ip = self.namespace.ADDRESSES[0]
         self.proxy_ip = self.namespace.ADDRESSES[1]
@@ -156,7 +156,7 @@ class CreateTests(TestCase):
         self.patch(create_proxy_to, "logger", logger)
 
         # Note - we're leaking iptables rules into the system here.
-        # https://github.com/clusterhq/flocker/issues/22
+        # https://github.com/ClusterHQ/flocker/issues/22
         create_proxy_to(self.server_ip, self.port)
 
         client = connect_nonblocking(self.proxy_ip, self.port)

--- a/flocker/volume/filesystems/interfaces.py
+++ b/flocker/volume/filesystems/interfaces.py
@@ -88,7 +88,7 @@ class IStoragePool(Interface):
 
         By default new filesystems will be automounted. In future
         iterations when remotely owned filesystems are added
-        (https://github.com/clusterhq/flocker/issues/93) this interface
+        (https://github.com/ClusterHQ/flocker/issues/93) this interface
         will be expanded to allow specifying that the filesystem should
         not be mounted.
 

--- a/flocker/volume/filesystems/memory.py
+++ b/flocker/volume/filesystems/memory.py
@@ -70,7 +70,7 @@ class DirectoryFilesystem(object):
             tarball.extractall(self.path.path)
         except:
             # This should really be dealt with, e.g. logged:
-            # https://github.com/clusterhq/flocker/issues/122
+            # https://github.com/ClusterHQ/flocker/issues/122
             pass
 
 

--- a/flocker/volume/filesystems/zfs.py
+++ b/flocker/volume/filesystems/zfs.py
@@ -139,7 +139,7 @@ class Filesystem(object):
     def writer(self):
         """Read in zfs stream."""
         # The temporary filesystem will be unnecessary once we have
-        # https://github.com/clusterhq/flocker/issues/46
+        # https://github.com/ClusterHQ/flocker/issues/46
         temp_filesystem = b"%s/%s" % (self.pool, random_name())
         process = subprocess.Popen([b"zfs", b"recv", b"-F", temp_filesystem],
                                    stdin=subprocess.PIPE)

--- a/flocker/volume/functional/test_script.py
+++ b/flocker/volume/functional/test_script.py
@@ -88,7 +88,7 @@ class MutatingProcessNode(ProcessNode):
     """Mutate the command being run in order to make tests work.
 
     Come up with something better in
-    https://github.com/clusterhq/flocker/issues/125
+    https://github.com/ClusterHQ/flocker/issues/125
     """
     def __init__(self, to_service):
         """

--- a/flocker/volume/functional/test_service.py
+++ b/flocker/volume/functional/test_service.py
@@ -18,7 +18,7 @@ from ..filesystems.memory import FilesystemStoragePool
 
 
 _if_root = skipIf(os.getuid() != 0, "Must run as root.")
-# This is terible (https://github.com/clusterhq/flocker/issues/85):
+# This is terible (https://github.com/ClusterHQ/flocker/issues/85):
 _if_docker = skipIf(subprocess.Popen([b"docker", b"version"]).wait(),
                     "Docker must be installed and running.")
 

--- a/flocker/volume/script.py
+++ b/flocker/volume/script.py
@@ -68,7 +68,7 @@ class VolumeOptions(Options):
         ["config", None, DEFAULT_CONFIG_PATH.path,
          "The path to the config file."],
         # Maybe we can come up with something better in
-        # https://github.com/clusterhq/flocker/issues/125
+        # https://github.com/ClusterHQ/flocker/issues/125
         ["pool", None, b"flocker",
          "The ZFS pool to use for volumes."],
         ["mountpoint", None, b"/flocker",

--- a/flocker/volume/service.py
+++ b/flocker/volume/service.py
@@ -18,7 +18,7 @@ from twisted.internet import reactor
 
 # We might want to make these utilities shared, rather than in zfs
 # module... but in this case the usage is temporary and should go away as
-# part of https://github.com/clusterhq/flocker/issues/64
+# part of https://github.com/ClusterHQ/flocker/issues/64
 from .filesystems.zfs import _AccumulatingProtocol, CommandFailed
 
 
@@ -88,7 +88,7 @@ class VolumeService(Service):
             for filesystem in filesystems:
                 # XXX It so happens that this works but it's kind of a
                 # fragile way to recover the information:
-                #    https://github.com/clusterhq/flocker/issues/78
+                #    https://github.com/ClusterHQ/flocker/issues/78
                 uuid, name = filesystem.get_path().basename().split(b".", 1)
                 yield Volume(
                     uuid=uuid.decode('utf8'),
@@ -151,7 +151,7 @@ class VolumeService(Service):
 
 # Communication with Docker should be done via its API, not with this
 # approach, but that depends on unreleased Twisted 14.1:
-# https://github.com/clusterhq/flocker/issues/64
+# https://github.com/ClusterHQ/flocker/issues/64
 def _docker_command(reactor, arguments):
     """Run the ``docker`` command-line tool with the given arguments.
 

--- a/flocker/volume/test/filesystemtests.py
+++ b/flocker/volume/test/filesystemtests.py
@@ -473,7 +473,7 @@ def make_istoragepool_tests(fixture):
         def test_consistent_naming_pattern(self):
             """``IFilesystem.get_path().basename()`` has a consistent naming
             pattern. This test should be removed as part of:
-                https://github.com/clusterhq/flocker/issues/78"""
+                https://github.com/ClusterHQ/flocker/issues/78"""
             pool = fixture(self)
             uuid = u"my-uuid"
             volume_name = u"myvolumename"

--- a/flocker/volume/test/test_service.py
+++ b/flocker/volume/test/test_service.py
@@ -113,7 +113,7 @@ class VolumeServiceAPITests(TestCase):
         """The created filesystem is readable/writable/executable by anyone.
 
         A better alternative will be implemented in
-        https://github.com/clusterhq/flocker/issues/34
+        https://github.com/ClusterHQ/flocker/issues/34
         """
         pool = FilesystemStoragePool(FilePath(self.mktemp()))
         service = VolumeService(FilePath(self.mktemp()), pool)


### PR DESCRIPTION
Our repo has moved to `ClusterHQ/flocker`; update all the references.

Closes #159.
