### PR TITLE
Use `FilePath` sibling instead of `os.path`.

### DIFF
--- a/flocker/node/functional/test_gear.py
+++ b/flocker/node/functional/test_gear.py
@@ -256,8 +256,7 @@ class GearClientTests(TestCase):
         image_name = b'flocker/send_bytes_to'
         # Create a Docker image
         image = DockerImageBuilder(
-            source_dir=FilePath(
-                os.path.join(os.path.dirname(__file__), 'docker')),
+            source_dir=FilePath(__file__).sibling('docker'),
             tag=image_name,
             working_dir=FilePath(self.mktemp())
         )


### PR DESCRIPTION
I noticed this reading through the code.
