### PR TITLE
[FLOC-1170] Pre-pull tutorial images

### DIFF
--- a/docs/gettingstarted/examples/environment.rst
+++ b/docs/gettingstarted/examples/environment.rst
@@ -25,29 +25,15 @@ If you have since shutdown or destroyed those VMs, boot them up again:
    Bringing machine 'node1' up with 'virtualbox' provider...
    ==> node1: Importing base box 'clusterhq/flocker-dev'...
 
-Download the Docker Image
-=========================
+Launch MySQL
+============
 
-The Docker image used by this example is quite large, so you should pre-fetch it to your nodes.
-
-.. code-block:: console
-
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.250 docker pull mysql:5.6.17
-   ...
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.251 docker pull mysql:5.6.17
-   ...
-   alice@mercury:~/flocker-tutorial$
+Download and save the following configuration files to the ``flocker-tutorial`` directory:
 
 .. note::
 
    The ``mysql:5.6.17`` Docker image is used in this example for compatibility with ZFS.
    Newer versions of the MySQL Docker image enable asynchronous I/O, which is not yet supported by ZFS on Linux.
-
-
-Launch MySQL
-============
-
-Download and save the following configuration files to the ``flocker-tutorial`` directory:
 
 :download:`mysql-application.yml`
 
@@ -58,7 +44,7 @@ Download and save the following configuration files to the ``flocker-tutorial`` 
 
 .. literalinclude:: mysql-deployment.yml
    :language: yaml
-   
+
 Now run ``flocker-deploy`` to deploy the MySQL application to the target Virtual Machine.
 
 .. code-block:: console
@@ -76,19 +62,19 @@ Connect using the client to the IP address of the Virtual Machine. In this case 
 
    alice@mercury:~/flocker-tutorial$ mysql -h172.16.255.250 -uroot -pclusterhq
 
-   Welcome to the MySQL monitor.  Commands end with ; or \g.  
+   Welcome to the MySQL monitor.  Commands end with ; or \g.
    ...
    mysql> CREATE DATABASE example;
    Query OK, 1 row affected (0.00 sec)
-   
+
    mysql> USE example;
    Database changed
    mysql> CREATE TABLE `testtable` (`id` INT NOT NULL AUTO_INCREMENT,`name` VARCHAR(45) NULL,PRIMARY KEY (`id`)) ENGINE = MyISAM;
    Query OK, 0 rows affected (0.05 sec)
-   
+
    mysql> INSERT INTO `testtable` VALUES('','flocker test');
    Query OK, 1 row affected, 1 warning (0.01 sec)
-    
+
    mysql> quit
    Bye
 
@@ -104,7 +90,7 @@ Download and save the following configuration file to your ``flocker-tutorial`` 
 
 .. literalinclude:: mysql-deployment-moved.yml
    :language: yaml
-   
+
 Then run ``flocker-deploy`` to move the MySQL application along with its data to the new destination host:
 
 .. code-block:: console
@@ -131,8 +117,8 @@ And is no longer running on the original host:
    alice@mercury:~/flocker-tutorial$ ssh root@172.16.255.250 docker ps
    CONTAINER ID        IMAGE                       COMMAND             CREATED             STATUS              PORTS                    NAMES
    alice@mercury:~/flocker-tutorial$
-   
-You can now connect to MySQL on its host and confirm the sample data has also moved:   
+
+You can now connect to MySQL on its host and confirm the sample data has also moved:
 
 .. code-block:: console
 
@@ -150,11 +136,11 @@ You can now connect to MySQL on its host and confirm the sample data has also mo
    | performance_schema |
    +--------------------+
    4 rows in set (0.02 sec)
-   
+
    mysql> USE example;
    Reading table information for completion of table and column names
    You can turn off this feature to get a quicker startup with -A
-   
+
    Database changed
    mysql> SELECT * FROM `testtable`;
    +----+--------------+
@@ -163,7 +149,7 @@ You can now connect to MySQL on its host and confirm the sample data has also mo
    |  1 | flocker test |
    +----+--------------+
    1 row in set (0.01 sec)
-   
+
    mysql>
 
 This concludes the MySQL example.

--- a/docs/gettingstarted/examples/linking.rst
+++ b/docs/gettingstarted/examples/linking.rst
@@ -31,32 +31,6 @@ If you have since shutdown or destroyed those VMs, boot them up again:
    Bringing machine 'node1' up with 'virtualbox' provider...
    ==> node1: Importing base box 'clusterhq/flocker-dev'...
 
-Download the Docker Images
-==========================
-
-The Docker images used by this example are quite large, so you should pre-fetch them to your nodes.
-
-.. code-block:: console
-
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.250 docker pull clusterhq/elasticsearch
-   ...
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.250 docker pull clusterhq/logstash
-   ...
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.250 docker pull clusterhq/kibana
-   ...
-   alice@mercury:~/flocker-tutorial$
-
-.. code-block:: console
-
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.251 docker pull clusterhq/elasticsearch
-   ...
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.251 docker pull clusterhq/logstash
-   ...
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.251 docker pull clusterhq/kibana
-   ...
-   alice@mercury:~/flocker-tutorial$
-
-
 Deploy on Node1
 ===============
 
@@ -125,7 +99,7 @@ Then run ``flocker-deploy`` to move the ``Elasticsearch`` application along with
 
    alice@mercury:~/flocker-tutorial$ flocker-deploy elk-deployment.yml elk-application.yml
    alice@mercury:~/flocker-tutorial$
-   
+
 Now verify that the ``ElasticSearch`` application has moved to the other VM:
 
 .. code-block:: console

--- a/docs/gettingstarted/examples/postgres.rst
+++ b/docs/gettingstarted/examples/postgres.rst
@@ -19,20 +19,6 @@ If you have since shutdown or destroyed those VMs, boot them up again:
    Bringing machine 'node1' up with 'virtualbox' provider...
    ==> node1: Importing base box 'clusterhq/flocker-dev'...
 
-Download the Docker Image
-=========================
-
-The Docker image used by this example is quite large, so you should pre-fetch it to your nodes.
-
-.. code-block:: console
-
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.250 docker pull postgres
-   ...
-   alice@mercury:~/flocker-tutorial$ ssh -t root@172.16.255.251 docker pull postgres
-   ...
-   alice@mercury:~/flocker-tutorial$
-
-
 Launch PostgreSQL
 =================
 
@@ -47,14 +33,14 @@ Download and save the following configuration files to your ``flocker-tutorial``
 
 .. literalinclude:: postgres-deployment.yml
    :language: yaml
-   
+
 Now run ``flocker-deploy`` to deploy the PostgreSQL application to the target Virtual Machine.
 
 .. code-block:: console
 
    alice@mercury:~/flocker-tutorial$ flocker-deploy postgres-deployment.yml postgres-application.yml
    alice@mercury:~/flocker-tutorial$
-   
+
 Confirm the container is running in its destination host:
 
 .. code-block:: console
@@ -85,22 +71,22 @@ Insert a Row into the Database
 ==============================
 
 .. code-block:: console
- 
+
    postgres=# CREATE DATABASE flockertest;
    CREATE DATABASE
    postgres=# \connect flockertest;
    psql (9.3.5)
    You are now connected to database "flockertest" as user "postgres".
-   flockertest=# CREATE TABLE testtable (testcolumn int); 
+   flockertest=# CREATE TABLE testtable (testcolumn int);
    CREATE TABLE
    flockertest=# INSERT INTO testtable (testcolumn) VALUES (3);
    INSERT 0 1
    flockertest=# SELECT * FROM testtable;
-    testcolumn 
+    testcolumn
    ------------
              3
    (1 row)
-   
+
    flockertest=# \quit
 
 
@@ -113,7 +99,7 @@ Download and save the following configuration file to your ``flocker-tutorial`` 
 
 .. literalinclude:: postgres-deployment-moved.yml
    :language: yaml
-   
+
 Then run ``flocker-deploy`` to move the PostgreSQL application along with its data to the new destination host:
 
 .. code-block:: console
@@ -140,7 +126,7 @@ And is no longer running on the original host:
    alice@mercury:~/flocker-tutorial$ ssh root@172.16.255.250 docker ps
    CONTAINER ID        IMAGE                       COMMAND             CREATED             STATUS              PORTS                    NAMES
    alice@mercury:~/flocker-tutorial$
-   
+
 You can now connect to PostgreSQL on its host and confirm the sample data has also moved:
 
 .. code-block:: console
@@ -153,7 +139,7 @@ You can now connect to PostgreSQL on its host and confirm the sample data has al
    psql (9.3.5)
    You are now connected to database "flockertest" as user "postgres".
    flockertest=# select * from testtable;
-    testcolumn 
+    testcolumn
    ------------
              3
    (1 row)

--- a/vagrant/tutorial/cache.sh
+++ b/vagrant/tutorial/cache.sh
@@ -13,5 +13,14 @@ echo "TMPDIR=/var/tmp" >> /etc/sysconfig/docker
 # Restart docker to ensure that it picks up the new tmpdir configuration.
 systemctl restart docker
 
-docker pull busybox
-docker pull clusterhq/mongodb
+while read image; do
+    docker pull "${image}"
+done <<EOF
+busybox
+clusterhq/mongodb
+mysql:5.6.17
+postgres
+clusterhq/elasticsearch
+clusterhq/logstash
+clusterhq/kibana
+EOF


### PR DESCRIPTION
All the images used in the tutorial examples are now included in the tutorial vagrant image.

This means that the separate pull steps can be removed from the documentation.

The acceptance tests don't seem to simulate the separate pull steps so no changes are needed there.

Fixes https://clusterhq.atlassian.net/browse/FLOC-1170