### PR TITLE
Removed marketing release tasks from the release documentation - fixes 607

### DIFF
--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -203,8 +203,8 @@ XXX Update download links on https://clusterhq.com:
 XXX Arrange to have download links on a page on https://clusterhq.com.
 See:
 
- - https://github.com/ClusterHQ/flocker/issues/359 and
- - https://www.pivotaltracker.com/n/projects/946740/stories/75538272
+- https://github.com/ClusterHQ/flocker/issues/359 and
+- https://www.pivotaltracker.com/n/projects/946740/stories/75538272
 
 
 .. _gsutil: https://developers.google.com/storage/docs/gsutil


### PR DESCRIPTION
Do we need a note, reminding the release manager to liaise with marketing about pre-releases and releases. Discuss.

Fixes #607 
