### PR TITLE
Maxdepth in sidebar 2 instead of 4

### DIFF
--- a/docs/_themes/bootstrap/layout.html
+++ b/docs/_themes/bootstrap/layout.html
@@ -43,11 +43,7 @@
         
         <script>
                 $( document ).ready(function() {
-                    $('#toctree .current').each(function() {
-                        if ($(this).children('ul').length > 0) {
-                            $(this).children('ul').show();
-                        }
-                    });
+                    $('#toctree li.current').find('ul').show();
                 });
         </script>
     {%- endif %}


### PR DESCRIPTION
This change makes it possible to only go two levels in the toctree from the sidebar.

Fixes #495 
