### PR TITLE
Pull a couple more images.

### DIFF
--- a/vagrant/tutorial/cache.sh
+++ b/vagrant/tutorial/cache.sh
@@ -13,5 +13,7 @@ echo "TMPDIR=/var/tmp" >> /etc/sysconfig/docker
 # Restart docker to ensure that it picks up the new tmpdir configuration.
 systemctl restart docker
 
-docker pull busybox
-docker pull clusterhq/mongodb
+for image in busybox clusterhq/mongodb dockerfile/redis clusterhq/flask; do
+    docker pull "${image}"
+done
+


### PR DESCRIPTION
Fixes FLOC-1295

After this is merged it will probably be necessary to re-build the tutorial box for 0.3.2 and upload it to the appropriate place (manually).

The command to re-build the tutorial box is:

```
./build-vagrant-box --box tutorial --flocker-version 0.3.2
```

This needs to be run from a release/flocker-0.3.2 checkout to pick up the changes made here.

This also needs to happen **after** the Docker 1.4.1/Fedora regression is fixed somehow.