### PR TITLE
Bump required docker-py version to 0.5.0.

### DIFF
--- a/python-flocker.spec.in
+++ b/python-flocker.spec.in
@@ -23,7 +23,7 @@ BuildRequires:  PyYAML = 3.10
 BuildRequires:  python-treq = 0.2.1
 BuildRequires:  python-netifaces >= 0.8.0
 BuildRequires:  python-ipaddr = 2.1.10
-BuildRequires:  python-docker-py = 0.4.0
+BuildRequires:  python-docker-py = 0.5.0
 # The test suite runs the ssh command-line client and uses other utilities such
 # as ssh-keygen.
 BuildRequires: openssh-clients

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         "netifaces >= 0.8",
         "ipaddr == 2.1.10",
 
-        "docker-py == 0.4.0"
+        "docker-py == 0.5.0"
         ],
 
     extras_require={


### PR DESCRIPTION
This version doesn't have a bogus dependency on coverage.
