### PR TITLE
[FLOC-909] Clarify that `zfs destroy` should be run on the remote node

### DIFF
--- a/docs/advanced/cleanup.rst
+++ b/docs/advanced/cleanup.rst
@@ -34,7 +34,7 @@ Removing Containers
 .. code-block:: console
 
    alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'docker ps -aq | xargs --no-run-if-empty docker rm'
-   
+
 These commands list the ID numbers of all the Docker containers on each host, including stopped containers and then pipes each ID to the `docker rm` command to purge.
 
 
@@ -46,15 +46,15 @@ To remove ZFS volumes created by Flocker, you can list the volumes on each host 
 .. code-block:: console
 
    alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs list -H -o name'
-   flocker   
+   flocker
    flocker/e16d5b2b-471d-4bbe-be23-d58bbc8f1b94.mysql-volume-example
    alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs destroy -r flocker/e16d5b2b-471d-4bbe-be23-d58bbc8f1b94.mysql-volume-example'
-   
+
 Alternatively if you wish to destroy **all** data sets created by Flocker, you can run the following command:
 
 .. code-block:: console
 
-   alice@mercury:~/flocker-mysql$ zfs destroy -r flocker
+   alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs destroy -r flocker'
 
 
 .. _`on the Flocker development path`: https://github.com/ClusterHQ/flocker/issues/682

--- a/docs/advanced/cleanup.rst
+++ b/docs/advanced/cleanup.rst
@@ -14,9 +14,11 @@ This will enable you to test, play around with Flocker or repeat the deployment 
    In addition, the verbatim commands documented below will destroy **all** Docker containers on the target node, regardless of whether or not they were deployed via Flocker.
    *Proceed at your own risk and only if you fully understand the effects of executing these commands.*
 
-You can run the necessary cleanup commands via SSH. The tutorial's virtual machines are created with IP addresses ``172.16.255.250`` and ``172.16.255.251``.
+You can run the necessary cleanup commands via SSH.
+The tutorial's virtual machines are created with IP addresses ``172.16.255.250`` and ``172.16.255.251``.
 Be sure to replace the example IP address in the commands below with the actual IP address of the node you wish to purge.
 
+The following sequence of steps must be performed in order:
 
 #. **Stop Containers**
 

--- a/docs/advanced/cleanup.rst
+++ b/docs/advanced/cleanup.rst
@@ -18,43 +18,40 @@ You can run the necessary cleanup commands via SSH. The tutorial's virtual machi
 Be sure to replace the example IP address in the commands below with the actual IP address of the node you wish to purge.
 
 
-Stopping Containers
-===================
+#. **Stop Containers**
 
-Docker containers must be stopped before they can be removed.
+   Docker containers must be stopped before they can be removed.
 
-.. code-block:: console
+   .. code-block:: console
 
-   alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'docker ps -q | xargs --no-run-if-empty docker stop'
-
-
-Removing Containers
-===================
-
-.. code-block:: console
-
-   alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'docker ps -aq | xargs --no-run-if-empty docker rm'
-
-These commands list the ID numbers of all the Docker containers on each host, including stopped containers and then pipes each ID to the `docker rm` command to purge.
+      alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'docker ps -q | xargs --no-run-if-empty docker stop'
 
 
-Removing ZFS Volumes
-====================
+#. **Remove Containers**
 
-To remove ZFS volumes created by Flocker, you can list the volumes on each host and then use the unique IDs in conjunction with the `zfs destroy` command.
+   .. code-block:: console
 
-.. code-block:: console
+      alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'docker ps -aq | xargs --no-run-if-empty docker rm'
 
-   alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs list -H -o name'
-   flocker
-   flocker/e16d5b2b-471d-4bbe-be23-d58bbc8f1b94.mysql-volume-example
-   alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs destroy -r flocker/e16d5b2b-471d-4bbe-be23-d58bbc8f1b94.mysql-volume-example'
+   These commands list the ID numbers of all the Docker containers on each host, including stopped containers and then pipes each ID to the `docker rm` command to purge.
 
-Alternatively if you wish to destroy **all** data sets created by Flocker, you can run the following command:
 
-.. code-block:: console
+#. **Remove ZFS Volumes**
 
-   alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs destroy -r flocker'
+   To remove ZFS volumes created by Flocker, you can list the volumes on each host and then use the unique IDs in conjunction with the `zfs destroy` command.
+
+   .. code-block:: console
+
+      alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs list -H -o name'
+      flocker
+      flocker/e16d5b2b-471d-4bbe-be23-d58bbc8f1b94.mysql-volume-example
+      alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs destroy -r flocker/e16d5b2b-471d-4bbe-be23-d58bbc8f1b94.mysql-volume-example'
+
+   Alternatively if you wish to destroy **all** data sets created by Flocker, you can run the following command:
+
+   .. code-block:: console
+
+      alice@mercury:~/flocker-mysql$ ssh root@172.16.255.250 'zfs destroy -r flocker'
 
 
 .. _`on the Flocker development path`: https://github.com/ClusterHQ/flocker/issues/682


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-909

It might also be worth making it clear that the cleanup steps need to be performed in sequence ie all the containers must  be stopped before removing their zfs volumes. Otherwise you get this:

```
(flocker-tutorial)[~/flocker-tutorial]$ ssh root@172.16.255.250 'zfs destroy -r flocker'
cannot destroy 'flocker/7b766437-2c5a-46aa-afb1-abedf99a04d0.default.mongodb-volume-example': dataset is busy
```

The steps could be converted from headings to a numbered list.