### PR TITLE
Fix tests on vagrant shaed folder.

### DIFF
--- a/flocker/testtools.py
+++ b/flocker/testtools.py
@@ -354,7 +354,7 @@ def find_free_port(interface='127.0.0.1', socket_family=socket.AF_INET,
         probe.close()
 
 
-def skip_on_virtualbox_share(test_method):
+def skip_on_broken_permissions(test_method):
     """
     Skips the wrapped test when the temporary directory is on a
     virtualbox shared folder.

--- a/flocker/volume/functional/test_script.py
+++ b/flocker/volume/functional/test_script.py
@@ -17,7 +17,7 @@ from ..service import VolumeService, Volume
 from .._ipc import ProcessNode
 from ..filesystems.zfs import StoragePool
 from .test_filesystems_zfs import create_zfs_pool
-from ...testtools import skip_on_virtualbox_share
+from ...testtools import skip_on_broken_permissions
 
 
 _require_installed = skipUnless(which("flocker-volume"),
@@ -70,7 +70,7 @@ class FlockerVolumeTests(TestCase):
         self.assertTrue(json.loads(path.getContent()))
 
     @skipIf(os.getuid() == 0, "root doesn't get permission errors.")
-    @skip_on_virtualbox_share
+    @skip_on_broken_permissions
     def test_no_permission(self):
         """If the config file is not writeable a meaningful response is
         written.

--- a/flocker/volume/test/test_service.py
+++ b/flocker/volume/test/test_service.py
@@ -19,7 +19,7 @@ from ..service import (
     )
 from ..filesystems.memory import FilesystemStoragePool
 from .._ipc import FakeNode
-from ...testtools import skip_on_virtualbox_share
+from ...testtools import skip_on_broken_permissions
 
 
 class VolumeServiceStartupTests(TestCase):
@@ -56,7 +56,7 @@ class VolumeServiceStartupTests(TestCase):
         self.assertTrue(path.exists())
 
     @skipIf(os.getuid() == 0, "root doesn't get permission errors.")
-    @skip_on_virtualbox_share
+    @skip_on_broken_permissions
     def test_config_makedirs_failed(self):
         """If creating the config directory fails then CreateConfigurationError
         is raised."""
@@ -69,7 +69,7 @@ class VolumeServiceStartupTests(TestCase):
         self.assertRaises(CreateConfigurationError, service.startService)
 
     @skipIf(os.getuid() == 0, "root doesn't get permission errors.")
-    @skip_on_virtualbox_share
+    @skip_on_broken_permissions
     def test_config_write_failed(self):
         """If writing the config fails then CreateConfigurationError
         is raised."""
@@ -112,7 +112,7 @@ class VolumeServiceAPITests(TestCase):
         volume = self.successResultOf(service.create(u"myvolume"))
         self.assertTrue(pool.get(volume).get_path().isdir())
 
-    @skip_on_virtualbox_share
+    @skip_on_broken_permissions
     def test_create_mode(self):
         """The created filesystem is readable/writable/executable by anyone.
 


### PR DESCRIPTION
Fixes #111.

It would be good to also have instructions on how to run the tests so that the temporary directory isn't a vagrant shared folder, but I'm not sure how to tell tox to put the temporary directory somewhere other than `.tox`.
