### PR TITLE
[FLOC-1252] Display marketing release version in documentation releases.

### DIFF
--- a/docs/_themes/clusterhq/layout.html
+++ b/docs/_themes/clusterhq/layout.html
@@ -109,19 +109,15 @@
                 {%- endif %}
                 <!-- DOCS PAGE DATA HERE -->
                 {%- block document %}
-                        <script>
-                            var release_re = /^[0-9]+\.[0-9]+\.[0-9]+$/
-                            if (!'{{ release }}'.match(release_re)) {
-                                document.write(
-                        '<div class="admonition note warning"> \
-                            <p class="last"> \
-                                You are reading an <strong>in-development version</strong> \
-                                of the documentation. \
-                                Some of the functionality may not work as expected.</p> \
-                        </div>');
-                            }
-                        </script>
-                        {% block body %} {% endblock %}
+                    {%- if not is_release -%}
+                        <div class="admonition note warning">
+                            <p class="last">
+                                You are reading an <strong>in-development version</strong>
+                                of the documentation.
+                                Some of the functionality may not work as expected.</p>
+                        </div>
+                    {%- endif -%}
+                    {% block body %} {% endblock %}
                 {%- endblock %}
                 <!-- END OF DOCS PAGE DATA -->
                 <div class="row">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,10 +55,10 @@ copyright = u'2014, ClusterHQ'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-# The short X.Y version.
 from flocker import __version__
-from flocker.docs import get_version
-version = get_version(__version__)
+from flocker.docs import get_doc_version, is_release
+# The short X.Y version.
+version = get_doc_version(__version__)
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,11 @@ from flocker.docs import get_doc_version, is_release
 # The short X.Y version.
 version = get_doc_version(__version__)
 
+html_context = {
+    # This is used to show the development version warning.
+    'is_release': is_release(__version__),
+}
+
 # The full version, including alpha/beta/rc tags.
 release = version
 
@@ -68,6 +73,7 @@ release = version
 # We override with our own variant to improve search results slightly.
 from sphinx.search.en import SearchEnglish
 from sphinx.search import languages as sphinx_languages
+
 
 class FlockerLanguage(SearchEnglish):
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,11 @@
 
 from twisted.python.filepath import FilePath
 
-import sys, os
+import sys
+import os
+import re
+
+sys.path.insert(0, FilePath(__file__).parent().parent().path)
 
 # Check if we are building on readthedocs
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -52,11 +56,9 @@ copyright = u'2014, ClusterHQ'
 # built documents.
 #
 # The short X.Y version.
-sys.path.insert(0, FilePath(__file__).parent().parent().path)
-from flocker import __version__ as version
-if version.endswith("-dirty"):
-    version = version[:-6]
-del sys.path[0]
+from flocker import __version__
+from flocker.docs import get_version
+version = get_version(__version__)
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -67,6 +67,8 @@ Preparing For a Release
 
 #. Check that all required versions of the dependency packages are built:
 
+   .. note:: Skip this step for a documentation release.
+
    #. Inspect the package versions listed in the ``install_requires`` section of ``setup.py``.
    #. Compare it to the package versions listed in the "Requires" lines in ``python-flocker.spec.in``.
    #. If there are any mismatches, change ``python-flocker.spec.in`` appropriately, commit the changes, and add any missing package names to the lists of downloaded packages in :ref:`pre-populating-rpm-repository`.
@@ -103,6 +105,8 @@ Preparing For a Release
 
 #. Update the version numbers in:
 
+   .. note:: Skip this step for a documentation release.
+
    - the ``pip install`` line in
      `docs/gettingstarted/linux-install.sh <https://github.com/ClusterHQ/flocker/blob/master/docs/gettingstarted/linux-install.sh>`_,
    - the ``box_version`` in
@@ -115,6 +119,7 @@ Preparing For a Release
      .. code-block:: console
 
         git commit -am "Bumped version numbers"
+   .. note:: Skip this step for a documentation release.
 
 #. Ensure the notes in `docs/advanced/whatsnew.rst <https://github.com/ClusterHQ/flocker/blob/master/docs/advanced/whatsnew.rst>`_ are up-to-date:
 
@@ -308,6 +313,8 @@ Release
 
 #. Build Python packages and upload them to ``archive.clusterhq.com``
 
+   .. note:: Skip this step for a documentation release.
+
    .. code-block:: console
 
       python setup.py sdist bdist_wheel
@@ -325,17 +332,23 @@ Release
 
 #. Build RPM packages and upload them to ``archive.clusterhq.com``
 
+   .. note:: Skip this step for a documentation release.
+
    .. code-block:: console
 
       admin/upload-rpms "${VERSION}"
 
 #. Build and upload the tutorial :ref:`Vagrant box <build-vagrant-box>`.
 
+   .. note:: Skip this step for a documentation release.
+
    .. warning:: This step requires ``Vagrant`` and should be performed on your own workstation;
                 **not** on a :doc:`Flocker development machine <vagrant>`.
                 This means that ``gsutil`` must be installed and configured on your workstation.
 
 #. Update the Homebrew recipe
+
+   .. note:: Skip this step for a documentation release.
 
    The aim of this step is to provide a version specific ``Homebrew`` recipe for each release.
 

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -17,6 +17,10 @@ By the end of the release process we will have:
 - a Python wheel in the `ClusterHQ package index <http://archive.clusterhq.com>`_,
 - Fedora 20 RPMs for software on the node and client,
 - a Vagrant base tutorial image and
+
+For a documentation release, we will have:
+
+- a tag in version control,
 - documentation on `docs.clusterhq.com <https://docs.clusterhq.com>`_.
 
 

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -119,7 +119,6 @@ Preparing For a Release
      .. code-block:: console
 
         git commit -am "Bumped version numbers"
-   .. note:: Skip this step for a documentation release.
 
 #. Ensure the notes in `docs/advanced/whatsnew.rst <https://github.com/ClusterHQ/flocker/blob/master/docs/advanced/whatsnew.rst>`_ are up-to-date:
 

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -44,6 +44,9 @@ Access
 - A member of a `ClusterHQ team on Vagrant Cloud <https://vagrantcloud.com/organization/clusterhq/teams>`_
 
 
+.. note:: For a documentation release, access to Google Cloud Storage and Vagrant Cloud is not required.
+
+
 Preparing For a Release
 -----------------------
 

--- a/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
+++ b/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
@@ -55,7 +55,7 @@ The version of a minor marketing release will have the micro version number incr
 
 Documentation Release
 ^^^^^^^^^^^^^^^^^^^^^
-Documentation releases will be made when documentation for a major or minor marketting release is to be updated, without doing a full release.
+Documentation releases will be made when documentation for a major or minor marketing release is to be updated, without doing a full release.
 
 Documentation releases will be planned and scheduled by ClusterHQ's product team, in consultation with the marketing and engineering teams.
 

--- a/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
+++ b/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
@@ -53,6 +53,15 @@ Minor marketing releases will be planned and scheduled by ClusterHQ's product te
 
 The version of a minor marketing release will have the micro version number incremented from the previous marketing release.
 
+Documentation Release
+^^^^^^^^^^^^^^^^^^^^^
+Documentation releases will be made when documentation for a major or minor marketting release is to be updated, without doing a full release.
+
+Documentation releases will be planned and scheduled by ClusterHQ's product team, in consultation with the marketing and engineering teams.
+
+The version of a documentation will have the version of the corresponding marketing release, with a ``+doc.X`` release, where ``X`` starts at ``1`` and is incremented for each pre-release.
+
+
 Weekly Development Release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Weekly releases are made primarily to facilitate the testing and automation of the release process itself.
@@ -74,21 +83,23 @@ Examples
 
 For example:
 
-+---------------+-------------------------------------------------+
-| ``0.3.0``     | 0.3.0 released                                  |
-+---------------+-------------------------------------------------+
-| ``0.3.1dev1`` | Weekly releases of 0.3.1                        |
-+---------------+-------------------------------------------------+
-| ``0.3.1``     | Micro marketing release                         |
-+---------------+-------------------------------------------------+
-| ``0.3.2dev1`` | Weekly release                                  |
-+---------------+-------------------------------------------------+
-| ``0.3.2dev2`` | Weekly release                                  |
-+---------------+-------------------------------------------------+
-| ``0.4.0pre1`` | Pre-release of 0.4.0                            |
-+---------------+-------------------------------------------------+
-| ``0.4.0``     | Major marketing release                         |
-+---------------+-------------------------------------------------+
++----------------+-------------------------------------------------+
+| ``0.3.0``      | 0.3.0 released                                  |
++----------------+-------------------------------------------------+
+| ``0.3.1dev1``  | Weekly releases of 0.3.1                        |
++----------------+-------------------------------------------------+
+| ``0.3.1``      | Micro marketing release                         |
++----------------+-------------------------------------------------+
+| ``0.3.1+doc1`` | Documentation release of 0.3.1                  |
++----------------+-------------------------------------------------+
+| ``0.3.2dev1``  | Weekly release                                  |
++----------------+-------------------------------------------------+
+| ``0.3.2dev2``  | Weekly release                                  |
++----------------+-------------------------------------------------+
+| ``0.4.0pre1``  | Pre-release of 0.4.0                            |
++----------------+-------------------------------------------------+
+| ``0.4.0``      | Major marketing release                         |
++----------------+-------------------------------------------------+
 
 Production Releases
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
+++ b/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
@@ -59,7 +59,7 @@ Documentation releases will be made when documentation for a major or minor mark
 
 Documentation releases will be planned and scheduled by ClusterHQ's product team, in consultation with the marketing and engineering teams.
 
-The version of a documentation will have the version of the corresponding marketing release, with a ``+doc.X`` release, where ``X`` starts at ``1`` and is incremented for each pre-release.
+The version of a documentation will have the version of the corresponding marketing release, with a ``+doc.X`` release, where ``X`` starts at ``1`` and is incremented for each documentation release.
 
 
 Weekly Development Release

--- a/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
+++ b/docs/gettinginvolved/infrastructure/release-schedule-versioning.rst
@@ -59,7 +59,7 @@ Documentation releases will be made when documentation for a major or minor mark
 
 Documentation releases will be planned and scheduled by ClusterHQ's product team, in consultation with the marketing and engineering teams.
 
-The version of a documentation will have the version of the corresponding marketing release, with a ``+doc.X`` release, where ``X`` starts at ``1`` and is incremented for each documentation release.
+The version of a documentation will have the version of the corresponding marketing release, with a ``+docX`` release, where ``X`` starts at ``1`` and is incremented for each documentation release.
 
 
 Weekly Development Release

--- a/flocker/docs/__init__.py
+++ b/flocker/docs/__init__.py
@@ -1,5 +1,5 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
-from ._version import get_version
+from ._version import get_doc_version, is_release
 
-__all__ = ['get_version']
+__all__ = ['get_doc_version', is_release]

--- a/flocker/docs/__init__.py
+++ b/flocker/docs/__init__.py
@@ -2,4 +2,4 @@
 
 from ._version import get_doc_version, is_release
 
-__all__ = ['get_doc_version', is_release]
+__all__ = ['get_doc_version', 'is_release']

--- a/flocker/docs/__init__.py
+++ b/flocker/docs/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+from ._version import get_version
+
+__all__ = ['get_version']

--- a/flocker/docs/__init__.py
+++ b/flocker/docs/__init__.py
@@ -1,5 +1,9 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
+"""
+Components for Flocker documentation.
+"""
+
 from ._version import get_doc_version, is_release
 
 __all__ = ['get_doc_version', 'is_release']

--- a/flocker/docs/_version.py
+++ b/flocker/docs/_version.py
@@ -8,6 +8,10 @@ from characteristic import attributes, Attribute
 _VERSION_RE = re.compile(
     # The base version
     r"(?P<major>[0-9])\.(?P<minor>[0-9]+)\.(?P<micro>[0-9]+)"
+    # Pre-release
+    r"(pre(?P<pre_release>[0-9]+))?"
+    # Weekly release
+    r"(dev(?P<weekly_release>[0-9]+))?"
     # The documentation release
     r"(\+doc\.(?P<documentation_revision>[0-9]+))?"
     # Development version
@@ -29,6 +33,8 @@ class UnparseableVersion(Exception):
     'major',
     'minor',
     'micro',
+    Attribute('pre_release', default_value=None),
+    Attribute('weekly_release', default_value=None),
     Attribute('documentation_revision', default_value=None),
     Attribute('commit_count', default_value=None),
     Attribute('commit_hash', default_value=None),
@@ -41,11 +47,15 @@ class FlockerVersion(object):
     :ivar str major: The major number of the (most recent) release.
     :ivar str minor: The minor number of the (most recent) release.
     :ivar str micro: The micro number of the (most recent) release.
+    :ivar str pre_release: The number of the (most recent) pre-release,
+        or ``None`` if there hasn't been a pre release.
+    :ivar str weekly_release: The number of the (most recent) weekly release,
+        or ``None`` if there hasn't been a weekly release.
     :ivar str documentation_revision: The documentation revision of the
         (most recent) release or ``None`` if there hasn't been a documentation
-        release..
+        release.
     :ivar str commit_count: The number of commits since the last release or
-        ``None if this is a release.
+        ``None`` if this is a release.
     :ivar str commit_hash: The hash of the current commit, or ``None`` if this
         is a release.
     :ivar str dirty: If the tree is dirty, the string '-dirty'.
@@ -90,8 +100,11 @@ def get_doc_version(version):
 
 def is_release(version):
     """
-    Return whether the version corresponds to a release.
+    Return whether the version corresponds to a marketing or documentation
+    release.
     """
     parsed_version = parse_version(version)
     return (parsed_version.commit_count is None
+            and parsed_version.pre_release is None
+            and parsed_version.weekly_release is None
             and parsed_version.dirty is None)

--- a/flocker/docs/_version.py
+++ b/flocker/docs/_version.py
@@ -1,0 +1,11 @@
+# -*- test-case-name: flocker.docs.test.test_version -*-
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+import re
+
+_VERSION_RE = re.compile('(?P<base>.*?)(\+doc\.(?P<doc>[0-9]+))?$')
+
+
+def get_version(version):
+    match = _VERSION_RE.match(version)
+    return match.group('base')

--- a/flocker/docs/_version.py
+++ b/flocker/docs/_version.py
@@ -3,9 +3,62 @@
 
 import re
 
-_VERSION_RE = re.compile('(?P<base>.*?)(\+doc\.(?P<doc>[0-9]+))?$')
+_VERSION_RE = re.compile(
+    # The base version (in 'release')
+    r"(?P<release>[0-9]\.[0-9]+\.[0-9]+)"
+    # For a documentation release, the release number.
+    # (in 'doc-release').
+    r"(\+doc\.(?P<doc>[0-9]+))?"
+    # For development version, the number of commits since the last
+    # release and git hash
+    r"((?P<development>-[0-9]+-g[0-9a-f]+))?"
+    # Wether the tree is dirty.
+    r"((?P<dirty>-dirty))?"
+    # Always match the entire version string.
+    r"$"
+    )
 
 
-def get_version(version):
+class UnparseableVersion(Exception):
+    """
+    A version was passed that was unable to be parsed.
+    """
+
+
+def parse_version(version):
+    """
+    Parse a flocker version.
+
+    :return dict: with the following keys. If a key isn't relevant, the value
+        is ``None``.
+
+        release
+            The base release
+        development
+            For development versions, the number of commits since the last
+            release and the commit hash, in the format used by ``git describe`.
+        doc
+            For a documentation only release, the relase number.
+        dirty
+            If the tree is dirty, the string '-dirty'.
+
+    :raises UnparseableVersion: If the version can't be parsed as a flocker
+        version.
+    """
     match = _VERSION_RE.match(version)
-    return match.group('base')
+    if match is None:
+        raise UnparseableVersion(version)
+    return match.groupdict()
+
+
+def get_doc_version(version):
+    parts = parse_version(version)
+    if is_release(version) and parts['doc'] is not None:
+        return parts['release']
+    else:
+        return version
+
+
+def is_release(version):
+    parts = parse_version(version)
+    return (parts['development'] is None and parts['dirty'] is None)

--- a/flocker/docs/_version.py
+++ b/flocker/docs/_version.py
@@ -13,7 +13,7 @@ _VERSION_RE = re.compile(
     # Weekly release
     r"(dev(?P<weekly_release>[0-9]+))?"
     # The documentation release
-    r"(\+doc\.(?P<documentation_revision>[0-9]+))?"
+    r"(\+doc(?P<documentation_revision>[0-9]+))?"
     # Development version
     r"(-(?P<commit_count>[0-9]+)-g(?P<commit_hash>[0-9a-f]+))?"
     # Wether the tree is dirty.

--- a/flocker/docs/test/__init__.py
+++ b/flocker/docs/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Tests for components for Flocker documentation.
+"""

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -7,45 +7,147 @@ Test for :module:`flocker.docs.version`.
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from .._version import get_version
+from .._version import parse_version, get_doc_version, is_release
 
 
-class GetVersionTests(SynchronousTestCase):
+class ParseVersionTests(SynchronousTestCase):
     """
-    Test for :function:`get_version`.
+    Test for :function:`parse_version`.
+    """
+    def assertParsedVersion(self, version, **expected_parts):
+        """
+        Assert that :function:`parse_version` returns ``expected_parts``.
+        Any parts not specified in ``expected_parts`` must be ``None``.
+        """
+        parts = {
+            'release': None,
+            'development': None,
+            'doc': None,
+            'dirty': None
+        }
+        parts.update(expected_parts)
+        self.assertEqual(parse_version(version), parts)
+
+    def test_release(self):
+        """
+        When the version is from a release, the documentation version is left
+        unchanged.
+        """
+        self.assertParsedVersion('0.3.2', release='0.3.2')
+
+    def test_development_vesion(self):
+        """
+        When the version is from a development version, the documentation
+        version is left unchanged.
+        """
+        self.assertParsedVersion('0.3.2-1-gf661a6a',
+                                 release='0.3.2',
+                                 development='-1-gf661a6a')
+
+    def test_dirty(self):
+        """
+        When the version is dirty, the documentation version is left unchanged.
+        """
+        self.assertParsedVersion('0.3.2-1-gf661a6a-dirty',
+                                 release='0.3.2',
+                                 development='-1-gf661a6a',
+                                 dirty='-dirty')
+
+    def test_doc(self):
+        """
+        When the documentation version is from a doc release, the trailing
+        '+doc.X' is stripped.
+        """
+        self.assertParsedVersion('0.3.2+doc.11',
+                                 release='0.3.2',
+                                 doc='11')
+
+    def test_doc_dirty(self):
+        """
+        When the version is from a doc release but is dirty, the documentation
+        version is left unchanged.
+        """
+        self.assertParsedVersion('0.3.2+doc.11-dirty',
+                                 release='0.3.2',
+                                 doc='11',
+                                 dirty='-dirty')
+
+
+class GetDocVersionTests(SynchronousTestCase):
+    """
+    Test for :function:`get_doc_version`.
     """
 
     def test_release(self):
         """
-        When the version is from a release, the version is left unchanged.
+        When the version is from a release, the documentation version is left
+        unchanged.
         """
-        self.assertEqual(get_version('0.3.2'), '0.3.2')
+        self.assertEqual(get_doc_version('0.3.2'), '0.3.2')
 
     def test_development_vesion(self):
         """
-        When the version is from a development version, the version is left
-        unchanged.
+        When the version is from a development version, the documentation
+        version is left unchanged.
         """
-        self.assertEqual(get_version('0.3.2-1-gf661a6a'), '0.3.2-1-gf661a6a')
+        self.assertEqual(get_doc_version('0.3.2-1-gf661a6a'),
+                         '0.3.2-1-gf661a6a')
 
     def test_dirty(self):
         """
-        When the version is dirty, the version is left unchanged.
+        When the version is dirty, the documentation version is left unchanged.
         """
-        self.assertEqual(get_version('0.3.2-1-gf661a6a-dirty'),
+        self.assertEqual(get_doc_version('0.3.2-1-gf661a6a-dirty'),
                          '0.3.2-1-gf661a6a-dirty')
 
     def test_doc(self):
         """
-        When the version is from a doc release, the trailing '+doc.X' is
-        stripped.
+        When the documentation version is from a doc release, the trailing
+        '+doc.X' is stripped.
         """
-        self.assertEqual(get_version('0.3.2+doc.11'), '0.3.2')
+        self.assertEqual(get_doc_version('0.3.2+doc.11'), '0.3.2')
 
     def test_doc_dirty(self):
         """
-        When the version is from a doc release but is dirty, the version is
-        left unchanged.
+        When the version is from a doc release but is dirty, the documentation
+        version is left unchanged.
         """
-        self.assertEqual(get_version('0.3.2+doc.0.dirty'),
-                         '0.3.2+doc.0.dirty')
+        self.assertEqual(get_doc_version('0.3.2+doc.0-dirty'),
+                         '0.3.2+doc.0-dirty')
+
+
+class IsReleaseTests(SynchronousTestCase):
+    """
+    Test for :function:`is_release`.
+    """
+
+    def test_release(self):
+        """
+        When the version is from a release, it is a release.
+        """
+        self.assertTrue(is_release('0.3.2'))
+
+    def test_development_vesion(self):
+        """
+        When the version is from a development version, it isn't a release.
+        """
+        self.assertFalse(is_release('0.3.2-1-gf661a6a'))
+
+    def test_dirty(self):
+        """
+        When the version is dirty, it isn't a release.
+        """
+        self.assertFalse(is_release('0.3.2-1-gf661a6a-dirty'))
+
+    def test_doc(self):
+        """
+        When the documentation version is from a doc release, it is a release.
+        """
+        self.assertTrue(is_release('0.3.2+doc.11'))
+
+    def test_doc_dirty(self):
+        """
+        When the version is from a doc release but is dirty, it isn't a
+        release.
+        """
+        self.assertFalse(is_release('0.3.2+doc.0-dirty'))

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -142,8 +142,8 @@ class GetDocVersionTests(SynchronousTestCase):
         When the version is from a documentation release but is dirty, the
         documentation version is left unchanged.
         """
-        self.assertEqual(get_doc_version('0.3.2+doc0-dirty'),
-                         '0.3.2+doc0-dirty')
+        self.assertEqual(get_doc_version('0.3.2+doc1-dirty'),
+                         '0.3.2+doc1-dirty')
 
 
 class IsReleaseTests(SynchronousTestCase):
@@ -192,4 +192,4 @@ class IsReleaseTests(SynchronousTestCase):
         When the version is from a documentation release but is dirty, it isn't
         a release.
         """
-        self.assertFalse(is_release('0.3.2+doc0-dirty'))
+        self.assertFalse(is_release('0.3.2+doc1-dirty'))

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -7,7 +7,10 @@ Test for :module:`flocker.docs.version`.
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from .._version import parse_version, get_doc_version, is_release
+from .._version import (
+    parse_version, FlockerVersion,
+    get_doc_version, is_release,
+)
 
 
 class ParseVersionTests(SynchronousTestCase):
@@ -17,23 +20,22 @@ class ParseVersionTests(SynchronousTestCase):
     def assertParsedVersion(self, version, **expected_parts):
         """
         Assert that :function:`parse_version` returns ``expected_parts``.
-        Any parts not specified in ``expected_parts`` must be ``None``.
+        The release is expected to be `0.3.2`.
         """
         parts = {
-            'release': None,
-            'development': None,
-            'doc': None,
-            'dirty': None
+            'major': '0',
+            'minor': '3',
+            'micro': '2',
         }
         parts.update(expected_parts)
-        self.assertEqual(parse_version(version), parts)
+        self.assertEqual(parse_version(version), FlockerVersion(**parts))
 
     def test_release(self):
         """
         When the version is from a release, the documentation version is left
         unchanged.
         """
-        self.assertParsedVersion('0.3.2', release='0.3.2')
+        self.assertParsedVersion('0.3.2')
 
     def test_development_vesion(self):
         """
@@ -41,16 +43,16 @@ class ParseVersionTests(SynchronousTestCase):
         version is left unchanged.
         """
         self.assertParsedVersion('0.3.2-1-gf661a6a',
-                                 release='0.3.2',
-                                 development='-1-gf661a6a')
+                                 commit_count='1',
+                                 commit_hash='f661a6a')
 
     def test_dirty(self):
         """
         When the version is dirty, the documentation version is left unchanged.
         """
         self.assertParsedVersion('0.3.2-1-gf661a6a-dirty',
-                                 release='0.3.2',
-                                 development='-1-gf661a6a',
+                                 commit_count='1',
+                                 commit_hash='f661a6a',
                                  dirty='-dirty')
 
     def test_doc(self):
@@ -59,8 +61,7 @@ class ParseVersionTests(SynchronousTestCase):
         '+doc.X' is stripped.
         """
         self.assertParsedVersion('0.3.2+doc.11',
-                                 release='0.3.2',
-                                 doc='11')
+                                 documentation_revision='11')
 
     def test_doc_dirty(self):
         """
@@ -68,8 +69,7 @@ class ParseVersionTests(SynchronousTestCase):
         version is left unchanged.
         """
         self.assertParsedVersion('0.3.2+doc.11-dirty',
-                                 release='0.3.2',
-                                 doc='11',
+                                 documentation_revision='11',
                                  dirty='-dirty')
 
 

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -57,16 +57,16 @@ class ParseVersionTests(SynchronousTestCase):
 
     def test_doc(self):
         """
-        When the documentation version is from a doc release, the trailing
-        '+doc.X' is stripped.
+        When the documentation version is from a documentation release, the
+        trailing '+doc.X' is stripped.
         """
         self.assertParsedVersion('0.3.2+doc.11',
                                  documentation_revision='11')
 
     def test_doc_dirty(self):
         """
-        When the version is from a doc release but is dirty, the documentation
-        version is left unchanged.
+        When the version is from a documentation release but is dirty, the
+        documentation version is left unchanged.
         """
         self.assertParsedVersion('0.3.2+doc.11-dirty',
                                  documentation_revision='11',
@@ -102,15 +102,15 @@ class GetDocVersionTests(SynchronousTestCase):
 
     def test_doc(self):
         """
-        When the documentation version is from a doc release, the trailing
-        '+doc.X' is stripped.
+        When the documentation version is from a documentation release, the
+        trailing '+doc.X' is stripped.
         """
         self.assertEqual(get_doc_version('0.3.2+doc.11'), '0.3.2')
 
     def test_doc_dirty(self):
         """
-        When the version is from a doc release but is dirty, the documentation
-        version is left unchanged.
+        When the version is from a documentation release but is dirty, the
+        documentation version is left unchanged.
         """
         self.assertEqual(get_doc_version('0.3.2+doc.0-dirty'),
                          '0.3.2+doc.0-dirty')
@@ -141,13 +141,13 @@ class IsReleaseTests(SynchronousTestCase):
 
     def test_doc(self):
         """
-        When the documentation version is from a doc release, it is a release.
-        """
+        When the documentation version is from a documentation release, it is a
+        release.  """
         self.assertTrue(is_release('0.3.2+doc.11'))
 
     def test_doc_dirty(self):
         """
-        When the version is from a doc release but is dirty, it isn't a
-        release.
+        When the version is from a documentation release but is dirty, it isn't
+        a release.
         """
         self.assertFalse(is_release('0.3.2+doc.0-dirty'))

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -74,9 +74,9 @@ class ParseVersionTests(SynchronousTestCase):
     def test_doc(self):
         """
         When the documentation version is from a documentation release, the
-        trailing '+doc.X' is stripped.
+        trailing '+docX' is stripped.
         """
-        self.assertParsedVersion('0.3.2+doc.11',
+        self.assertParsedVersion('0.3.2+doc11',
                                  documentation_revision='11')
 
     def test_doc_dirty(self):
@@ -84,7 +84,7 @@ class ParseVersionTests(SynchronousTestCase):
         When the version is from a documentation release but is dirty, the
         documentation version is left unchanged.
         """
-        self.assertParsedVersion('0.3.2+doc.11-dirty',
+        self.assertParsedVersion('0.3.2+doc11-dirty',
                                  documentation_revision='11',
                                  dirty='-dirty')
 
@@ -133,17 +133,17 @@ class GetDocVersionTests(SynchronousTestCase):
     def test_doc(self):
         """
         When the documentation version is from a documentation release, the
-        trailing '+doc.X' is stripped.
+        trailing '+docX' is stripped.
         """
-        self.assertEqual(get_doc_version('0.3.2+doc.11'), '0.3.2')
+        self.assertEqual(get_doc_version('0.3.2+doc11'), '0.3.2')
 
     def test_doc_dirty(self):
         """
         When the version is from a documentation release but is dirty, the
         documentation version is left unchanged.
         """
-        self.assertEqual(get_doc_version('0.3.2+doc.0-dirty'),
-                         '0.3.2+doc.0-dirty')
+        self.assertEqual(get_doc_version('0.3.2+doc0-dirty'),
+                         '0.3.2+doc0-dirty')
 
 
 class IsReleaseTests(SynchronousTestCase):
@@ -185,11 +185,11 @@ class IsReleaseTests(SynchronousTestCase):
         """
         When the documentation version is from a documentation release, it is a
         release.  """
-        self.assertTrue(is_release('0.3.2+doc.11'))
+        self.assertTrue(is_release('0.3.2+doc11'))
 
     def test_doc_dirty(self):
         """
         When the version is from a documentation release but is dirty, it isn't
         a release.
         """
-        self.assertFalse(is_release('0.3.2+doc.0-dirty'))
+        self.assertFalse(is_release('0.3.2+doc0-dirty'))

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -1,7 +1,7 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
 """
-Test for :module:`flocker.docs.version`.
+Tests for :module:`flocker.docs.version`.
 """
 
 
@@ -15,7 +15,7 @@ from .._version import (
 
 class ParseVersionTests(SynchronousTestCase):
     """
-    Test for :function:`parse_version`.
+    Tests for :function:`parse_version`.
     """
     def assertParsedVersion(self, version, **expected_parts):
         """
@@ -75,7 +75,7 @@ class ParseVersionTests(SynchronousTestCase):
 
 class GetDocVersionTests(SynchronousTestCase):
     """
-    Test for :function:`get_doc_version`.
+    Tests for :function:`get_doc_version`.
     """
 
     def test_release(self):
@@ -118,7 +118,7 @@ class GetDocVersionTests(SynchronousTestCase):
 
 class IsReleaseTests(SynchronousTestCase):
     """
-    Test for :function:`is_release`.
+    Tests for :function:`is_release`.
     """
 
     def test_release(self):

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -1,0 +1,51 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Test for :module:`flocker.docs.version`.
+"""
+
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from .._version import get_version
+
+
+class GetVersionTests(SynchronousTestCase):
+    """
+    Test for :function:`get_version`.
+    """
+
+    def test_release(self):
+        """
+        When the version is from a release, the version is left unchanged.
+        """
+        self.assertEqual(get_version('0.3.2'), '0.3.2')
+
+    def test_development_vesion(self):
+        """
+        When the version is from a development version, the version is left
+        unchanged.
+        """
+        self.assertEqual(get_version('0.3.2-1-gf661a6a'), '0.3.2-1-gf661a6a')
+
+    def test_dirty(self):
+        """
+        When the version is dirty, the version is left unchanged.
+        """
+        self.assertEqual(get_version('0.3.2-1-gf661a6a-dirty'),
+                         '0.3.2-1-gf661a6a-dirty')
+
+    def test_doc(self):
+        """
+        When the version is from a doc release, the trailing '+doc.X' is
+        stripped.
+        """
+        self.assertEqual(get_version('0.3.2+doc.11'), '0.3.2')
+
+    def test_doc_dirty(self):
+        """
+        When the version is from a doc release but is dirty, the version is
+        left unchanged.
+        """
+        self.assertEqual(get_version('0.3.2+doc.0.dirty'),
+                         '0.3.2+doc.0.dirty')

--- a/flocker/docs/test/test_version.py
+++ b/flocker/docs/test/test_version.py
@@ -30,12 +30,28 @@ class ParseVersionTests(SynchronousTestCase):
         parts.update(expected_parts)
         self.assertEqual(parse_version(version), FlockerVersion(**parts))
 
-    def test_release(self):
+    def test_marketing_release(self):
         """
-        When the version is from a release, the documentation version is left
-        unchanged.
+        When the version is from a marketing release, the documentation version
+        is left unchanged.
         """
         self.assertParsedVersion('0.3.2')
+
+    def test_weekly_release(self):
+        """
+        When the version is from a weekly release, the documentation version
+        is left unchanged.
+        """
+        self.assertParsedVersion('0.3.2dev1',
+                                 weekly_release='1')
+
+    def test_pre_release(self):
+        """
+        When the version is from a pre-release, the documentation version
+        is left unchanged.
+        """
+        self.assertParsedVersion('0.3.2pre1',
+                                 pre_release='1')
 
     def test_development_vesion(self):
         """
@@ -78,12 +94,26 @@ class GetDocVersionTests(SynchronousTestCase):
     Tests for :function:`get_doc_version`.
     """
 
-    def test_release(self):
+    def test_marketing_release(self):
         """
-        When the version is from a release, the documentation version is left
-        unchanged.
+        When the version is from a marketing release, the documentation version
+        is left unchanged.
         """
         self.assertEqual(get_doc_version('0.3.2'), '0.3.2')
+
+    def test_weekly_release(self):
+        """
+        When the version is from a weekly release, the documentation version
+        is left unchanged.
+        """
+        self.assertEqual(get_doc_version('0.3.2dev1'), '0.3.2dev1')
+
+    def test_pre_release(self):
+        """
+        When the version is from a pre-release, the documentation version
+        is left unchanged.
+        """
+        self.assertEqual(get_doc_version('0.3.2pre1'), '0.3.2pre1')
 
     def test_development_vesion(self):
         """
@@ -121,11 +151,23 @@ class IsReleaseTests(SynchronousTestCase):
     Tests for :function:`is_release`.
     """
 
-    def test_release(self):
+    def test_marketing_release(self):
         """
-        When the version is from a release, it is a release.
+        When the version is from a marketing release, it is a release.
         """
         self.assertTrue(is_release('0.3.2'))
+
+    def test_weekly_release(self):
+        """
+        When the version is from a weekly release, it isn't a release.
+        """
+        self.assertFalse(is_release('0.3.2dev1'))
+
+    def test_pre_release(self):
+        """
+        When the version is from a pre-release, it isn't a release.
+        """
+        self.assertFalse(is_release('0.3.2pre1'))
 
     def test_development_vesion(self):
         """


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1252

I decided that we should tag documentation releases (with `+doc.X`). This is stripped in the documentation.