### PR TITLE
Release Flocker 0.1.3 - 805

### DIFF
--- a/docs/gettingstarted/installation.rst
+++ b/docs/gettingstarted/installation.rst
@@ -56,7 +56,7 @@ The ``flocker-deploy`` command line program will now be available in ``flocker-t
 
    alice@mercury:~$ cd flocker-tutorial
    alice@mercury:~/flocker-tutorial$ bin/flocker-deploy --version
-   0.1.2
+   0.1.3
    alice@mercury:~/flocker-tutorial$
 
 If you want to omit the prefix path you can add the appropriate directory to your ``$PATH``.
@@ -66,7 +66,7 @@ You'll need to do this every time you start a new shell.
 
    alice@mercury:~/flocker-tutorial$ export PATH="${PATH:+${PATH}:}${PWD}/bin"
    alice@mercury:~/flocker-tutorial$ flocker-deploy --version
-   0.1.2
+   0.1.3
    alice@mercury:~/flocker-tutorial$
 
 OS X
@@ -90,9 +90,9 @@ Add the ``ClusterHQ/flocker`` tap to Homebrew and install ``flocker``:
 
    alice@mercury:~$ brew tap ClusterHQ/tap
    ...
-   alice@mercury:~$ brew install flocker-0.1.2
+   alice@mercury:~$ brew install flocker-0.1.3
    ...
-   alice@mercury:~$ brew test flocker-0.1.2
+   alice@mercury:~$ brew test flocker-0.1.3
    ...
    alice@mercury:~$
 
@@ -103,7 +103,7 @@ The ``flocker-deploy`` command line program will now be available:
 .. code-block:: console
 
    alice@mercury:~$ flocker-deploy --version
-   0.1.2
+   0.1.3
    alice@mercury:~$
 
 .. _Homebrew: http://brew.sh

--- a/docs/gettingstarted/linux-install.sh
+++ b/docs/gettingstarted/linux-install.sh
@@ -11,5 +11,5 @@ flocker-tutorial/bin/pip install --upgrade pip
 
 # Install flocker-cli and dependencies inside the virtualenv:
 echo "Installing Flocker and dependencies, this may take a few minutes with no output to the terminal..."
-flocker-tutorial/bin/pip install --quiet https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.1.2-py2-none-any.whl
+flocker-tutorial/bin/pip install --quiet https://storage.googleapis.com/archive.clusterhq.com/downloads/flocker/Flocker-0.1.3-py2-none-any.whl
 echo "Done!"

--- a/docs/gettingstarted/tutorial/Vagrantfile
+++ b/docs/gettingstarted/tutorial/Vagrantfile
@@ -12,7 +12,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "clusterhq/flocker-tutorial"
-  config.vm.box_version = "= 0.1.2"
+  config.vm.box_version = "= 0.1.3"
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box


### PR DESCRIPTION
This is a pre-release and should not be merged. 

The associated documentation is at: https://flocker.readthedocs.org/en/0.1.3/gettingstarted/index.html

And the client utilities can be installed using `brew install https://raw.githubusercontent.com/ClusterHQ/homebrew-tap/release/flocker-0.1.3/flocker-0.1.3.rb`

Fixes #805
