### PR TITLE
[FLOC-1028] Fix broken test.

### DIFF
--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -185,6 +185,7 @@ class GenericDockerClientTests(TestCase):
         name = random_name()
         d = self.start_container(unit_name=name, image_name="busybox",
                                  expected_states=(u'inactive',))
+
         def remove_container(client):
             client.remove(name)
         d.addCallback(remove_container)


### PR DESCRIPTION
flocker.node.functional.test_docker.NamespacedDockerClientTests.test_dead_is_removed
was merged broken, since buildbot was reporting statuses incorrectly.
