### PR TITLE
minor ReST markup fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,10 @@ Tests
 -----
 
 Flocker's test suite is based on `unittest`_ and `Twisted Trial`_.
-The preferred way to run the test suite is using the command `trial flocker`.
+The preferred way to run the test suite is using the command ``trial flocker``.
 Flocker also includes a `tox`_ configuration to run the test suite in multiple environments and to run additional checks
 (such as flake8 and build the documentation with Sphinx).
-You can run all of the tox environments using the command `tox`.
+You can run all of the tox environments using the command ``tox``.
 
 Flocker is also tested using `continuous integration`_.
 


### PR DESCRIPTION
A matched pair of backticks for monospace is Markdown, ReST requires that you double them.
