### PR TITLE
Add admin environment for runnning tests for admin commands.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,8 @@ commands =
     sphinx-build -a -b spelling docs/ docs/_build/spelling
     sphinx-build -a -b html docs/ docs/_build/html
     sphinx-build -a -b linkcheck docs/ docs/_build/linkcheck
+
+[testenv:admin]
+basepython = python2.7
+usedevelop = True
+commands = trial --rterrors admin


### PR DESCRIPTION
Fixes #862.

This only handles tox, not buildbot.
