### PR TITLE
[FLOC-1392] Array APIs now get documented

### DIFF
--- a/flocker/control/schema/endpoints.yml
+++ b/flocker/control/schema/endpoints.yml
@@ -14,6 +14,7 @@ definitions:
     additionalProperties: false
 
   configuration_dataset:
+    description: "The configuration for a particular dataset."
     type: object
     properties:
       primary:
@@ -34,17 +35,15 @@ definitions:
 
   # A sequence of datasets
   configuration_datasets_array:
+    description: "An array of configuration datasets."
     type: array
-    items:
-      description: "An array of datasets"
-      type: object
-      oneOf:
-        - {"$ref": "#/definitions/configuration_dataset" }
+    items: {"$ref": "#/definitions/configuration_dataset" }
 
   state_datasets_array:
+    description: "An array of state datasets."
     type: array
     items:
-      description: "An array of datasets"
+      description: "The state of a particular dataset."
       type: object
       properties:
         primary:

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -184,23 +184,11 @@ def _introspectRoute(route, exampleByIdentifier, schema_store):
     inputSchema = route.attributes.get('inputSchema', None)
     outputSchema = route.attributes.get('outputSchema', None)
     if inputSchema:
-        # _parseSchema doesn't handle all JSON Schema yet
-        # Fail softly by simply not including the documentation
-        # for it.
-        # https://clusterhq.atlassian.net/browse/FLOC-1171
-        try:
-            result['input'] = _parseSchema(inputSchema, schema_store)
-        except:
-            pass
+        result['input'] = _parseSchema(inputSchema, schema_store)
         result["input_schema"] = inputSchema
 
     if outputSchema:
-        # See above
-        # https://clusterhq.atlassian.net/browse/FLOC-1171
-        try:
-            result['output'] = _parseSchema(outputSchema, schema_store)
-        except:
-            pass
+        result['output'] = _parseSchema(outputSchema, schema_store)
         result["output_schema"] = outputSchema
 
     examples = route.attributes.get("examples") or []

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -26,7 +26,7 @@ from twisted.python.filepath import FilePath
 
 from characteristic import attributes
 
-from .._schema import LocalRefResolver, resolveSchema
+from .._schema import resolveSchema
 
 # Disable "HTTP Routing Table" index:
 httpdomain.HTTPDomain.indices = []

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -100,6 +100,10 @@ def _parseSchema(schema, schema_store):
     """
     Parse a JSON Schema and return some information to document it.
 
+    This supports only two kinds of schemas: objects, and arrays of a
+    single kind of object. If your schema is more complex you may need to
+    expand this code to address that.
+
     @param schema: L{dict} representing a JSON Schema.
 
     @param dict schema_store: A mapping between schema paths
@@ -126,8 +130,6 @@ def _parseSchema(schema, schema_store):
         fill_in_result(schema)
     elif schema[u"type"] == u"array":
         result["type"] = "array"
-        # Assume children of array are objects, and there's only one
-        # kind allowed.
         child_schema = schema[u"items"]
         if child_schema.get("type") == "object":
             fill_in_result(child_schema)
@@ -202,6 +204,8 @@ def _introspectRoute(route, exampleByIdentifier, schema_store):
 def _formatSchema(data, incoming):
     """
     Generate the rst associated to a JSON schema.
+
+    See sphinxcontrib-httpdomain documentation for details.
 
     :param data: See L{inspectRoute}.
     :param bool incoming: If True, this is request parameter, otherwise
@@ -324,14 +328,10 @@ def _formatRouteBody(data, schema_store):
             yield line
 
     if 'input' in data:
-        # <json is what sphinxcontrib-httpdomain wants to call "json in a
-        # request body"
         for line in _formatSchema(data['input'], True):
             yield line
 
     if 'output' in data:
-        # >json is what sphinxcontrib-httpdomain wants to call "json in a
-        # response body"
         for line in _formatSchema(data['output'], False):
             yield line
 

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -335,7 +335,7 @@ class MakeRstTests(SynchronousTestCase):
             },
         }}
 
-    def test_ouputSchema(self):
+    def test_outputSchema(self):
         """
         The generated API documentation includes the output schema.
         """
@@ -407,9 +407,10 @@ class MakeRstTests(SynchronousTestCase):
             },
         }}
 
-    def test_ouputArraySchema(self):
+    def test_outputArraySchema(self):
         """
-        The generated API documentation includes the output schema.
+        The generated API documentation includes the output schema in cases
+        where the output is an array.
         """
         app = Klein()
 

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -283,7 +283,7 @@ class MakeRstTests(SynchronousTestCase):
 
         rest = list(makeRst(b"/prefix", app, None, self.INPUT_ARRAY_SCHEMAS))
 
-        self.assertEqual(rest, [
+        self.assertListEqual(rest, [
             '',
             '.. http:get:: /prefix/',
             '',
@@ -295,7 +295,7 @@ class MakeRstTests(SynchronousTestCase):
             '   ',
             '       {',
             '           "$schema": "http://json-schema.org/draft-04/schema#",',
-            '           "items":',
+            '           "items": {',
             '               "properties": {',
             '                   "param": {',
             '                       "description": "one\\ntwo",',
@@ -308,10 +308,9 @@ class MakeRstTests(SynchronousTestCase):
             '               ],',
             '               "type": "object"',
             '           },',
-            '       "type": "array"',
+            '           "type": "array"',
             '       }',
             '   ',
-            # YAML is unorderd :(
             '   :<jsonarr string param: *(required)* TITLE',
             '   ',
             '      one',
@@ -425,9 +424,9 @@ class MakeRstTests(SynchronousTestCase):
             Developer docs,
             """
 
-        rest = list(makeRst(b"/prefix", app, None, self.OUTPUT_SCHEMAS))
+        rest = list(makeRst(b"/prefix", app, None, self.OUTPUT_ARRAY_SCHEMAS))
 
-        self.assertEqual(rest, [
+        self.assertListEqual(rest, [
             '',
             '.. http:get:: /prefix/',
             '',
@@ -439,7 +438,7 @@ class MakeRstTests(SynchronousTestCase):
             '   ',
             '       {',
             '           "$schema": "http://json-schema.org/draft-04/schema#",',
-            '           "items": {'
+            '           "items": {',
             '               "properties": {',
             '                   "param": {',
             '                       "description": "one\\ntwo",',
@@ -450,7 +449,7 @@ class MakeRstTests(SynchronousTestCase):
             '               "required": [',
             '                   "param"',
             '               ],',
-            '               "type": "object",',
+            '               "type": "object"',
             '           },',
             '           "type": "array"',
             '       }',


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1392

To review visually, compare documentation for `GET /v1/configuration/datasets` and `GET /v1/state/datasets` in build results and in http://doc-dev.clusterhq.com/advanced/api.html