### PR TITLE
Fixed width on #logo

### DIFF
--- a/docs/_themes/bootstrap/static/sphinx-bootstrap.css
+++ b/docs/_themes/bootstrap/static/sphinx-bootstrap.css
@@ -187,6 +187,7 @@ input[type="submit"].active, input[type="submit"]:active {
 
 #logo {
     padding-top: 21px;
+    width: 238px;
 }
 
 #menubar #navul {


### PR DESCRIPTION
Stop the logo being 100% width by setting the div to be a fixed width in the docs.

![](http://entirely.pro/img/1407332486-NPdJ.jpg)

Fixes #454 
