### PR TITLE
Added Coveralls badge to Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 .. image:: https://coveralls.io/repos/ClusterHQ/flocker/badge.png
   :target: https://coveralls.io/r/ClusterHQ/flocker
+  :alt: 'Buildbot build coverage status'
 
 =======
 Flocker


### PR DESCRIPTION
This is a companion to https://github.com/ClusterHQ/build.clusterhq.com/pull/2

This should not be merged until the companion branch is merged and deployed.

Fixes #119 
