### PR TITLE
[FLOC-1442] Update copyright and add test for current copyright

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,9 @@
 
 from twisted.python.filepath import FilePath
 
+import datetime
 import sys
 import os
-import re
 
 sys.path.insert(0, FilePath(__file__).parent().parent().path)
 
@@ -59,7 +59,12 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Flocker'
-copyright = u'2014, ClusterHQ'
+copyright = u'2014-2015 ClusterHQ'
+
+# If this assert fails, either update the copyright string above,
+# or, if the code is no longer being updated remove the assert.
+assert str(datetime.date.today().year) in copyright, \
+    'Copyright does not include current year'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Rather than attempt to update copyright automatically, this code causes the doc build to fail if the current year does not exisdt in the copyright. So, after New Year, doc tests will fail until someone changes the copyright (or removes the assert).

Design question - should this fail as above, or emit a warning (practically invisible to all but most observant watchers), or should we handle it a differewnt way?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1171)
<!-- Reviewable:end -->
