### PR TITLE
[FLOC-1064] Fail skips

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,8 +76,6 @@ Running Tests
 
 You can run all unit tests by doing:
 
-.. Document the FLOCKER_TEST_NO_SKIPS environment variable here
-
 .. code-block:: console
 
    $ tox
@@ -91,6 +89,8 @@ In addition, ``tox`` needs to be run as root:
 
 Since these tests involve global state on your machine (filesystems, ``iptables``, Docker containers, etc.) we recommend running them in the development Vagrant image.
 
+The ``FLOCKER_TEST_NO_SKIPS`` environment variable can be used to specify tests with which should be counted as failing if they are skipped.
+For example, ``FLOCKER_TEST_NO_SKIPS=flocker.acceptance tox`` will cause test failures if the acceptance tests are skipped.
 
 Documentation
 =============

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,8 +89,8 @@ In addition, ``tox`` needs to be run as root:
 
 Since these tests involve global state on your machine (filesystems, ``iptables``, Docker containers, etc.) we recommend running them in the development Vagrant image.
 
-The ``FLOCKER_TEST_NO_SKIPS`` environment variable can be used to specify tests with which should be counted as failing if they are skipped.
-For example, ``FLOCKER_TEST_NO_SKIPS=flocker.acceptance tox`` will cause test failures if the acceptance tests are skipped.
+The ``FLOCKER_TEST_FAIL_IF_SKIPS`` environment variable can be used to specify tests with which should be counted as failing if they are skipped.
+For example, ``FLOCKER_TEST_FAIL_IF_SKIPS=flocker.acceptance tox`` will cause test failures if the acceptance tests are skipped.
 
 Documentation
 =============

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,6 +76,8 @@ Running Tests
 
 You can run all unit tests by doing:
 
+.. Document the FLOCKER_TEST_NO_SKIPS environment variable here
+
 .. code-block:: console
 
    $ tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -91,6 +91,7 @@ Since these tests involve global state on your machine (filesystems, ``iptables`
 
 The ``FLOCKER_TEST_FAIL_IF_SKIPS`` environment variable can be used to specify tests with which should be counted as failing if they are skipped.
 For example, ``FLOCKER_TEST_FAIL_IF_SKIPS=flocker.acceptance tox`` will cause test failures if the acceptance tests are skipped.
+To support this environment variable, all tests which need skip logic must use either ``flocker.testtools.skips.skipIf``, ``flocker.testtools.skips.skipUnless`` or ``flocker.testtools.skips.SkipTest``.
 
 Documentation
 =============

--- a/flocker/sample/__init__.py
+++ b/flocker/sample/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Sample tests for ``flocker``.
+"""

--- a/flocker/sample/test_linking.py
+++ b/flocker/sample/test_linking.py
@@ -3,25 +3,32 @@
 """
 Sample tests for skipping.
 """
-from unittest import SkipTest, skipUnless
+from flocker.testtools.skips import skipUnless, skipIf, SkipTest
 from twisted.trial.unittest import TestCase
 
-skip_this_test = skipUnless(
+skip_this_test_with_skipUnless = skipUnless(
     False, "This test should be skipped.")
 
+skip_this_test_with_skipIf = skipIf(
+    True, "This test should be skipped.")
 
 class SkippedSetUp(TestCase):
-    @skip_this_test
+    @skip_this_test_with_skipUnless
     def setUp(self):
         pass
 
     def test_not_decorated(self):
         pass
 
-class SkippedTest(TestCase):
-    def setUp(self):
+class SkippedTests(TestCase):
+    @skip_this_test_with_skipUnless
+    def test_decorated_with_skipUnless(self):
         pass
 
-    @skip_this_test
-    def test_not_decorated(self):
+    @skip_this_test_with_skipIf
+    def test_decorated_with_skipIf(self):
         pass
+
+class SkipTestRaised(TestCase):
+    def test_raises_skiptest(self):
+        raise SkipTest(self, "Skipping this test.")

--- a/flocker/sample/test_linking.py
+++ b/flocker/sample/test_linking.py
@@ -29,6 +29,5 @@ class SkippedTests(TestCase):
     def test_decorated_with_skipIf(self):
         pass
 
-class SkipTestRaised(TestCase):
     def test_raises_skiptest(self):
         raise SkipTest(self, "Skipping this test.")

--- a/flocker/sample/test_linking.py
+++ b/flocker/sample/test_linking.py
@@ -1,0 +1,27 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Sample tests for skipping.
+"""
+from unittest import SkipTest, skipUnless
+from twisted.trial.unittest import TestCase
+
+skip_this_test = skipUnless(
+    False, "This test should be skipped.")
+
+
+class SkippedSetUp(TestCase):
+    @skip_this_test
+    def setUp(self):
+        pass
+
+    def test_not_decorated(self):
+        pass
+
+class SkippedTest(TestCase):
+    def setUp(self):
+        pass
+
+    @skip_this_test
+    def test_not_decorated(self):
+        pass

--- a/flocker/sample/test_sample.py
+++ b/flocker/sample/test_sample.py
@@ -29,5 +29,5 @@ class SkippedTests(TestCase):
     def test_decorated_with_skipIf(self):
         pass
 
-    def test_raises_skiptest(self):
+    def test_which_raises_skiptest(self):
         raise SkipTest(self, "Skipping this test.")

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -46,11 +46,7 @@ def skipUnless2(condition, reason):
             @wraps(test_item)
             def skip_wrapper(*args, **kwargs):
                 raise SkipTest(reason)
-            test_item = skip_wrapper
-
-            test_item.__unittest_skip__ = True
-            test_item.__unittest_skip_why__ = reason
-            return test_item
+            return skip_wrapper
 
     return fail_or_skip
 

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -3,6 +3,7 @@
 """
 Utilities to help with skipping tests.
 """
+from os import environ
 
 
 def fail_if_skipped(test_item):
@@ -14,7 +15,10 @@ def fail_if_skipped(test_item):
     :return: True if ``test_object`` is covered by environment variable
         FLOCKER_TEST_FAIL_IF_SKIPS, else False.
     """
+    test_fail_if_skips = environ.get("FLOCKER_TEST_FAIL_IF_SKIPS")
     return True
+    # if test_fail_if_skips is None:
+    #     return False
 
 
 def skipUnless(condition, reason):

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -15,14 +15,16 @@ def ignore_skip(test_object):
     :return: True if ``test_object`` is covered by environment variable
         FLOCKER_TEST_NO_SKIPS, else False.
     """
+    return True
 
 # The following functions need suitable names.
 # Ideally those names would read well, like how:
 # skipUnless(SELENIUM_INSTALLED) reads like "skip unless selenium is installed".
 # One option is to have them called skipIf and skipUnless, like the unittest
 # methods, and then only import lines must be changed.
+# another option is "skipOrFailUnless" and "skipOrFailIf"
 
-def skipUnlessForcedOr(condition, reason):
+def skipUnless2(condition, reason):
     """
     Ignore skipUnless if an environment variable has been set instructing to do
     so.
@@ -31,13 +33,17 @@ def skipUnlessForcedOr(condition, reason):
     """
     def skip_unless_condition_or_forced(function):
         if ignore_skip(test_object=function):
-            return function
+            # instead make the test fail
+            import pdb; pdb.set_trace()
+            return function.fail("HELLO")
+
+            # return function
         else:
             return skipUnless(condition, reason)
 
     return skip_unless_condition_or_forced
 
-def skipUnlessForcedIf(condition, reason):
+def skipIf2(condition, reason):
     """
     Ignore skipIf if an environment variable has been set instructing to do
     so.
@@ -55,8 +61,4 @@ def skipUnlessForcedIf(condition, reason):
 # also handle all raise SkipTests
 # also handle .skip
 
-# follow up issues for skipping setUp when skipping tests
 # add to tox / buildbot reconfiguration
-# check that this will work with tox
-# document this in CONTRIBUTING.rst
-# tests for this

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -4,10 +4,6 @@
 Utilities to help with skipping tests.
 """
 
-from unittest import SkipTest
-from functools import wraps
-
-
 def fail_if_skipped(test_item):
     """
     Check whether to fail the given test object if it will be skipped.
@@ -17,9 +13,10 @@ def fail_if_skipped(test_item):
     :return: True if ``test_object`` is covered by environment variable
         FLOCKER_TEST_NO_SKIPS, else False.
     """
+    return False
 
 
-def skipUnless(condition, reason):
+def skipUnless2(condition, reason):
     """
     A test object decorator to skip the test unless ``condition`` evaluates to
     ``True``. Fail the test if an environment variable says to fail the
@@ -33,11 +30,7 @@ def skipUnless(condition, reason):
         elif fail_if_skipped(test_item=test_item):
             return lambda test_item: test_item.fail(reason)
         else:
-
-            @wraps(test_item)
-            def skip_wrapper(*args, **kwargs):
-                raise SkipTest(reason)
-            return skip_wrapper
+            return lambda test_item: test_item.skipTest(reason)
 
     return fail_or_skip
 

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -16,7 +16,7 @@ def fail_if_skipped(test_item):
     return False
 
 
-def skipUnless2(condition, reason):
+def skipUnless(condition, reason):
     """
     A test object decorator to skip the test unless ``condition`` evaluates to
     ``True``. Fail the test if an environment variable says to fail the

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -12,7 +12,7 @@ def fail_if_skipped(test_item):
     :param test_object: test method or class with a skip decorator.
 
     :return: True if ``test_object`` is covered by environment variable
-        FLOCKER_TEST_NO_SKIPS, else False.
+        FLOCKER_TEST_FAIL_IF_SKIPS, else False.
     """
     return True
 

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -6,13 +6,18 @@ Utilities to help with skipping unit and functional tests.
 
 from unittest import skipUnless
 
-def check_if_test_in_flocker_test_no_skips(testcase):
-    pass
-    # return True / False depending on whether test is covered by
-    # FLOCKER_TEST_NO_SKIPS
+def check_if_in_flocker_test_no_skips(test_object):
+    return False
+    # return True if test is covered by FLOCKER_TEST_NO_SKIPS, else False
 
 def skipUnless2(condition, message):
-    pass
+    def maybe_ignore_skips(function):
+        if check_if_in_flocker_test_no_skips(test_object=function):
+            return function
+        else:
+            return skipUnless(condition, message)
+
+    return maybe_ignore_skips
     # check the environment variable FLOCKER_TEST_NO_SKIPS
     # get modules defined in FLOCKER_TEST_NO_SKIPS
     # if decorated function is in one of those modules, return the function
@@ -29,4 +34,5 @@ def skipUnless2(condition, message):
 
 # follow up issues for skipping setUp when skipping tests
 # add to tox / buildbot reconfiguration
-# document this
+# check that this will work with tox
+# document this in CONTRIBUTING.rst

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -1,0 +1,15 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Utilities to help with skipping unit and functional tests.
+"""
+
+from unittest import skipUnless
+
+def 
+def skipUnless2(condition, message):
+    # check the environment variable FLOCKER_TEST_NO_SKIPS
+    # get modules defined in FLOCKER_TEST_NO_SKIPS
+    # if decorated function is in one of those modules, return the function
+    # without the skipUnless decorator
+    # same for skipIf

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -29,3 +29,4 @@ def skipUnless2(condition, message):
 
 # follow up issues for skipping setUp when skipping tests
 # add to tox / buildbot reconfiguration
+# document this

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -6,10 +6,26 @@ Utilities to help with skipping unit and functional tests.
 
 from unittest import skipUnless
 
-def 
+def check_if_test_in_flocker_test_no_skips(testcase):
+    pass
+    # return True / False depending on whether test is covered by
+    # FLOCKER_TEST_NO_SKIPS
+
 def skipUnless2(condition, message):
+    pass
     # check the environment variable FLOCKER_TEST_NO_SKIPS
     # get modules defined in FLOCKER_TEST_NO_SKIPS
     # if decorated function is in one of those modules, return the function
     # without the skipUnless decorator
     # same for skipIf
+    # should this be called skipUnless and so import lines only can be changed
+    # alternatively it could have a unique function name e.g. skipUnlessForced
+    # one issue with that is that:
+    # skipUnless(SELENIUM_INSTALLED) reads like "skip unless selenium is installed"
+    # skipUnlessForced(SELENIUM_INSTALLED) does not read as clearly
+
+# also handle all raise SkipTests
+# also handle .skip
+
+# follow up issues for skipping setUp when skipping tests
+# add to tox / buildbot reconfiguration

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -17,18 +17,9 @@ def fail_if_skipped(test_item):
     :return: True if ``test_object`` is covered by environment variable
         FLOCKER_TEST_NO_SKIPS, else False.
     """
-    return True
-
-# The following functions need suitable names.
-# Ideally those names would read well, like how
-# skipUnless(SELENIUM_INSTALLED) reads like "skip unless selenium is
-# installed".
-# One option is to have them called skipIf and skipUnless, like the unittest
-# methods, and then only import lines must be changed.
-# another option is "skipOrFailUnless" and "skipOrFailIf"
 
 
-def skipUnless2(condition, reason):
+def skipUnless(condition, reason):
     """
     A test object decorator to skip the test unless ``condition`` evaluates to
     ``True``. Fail the test if an environment variable says to fail the
@@ -51,7 +42,7 @@ def skipUnless2(condition, reason):
     return fail_or_skip
 
 
-def skipIf2(condition, reason):
+def skipIf(condition, reason):
     """
     A test object decorator to skip the test if ``condition`` evaluates to
     ``True``. Fail the test if an environment variable says to fail the
@@ -59,11 +50,3 @@ def skipIf2(condition, reason):
 
     See unittest.skipIf for parameter documentation.
     """
-
-# also handle all raise SkipTests
-# also handle .skip
-
-# This requires follow-up issues to modify tox configurations and buildbot
-# builders
-
-# all skips will have to be changed

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -4,6 +4,7 @@
 Utilities to help with skipping tests.
 """
 
+
 def fail_if_skipped(test_item):
     """
     Check whether to fail the given test object if it will be skipped.
@@ -13,7 +14,7 @@ def fail_if_skipped(test_item):
     :return: True if ``test_object`` is covered by environment variable
         FLOCKER_TEST_NO_SKIPS, else False.
     """
-    return False
+    return True
 
 
 def skipUnless(condition, reason):
@@ -43,3 +44,28 @@ def skipIf(condition, reason):
 
     See unittest.skipIf for parameter documentation.
     """
+    def fail_or_skip(test_item):
+        if not condition:
+            return test_item
+        elif fail_if_skipped(test_item=test_item):
+            return lambda test_item: test_item.fail(reason)
+        else:
+            return lambda test_item: test_item.skipTest(reason)
+
+    return fail_or_skip
+
+class SkipTest(Exception):
+    """
+    Similar to ``unittest.skipTest`` except the test being run when this is
+    raised will fail if an environment variable says to fail the
+    decorated test if it is going to be skipped.
+    """
+    def __init__(self, test_item, value):
+        self.value = value
+        if fail_if_skipped(test_item=test_item):
+            test_item.fail(value)
+        else:
+            test_item.skipTest(value)
+
+    def __str__(self):
+        return repr(self.value)

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -1,33 +1,56 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
 """
-Utilities to help with skipping unit and functional tests.
+Utilities to help with skipping tests.
 """
 
-from unittest import skipUnless
+from unittest import skipIf, skipUnless
 
-def check_if_in_flocker_test_no_skips(test_object):
-    return False
-    # return True if test is covered by FLOCKER_TEST_NO_SKIPS, else False
+def ignore_skip(test_object):
+    """
+    Check whether to ignore any skip decorators on a test object.
 
-def skipUnless2(condition, message):
-    def maybe_ignore_skips(function):
-        if check_if_in_flocker_test_no_skips(test_object=function):
+    :param test_object: test method or class with a skip decorator.
+
+    :return: True if ``test_object`` is covered by environment variable
+        FLOCKER_TEST_NO_SKIPS, else False.
+    """
+
+# The following functions need suitable names.
+# Ideally those names would read well, like how:
+# skipUnless(SELENIUM_INSTALLED) reads like "skip unless selenium is installed".
+# One option is to have them called skipIf and skipUnless, like the unittest
+# methods, and then only import lines must be changed.
+
+def skipUnlessForcedOr(condition, reason):
+    """
+    Ignore skipUnless if an environment variable has been set instructing to do
+    so.
+
+    See unittest.skipUnless for parameter documentation.
+    """
+    def skip_unless_condition_or_forced(function):
+        if ignore_skip(test_object=function):
             return function
         else:
-            return skipUnless(condition, message)
+            return skipUnless(condition, reason)
 
-    return maybe_ignore_skips
-    # check the environment variable FLOCKER_TEST_NO_SKIPS
-    # get modules defined in FLOCKER_TEST_NO_SKIPS
-    # if decorated function is in one of those modules, return the function
-    # without the skipUnless decorator
-    # same for skipIf
-    # should this be called skipUnless and so import lines only can be changed
-    # alternatively it could have a unique function name e.g. skipUnlessForced
-    # one issue with that is that:
-    # skipUnless(SELENIUM_INSTALLED) reads like "skip unless selenium is installed"
-    # skipUnlessForced(SELENIUM_INSTALLED) does not read as clearly
+    return skip_unless_condition_or_forced
+
+def skipUnlessForcedIf(condition, reason):
+    """
+    Ignore skipIf if an environment variable has been set instructing to do
+    so.
+
+    See unittest.skipIf for parameter documentation.
+    """
+    def skip_if_condition_or_forced(function):
+        if ignore_skip(test_object=function):
+            return function
+        else:
+            return skipIf(condition, reason)
+
+    return skip_if_condition_or_forced
 
 # also handle all raise SkipTests
 # also handle .skip
@@ -36,3 +59,4 @@ def skipUnless2(condition, message):
 # add to tox / buildbot reconfiguration
 # check that this will work with tox
 # document this in CONTRIBUTING.rst
+# tests for this

--- a/flocker/testtools/skips.py
+++ b/flocker/testtools/skips.py
@@ -4,61 +4,73 @@
 Utilities to help with skipping tests.
 """
 
-from unittest import skipIf, skipUnless
+from unittest import SkipTest, skip, skipUnless
 
-def ignore_skip(test_object):
+
+def fail_if_skipped(test_object):
     """
-    Check whether to ignore any skip decorators on a test object.
+    Check whether to fail the given test object if it will be skipped.
 
     :param test_object: test method or class with a skip decorator.
 
     :return: True if ``test_object`` is covered by environment variable
         FLOCKER_TEST_NO_SKIPS, else False.
     """
-    return True
+    return False
 
 # The following functions need suitable names.
 # Ideally those names would read well, like how:
-# skipUnless(SELENIUM_INSTALLED) reads like "skip unless selenium is installed".
+# skipUnless(SELENIUM_INSTALLED) reads like "skip unless selenium is
+# installed".
 # One option is to have them called skipIf and skipUnless, like the unittest
 # methods, and then only import lines must be changed.
 # another option is "skipOrFailUnless" and "skipOrFailIf"
 
+
 def skipUnless2(condition, reason):
     """
-    Ignore skipUnless if an environment variable has been set instructing to do
-    so.
+    A test object decorator to skip the test unless ``condition`` evaluates to
+    ``True``. Fail the test if an environment variable says to fail the
+    decorated test if it is going to be skipped.
 
     See unittest.skipUnless for parameter documentation.
     """
-    def skip_unless_condition_or_forced(function):
-        if ignore_skip(test_object=function):
-            # instead make the test fail
-            import pdb; pdb.set_trace()
-            return function.fail("HELLO")
-
-            # return function
+    def fail_or_skip(function):
+        if not condition:
+            if fail_if_skipped(test_object=function):
+                return lambda function: function.fail(reason)
+            else:
+                return skipUnless(condition, reason)
+                # raise SkipTest("HELLO")
+                # return skipUnless(condition, reason)
         else:
-            return skipUnless(condition, reason)
+            return function
 
-    return skip_unless_condition_or_forced
+    return fail_or_skip
 
 def skipIf2(condition, reason):
     """
-    Ignore skipIf if an environment variable has been set instructing to do
-    so.
+    A test object decorator to skip the test if ``condition`` evaluates to
+    ``True``. Fail the test if an environment variable says to fail the
+    decorated test if it is going to be skipped.
 
     See unittest.skipIf for parameter documentation.
     """
-    def skip_if_condition_or_forced(function):
-        if ignore_skip(test_object=function):
-            return function
+    def fail_or_skip(function):
+        if condition:
+            if fail_if_skipped(test_object=function):
+                return lambda function: function.fail(reason)
+            else:
+                raise SkipTest(reason)
         else:
-            return skipIf(condition, reason)
+            return function
 
-    return skip_if_condition_or_forced
+    return fail_or_skip
 
 # also handle all raise SkipTests
 # also handle .skip
 
-# add to tox / buildbot reconfiguration
+# This requires follow-up issues to modify tox configurations and buildbot
+# builders
+
+# all skips will have to be changed


### PR DESCRIPTION
This is a design for part of FLOC-1064. I'd like it to be looked at before I go too deep into overriding all the ways to skip a test.

There are multiple ways to skip a test:
* `@skipIf` / `@skipUnless` decorators
* `raise SkipTest(reason)`
* `test_case.skipTest(reason)`
* `test_case.skip = reason`

and maybe others?

However, not all of these are used in our codebase. Is it worthwhile writing code to cover those cases which are not used. It seems entirely possible to avoid some of these options (e.g. avoid `raise SkipTest(reason)` and only use `test_case.skipTest(reason)`.

Of course implementing this would involve changing all the current skips in the codebase, as well as changing the buildbot and tox configurations.

These are test tools, and so I didn't add tests for them, but in doing an initial implementation sketch it became quite tedious testing manually, so I think that this should have tests. Thoughts?

If the work remaining is as suggested above, I believe that this will take more than the 2 hour estimate to complete, which is one reason why I am requesting a look over before designing most of the issue.

This is the work of me and @wallrj .