### PR TITLE
Added ClusterHQ favicon

### DIFF
--- a/docs/_themes/bootstrap/layout.html
+++ b/docs/_themes/bootstrap/layout.html
@@ -99,6 +99,7 @@
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
+    <link rel="shortcut icon" href="//clusterhq.com/wp-content/themes/hybrid-cluster-v3/assets/img/favicon.ico"/>
     {%- if not embedded %}
         <script type="text/javascript">
             var DOCUMENTATION_OPTIONS = {


### PR DESCRIPTION
Adds the ClusterHQ website's favicon to the documentation.

Fixed #473
