### PR TITLE
Ignore coverage for flocker/_version.py.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 omit =
-    flocker/_version.py
+    */flocker/_version.py


### PR DESCRIPTION
We don't maintain this file, so we don't care about coverage for it.

Fixes ClusterHQ/build.clusterhq.com#6 (buildbot support in ClusterHQ/build.clusterhq.com#15).
