### PR TITLE
Add whitespace into "Managing Volumes" section of docs/introduction.rst

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -116,6 +116,7 @@ Managing Volumes
   * Association is done based on container names.
 
 * Data model
+
   * Volumes are owned by a specific node.
 
   * Node A can push a copy to node B but node A still owns the volume.


### PR DESCRIPTION
Sphinx currently interprets it as continuing from the previous line ("Data Model") without the line break, and hence looks a tad ugly.

Link to current published docs for reference: https://docs.clusterhq.com/en/0.3.2/introduction.html#managing-volumes