### PR TITLE
Version number changes for the 0.1.2 release

### DIFF
--- a/docs/gettingstarted/installation.rst
+++ b/docs/gettingstarted/installation.rst
@@ -56,7 +56,7 @@ The ``flocker-deploy`` command line program will now be available in ``flocker-t
 
    alice@mercury:~$ cd flocker-tutorial
    alice@mercury:~/flocker-tutorial$ bin/flocker-deploy --version
-   0.1.0
+   0.1.2
    alice@mercury:~/flocker-tutorial$
 
 If you want to omit the prefix path you can add the appropriate directory to your ``$PATH``.
@@ -66,7 +66,7 @@ You'll need to do this every time you start a new shell.
 
    alice@mercury:~/flocker-tutorial$ export PATH="${PATH:+${PATH}:}${PWD}/bin"
    alice@mercury:~/flocker-tutorial$ flocker-deploy --version
-   0.1.0
+   0.1.2
    alice@mercury:~/flocker-tutorial$
 
 OS X
@@ -90,9 +90,9 @@ Add the ``ClusterHQ/flocker`` tap to Homebrew and install ``flocker``:
 
    alice@mercury:~$ brew tap ClusterHQ/tap
    ...
-   alice@mercury:~$ brew install flocker
+   alice@mercury:~$ brew install flocker-0.1.2
    ...
-   alice@mercury:~$ brew test flocker
+   alice@mercury:~$ brew test flocker-0.1.2
    ...
    alice@mercury:~$
 
@@ -103,7 +103,7 @@ The ``flocker-deploy`` command line program will now be available:
 .. code-block:: console
 
    alice@mercury:~$ flocker-deploy --version
-   0.1.0
+   0.1.2
    alice@mercury:~$
 
 .. _Homebrew: http://brew.sh

--- a/docs/gettingstarted/linux-install.sh
+++ b/docs/gettingstarted/linux-install.sh
@@ -11,5 +11,5 @@ flocker-tutorial/bin/pip install --upgrade pip
 
 # Install flocker-cli and dependencies inside the virtualenv:
 echo "Installing Flocker and dependencies, this may take a few minutes with no output to the terminal..."
-flocker-tutorial/bin/pip install --quiet https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.1.1-py2-none-any.whl
+flocker-tutorial/bin/pip install --quiet https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.1.2-py2-none-any.whl
 echo "Done!"

--- a/docs/gettingstarted/tutorial/Vagrantfile
+++ b/docs/gettingstarted/tutorial/Vagrantfile
@@ -20,7 +20,7 @@ yum localinstall -y https://storage.googleapis.com/archive.clusterhq.com/fedora/
 # For reasons I do not understand this doesn't work (https://github.com/ClusterHQ/flocker/issues/510):
 #yum install -y flocker-node
 # So instead do it the stupid way:
-yum install -y https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/python-flocker-0.1.1-1.fc20.noarch.rpm https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/flocker-node-0.1.1-1.fc20.noarch.rpm
+yum install -y https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/python-flocker-0.1.2-1.fc20.noarch.rpm https://storage.googleapis.com/archive.clusterhq.com/fedora/20/x86_64/flocker-node-0.1.2-1.fc20.noarch.rpm
 
 # At the end of this bootstrap we'll (indirectly) ask Docker to write a very
 # large file to its temporary directory.  /tmp is a small tmpfs mount which


### PR DESCRIPTION
Some improvements since the last release:
- Also updated version numbers in the installation narrative documentation
- Modified the homebrew installation instructions to install a specific version of flocker from a separate brew file (see https://github.com/ClusterHQ/homebrew-tap/pull/6)
- Built the documentation on ReadTheDocs (but have not made it the default)

See https://github.com/ClusterHQ/flocker/pull/665 for the changes I made while performing this release.

Fixes #692
