### PR TITLE
Disable hardlinking if installing inside a shared /vagrant directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,11 @@ cmdclass.update(versioneer.get_cmdclass())
 # Hard linking doesn't work inside VirtualBox shared folders. This means that
 # you can't use tox in a directory that is being shared with Vagrant,
 # since tox relies on `python setup.py sdist` which uses hard links. As a
-# workaround, disable hard-linking if it looks like we're running inside a
-# Vagrant VM.
+# workaround, disable hard-linking if setup.py is a descendant of /vagrant.
 # See
 # https://stackoverflow.com/questions/7719380/python-setup-py-sdist-error-operation-not-permitted
 # for more details.
-if os.path.dirname(os.path.abspath(__file__)) == '/vagrant':
+if os.path.abspath(__file__).split(os.path.sep)[1] == 'vagrant':
     del os.link
 
 with open("README.rst") as readme:


### PR DESCRIPTION
Fixes: #260 
