### PR TITLE
Replace old names with ClusterHQ in most places - fixes 369

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,8 +2,8 @@
 Authors
 =======
 
-Flocker is maintained by Hybrid Logic Ltd. and is licensed under the Apache Software License 2.0.
+Flocker is maintained by ClusterHQ and is licensed under the Apache Software License 2.0.
 
 The following people and organizations contributed to its development; please add your name in alphabetical order with your first pull request:
 
-* Hybrid Logic Ltd.
+* ClusterHQ (formerly Hybrid Logic Ltd.)

--- a/README.rst
+++ b/README.rst
@@ -47,4 +47,4 @@ Flocker is also tested using `continuous integration`_.
 .. _unittest: https://docs.python.org/2/library/unittest.html
 .. _Twisted Trial: https://twistedmatrix.com/trac/wiki/TwistedTrial
 .. _tox: https://tox.readthedocs.org/
-.. _continuous integration: http://build.flocker.hybridcluster.net/
+.. _continuous integration: http://build.clusterhq.com/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Flocker'
-copyright = u'2014, HybridCluster'
+copyright = u'2014, ClusterHQ'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -184,7 +184,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'Flocker.tex', u'Flocker Documentation',
-   u'HybridCluster', 'manual'),
+   u'ClusterHQ', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -214,7 +214,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'flocker', u'Flocker Documentation',
-     [u'HybridCluster'], 1)
+     [u'ClusterHQ'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -228,7 +228,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'Flocker', u'Flocker Documentation',
-   u'HybridCluster', 'Flocker', 'One line description of project.',
+   u'ClusterHQ', 'Flocker', 'Data-oriented Docker clustering.',
    'Miscellaneous'),
 ]
 

--- a/python-flocker.spec.in
+++ b/python-flocker.spec.in
@@ -7,7 +7,7 @@ Summary:        Libraries for flocker
 BuildArch:      noarch
 
 License:        ASL 2.0
-URL:            https://hybridcluster.github.io/
+URL:            https://clusterhq.com
 Source0:        Flocker-%{flocker_version}.tar.gz
 
 BuildRequires:  python-devel

--- a/setup.py
+++ b/setup.py
@@ -57,11 +57,11 @@ setup(
     version=versioneer.get_version(),
     # This identifies the creators of this software.  This is left symbolic for
     # ease of maintenance.
-    author="HybridCluster Team",
+    author="ClusterHQ Team",
     # This is contact information for the authors.
-    author_email="support@hybridcluster.com",
+    author_email="support@clusterhq.com",
     # Here is a website where more information about the software is available.
-    url="http://hybridcluster.com/",
+    url="https://clusterhq.com/",
 
     # A short identifier for the license under which the project is released.
     license="Apache License, Version 2.0",


### PR DESCRIPTION
Fixes #369.
