### PR TITLE
Strip -dirty from documentation version so it doesn't show up in RTD - fixes 544

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,8 @@ copyright = u'2014, ClusterHQ'
 # The short X.Y version.
 sys.path.insert(0, FilePath(__file__).parent().parent().path)
 from flocker import __version__ as version
+if version.endswith("-dirty"):
+    version = version[:-6]
 del sys.path[0]
 
 # The full version, including alpha/beta/rc tags.


### PR DESCRIPTION
Fixes #544.
