### PR TITLE
Highlight current location in sidebar table of contents - fixes 466

### DIFF
--- a/docs/_themes/bootstrap/static/sphinx-bootstrap.css
+++ b/docs/_themes/bootstrap/static/sphinx-bootstrap.css
@@ -286,3 +286,8 @@ p {
 .pagination {
     text-transform: capitalize;
 }
+
+#toctree a.current {
+    font-weight: bold;
+    font-style: italic;
+}


### PR DESCRIPTION
Fixes #466.
