### PR TITLE
[FLOC-1464] Continuous Integration for OS X Homebrew scripts

### DIFF
--- a/admin/homebrew.py
+++ b/admin/homebrew.py
@@ -6,6 +6,7 @@ Create a Homebrew recipe for Flocker, using the VERSION environment variable.
 Inspired by https://github.com/tdsmith/labmisc/blob/master/mkpydeps.
 """
 
+import sys
 from os import environ
 from json import load
 from urllib2 import HTTPError, urlopen
@@ -132,13 +133,15 @@ def get_resource_stanzas(dependency_graph):
 
 def main():
     """
-    Print a Homebrew recipe for Flocker, using the VERSION environment
-    variable.
+    Print a Homebrew recipe for the Flocker distribution.
     """
     version = get_version()
-    url = (b"https://storage.googleapis.com/archive.clusterhq.com/"
-           "downloads/flocker/Flocker-{version}.tar.gz").format(
-               version=version)
+    if len(sys.argv) < 2:
+        url = (b"https://storage.googleapis.com/archive.clusterhq.com/"
+               "downloads/flocker/Flocker-{version}.tar.gz").format(
+                   version=version)
+    else:
+        url = sys.argv[1]
 
     dependency_graph = get_dependency_graph(u"flocker")
 
@@ -169,7 +172,7 @@ class {class_name} < Formula
     system "#{{bin}}/flocker-deploy", "--version"
   end
 end
-""".format(version=version, url=url, sha1=get_checksum(url),
+""".format(url=url, sha1=get_checksum(url),
            class_name=get_class_name(version),
            resources=get_resource_stanzas(dependency_graph),
            dependencies=get_formatted_dependency_list(dependency_graph))


### PR DESCRIPTION
Allow the path to the Flocker source distribution to be specified on the command line for the `admin/homebrew.py` code.  This allows the recipe to be created and tested based on a local source distribution, rather than requiring upload to a repository.  With this change, the Homebrew recipe can be tested using the following commands:

```
# Install pip, via the brew version of Python
brew install python
# Clone a copy of Flocker - may specify tag / SHA here
git clone https://github.com/ClusterHQ/flocker.git
cd flocker/
git checkout homebrew-recipe-FLOC-1464
pip install virtualenv
virtualenv vbuild
source ./vbuild/bin/activate
# Stop complaints about non-PEP440 versions
pip install --upgrade 'setuptools<8.0'
# get dependencies to run admin.homebrew
pip install -e .[release]
python setup.py sdist
# Use fake version number to avoid problems with Homebrew's name mangling
export VERSION=1
python -m admin.homebrew "file:///Users/ClusterHQVM/flocker/dist/Flocker-`python setup.py --version`.tar.gz" > Flocker1.rb
deactivate
cd
virtualenv vtest
source ./vtest/bin/activate
brew update
brew install --verbose --debug flocker/Flocker1.rb
brew test flocker/Flocker1.rb
```

With a script like this available to the OS X guest, we require the OS X host to start the VM, trigger this script, passing in the appropriate Git commit SHA, and test the exit code. This would likely be a modification to the `start_homebrew_machine` script, using Fabric or Vagrant provisioning to run these commands.

To provide Continuous Integration, this modified host script can be started by the Buildbot slave running on the OS X host.