### PR TITLE
[FLOC-921] Sphinx apidocs generation

### DIFF
--- a/flocker/restapi/__init__.py
+++ b/flocker/restapi/__init__.py
@@ -5,8 +5,8 @@ Infrastructure for publishing a REST HTTP API.
 """
 
 from ._infrastructure import (
-    structured, EndpointResponse, userDocumentation,
+    structured, EndpointResponse, user_documentation,
     )
 
 
-__all__ = ["structured", "EndpointResponse", "userDocumentation"]
+__all__ = ["structured", "EndpointResponse", "user_documentation"]

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -197,7 +197,7 @@ def structured(inputSchema, outputSchema, schema_store=None):
     return deco
 
 
-def userDocumentation(doc, examples=None):
+def user_documentation(doc, examples=None):
     """
     Annotate a klein-style endpoint to include user-facing documentation.
 

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -6,7 +6,7 @@ This module implements tools for exposing Python methods as API endpoints.
 from __future__ import absolute_import
 
 __all__ = [
-    "EndpointResponse", "structured", "userDocumentation",
+    "EndpointResponse", "structured", "user_documentation",
     ]
 
 from functools import wraps

--- a/flocker/restapi/docs/__init__.py
+++ b/flocker/restapi/docs/__init__.py
@@ -1,0 +1,3 @@
+"""
+Sphinx extensions to document APIs created with ``flocker.restapi``.
+"""

--- a/flocker/restapi/docs/__init__.py
+++ b/flocker/restapi/docs/__init__.py
@@ -1,3 +1,4 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 """
 Sphinx extensions to document APIs created with ``flocker.restapi``.
 """

--- a/flocker/restapi/docs/hidden_code_block.py
+++ b/flocker/restapi/docs/hidden_code_block.py
@@ -1,0 +1,137 @@
+"""Simple, inelegant Sphinx extension which adds a directive for a
+highlighted code-block that may be toggled hidden and shown in HTML.  
+This is possibly useful for teaching courses.
+
+The directive, like the standard code-block directive, takes
+a language argument and an optional linenos parameter.  The
+hidden-code-block adds starthidden and label as optional 
+parameters.
+
+Examples:
+
+.. hidden-code-block:: python
+    :starthidden: False
+
+    a = 10
+    b = a + 5
+
+.. hidden-code-block:: python
+    :label: --- SHOW/HIDE ---
+
+    x = 10
+    y = x + 5
+
+Thanks to http://www.javascriptkit.com/javatutors/dom3.shtml for 
+inspiration on the javascript.  
+
+Thanks to Milad 'animal' Fatenejad for suggesting this extension 
+in the first place.
+
+Written by Anthony 'el Scopz' Scopatz, January 2012.
+
+Released under the WTFPL (http://sam.zoy.org/wtfpl/).
+"""
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.directives.code import CodeBlock
+
+HCB_COUNTER = 0
+
+js_showhide = """\
+<script type="text/javascript">
+    function showhide(element){
+        if (!document.getElementById)
+            return
+
+        if (element.style.display == "block")
+            element.style.display = "none"
+        else
+            element.style.display = "block"
+    };
+</script>
+"""
+
+def nice_bool(arg):
+    tvalues = ('true',  't', 'yes', 'y')
+    fvalues = ('false', 'f', 'no',  'n')
+    arg = directives.choice(arg, tvalues + fvalues)
+    return arg in tvalues
+
+
+class hidden_code_block(nodes.General, nodes.FixedTextElement):
+    pass
+
+
+class HiddenCodeBlock(CodeBlock):
+    """Hidden code block is Hidden"""
+
+    option_spec = dict(starthidden=nice_bool, 
+                       label=str,
+                       **CodeBlock.option_spec)
+
+    def run(self):
+        # Body of the method is more or less copied from CodeBlock
+        code = u'\n'.join(self.content)
+        hcb = hidden_code_block(code, code)
+        hcb['language'] = self.arguments[0]
+        hcb['linenos'] = 'linenos' in self.options
+        hcb['starthidden'] = self.options.get('starthidden', True)
+        hcb['label'] = self.options.get('label', '+ show/hide code')
+        hcb.line = self.lineno
+        return [hcb]
+
+
+def visit_hcb_html(self, node):
+    """Visit hidden code block"""
+    global HCB_COUNTER
+    HCB_COUNTER += 1
+
+    # We want to use the original highlighter so that we don't
+    # have to reimplement it.  However it raises a SkipNode 
+    # error at the end of the function call.  Thus we intercept
+    # it and raise it again later.
+    try: 
+        self.visit_literal_block(node)
+    except nodes.SkipNode:
+        pass
+
+    # The last element of the body should be the literal code 
+    # block that was just made.
+    code_block = self.body[-1]
+
+    fill_header = {'divname': 'hiddencodeblock{0}'.format(HCB_COUNTER), 
+                   'startdisplay': 'none' if node['starthidden'] else 'block', 
+                   'label': node.get('label'), 
+                   }
+
+    divheader = ("""<p><strong><a href="javascript:showhide(document.getElementById('{divname}'))">"""
+                 """{label}</a></strong></p>"""
+                 '''<div id="{divname}" style="display: {startdisplay}">'''
+                 ).format(**fill_header)
+
+    code_block = js_showhide + divheader + code_block + "</div>"
+
+    # reassign and exit
+    self.body[-1] = code_block
+    raise nodes.SkipNode
+
+
+def depart_hcb_html(self, node):
+    """Depart hidden code block"""
+    # Stub because of SkipNode in visit
+
+
+def visit_hcb_latex(self, node):
+    pass
+
+
+def depart_hcb_latex(self, node):
+    pass
+
+
+def setup(app):
+    app.add_directive('hidden-code-block', HiddenCodeBlock)
+    app.add_node(hidden_code_block,
+            html=(visit_hcb_html, depart_hcb_html),
+            latex=(visit_hcb_latex, depart_hcb_latex))

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -1,0 +1,454 @@
+# -*- test-case-name: hybridcluster.tests.test_docs_publicapi -*-
+"""
+Sphinx extension for automatically documenting api endpoints.
+"""
+
+from inspect import getsourcefile
+from collections import namedtuple
+from base64 import b64encode
+import json
+
+from yaml import safe_load
+from docutils import nodes
+
+from sphinxcontrib import httpdomain
+from sphinxcontrib.autohttp.flask import translate_werkzeug_rule
+from sphinxcontrib.autohttp.common import http_directive
+
+from sphinx.util.compat import Directive
+from sphinx.util.nodes import nested_parse_with_titles
+from sphinx.util.docstrings import prepare_docstring
+from docutils.statemachine import ViewList
+from docutils.parsers.rst import directives
+
+from twisted.python.reflect import namedAny
+
+from hybridcluster.common import HYBRIDCLUSTER_ROOT
+from hybridcluster.publicapi._schema import (
+    LocalRefResolver, SCHEMAS, resolveSchema,
+    )
+
+# sphinxcontrib-httpdomain only supports a limited way of describing JSON
+# https://www.pivotaltracker.com/story/show/67579818
+# The following is monkey-patching part of
+# https://bitbucket.org/birkenfeld/sphinx-contrib/pull-request/54/issue-41-describe-response-json-with/diff
+# but I think perhaps we will want to go with a richer presentation
+from sphinxcontrib.httpdomain import HTTPResource
+from sphinx.util.docfields import TypedField
+HTTPResource.doc_field_types.append(
+        TypedField('responsejsonparameter', label='Response JSON Parameters',
+                   names=('responsejsonparameter', 'responsejsonparam', 'responsejson'),
+                   typerolename='obj', typenames=('jsonparamtype', 'jsontype')),
+)
+del HTTPResource, TypedField
+
+
+
+class KleinRoute(namedtuple('KleinRoute', 'path methods endpoint attributes')):
+    """
+    A L{KleinRoute} instance represents a route in a L{klein.Klein} application,
+    along with the metadata associated to the route function.
+
+    @ivar methods: The HTTP methods the route accepts.
+    @ivar path: The path of this route.
+    @ivar endpoint: The L{werkzeug} endpoint name.
+    @ivar attributes: The attributes function associated with this route.
+    """
+
+
+
+class Example(namedtuple("Example", "request response")):
+    """
+    An L{Example} instance represents a single HTTP session example.
+
+    @ivar request: The example HTTP request.
+    @type request: L{unicode}
+
+    @ivar response: The example HTTP response.
+    @type response: L{unicode}
+    """
+    @classmethod
+    def fromDictionary(cls, d):
+        """
+        Create an L{Example} from a L{dict} with C{u"request"} and
+        C{u"response"} keys and L{unicode} values.
+        """
+        return cls(d[u"request"], d[u"response"])
+
+
+
+def getRoutes(app):
+    """
+    Get the routes assoicated with a L{klein} application.
+
+    @param app: The L{klein} application to introspect.
+    @type app: L{klein.Klein}
+
+    @return: The routes associated to the application.
+    @rtype: A generator of L{KleinRoute}s
+    """
+    # This accesses private attributes of Klein:
+    # https://github.com/twisted/klein/issues/49
+    # Adapted from sphinxcontrib.autohttp.flask
+    for rule in app._url_map.iter_rules():
+        methods = rule.methods.difference(['HEAD'])
+        path = translate_werkzeug_rule(rule.rule)
+
+        # Klein sets `segment_count` which we don't care about
+        # so ignore it.
+        attributes = vars(app._endpoints[rule.endpoint]).copy()
+        if 'segment_count' in attributes:
+            del attributes['segment_count']
+
+        yield KleinRoute(
+                methods=methods, path=path, endpoint=rule.endpoint,
+                attributes=attributes)
+
+
+
+def _parseSchema(schema):
+    """
+    Parse a JSON Schema and return some information to document it.
+
+    @param schema: L{dict} representing a JSON Schema.
+
+    @return: A L{dict} representing the information needed to
+        document the schema.
+    """
+    result = {}
+
+    resolver = LocalRefResolver(
+            base_uri=b'',
+            referrer=schema, store=SCHEMAS)
+
+    if schema.get(u'$ref') is None:
+        raise Exception('Non-$ref top-level definitions not supported.')
+
+    with resolver.resolving(schema[u'$ref']) as schema:
+        if schema[u'type'] != u'object':
+            raise Exception('Non-object top-level definitions not supported.')
+
+        result['properties'] = {}
+        for property, propSchema in schema[u'properties'].iteritems():
+            attr = result['properties'][property] = {}
+            with resolver.resolving(propSchema['$ref']) as propSchema:
+                attr['title'] = propSchema['title']
+                attr['description'] = prepare_docstring(propSchema['description'])
+                attr['required'] = property in schema.get('required', [])
+    return result
+
+
+
+def _introspectRoute(route, exampleByIdentifier):
+    """
+    Given a L{KleinRoute}, extract the information to generate documentation.
+
+    @param route: Route to inspect
+    @type route: L{KleinRoute}
+
+    @param exampleByIdentifier: A one-argument callable that accepts an example
+        identifier and returns an HTTP session example.
+
+    @return: Information about the route
+    @rtype: L{dict} with the following keys.
+      - C{'description'}:
+             L{list} of L{str} containing a prose description of the endpoint.
+      - C{'input'} I{(optional)}:
+             L{dict} describing the input schema. Has C{'properties'} key with
+             a L{list} of L{dict} of L{dict} with keys C{'title'},
+             C{'description'} and C{'required'} describing the toplevel
+             properties of the schema.
+      - C{'input_schema'} I{(optional)}:
+             L{dict} including the verbatim input JSON Schema.
+      - C{'output'} I{(optional)}:
+            see C{'input'}.
+      - C{'output_schema'} I{(optional)}:
+             L{dict} including the verbatim output JSON Schema.
+      - C{'paged'} I{(optional)}:
+            If present, the endpoint is paged.
+            L{dict} with keys C{'defaultKey'} and C{'otherKeys'} giving the
+            names of default and available sort keys.
+      - C{'examples'}:
+            A list of examples (L{Example} instances) for this endpoint.
+    """
+    result = {}
+
+    userDocumentation = route.attributes.get("userDocumentation", "Undocumented.")
+    result['description'] = prepare_docstring(userDocumentation)
+
+    inputSchema = route.attributes.get('inputSchema', None)
+    outputSchema = route.attributes.get('outputSchema', None)
+    if inputSchema:
+        # _parseSchema doesn't handle all JSON Schema yet
+        # Fail softly by simply not including the documentation
+        # for it.
+        # https://www.pivotaltracker.com/story/show/67579818
+        try:
+            result['input'] = _parseSchema(inputSchema)
+        except:
+            pass
+        result["input_schema"] = inputSchema
+
+    if outputSchema:
+        # See above
+        # https://www.pivotaltracker.com/story/show/67579818
+        try:
+            result['output'] = _parseSchema(outputSchema)
+        except:
+            pass
+        result["output_schema"] = outputSchema
+
+    paged = route.attributes.get("paged", False)
+    if paged:
+        keys = [key.apiName for key in route.attributes.get("sortKeys", [])]
+        result['paged'] = {'defaultKey': keys[0], 'otherKeys': keys[1:]}
+
+    examples = route.attributes.get("examples") or []
+    result['examples'] = list(
+        Example.fromDictionary(exampleByIdentifier(identifier))
+        for identifier in examples)
+
+    return result
+
+
+
+def _formatSchema(data, param):
+    """
+    Generate the rst associated to a JSON schema.
+
+    @param data: See L{inspectRoute}.
+    @param param: rst entity to use for JSON properties.
+    @type param: L{str}
+    """
+    for property, attr in sorted(data[u'properties'].iteritems()):
+        if attr['required']:
+            required = '*(required)* '
+        else:
+            required = ''
+        yield ':%s %s: %s%s' % (param, property, required, attr['title'])
+        yield ''
+        for line in attr['description']:
+            yield '   ' + line
+
+
+
+def _formatActualSchema(schema, title):
+    yield ".. hidden-code-block:: json"
+    yield "    :label: " + title
+    yield "    :starthidden: True"
+    yield ""
+    schema = resolveSchema(schema, SCHEMAS)
+    lines = json.dumps(schema, indent=4, separators=(',', ': '),
+                       sort_keys=True).splitlines()
+    for line in lines:
+        yield "    " + line
+    yield ""
+
+
+
+def _formatExample(example, substitutions):
+    """
+    Generate the rst associated with an HTTP session example.
+
+    @param example: An L{Example} to format.
+
+    @param substitutions: A L{dict} to use to interpolate variables in the
+        example request and response.
+
+    @return: A generator which yields L{unicode} strings each of which should
+        be a line in the resulting rst document.
+    """
+    yield u"**example request**"
+    yield u""
+    yield u".. sourcecode:: http"
+    yield u""
+
+    credentials = b64encode(b'alice:password').decode('ascii')
+
+    lines = (example.request % substitutions).splitlines()
+    lines.insert(1, u'Authorization: Basic ' + credentials)
+    lines.insert(1, u"Content-Type: application/json")
+    lines.insert(1, u"Host: api.%(DOMAIN)s" % substitutions)
+    for line in lines:
+        yield u"   " + line.rstrip()
+    yield u""
+
+    yield u"**example response**"
+    yield u""
+    yield u".. sourcecode:: http"
+    yield u""
+
+    lines = (example.response % substitutions).splitlines()
+    lines.insert(1, u"Content-Type: application/json")
+    for line in lines:
+        yield u"   " + line.rstrip()
+    yield u""
+
+
+
+def _formatRouteBody(data):
+    """
+    Generate the description of a L{klein} route.
+
+    @param data: Result of L{_introspectRoute}.
+
+    @return: The lines of sphinx representing the generated documentation.
+    @rtype: A generator of L{str}s.
+    """
+    baseSubstitutions = {
+        u"DOMAIN": u"example.com",
+        u"SERVER_IP": u"10.0.42.1",
+        u"USER_ID": u"54321",
+        }
+
+    for line in data['description']:
+        yield line
+
+    if 'paged' in data:
+        yield "This endpoint is a collection and supports the :ref:`common query parameters<api-collections>` associated to them."
+        yield "It supports the following sort keys:"
+        yield ""
+        yield "  * ``%s`` *(default)*" % (data['paged']['defaultKey'],)
+        for key in data['paged']['otherKeys']:
+            yield "  * ``%s``" % (key,)
+        yield ""
+
+    if 'input' in data:
+        for line in _formatActualSchema(data['input_schema'],
+                                        "+ Request JSON Schema"):
+            yield line
+    if 'output' in data:
+        for line in _formatActualSchema(data['output_schema'],
+                                        "+ Response JSON Schema"):
+            yield line
+
+    for example in data['examples']:
+        substitutions = baseSubstitutions.copy()
+        for line in _formatExample(example, substitutions):
+            yield line
+
+    if 'input' in data:
+        for line in _formatSchema(data['input'], 'jsonparam'):
+            yield line
+
+    if 'output' in data:
+        for line in _formatSchema(data['output'], 'responsejsonparam'):
+            yield line
+
+
+
+def makeRst(prefix, app, exampleByIdentifier):
+    """
+    Generate the sphinx documentation associated with a L{klein} application.
+
+    @param prefix: The URL prefix of the URLs in this application.
+    @type prefix: L{bytes}
+
+    @param app: The L{klein} application to introspect.
+    @type app: L{klein.Klein}
+
+    @param exampleByIdentifier: A one-argument callable that accepts an example
+        identifier and returns an HTTP session example.
+
+    @return: The lines of sphinx representing the generated documentation.
+    @rtype: A generator of L{str}s.
+    """
+    # Adapted from sphinxcontrib.autohttp.flask
+    for route in sorted(getRoutes(app)):
+        data = _introspectRoute(route, exampleByIdentifier)
+        for method in route.methods:
+            body = _formatRouteBody(data)
+            for line in http_directive(method, prefix + route.path, body):
+                yield line
+
+
+
+def _loadExamples(path):
+    """
+    Read the YAML-format HTTP session examples from the file at the given path.
+
+    @type path: L{FilePath}
+
+    @raise Exception: If any example identifier is used more than once.
+
+    @return: A L{dict} mapping example identifiers to example L{dict}s.
+    """
+    # Load all of the examples so they're available for the loader when we
+    # get there.
+    examplesRaw = safe_load(path.getContent())
+    examplesMap = dict(
+        (example["id"], example)
+        for example in examplesRaw)
+
+    # Avoid duplicate identifiers.
+    if len(examplesRaw) != len(examplesMap):
+        identifiers = [example["id"] for example in examplesRaw]
+        duplicates = list(
+            identifier
+            for (index, identifier)
+            in enumerate(identifiers)
+            if identifiers.index(identifier) != index)
+        raise Exception("Duplicate identifiers in example file: %r" % (duplicates,))
+    return examplesMap
+
+
+
+class AutoKleinDirective(Directive):
+    """
+    Implementation of the C{autoklein} directive.
+    """
+    has_content = True
+    required_arguments = 1
+
+    option_spec = {'prefix': directives.unchanged}
+
+    EXAMPLE_PATH = HYBRIDCLUSTER_ROOT.descendant([
+            b"doc", b"06-integrate", b"hybridcluster-api-examples.yml"])
+
+    def run(self):
+        appContainer = namedAny(self.arguments[0])
+
+        self._examples = _loadExamples(self.EXAMPLE_PATH)
+
+        # The contents of the example file are included in the output so the
+        # example file is a dependency of the document.
+        self.state.document.settings.record_dependencies.add(self.EXAMPLE_PATH.path)
+
+        # The following three lines record (some?) of the dependencies of the
+        # directive, so automatic regeneration happens.
+        # Specifically, it records this file, and the file where the app is declared.
+        # If we ever have routes for a single app declared across multiple files, this will
+        # need to be updated.
+        appFileName = getsourcefile(appContainer)
+        self.state.document.settings.record_dependencies.add(appFileName)
+        self.state.document.settings.record_dependencies.add(__file__)
+
+        # Copied from sphinxcontrib.autohttp.flask
+        # Return the result of parsing the rst f
+        node = nodes.section()
+        node.document = self.state.document
+        result = ViewList()
+        restLines = makeRst(
+            prefix=self.options['prefix'], app=appContainer.app,
+            exampleByIdentifier=self._exampleByIdentifier)
+        for line in restLines:
+            result.append(line, '<autoklein>')
+        nested_parse_with_titles(self.state, result, node)
+        return node.children
+
+
+    def _exampleByIdentifier(self, identifier):
+        """
+        Get one of the examples defined in C{self.EXAMPLE_PATH}.
+        """
+        return self._examples[identifier]
+
+
+
+def setup(app):
+    """
+    Entry point for sphinx extension.
+    """
+    if 'http' not in app.domains:
+        httpdomain.setup(app)
+    app.add_directive('autoklein', AutoKleinDirective)

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -5,7 +5,6 @@ Sphinx extension for automatically documenting api endpoints.
 
 from inspect import getsourcefile
 from collections import namedtuple
-from base64 import b64encode
 import json
 
 from yaml import safe_load
@@ -33,25 +32,24 @@ from .._schema import LocalRefResolver, resolveSchema
 from sphinxcontrib.httpdomain import HTTPResource
 from sphinx.util.docfields import TypedField
 HTTPResource.doc_field_types.append(
-        TypedField('responsejsonparameter', label='Response JSON Parameters',
-                   names=('responsejsonparameter', 'responsejsonparam', 'responsejson'),
-                   typerolename='obj', typenames=('jsonparamtype', 'jsontype')),
+    TypedField(
+        'responsejsonparameter', label='Response JSON Parameters',
+        names=('responsejsonparameter', 'responsejsonparam', 'responsejson'),
+        typerolename='obj', typenames=('jsonparamtype', 'jsontype')),
 )
 del HTTPResource, TypedField
 
 
-
 class KleinRoute(namedtuple('KleinRoute', 'path methods endpoint attributes')):
     """
-    A L{KleinRoute} instance represents a route in a L{klein.Klein} application,
-    along with the metadata associated to the route function.
+    A L{KleinRoute} instance represents a route in a L{klein.Klein}
+    application, along with the metadata associated to the route function.
 
     @ivar methods: The HTTP methods the route accepts.
     @ivar path: The path of this route.
     @ivar endpoint: The L{werkzeug} endpoint name.
     @ivar attributes: The attributes function associated with this route.
     """
-
 
 
 class Example(namedtuple("Example", "request response")):
@@ -71,7 +69,6 @@ class Example(namedtuple("Example", "request response")):
         C{u"response"} keys and L{unicode} values.
         """
         return cls(d[u"request"], d[u"response"])
-
 
 
 def getRoutes(app):
@@ -98,9 +95,8 @@ def getRoutes(app):
             del attributes['segment_count']
 
         yield KleinRoute(
-                methods=methods, path=path, endpoint=rule.endpoint,
-                attributes=attributes)
-
+            methods=methods, path=path, endpoint=rule.endpoint,
+            attributes=attributes)
 
 
 def _parseSchema(schema, schema_store):
@@ -118,8 +114,8 @@ def _parseSchema(schema, schema_store):
     result = {}
 
     resolver = LocalRefResolver(
-            base_uri=b'',
-            referrer=schema, store=schema_store)
+        base_uri=b'',
+        referrer=schema, store=schema_store)
 
     if schema.get(u'$ref') is None:
         raise Exception('Non-$ref top-level definitions not supported.')
@@ -133,10 +129,10 @@ def _parseSchema(schema, schema_store):
             attr = result['properties'][property] = {}
             with resolver.resolving(propSchema['$ref']) as propSchema:
                 attr['title'] = propSchema['title']
-                attr['description'] = prepare_docstring(propSchema['description'])
+                attr['description'] = prepare_docstring(
+                    propSchema['description'])
                 attr['required'] = property in schema.get('required', [])
     return result
-
 
 
 def _introspectRoute(route, exampleByIdentifier, schema_store):
@@ -176,7 +172,8 @@ def _introspectRoute(route, exampleByIdentifier, schema_store):
     """
     result = {}
 
-    userDocumentation = route.attributes.get("userDocumentation", "Undocumented.")
+    userDocumentation = route.attributes.get(
+        "userDocumentation", "Undocumented.")
     result['description'] = prepare_docstring(userDocumentation)
 
     inputSchema = route.attributes.get('inputSchema', None)
@@ -209,7 +206,6 @@ def _introspectRoute(route, exampleByIdentifier, schema_store):
     return result
 
 
-
 def _formatSchema(data, param):
     """
     Generate the rst associated to a JSON schema.
@@ -227,7 +223,6 @@ def _formatSchema(data, param):
         yield ''
         for line in attr['description']:
             yield '   ' + line
-
 
 
 def _formatActualSchema(schema, title, schema_store):
@@ -251,7 +246,6 @@ def _formatActualSchema(schema, title, schema_store):
     for line in lines:
         yield "    " + line
     yield ""
-
 
 
 def _formatExample(example, substitutions):
@@ -290,7 +284,6 @@ def _formatExample(example, substitutions):
     yield u""
 
 
-
 def _formatRouteBody(data, schema_store):
     """
     Generate the description of a L{klein} route.
@@ -313,7 +306,9 @@ def _formatRouteBody(data, schema_store):
         yield line
 
     if 'paged' in data:
-        yield "This endpoint is a collection and supports the :ref:`common query parameters<api-collections>` associated to them."
+        yield ("This endpoint is a collection and supports the " +
+               ":ref:`common query parameters<api-collections>` " +
+               "associated to them.")
         yield "It supports the following sort keys:"
         yield ""
         yield "  * ``%s`` *(default)*" % (data['paged']['defaultKey'],)
@@ -346,7 +341,6 @@ def _formatRouteBody(data, schema_store):
             yield line
 
 
-
 def makeRst(prefix, app, exampleByIdentifier, schema_store):
     """
     Generate the sphinx documentation associated with a L{klein} application.
@@ -375,7 +369,6 @@ def makeRst(prefix, app, exampleByIdentifier, schema_store):
                 yield line
 
 
-
 def _loadExamples(path):
     """
     Read the YAML-format HTTP session examples from the file at the given path.
@@ -401,9 +394,9 @@ def _loadExamples(path):
             for (index, identifier)
             in enumerate(identifiers)
             if identifiers.index(identifier) != index)
-        raise Exception("Duplicate identifiers in example file: %r" % (duplicates,))
+        raise Exception(
+            "Duplicate identifiers in example file: %r" % (duplicates,))
     return examplesMap
-
 
 
 class AutoKleinDirective(Directive):
@@ -431,13 +424,15 @@ class AutoKleinDirective(Directive):
 
         # The contents of the example file are included in the output so the
         # example file is a dependency of the document.
-        self.state.document.settings.record_dependencies.add(examples_path.path)
+        self.state.document.settings.record_dependencies.add(
+            examples_path.path)
 
         # The following three lines record (some?) of the dependencies of the
         # directive, so automatic regeneration happens.
-        # Specifically, it records this file, and the file where the app is declared.
-        # If we ever have routes for a single app declared across multiple files, this will
-        # need to be updated.
+
+        # Specifically, it records this file, and the file where the app
+        # is declared.  If we ever have routes for a single app declared
+        # across multiple files, this will need to be updated.
         appFileName = getsourcefile(appContainer)
         self.state.document.settings.record_dependencies.add(appFileName)
         self.state.document.settings.record_dependencies.add(__file__)
@@ -456,13 +451,11 @@ class AutoKleinDirective(Directive):
         nested_parse_with_titles(self.state, result, node)
         return node.children
 
-
     def _exampleByIdentifier(self, identifier):
         """
         Get one of the examples defined in the examples file.
         """
         return self._examples[identifier]
-
 
 
 def setup(app):

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -271,10 +271,7 @@ def _formatExample(example, substitutions):
     yield u".. sourcecode:: http"
     yield u""
 
-    credentials = b64encode(b'alice:password').decode('ascii')
-
     lines = (example.request % substitutions).splitlines()
-    lines.insert(1, u'Authorization: Basic ' + credentials)
     lines.insert(1, u"Content-Type: application/json")
     lines.insert(1, u"Host: api.%(DOMAIN)s" % substitutions)
     for line in lines:

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -1,4 +1,5 @@
-# -*- test-case-name: hybridcluster.tests.test_docs_publicapi -*-
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# -*- test-case-name: flocker.restapi.docs.test.test_publicapi -*-
 """
 Sphinx extension for automatically documenting api endpoints.
 """

--- a/flocker/restapi/docs/test/__init__.py
+++ b/flocker/restapi/docs/test/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for `flocker.restapi.docs`.
+"""

--- a/flocker/restapi/docs/test/__init__.py
+++ b/flocker/restapi/docs/test/__init__.py
@@ -1,3 +1,4 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 """
 Tests for `flocker.restapi.docs`.
 """

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -145,7 +145,6 @@ class MakeRstTests(SynchronousTestCase):
              '      GET /prefix/ HTTP/1.1',
              '      Host: api.example.com',
              '      Content-Type: application/json',
-             '      Authorization: Basic YWxpY2U6cGFzc3dvcmQ=',
              '      ',
              # This blank line is necessary to satisfy reST for some reason.
              '   ',
@@ -326,7 +325,6 @@ class FormatExampleTests(SynchronousTestCase):
              u'   GET FOO',
              u'   Host: api.example.com',
              u'   Content-Type: application/json',
-             u'   Authorization: Basic YWxpY2U6cGFzc3dvcmQ=',
              u'',
              u'**example response**',
              u'',
@@ -358,7 +356,6 @@ class FormatExampleTests(SynchronousTestCase):
              u'   GET /some/path HTTP/1.1',
              u'   Host: api.example.com',
              u'   Content-Type: application/json',
-             u'   Authorization: Basic YWxpY2U6cGFzc3dvcmQ=',
              u'',
              u'**example response**',
              u'',

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -20,7 +20,7 @@ else:
     from ..publicapi import (
         Example, KleinRoute, getRoutes, _loadExamples, _formatExample, makeRst)
 
-from ..._infrastructure import userDocumentation, structured
+from ..._infrastructure import user_documentation, structured
 
 
 class GetRoutesTests(SynchronousTestCase):
@@ -69,7 +69,7 @@ class MakeRstTests(SynchronousTestCase):
             Developer docs.
             """
         @app.route(b"/g", methods=[b"PUT"])
-        @userDocumentation("""
+        @user_documentation("""
             Does G-like stuff.
 
             Like g, G and gg.
@@ -105,7 +105,7 @@ class MakeRstTests(SynchronousTestCase):
         app = Klein()
 
         @app.route("/", methods=["GET"])
-        @userDocumentation(
+        @user_documentation(
             """
             Demonstrates examples.
             """, ["example-example"])

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -1,0 +1,399 @@
+"""
+Tests for ``flocker.restapi.docs.publicapi``.
+"""
+
+from yaml import safe_dump
+
+from twisted.python.filepath import FilePath
+from twisted.trial.unittest import SynchronousTestCase
+from twisted.python.reflect import namedModule
+
+from klein import Klein
+
+try:
+    namedModule("sphinxcontrib")
+    namedModule("sphinx")
+    namedModule("docutils")
+except ImportError:
+    skip = "Sphinx not installed."
+else:
+    from ..xpublicapi import (
+        Example, KleinRoute, getRoutes, _loadExamples, _formatExample, makeRst)
+
+from ..._infrastructure import userDocumentation, structured
+
+
+class GetRoutesTests(SynchronousTestCase):
+    """
+    Tests for L{getRoutes}.
+    """
+
+    def test_routes(self):
+        """
+        L{getRoutes} returns all the defined routes and their attributes.
+        """
+        app = Klein()
+
+        def f():
+            pass
+        f.attr = "attr"
+        def g():
+            pass
+        g.attr = "G"
+        app.route(b"/", methods=[b"GET"])(f)
+        app.route(b"/g", methods=[b"PUT", b"OPTIONS"])(g)
+
+        routes = sorted(getRoutes(app))
+        self.assertEqual(routes, [
+            KleinRoute(methods={b"GET"}, path=b"/", endpoint="f",
+                       attributes={'attr': 'attr'}),
+            KleinRoute(methods={b'PUT', b'OPTIONS'}, path=b'/g', endpoint='g',
+                       attributes={'attr': 'G'})])
+
+
+class MakeRstTests(SynchronousTestCase):
+    """
+    Tests for L{makeRst}.
+    """
+
+    def test_stuff(self):
+        """
+        L{makeRst} returns a generator that returns a bunch of lines of rest.
+        """
+        app = Klein()
+
+        @app.route(b"/", methods=[b"GET"])
+        def f():
+            """
+            Developer docs.
+            """
+        @app.route(b"/g", methods=[b"PUT"])
+        @userDocumentation("""
+            Does G-like stuff.
+
+            Like g, G and gg.
+            """)
+        def g():
+            pass
+
+        rest = list(makeRst(b"/prefix", app, None))
+
+        self.assertEqual(rest, [
+            '',
+            '.. http:get:: /prefix/',
+            '',
+            '   Undocumented.',
+            '   ',
+            '',
+            '',
+            '.. http:put:: /prefix/g',
+            '',
+            '   Does G-like stuff.',
+            '   ',
+            '   Like g, G and gg.',
+            '   ',
+            '',
+            ])
+
+
+    def test_example(self):
+        """
+        When the endpoint being documented references an example HTTP session
+        that session is included in the generated API documentation, marked up
+        as HTTP.
+        """
+        app = Klein()
+
+        @app.route("/", methods=["GET"])
+        @userDocumentation(
+            """
+            Demonstrates examples.
+            """, ["example-example"])
+        def hasExamples():
+            pass
+
+        examples = {
+            u"example-example": {
+                u"id": u"example-example",
+                u"doc": u"This example demonstrates examples.",
+                u"request":
+                    u"GET /prefix/ HTTP/1.1\n"
+                    u"\n",
+                u"response":
+                    u"HTTP/1.1 200 OK\n"
+                    u"\n"
+                    u'{"error": false, "result": "%(DOMAIN)s"}\n',
+                },
+            }
+
+        rest = list(makeRst(b"/prefix", app, examples.get))
+        self.assertEqual(
+            ['',
+             # This line introduces the endpoint
+             '.. http:get:: /prefix/',
+             '',
+             # Here is the prose documentation for the endpoint.
+             '   Demonstrates examples.',
+             '   ',
+             # This is a header introducing the request portion of the session.
+             '   **example request**',
+             # This blank line is necessary to satisfy reST for some reason.
+             '   ',
+             '   .. sourcecode:: http',
+             '   ',
+             # Here's the bytes of the HTTP request.
+             '      GET /prefix/ HTTP/1.1',
+             '      Host: api.example.com',
+             '      Content-Type: application/json',
+             '      Authorization: Basic YWxpY2U6cGFzc3dvcmQ=',
+             '      ',
+             # This blank line is necessary to satisfy reST for some reason.
+             '   ',
+             # The same again but for the HTTP response.
+             '   **example response**',
+             '   ',
+             '   .. sourcecode:: http',
+             '   ',
+             '      HTTP/1.1 200 OK',
+             '      Content-Type: application/json',
+             '      ',
+             '      {"error": false, "result": "example.com"}',
+             '   ',
+             '',
+             ], rest)
+
+
+    def test_inputSchema(self):
+        """
+        The generated API documentation includes the input schema.
+        """
+        from .. import publicapi
+        self.patch(publicapi, "SCHEMAS", {
+            b'/v0/test.json':{
+                'endpoint': {
+                    'type': 'object',
+                    'properties': {
+                        'param': {'$ref': 'test.json#/type'},
+                        'optional': {'$ref': 'test.json#/type'},
+                    },
+                    'required' : ['param'],
+                },
+                'type': {
+                    'title': 'TITLE',
+                    'description': 'one\ntwo',
+                },
+            }})
+        app = Klein()
+
+        @app.route(b"/", methods=[b"GET"])
+        @structured(
+            inputSchema={'$ref': '/v0/test.json#/endpoint'},
+            outputSchema={},
+        )
+        def f():
+            """
+            Developer docs,
+            """
+
+        rest = list(makeRst(b"/prefix", app, None))
+
+        self.assertEqual(rest, [
+            '',
+            '.. http:get:: /prefix/',
+            '',
+            '   Undocumented.',
+            '   ',
+            '   .. hidden-code-block:: json',
+            '       :label: + Request JSON Schema',
+            '       :starthidden: True',
+            '   ',
+            '       {',
+            '           "$schema": "http://json-schema.org/draft-04/schema#",',
+            '           "properties": {',
+            '               "optional": {',
+            '                   "description": "one\\ntwo",',
+            '                   "title": "TITLE"',
+            '               },',
+            '               "param": {',
+            '                   "description": "one\\ntwo",',
+            '                   "title": "TITLE"',
+            '               }',
+            '           },',
+            '           "required": [',
+            '               "param"',
+            '           ],',
+            '           "type": "object"',
+            '       }',
+            '   ',
+            # YAML is unorderd :(
+            '   :jsonparam optional: TITLE',
+            '   ',
+            '      one',
+            '      two',
+            '      ',
+            '   :jsonparam param: *(required)* TITLE',
+            '   ',
+            '      one',
+            '      two',
+            '      ',
+            '',
+            ])
+
+
+    def test_ouputSchema(self):
+        """
+        The generated API documentation includes the output schema.
+        """
+        from hybridcluster.docs import publicapi
+        self.patch(publicapi, "SCHEMAS", {
+            b'/v0/test.json':{
+                'endpoint': {
+                    'type': 'object',
+                    'properties': {
+                        'param': {'$ref': '#/type'},
+                    },
+                    'required' : ['param'],
+                },
+                'type': {
+                    'title': 'TITLE',
+                    'description': 'one\ntwo',
+                },
+            }})
+        app = Klein()
+
+        @app.route(b"/", methods=[b"GET"])
+        @structured(
+            inputSchema={},
+            outputSchema={'$ref': '/v0/test.json#/endpoint'},
+        )
+        def f():
+            """
+            Developer docs,
+            """
+
+        rest = list(makeRst(b"/prefix", app, None))
+
+        self.assertEqual(rest, [
+            '',
+            '.. http:get:: /prefix/',
+            '',
+            '   Undocumented.',
+            '   ',
+            '   .. hidden-code-block:: json',
+            '       :label: + Response JSON Schema',
+            '       :starthidden: True',
+            '   ',
+            '       {',
+            '           "$schema": "http://json-schema.org/draft-04/schema#",',
+            '           "properties": {',
+            '               "param": {',
+            '                   "description": "one\\ntwo",',
+            '                   "title": "TITLE"',
+            '               }',
+            '           },',
+            '           "required": [',
+            '               "param"',
+            '           ],',
+            '           "type": "object"',
+            '       }',
+            '   ',
+            '   :responsejsonparam param: *(required)* TITLE',
+            '   ',
+            '      one',
+            '      two',
+            '      ',
+            '',
+            ])
+
+
+
+class FormatExampleTests(SynchronousTestCase):
+    """
+    Tests for L{_formatExample}.
+    """
+    def test_requestAndResponse(self):
+        """
+        L{_formatExample} yields L{unicode} instances representing the lines of
+        a reST document describing an example HTTP session.
+        """
+        example = Example(b"GET FOO", b"200 OK")
+        lines = list(_formatExample(example, {u"DOMAIN": u"example.com"}))
+        self.assertEqual(
+            [u'**example request**',
+             u'',
+             u'.. sourcecode:: http',
+             u'',
+             u'   GET FOO',
+             u'   Host: api.example.com',
+             u'   Content-Type: application/json',
+             u'   Authorization: Basic YWxpY2U6cGFzc3dvcmQ=',
+             u'',
+             u'**example response**',
+             u'',
+             u'.. sourcecode:: http',
+             u'',
+             u'   200 OK',
+             u'   Content-Type: application/json',
+             u''], lines)
+
+
+    def test_substitution(self):
+        """
+        L{_formatExample} replaces I{%(FOO)s}-style variables with values from
+        the substitutions dictionary passed to it.
+        """
+        substitutions = {
+            u"DOMAIN": u"example.com",
+            u"PATH": u"/some/path",
+            u"CODE": u"4242"}
+        request = b"GET %(PATH)s HTTP/1.1"
+        response = b"HTTP/1.1 %(CODE)s Ok"
+        example = Example(request, response)
+        lines = list(_formatExample(example, substitutions))
+        self.assertEqual(
+            [u'**example request**',
+             u'',
+             u'.. sourcecode:: http',
+             u'',
+             u'   GET /some/path HTTP/1.1',
+             u'   Host: api.example.com',
+             u'   Content-Type: application/json',
+             u'   Authorization: Basic YWxpY2U6cGFzc3dvcmQ=',
+             u'',
+             u'**example response**',
+             u'',
+             u'.. sourcecode:: http',
+             u'',
+             u'   HTTP/1.1 4242 Ok',
+             u'   Content-Type: application/json',
+             u''], lines)
+
+
+
+class LoadExamplesTests(SynchronousTestCase):
+    """
+    Tests for L{_loadExamples}.
+    """
+    def test_loaded(self):
+        """
+        The examples are loaded into a L{dict} mapping example identifiers to
+        example L{dict}s.
+        """
+        foo = {u"id": u"foo", u"foo_value": True}
+        bar = {u"id": u"bar", u"bar_value": False}
+        path = FilePath(self.mktemp())
+        path.setContent(safe_dump([foo, bar]))
+        examples = _loadExamples(path)
+        self.assertEqual({foo[u"id"]: foo, bar[u"id"]: bar}, examples)
+
+
+    def test_duplicate(self):
+        """
+        L{_loadExamples} raises L{Exception} if an id is used by more than one
+        example.
+        """
+        foo = {u"id": u"foo", u"foo_value": True}
+        bar = {u"id": u"bar", u"bar_value": False}
+        path = FilePath(self.mktemp())
+        path.setContent(safe_dump([foo, foo, bar]))
+        self.assertRaises(Exception, _loadExamples, path)

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -37,6 +37,7 @@ class GetRoutesTests(SynchronousTestCase):
         def f():
             pass
         f.attr = "attr"
+
         def g():
             pass
         g.attr = "G"
@@ -94,7 +95,6 @@ class MakeRstTests(SynchronousTestCase):
             '   ',
             '',
             ])
-
 
     def test_example(self):
         """
@@ -305,7 +305,6 @@ class MakeRstTests(SynchronousTestCase):
             ])
 
 
-
 class FormatExampleTests(SynchronousTestCase):
     """
     Tests for L{_formatExample}.
@@ -333,7 +332,6 @@ class FormatExampleTests(SynchronousTestCase):
              u'   200 OK',
              u'   Content-Type: application/json',
              u''], lines)
-
 
     def test_substitution(self):
         """
@@ -366,7 +364,6 @@ class FormatExampleTests(SynchronousTestCase):
              u''], lines)
 
 
-
 class LoadExamplesTests(SynchronousTestCase):
     """
     Tests for L{_loadExamples}.
@@ -382,7 +379,6 @@ class LoadExamplesTests(SynchronousTestCase):
         path.setContent(safe_dump([foo, bar]))
         examples = _loadExamples(path)
         self.assertEqual({foo[u"id"]: foo, bar[u"id"]: bar}, examples)
-
 
     def test_duplicate(self):
         """

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -1,3 +1,4 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 """
 Tests for ``flocker.restapi.docs.publicapi``.
 """

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -17,7 +17,7 @@ from twisted.web.http import (
 from twisted.trial.unittest import SynchronousTestCase
 
 from .._infrastructure import (
-    EndpointResponse, userDocumentation, structured)
+    EndpointResponse, user_documentation, structured)
 from .._logging import REQUEST
 from .._error import (
     ILLEGAL_CONTENT_TYPE_DESCRIPTION, DECODING_ERROR_DESCRIPTION,
@@ -535,16 +535,16 @@ class StructuredJSONTests(SynchronousTestCase):
 
 class UserDocumentationTests(SynchronousTestCase):
     """
-    Tests for L{userDocumentation}.
+    Tests for L{user_documentation}.
     """
 
     def test_decoration(self):
         """
-        Decorating a function with L{userDocumentation} sets the
-        C{userDocumentation} attribtue of the function to the passed
+        Decorating a function with L{user_documentation} sets the
+        C{user_documentation} attribtue of the function to the passed
         argument.
         """
-        @userDocumentation("Some text")
+        @user_documentation("Some text")
         def f():
             pass
         self.assertEqual(f.userDocumentation, "Some text")

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ setup(
             "pyenchant==1.6.6",
             "sphinxcontrib-spelling==2.1.1",
             "sphinx-prompt==0.2.2",
+            "sphinxcontrib-httpdomain==1.3.0",
             ],
         # This extra is for developers who need to work on Flocker itself.
         "dev": [

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
     sphinx-build -a -b spelling docs/ docs/_build/spelling
     sphinx-build -a -b html docs/ docs/_build/html
     sphinx-build -a -b linkcheck docs/ docs/_build/linkcheck
+    trial --rterror flocker.restapi.docs
 
 [testenv:admin]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ basepython = python2.7
 basepython = python2.7
 deps = flake8
 changedir = {toxinidir}
-commands = flake8 --exclude=_version.py flocker
+commands = flake8 --exclude=_version.py,flocker/restapi/docs/hidden_code_block.py flocker
 
 [testenv:sphinx]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps = pip>=1.5.6
 changedir = {envtmpdir}
 commands =
     pip install Flocker[dev]
+    pip install Flocker[doc] # necessary for flocker.restapi.docs tests
     trial --rterrors flocker
 setenv =
     PYTHONHASHSEED=random
@@ -34,7 +35,6 @@ commands =
     sphinx-build -a -b spelling docs/ docs/_build/spelling
     sphinx-build -a -b html docs/ docs/_build/html
     sphinx-build -a -b linkcheck docs/ docs/_build/linkcheck
-    trial --rterror flocker.restapi.docs
 
 [testenv:admin]
 basepython = python2.7


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-921

1. I'm not sure this is the best way to change the directive to support non-hardcoded schema store and examples, but lacking an actual usage of the code it's not clear what a better way is.
2. Directive is untested, as it was in original code this is copied from...

I suggest limiting this branch to what it is (minimal port of existing code) and when we have issues actually using it (as is likely), fix those in a follow-up issue.