### PR TITLE
[FLOC-1048] Docker internal server error when stopping an exiting / exited container

### DIFF
--- a/flocker/node/functional/test_race.py
+++ b/flocker/node/functional/test_race.py
@@ -57,7 +57,8 @@ class DockerClientTests(TestCase):
         """
         self.client = Client(version="1.15", base_url=BASE_DOCKER_API_URL)
         name = random_name()
-        self.client.create_container(name=name, image=u"busybox")
+        self.client.create_container(
+            name=name, image=u"busybox", command="/bin/true")
         self.client.start(container=name)
         self.container_name = name
 


### PR DESCRIPTION
Here are a couple of self-contained test cases to reproduce some of the errors that we're seeing in the `flocker.node.functional` test suite.
