### PR TITLE
Dockerclient list images ports 207

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -65,10 +65,6 @@ class Unit(object):
     """
     Information about a unit managed by Docker.
 
-    XXX: The ``container_image`` attribute defaults to ``None`` until we
-    have code to call docker for images associated with its
-    containers. See https://github.com/ClusterHQ/flocker/issues/207
-
     XXX "Unit" is geard terminology, and should be renamed. See
     https://github.com/ClusterHQ/flocker/issues/819
 
@@ -375,16 +371,18 @@ class DockerClient(object):
                 image = data[u"Config"][u"Image"]
                 ports = []
                 container_ports = data[u"NetworkSettings"][u"Ports"]
-                for internal, hostmap in container_ports.items():
-                    internal_map = internal.split(u'/')
-                    internal_port = internal_map[0]
-                    internal_port = int(internal_port)
-                    for host in hostmap:
-                        external_port = host[u"HostPort"]
-                        external_port = int(external_port)
-                        portmap = PortMap(internal_port=internal_port,
-                                          external_port=external_port)
-                        ports.append(portmap)
+                if container_ports:
+                    for internal, hostmap in container_ports.items():
+                        internal_map = internal.split(u'/')
+                        internal_port = internal_map[0]
+                        internal_port = int(internal_port)
+                        if hostmap:
+                            for host in hostmap:
+                                external_port = host[u"HostPort"]
+                                external_port = int(external_port)
+                                portmap = PortMap(internal_port=internal_port,
+                                                  external_port=external_port)
+                                ports.append(portmap)
                 if name.startswith(u"/" + self.namespace):
                     name = name[1 + len(self.namespace):]
                 else:

--- a/flocker/node/test/test_docker.py
+++ b/flocker/node/test/test_docker.py
@@ -103,16 +103,15 @@ def make_idockerclient_tests(fixture):
             """An added unit is included in the output of ``list()``."""
             client = fixture(self)
             name = random_name()
+            image = u"openshift/busybox-http-app"
             self.addCleanup(client.remove, name)
-            d = client.add(name, u"openshift/busybox-http-app")
+            d = client.add(name, image)
             d.addCallback(lambda _: client.list())
 
             def got_list(units):
-                # XXX: DockerClient.list should also return container_image
-                # information
-                # See https://github.com/ClusterHQ/flocker/issues/207
-                self.assertEqual([name], [unit.name for unit in units
-                                          if unit.name == name])
+                unit_data = [[unit.name, unit.container_image]
+                             for unit in units if unit.name == name]
+                self.assertEqual([name, image], unit_data[0])
             d.addCallback(got_list)
             return d
 


### PR DESCRIPTION
Design review only (issue #207), there are a few other bits of code throughout flocker that need to swap out "unknown" or other null / fake information for real image and ports info coming from `DockerClient.list()`

This locally passes unit and functional tests for the two tests added (test image name from `list()` and test `PortMap`s from `list()`)

There is a theoretical possibility of a `ValueError` when `list()` attempts to cast the `unicode` port values retrieved from Docker to `int`s. I don't know whether to catch those in this code, or leave it to the caller of `list()`'s returned `Deferred` to add an `errback` - comments on this would be appreciated.
