### PR TITLE
Make `flocker-deploy` more universal

### DIFF
--- a/contrib/flocker-deploy-dev.sh
+++ b/contrib/flocker-deploy-dev.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Flocker CLI running against live code base
+
+# Install by symlinking this file into your executbales path, eg;
+# `sudo ln -s $(pwd)/flocker-deploy-dev /usr/local/bin/fl-dev'
+
+set -e
+
+FLOCKER_ROOT="$(dirname "$(test -L "$0" && readlink "$0" || echo "$0")")/.."
+
+if [ ! -d "$FLOCKER_ROOT/env" ]; then
+	printf "Please setup Virtualenv at 'env/'"
+	echo " and install dependencies with \`python setup.py install .[doc,dev]'"
+ 	exit 1
+fi
+
+$FLOCKER_ROOT/env/bin/python \
+	-c 'from flocker.cli.script import flocker_deploy_main; flocker_deploy_main()' $@

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,34 +5,35 @@ Installing Flocker
 Flocker has two components that need installing:
 
 1. The ``flocker-node`` package that runs on each node in the cluster.
-   For now we recommend running the cluster using a pre-packaged Vagrant setup; see :doc:`tutorial/vagrant-setup`.
-2. The ``flocker-cli`` package which provides command line tools to controls the cluster.
-   This should be installed on a machine with SSH credentials to control the cluster nodes, e.g. the machine which is running Vagrant.
+   For now we recommend running the cluster using a pre-packaged Vagrant setup;
+   see :doc:`tutorial/vagrant-setup`.
+2. The ``flocker-cli`` package which provides command line tools to control the cluster.
+   This should be installed on a machine with SSH credentials to control the cluster nodes, e.g. the
+   host machine which is running the above pre-packaged Vagrant box. See below;
 
+``flocker-cli`` Installation
+============================
 
-Ubuntu
-======
+The Flocker CLI tool is installed using Pip_, which is available on most operating systems,
+including; Windows, OSX and Linux.
 
-To install ``flocker-cli`` on Ubuntu you can run the following script:
+(Once 'flocker-cli' is available on the Pip package index) All you need to do to install is;
+``pip install flocker-cli``.
 
-:download:`ubuntu-install.sh`
-
-.. literalinclude:: ubuntu-install.sh
-   :language: sh
-
-Save the script to a file, and then run it:
-
-.. code-block:: console
-
-   alice@mercury:~$ sh ubuntu-install.sh
-
-The ``flocker-deploy`` command line program will now be available in ``flocker-tutorial/bin/``:
+(Until then) You can also install the bleeding edge client from the current Github repo using
+Virtualenv_. On a \*nix-based system you can do the following;
 
 .. code-block:: console
 
-   alice@mercury:~$ cd flocker-tutorial
-   alice@mercury:~/flocker-tutorial$ bin/flocker-deploy --version
+   alice@mercury:~$ git clone git@github.com:ClusterHQ/flocker.git
+   alice@mercury:~$ cd flocker
+   alice@mercury:~/flocker$ virtualenv env
+   alice@mercury:~/flocker$ python setup.py install .[doc,dev]
+   alice@mercury:~/flocker$ sudo ln -s $(pwd)/contrib/flocker-deploy-dev.sh /usr/local/bin/fl-dev
+   alice@mercury:~/flocker$ cd ~
+   alice@mercury:~$ fl-dev --version
    0.1.0
-   alice@mercury:~/flocker-tutorial$ export PATH="${PATH:+${PATH}:}${PWD}/bin"
-   alice@mercury:~/flocker-tutorial$ flocker-deploy --version
-   0.1.0
+
+
+.. _Pip: http://pip.readthedocs.org/en/latest/installing.html
+.. _Virtualenv: http://virtualenv.readthedocs.org/en/latest/virtualenv.html


### PR DESCRIPTION
I'm starting to play with Flocker for the first time. So just thought I'd offer some perspective from fresh eyes. Note that I'm only vaguely aware of other factors that I'm not taking into consideration, eg; #259, #359

Two things struck me about the [current installation docs for the command client](http://doc-dev.clusterhq.com/installation.html);
- The implication that the client can only be installed on Ubuntu. I can't believe this is the case. And is surely off-putting to potential users, when I suspect the client will work perfectly well on Windows even.
- The manipulation of a user's `$PATH`. I consider this bad etiquette and should be avoided at all costs.

So regarding #359. Can Pip's package index not be used for the `flocker-cli` component at least? It has download counts and HTTPS. And then RPMs/debs for the `flocker-node` component? 

I've provided a suggestion `contrib/flocker-deploy-dev.sh` script that overcomes the need for altering `$PATH`. I'm assuming that at some point there will be an official means of installing the client which will place the binary in the system path. Therefore any other means of running the client needs to have another name to avoid conflict and also needs to offer something different, which is why I've made it run the live code from the repo, rather than the setuptools-installed flocker lib version of flocker.

BTW, how do you recommend developing against the command line? Do you use something similar to a `fl-dev` script? Or are you working in a pure TDD style?
