### PR TITLE
Explain links in a bit more detail

### DIFF
--- a/docs/advanced/configuration.rst
+++ b/docs/advanced/configuration.rst
@@ -69,8 +69,9 @@ The following parameters are optional when defining an application:
 
      As you may have noticed in the example above, unlike Docker links, the destination port will not be the port used to create the environment variable names.
      Flocker implements linking via the ports exposed to the network, whereas Docker creates an internal tunnel between linked containers, an approach that is not compatible with the deployment of links across multiple nodes.
-     
-     It is also worth noting that at this time, only TCP links are supported by Flocker, therefore the ``TCP`` portion of the environment variable names and the ``tcp`` value of the ``_PROTO`` and ``_TCP`` variables are not configurable.
+
+  .. note::
+     Only TCP links are supported by Flocker, therefore the ``TCP`` portion of the environment variable names and the ``tcp`` value of the ``_PROTO`` and ``_TCP`` variables are not configurable.
 
 - ``volume``
 


### PR DESCRIPTION
Fixes #689 

Not sure this is perfect, but hopefully an improvement on what we had before. It would've helped massively if Docker's own documentation on container linking hadn't shown an example with incorrect environment variable names, something I have also opened a PR for:

https://github.com/docker/docker/pull/8008

(for a while I got confused, thinking I was fundamentally misunderstanding something about how environment variables were named)
