### PR TITLE
[FLOC-1366] [FLOC-1363] packaging: Get version from package.__version__ instead of pip.

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -761,7 +761,7 @@ def omnibus_package_builder(
     virtualenv = VirtualEnv(root=virtualenv_dir)
 
     get_package_version_step = GetPackageVersion(
-        virtualenv=virtualenv, package_name='Flocker')
+        virtualenv=virtualenv, package_name='flocker')
     rpm_version = DelayedRpmVersion(
         package_version_step=get_package_version_step)
 

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -391,12 +391,7 @@ class CreateLinks(object):
 class GetPackageVersion(object):
     """
     Record the version of ``package_name`` installed in ``virtualenv_path`` by
-    parsing the output of ``pip show``.
-
-    XXX: This wouldn't be necessary if pip had a way to report the version of
-    the package that it is about to install eg
-    ``pip install --dry-run http://www.example.com/my/wheel.whl``
-    See: https://github.com/pypa/pip/issues/53
+    examining ``<package_name>.__version__``.
 
     :ivar VirtualEnv virtualenv: The ``virtualenv`` containing the package.
     :ivar bytes package_name: The name of the package whose version will be
@@ -409,20 +404,15 @@ class GetPackageVersion(object):
     version = None
 
     def run(self):
-        # We can't just call pip directly, because in the virtualenvs created
-        # in tests, the shebang line becomes too long and triggers an
-        # error. See http://www.in-ulm.de/~mascheck/various/shebang/#errors
         python_path = self.virtualenv.root.child('bin').child('python').path
         output = check_output(
-            [python_path, '-m', 'pip', 'show', self.package_name])
+            [python_path,
+             '-c', '; '.join([
+                 'from sys import stdout',
+                 'stdout.write(__import__(%r).__version__)' % self.package_name
+             ])])
 
-        for line in output.splitlines():
-            parts = [part.strip() for part in line.split(':', 1)]
-            if len(parts) == 2:
-                key, value = parts
-                if key.lower() == 'version':
-                    self.version = value
-                    return
+        self.version = output
 
 
 @attributes([

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -859,7 +859,7 @@ class OmnibusPackageBuilderTests(TestCase):
         expected_package_uri = b'https://www.example.com/foo/Bar-1.2.3.whl'
         expected_package_version_step = GetPackageVersion(
             virtualenv=VirtualEnv(root=expected_virtualenv_path),
-            package_name='Flocker'
+            package_name='flocker'
         )
         expected_version = DelayedRpmVersion(
             package_version_step=expected_package_version_step

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -492,8 +492,15 @@ def canned_package(root):
         setup(
             name="{package_name}",
             version="{package_version}",
+            py_modules=["{package_name}"],
         )
         """).format(package_name=name, package_version=version)
+    )
+    package_module = root.child(name + ".py")
+    package_module.setContent(
+        dedent("""
+        __version__ = "{package_version}"
+        """).format(package_version=version)
     )
 
     return PythonPackage(name=name, version=version)

--- a/admin/vagrant.py
+++ b/admin/vagrant.py
@@ -55,9 +55,10 @@ def vagrant_version(version):
     """
     Convert a python version to a version number acceptable to vagrant.
     """
-    # Vagrant doesn't like - in version numbers.
-    # It also doesn't like _ but we don't generate that.
-    return version.replace('-', '.')
+    # Vagrant doesn't like -, + or _ in version numbers.
+    return (version.replace('-', '.')
+                   .replace('_', '.')
+                   .replace('+', '.'))
 
 
 def box_metadata(name, version, path):


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1366
https://clusterhq.atlassian.net/browse/FLOC-1363

Pip (via setuptools) normalizes the version of the package according
to PEP440, if the version is a valid PEP440 version.

The version versioneer generates isn't a valid PEP440 version, except
- if we are building a tag, in which case a ``.`` is inserted before
  ``dev`` and ``pre`` is turned into ``.rc``
or
- if the latest tag is has a local part (e.g. ``+docX``), in which case,
  ``-`` after ``+`` are turned into ``.``.