### PR TITLE
SSH shell quoting - fixes 318, 331

### DIFF
--- a/flocker/common/_ipc.py
+++ b/flocker/common/_ipc.py
@@ -112,8 +112,7 @@ class ProcessNode(object):
             # disabling this leads for mDNS lookups on every SSH, which
             # can slow down connections very noticeably:
             b"-o", b"GSSAPIAuthentication=no",
-            b"-p", b"%d" % (port,), host),
-                   quote=quote)
+            b"-p", b"%d" % (port,), host), quote=quote)
 
 
 @implementer(INode)

--- a/flocker/common/functional/test_ipc.py
+++ b/flocker/common/functional/test_ipc.py
@@ -3,7 +3,6 @@
 """Functional tests for IPC."""
 
 import os
-from getpass import getuser
 from unittest import skipIf
 
 from twisted.internet.threads import deferToThread


### PR DESCRIPTION
Fixes #318, #331.

This doesn't explicitly test that quoting is done, which I can add if requested, but the SSH tests now fail if quoting is disabled because they use things like `(` and spaces in their commands.
