### PR TITLE
Updated versions in installers and vagrantfiles

### DIFF
--- a/docs/gettingstarted/osx-install.sh
+++ b/docs/gettingstarted/osx-install.sh
@@ -10,4 +10,4 @@ virtualenv --python=/usr/local/bin/python2.7 flocker-tutorial
 flocker-tutorial/bin/pip install --upgrade pip
 
 # Install flocker-cli and dependencies inside the virtualenv:
-flocker-tutorial/bin/pip install https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.0.6-py2-none-any.whl
+flocker-tutorial/bin/pip install https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.0.7-py2-none-any.whl

--- a/docs/gettingstarted/tutorial/Vagrantfile
+++ b/docs/gettingstarted/tutorial/Vagrantfile
@@ -19,7 +19,7 @@ yum localinstall -y https://storage.googleapis.com/archive.clusterhq.com/fedora/
 # For reasons I do not understand this doesn't work (https://github.com/ClusterHQ/flocker/issues/510):
 #yum install -y flocker-node
 # So instead do it the stupid way:
-yum install -y https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/python-flocker-0.0.6-1.fc20.noarch.rpm https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/flocker-node-0.0.6-1.fc20.noarch.rpm
+yum install -y https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/python-flocker-0.0.7-1.fc20.noarch.rpm https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/flocker-node-0.0.7-1.fc20.noarch.rpm
 
 # At the end of this bootstrap we'll (indirectly) ask Docker to write a very
 # large file to its temporary directory.  /tmp is a small tmpfs mount which

--- a/docs/gettingstarted/ubuntu-install.sh
+++ b/docs/gettingstarted/ubuntu-install.sh
@@ -13,4 +13,4 @@ virtualenv --python=/usr/bin/python2.7 flocker-tutorial
 flocker-tutorial/bin/pip install --upgrade pip
 
 # Install flocker-cli and dependencies inside the virtualenv:
-flocker-tutorial/bin/pip install https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.0.6-py2-none-any.whl
+flocker-tutorial/bin/pip install https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.0.7-py2-none-any.whl


### PR DESCRIPTION
Fixes #530 

This is an odd situation because I am acting like this is a major/minor release but changing the version number as if it is a patch release. I therefore deleted the branch "release/flocker-0.0" near the start.
