### PR TITLE
Sumo package design - 508

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -9,27 +9,26 @@ from tempfile import mkdtemp
 
 from twisted.python.filepath import FilePath
 from characteristic import attributes
+import virtualenv
 
 from .release import make_rpm_version
 
 @attributes(['steps'])
 class BuildSequence(object):
     """
+    Run the supplied `steps` in consecutively.
     """
     def run(self):
-        """
-        """
         for step in self.steps:
             step.run()
 
 
 @attributes(['target_path'])
 class InstallVirtualEnv(object):
+    """
+    Install a virtualenv in the supplied `target_path`.
+    """
     def run(self):
-        """
-        """
-        import virtualenv
-
         virtualenv.create_environment(
             self.target_path.path,
             site_packages=False,
@@ -46,11 +45,11 @@ class InstallVirtualEnv(object):
 
 @attributes(['virtualenv_path', 'package_path'])
 class InstallApplication(object):
+    """
+    Install the supplied `package_path` using `pip` from the supplied
+    `virtualenv_path`.
+    """
     def run(self):
-        """
-        Install the supplied `package_path` using `pip` from the supplied
-        `virtualenv_path`.
-        """
         pip_path = self.virtualenv_path.child('bin').child('pip').path
         check_call(
             [pip_path, '--quiet', 'install', self.package_path.path]
@@ -59,6 +58,9 @@ class InstallApplication(object):
 
 @attributes(['source_path', 'name', 'rpm_version', 'license', 'url'])
 class BuildRpm(object):
+    """
+    Use `fpm` to build an RPM file from the supplied `source_path`.
+    """
     def run(self):
         """
         """
@@ -77,6 +79,9 @@ class BuildRpm(object):
 
 def sumo_rpm_builder(package_path, version, target_dir=None):
     """
+    Build an RPM file containing the supplied `package` and all its
+    dependencies.
+
     Motivation:
     * We depend on libraries which are not packaged for the target OS.
     * We depend on newer versions of libraries which have not yet been included in the target OS.
@@ -131,7 +136,8 @@ def sumo_rpm_builder(package_path, version, target_dir=None):
     return BuildSequence(
         steps=(
             InstallVirtualEnv(target_path=target_dir),
-            InstallApplication(virtualenv_path=target_dir, package_path=package_path),
+            InstallApplication(virtualenv_path=target_dir, 
+                               package_path=package_path),
             BuildRpm(
                 source_path=target_dir,
                 name='Flocker',

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -4,7 +4,6 @@
 Tests for ``admin.packaging``.
 """
 from glob import glob
-import os
 from subprocess import check_output
 
 from twisted.python.filepath import FilePath
@@ -21,7 +20,7 @@ FLOCKER_PATH = FilePath(__file__).parent().parent().parent()
 
 def assert_dict_contains(test_case, expected_dict, actual_dict, message=''):
     """
-    `actual_dict` contains all the items in `expected_dict`
+    `actual_dict` contains all the items in `expected_dict`.
     """
     missing_items = []
     mismatch_items = []
@@ -65,6 +64,11 @@ def assert_rpm_headers(test_case, expected_headers, rpm_path):
 
 def fake_virtual_env(test_case):
     """
+    Create a directory containing a fake pip executable which records its
+    arguments when executed.
+
+    Return an object containing methods with which to make assertions about the
+    fake virtualenv.
     """
     virtualenv_path = FilePath(test_case.mktemp())
     pip_log_path = virtualenv_path.child('pip.log')
@@ -97,11 +101,10 @@ def fake_virtual_env(test_case):
 
 class SpyStep(object):
     """
+    A `BuildStep` which records the fact that it has been run.
     """
     ran = False
     def run(self):
-        """
-        """
         self.ran = True
 
 


### PR DESCRIPTION
I'm not finished, but here are some notes on why we're doing sumo packages, how we can do them and a bunch of related tasks which may or may not be included in the 0.3 release. 

These notes are mostly based on ideas in:
- https://hynek.me/articles/python-app-deployment-with-native-packages/

Note: I've branched from my pre-release-rpm branch to pick up the version number function and `admin` package in that branch.

This afternoon I'll try and upload a little prototype code and tests for building RPMs using `fpm`.

Meanwhile:
- @ryao We can discuss how this fits in with a future sumo flocker-node package for CoreOS 
- We can also discuss Homebrew  vs building native MacOSX packages (see the notes below)
- @tomprince We can discuss whether you approve of `fpm` 
- setting up a debian, gentoo, MacOSX build slave
- and whether we can automatically update our package repo using buildbot.

Anyway, take a look at what I've written below and see if it makes any sense.

Refs #508
