### PR TITLE
Include warning if version of documentation is not x.y.z - fixes 560

### DIFF
--- a/docs/_themes/bootstrap/layout.html
+++ b/docs/_themes/bootstrap/layout.html
@@ -187,7 +187,7 @@
             {%- block document %}
                 <div class="span9">
                     <script>
-                        var release_re = /^[0-9]*\.[0-9]*\.[0-9]*$/
+                        var release_re = /^[0-9]+\.[0-9]+\.[0-9]+$/
                         if (!'{{ release }}'.match(release_re)) {
                             document.write(
                     '<div class="admonition note"> \


### PR DESCRIPTION
Fixes #560.

This strategy may need a slight tweak as part of #561, depending how we keep the version in `conf.py` stable on release branches.
