### PR TITLE
Use extra to install flake8 in tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,10 @@ basepython = python2.7
 
 [testenv:lint]
 basepython = python2.7
-deps = flake8
 changedir = {toxinidir}
-commands = flake8 --exclude=_version.py,flocker/restapi/docs/hidden_code_block.py flocker
+commands =
+    pip install Flocker[dev]
+    flake8 --exclude=_version.py,flocker/restapi/docs/hidden_code_block.py flocker
 
 [testenv:sphinx]
 basepython = python2.7


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1372

Otherwise, we automatically get newer versions, which cause spurious failures.