### PR TITLE
Pass the supplied Application environment during StartApplication state changes - fixes 586

### DIFF
--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -12,7 +12,7 @@ from characteristic import attributes
 from twisted.internet.defer import gatherResults, fail, DeferredList, succeed
 from twisted.python.filepath import FilePath
 
-from .gear import GearClient, PortMap
+from .gear import GearClient, PortMap, GearEnvironment
 from ._model import (
     Application, VolumeChanges, AttachedVolume, VolumeHandoff,
     )
@@ -115,10 +115,19 @@ class StartApplication(object):
                             application.ports)
         else:
             port_maps = []
+
+        if application.environment is not None:
+            environment = GearEnvironment(
+                id=application.name,
+                variables=application.environment)
+        else:
+            environment = None
+
         d.addCallback(lambda _: deployer.gear_client.add(
             application.name,
             application.image.full_name,
             ports=port_maps,
+            environment=environment
         ))
         return d
 

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -388,13 +388,37 @@ class StartApplicationTests(SynchronousTestCase):
             image=DockerImage(repository=u'clusterhq/postgresql',
                               tag=u'9.3.5'),
             environment=variables.copy())
+
+        StartApplication(application=application).run(deployer)
+
         expected_environment = GearEnvironment(
             id=application_name, variables=variables.copy())
+
+        self.assertEqual(
+            expected_environment,
+            fake_gear._units[application_name].environment
+        )
+
+    def test_environment_not_supplied(self):
+        """
+        ``StartApplication.run()`` only passes a a ``GearEnvironment`` instance
+        if the application defines an environment.
+        """
+        volume_service = create_volume_service(self)
+        fake_gear = FakeGearClient()
+        deployer = Deployer(volume_service, fake_gear)
+
+        application_name = u'site-example.com'
+        application = Application(
+            name=application_name,
+            image=DockerImage(repository=u'clusterhq/postgresql',
+                              tag=u'9.3.5'),
+            environment=None)
 
         StartApplication(application=application).run(deployer)
 
         self.assertEqual(
-            expected_environment,
+            None,
             fake_gear._units[application_name].environment
         )
 


### PR DESCRIPTION
I thought about adding a functional test too, but it seemed unnecessary since there's already functional testing of GearClient.add with environment supplied.

This branch does make me think that I went OTT with the GearEnvironment class. It seems unnecessary unless we ever support the shared environment features of gear.

Perhaps I should simplify it now.

Fixes #586
