### PR TITLE
Modify MySQL example doc's title and intro

### DIFF
--- a/docs/gettingstarted/mysql-example.rst
+++ b/docs/gettingstarted/mysql-example.rst
@@ -2,7 +2,8 @@
 Example: Using Environment Variables
 ====================================
 
-Once you've successfully followed through :doc:`./tutorial/index` this example will demonstrate Flocker's capability to apply custom environment variables to an application container. We'll deploy an example MySQL application where an environment variable will be used to set the database server's root user password.
+Once you've successfully followed through :doc:`./tutorial/index` this example will demonstrate Flocker's capability to apply custom environment variables to an application container.
+We'll deploy an example MySQL application where an environment variable will be used to set the database server's root user password.
 
 Next we'll insert some data and use ``flocker-deploy`` to move the MySQL server container to another virtual machine.
 The data in the database will be moved along with the application.


### PR DESCRIPTION
```
changes title and intro text to reference the use of environment variables rather than deploying MySQL
```

fixes #691 
