### PR TITLE
Change rellink order

### DIFF
--- a/docs/_themes/bootstrap/layout.html
+++ b/docs/_themes/bootstrap/layout.html
@@ -10,16 +10,16 @@
             {%- block rootrellink %}
                 <li class=""><a class="" href="{{ pathto(master_doc) }}">{{ project|e }}</a></li>
             {%- endblock %}
-            {%- for rellink in rellinks %}
+            {%- for parent in parents %}
+                <li><a href="{{ parent.link|e }}"
+                        {% if loop.last %}{{ accesskey("U") }}{% endif %}>{{ parent.title }}</a>
+                </li>
+            {%- endfor %}
+            {%- for rellink in rellinks|reverse %}
                 <li>
                     <a href="{{ pathto(rellink[0]) }}"
                        title="{{ rellink[1]|striptags|e }}" {{ accesskey(rellink[2]) }}>{{ rellink[3] }}</a>
                     {%- if not loop.first %}{% endif %}
-                </li>
-            {%- endfor %}
-            {%- for parent in parents %}
-                <li><a href="{{ parent.link|e }}"
-                        {% if loop.last %}{{ accesskey("U") }}{% endif %}>{{ parent.title }}</a>
                 </li>
             {%- endfor %}
             {%- block relbaritems %} {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False


### PR DESCRIPTION
Change the order of the links on the documentation and remove the blank index page.

Fixes #453 
