### PR TITLE
Require vagrant >= 1.6.2

### DIFF
--- a/docs/gettingstarted/tutorial/Vagrantfile
+++ b/docs/gettingstarted/tutorial/Vagrantfile
@@ -3,6 +3,7 @@
 
 # This requires Vagrant 1.6.2 or newer (earlier versions can't reliably
 # configure the Fedora 20 network stack).
+Vagrant.require_version ">= 1.6.2"
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"

--- a/vagrant/base/Vagrantfile
+++ b/vagrant/base/Vagrantfile
@@ -1,8 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.require_version ">= 1.6.2"
-
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 


### PR DESCRIPTION
Fixes #524

I tested this only by putting the required version to a made up one higher than my own and seeing the following (in red)

```
This Vagrant environment has specified that it requires the Vagrant
version to satisfy the following version requirements:

  >= 1.9.5

You are running Vagrant 1.6.3, which does not satisfy
these requirements. Please change your Vagrant version or update
the Vagrantfile to allow this Vagrant version. However, be warned
that if the Vagrantfile has specified another version, it probably has
good reason to do so, and changing that may cause the environment to
not function properly.
```

I'm not sure how to test that I need the change in `vagrant/base/Vagrantfile` but put it in on @itamarst 's suggestion.
