### PR TITLE
Handle 500 from stopping a container.

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -496,19 +496,15 @@ class DockerClient(object):
                 try:
                     self._client.stop(container_name)
                 except APIError as e:
-                    from twisted.python import log
                     if e.response.status_code == NOT_FOUND:
                         # If the container doesn't exist, we swallow the error,
                         # since this method is supposed to be idempotent.
-                        log.msg("BREAK")
                         break
                     elif e.response.status_code == INTERNAL_SERVER_ERROR:
                         # Docker returns this if the process had died, but
                         # hasn't noticed it yet.
-                        log.msg("CONTINUE")
                         continue
                     else:
-                        log.msg("RAISE")
                         raise
                 else:
                     break


### PR DESCRIPTION
There appears to be a race condition between
- a process dying, a SIGCHLD being sent, and docker processing that signal,
  marking the container as stopped
  and
- docker receiving a request to kill a container, checking that the container
  is still alive, and sending the signal.

This partially reverts commit c9a58bdc262d410f90588a3bd0a9dd18feb4bec8.
