### PR TITLE
[FLOC-1535] Update cluster local state before supplying it to calculate_necessary_state_changes

### DIFF
--- a/flocker/node/__init__.py
+++ b/flocker/node/__init__.py
@@ -4,8 +4,8 @@
 Local node manager for Flocker.
 """
 
-from ._deploy import P2PNodeDeployer, change_node_state
+from ._deploy import P2PNodeDeployer, change_node_state, IDeployer
 
 __all__ = [
-    'P2PNodeDeployer', 'change_node_state'
+    'P2PNodeDeployer', 'change_node_state', 'IDeployer'
 ]

--- a/flocker/node/__init__.py
+++ b/flocker/node/__init__.py
@@ -4,8 +4,10 @@
 Local node manager for Flocker.
 """
 
-from ._deploy import P2PNodeDeployer, change_node_state, IDeployer
+from ._deploy import (
+    P2PNodeDeployer, change_node_state, IDeployer, IStateChange
+)
 
 __all__ = [
-    'P2PNodeDeployer', 'change_node_state', 'IDeployer'
+    'P2PNodeDeployer', 'change_node_state', 'IDeployer', 'IStateChange'
 ]

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -546,11 +546,6 @@ class P2PNodeDeployer(object):
 
         :return: A ``IStateChange`` provider.
         """
-        # Current cluster state is likely out of date as regards the
-        # local state, so update it accordingly:
-        current_cluster_state = current_cluster_state.update_node(
-            local_state.to_node())
-
         phases = []
 
         desired_proxies = set()

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -266,7 +266,9 @@ class ConvergenceLoop(object):
         def got_local_state(local_state):
             # Current cluster state is likely out of date as regards the
             # local state, so update it accordingly:
-            self.cluster_state = self.cluster_state.update_node(local_state.to_node())
+            # self.cluster_state = self.cluster_state.update_node(
+            #     local_state.to_node()
+            # )
             self.client.callRemote(NodeStateCommand, node_state=local_state)
             action = self.deployer.calculate_necessary_state_changes(
                 local_state, self.configuration, self.cluster_state
@@ -291,7 +293,7 @@ class ConvergenceLoop(object):
         # https://clusterhq.atlassian.net/browse/FLOC-1357
 
 
-def build_convergence_loop_fsm(reactor, deployer, loop_factory=ConvergenceLoop):
+def build_convergence_loop_fsm(reactor, deployer):
     """
     Create a convergence loop FSM.
 
@@ -319,10 +321,10 @@ def build_convergence_loop_fsm(reactor, deployer, loop_factory=ConvergenceLoop):
             I.ITERATION_DONE: ([], S.STOPPED),
         })
 
-    loop = loop_factory(reactor, deployer)
+    loop = ConvergenceLoop(reactor, deployer)
     fsm = constructFiniteStateMachine(
         inputs=I, outputs=O, states=S, initial=S.STOPPED, table=table,
-        richInputs=[_ClientStatusUpdate], inputContext={},
+        richInputs=[_ClientStatusUpdate], inputContext ={},
         world=MethodSuffixOutputer(loop))
     loop.fsm = fsm
     return fsm

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -264,6 +264,10 @@ class ConvergenceLoop(object):
         d = self.deployer.discover_local_state()
 
         def got_local_state(local_state):
+            # Update cluster_state here and then no need to pass local state to calculate_necessary_state_changes.
+            # Avoids having to modify all IDeployers and needs only one test.
+            # Add unit test for ConvergenceLoop
+            self.cluster_state = self.cluster_state.update_node(local_state.to_node())
             self.client.callRemote(NodeStateCommand, node_state=local_state)
             action = self.deployer.calculate_necessary_state_changes(
                 local_state, self.configuration, self.cluster_state

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -264,9 +264,8 @@ class ConvergenceLoop(object):
         d = self.deployer.discover_local_state()
 
         def got_local_state(local_state):
-            # Update cluster_state here and then no need to pass local state to calculate_necessary_state_changes.
-            # Avoids having to modify all IDeployers and needs only one test.
-            # Add unit test for ConvergenceLoop
+            # Current cluster state is likely out of date as regards the
+            # local state, so update it accordingly:
             self.cluster_state = self.cluster_state.update_node(local_state.to_node())
             self.client.callRemote(NodeStateCommand, node_state=local_state)
             action = self.deployer.calculate_necessary_state_changes(

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -264,8 +264,8 @@ class ConvergenceLoop(object):
         d = self.deployer.discover_local_state()
 
         def got_local_state(local_state):
-            # Current cluster state is likely out of date as regards the
-            # local state, so update it accordingly:
+            # Current cluster state is likely out of date as regards the local
+            # state, so update it accordingly:
             self.cluster_state = self.cluster_state.update_node(
                 local_state.to_node()
             )

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -324,7 +324,7 @@ def build_convergence_loop_fsm(reactor, deployer):
     loop = ConvergenceLoop(reactor, deployer)
     fsm = constructFiniteStateMachine(
         inputs=I, outputs=O, states=S, initial=S.STOPPED, table=table,
-        richInputs=[_ClientStatusUpdate], inputContext ={},
+        richInputs=[_ClientStatusUpdate], inputContext={},
         world=MethodSuffixOutputer(loop))
     loop.fsm = fsm
     return fsm

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -266,7 +266,8 @@ class ConvergenceLoop(object):
         def got_local_state(local_state):
             self.client.callRemote(NodeStateCommand, node_state=local_state)
             action = self.deployer.calculate_necessary_state_changes(
-                local_state, self.configuration, self.cluster_state)
+                local_state, self.configuration, self.cluster_state
+            )
             return action.run(self.deployer)
         d.addCallback(got_local_state)
 
@@ -287,7 +288,7 @@ class ConvergenceLoop(object):
         # https://clusterhq.atlassian.net/browse/FLOC-1357
 
 
-def build_convergence_loop_fsm(reactor, deployer):
+def build_convergence_loop_fsm(reactor, deployer, loop_factory=ConvergenceLoop):
     """
     Create a convergence loop FSM.
 
@@ -315,7 +316,7 @@ def build_convergence_loop_fsm(reactor, deployer):
             I.ITERATION_DONE: ([], S.STOPPED),
         })
 
-    loop = ConvergenceLoop(reactor, deployer)
+    loop = loop_factory(reactor, deployer)
     fsm = constructFiniteStateMachine(
         inputs=I, outputs=O, states=S, initial=S.STOPPED, table=table,
         richInputs=[_ClientStatusUpdate], inputContext={},

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -266,9 +266,9 @@ class ConvergenceLoop(object):
         def got_local_state(local_state):
             # Current cluster state is likely out of date as regards the
             # local state, so update it accordingly:
-            # self.cluster_state = self.cluster_state.update_node(
-            #     local_state.to_node()
-            # )
+            self.cluster_state = self.cluster_state.update_node(
+                local_state.to_node()
+            )
             self.client.callRemote(NodeStateCommand, node_state=local_state)
             action = self.deployer.calculate_necessary_state_changes(
                 local_state, self.configuration, self.cluster_state

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -18,6 +18,7 @@ from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.python.filepath import FilePath
 
 from .. import P2PNodeDeployer, change_node_state
+from ..testtools import ControllableDeployer
 from ...control import (
     Application, DockerImage, Deployment, Node, Port, Link,
     NodeState)
@@ -3408,6 +3409,19 @@ class P2PNodeDeployerInterfaceTests(ideployer_tests_factory(
                                      create_volume_service(test),
                                      FakeDockerClient(),
                                      make_memory_network()))):
+    """
+    ``IDeployer`` tests for ``P2PNodeDeployer``.
+    """
+
+
+class ControllableDeployerInterfaceTests(
+        ideployer_tests_factory(
+            lambda test: ControllableDeployer(
+                local_states=[],
+                calculated_actions=[],
+            )
+        )
+):
     """
     ``IDeployer`` tests for ``P2PNodeDeployer``.
     """

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -2799,46 +2799,6 @@ class DeployerCalculateNecessaryStateChangesDatasetOnlyTests(
         ])
         self.assertEqual(expected, changes)
 
-    def test_local_state_overrides_cluster_state(self):
-        """
-        ``P2PNodeDeployer.calculate_necessary_state_changes`` uses the given
-        local state to override cluster state, since the latter may be
-        stale.
-        """
-        volume_service = create_volume_service(self)
-        self.successResultOf(volume_service.create(
-            volume_service.get(_to_volume_name(DATASET_ID))))
-
-        docker = FakeDockerClient(units={})
-
-        current_node = Node(
-            hostname=u"node1.example.com",
-            manifestations={MANIFESTATION.dataset_id: MANIFESTATION},
-        )
-        desired_node = current_node
-
-        desired = Deployment(nodes=frozenset([desired_node]))
-        # This is at odds with local state, which knows that the dataset
-        # does actually exist:
-        current = Deployment(nodes=frozenset())
-
-        api = P2PNodeDeployer(
-            current_node.hostname,
-            volume_service, docker_client=docker,
-            network=make_memory_network()
-        )
-
-        changes = api.calculate_necessary_state_changes(
-            self.successResultOf(api.discover_local_state()),
-            desired_configuration=desired,
-            current_cluster_state=current,
-        )
-
-        # If P2PNodeDeployer is buggy and not overriding cluster state
-        # with local state this would result in a dataset creation action:
-        expected = Sequentially(changes=[])
-        self.assertEqual(expected, changes)
-
 
 class SetProxiesTests(SynchronousTestCase):
     """

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -147,11 +147,18 @@ DeleteDatasetTests = make_istatechange_tests(
     DeleteDataset,
     dict(dataset=Dataset(dataset_id=unicode(uuid4()))),
     dict(dataset=Dataset(dataset_id=unicode(uuid4()))))
-ControllableActionIStateChangeTests = make_istatechange_tests(
-    ControllableAction,
-    kwargs1=dict(result=1),
-    kwargs2=dict(result=2),
-)
+
+
+class ControllableActionIStateChangeTests(
+        make_istatechange_tests(
+            ControllableAction,
+            kwargs1=dict(result=1),
+            kwargs2=dict(result=2),
+        )
+):
+    """
+    Tests for ``ControllableAction``.
+    """
 
 
 NOT_CALLED = object()

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -160,9 +160,6 @@ class ControllableActionIStateChangeTests(
     """
 
 
-NOT_CALLED = object()
-
-
 class SequentiallyTests(SynchronousTestCase):
     """
     Tests for ``Sequentially``.
@@ -3001,9 +2998,12 @@ class ChangeNodeStateTests(SynchronousTestCase):
                               create_volume_service(self),
                               docker_client=FakeDockerClient(),
                               network=make_memory_network())
-        self.patch(api, "calculate_necessary_state_changes",
-                   lambda *args, **kwargs: succeed(
-                       ControllableAction(result=deferred))
+        self.patch(
+            api,
+            "calculate_necessary_state_changes",
+            lambda *args, **kwargs: succeed(
+                ControllableAction(result=deferred)
+            )
         )
         result = change_node_state(api, desired_configuration=EMPTY,
                                    current_cluster_state=EMPTY)

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -3417,11 +3417,11 @@ class P2PNodeDeployerInterfaceTests(ideployer_tests_factory(
 class ControllableDeployerInterfaceTests(
         ideployer_tests_factory(
             lambda test: ControllableDeployer(
-                local_states=[],
-                calculated_actions=[],
+                local_states=[succeed(NodeState(hostname=b'192.0.2.123'))],
+                calculated_actions=[InParallel(changes=[])],
             )
         )
 ):
     """
-    ``IDeployer`` tests for ``P2PNodeDeployer``.
+    ``IDeployer`` tests for ``ControllableDeployer``.
     """

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -18,7 +18,7 @@ from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.python.filepath import FilePath
 
 from .. import P2PNodeDeployer, change_node_state
-from ..testtools import ControllableDeployer
+from ..testtools import ControllableDeployer, ControllableAction
 from ...control import (
     Application, DockerImage, Deployment, Node, Port, Link,
     NodeState)
@@ -147,6 +147,11 @@ DeleteDatasetTests = make_istatechange_tests(
     DeleteDataset,
     dict(dataset=Dataset(dataset_id=unicode(uuid4()))),
     dict(dataset=Dataset(dataset_id=unicode(uuid4()))))
+ControllableActionIStateChangeTests = make_istatechange_tests(
+    ControllableAction,
+    kwargs1=dict(result=1),
+    kwargs2=dict(result=2),
+)
 
 
 NOT_CALLED = object()

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -286,18 +286,22 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
 
     def test_convergence_done_notify(self):
         """
-        A FSM doing convergence that gets a discovery result send the
+        A FSM doing convergence that gets a discovery result, sends the
         discovered state to the control service using the last received
         client.
         """
-        local_state = object()
+        local_state = NodeState(hostname=b'192.0.2.123')
         client = self.successful_amp_client([local_state])
         action = ControllableAction(Deferred())
         deployer = ControllableDeployer([succeed(local_state)], [action])
         loop = build_convergence_loop_fsm(Clock(), deployer)
         loop.receive(_ClientStatusUpdate(client=client,
-                                         configuration=object(),
-                                         state=object()))
+                                         configuration=Deployment(
+                                             nodes=frozenset([local_state.to_node()])
+                                         ),
+                                         state=Deployment(
+                                             nodes=frozenset([local_state.to_node()])
+                                         )))
         self.assertEqual(client.calls, [(NodeStateCommand,
                                          dict(node_state=local_state))])
 

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -5,7 +5,6 @@ Tests for ``flocker.node._loop``.
 """
 
 from uuid import uuid4
-from zope.interface import implementer
 
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.test.proto_helpers import StringTransport, MemoryReactorClock
@@ -20,8 +19,7 @@ from .._loop import (
     ConvergenceLoopStates, build_convergence_loop_fsm, AgentLoopService,
     ClusterStatus, ConvergenceLoop,
     )
-from .._deploy import IStateChange
-from ..testtools import ControllableDeployer
+from ..testtools import ControllableDeployer, ControllableAction
 from ...control import NodeState, Deployment, Node, Manifestation, Dataset
 from ...control._protocol import NodeStateCommand, _AgentLocator, AgentAMP
 from ...control.test.test_protocol import iconvergence_agent_tests_factory
@@ -226,22 +224,6 @@ class ClusterStatusFSMTests(SynchronousTestCase):
         self.fsm.receive(_StatusUpdate(configuration=desired, state=state))
         # We never send anything to convergence loop FSM:
         self.assertConvergenceLoopInputted([])
-
-
-@implementer(IStateChange)
-class ControllableAction(object):
-    """
-    ``IStateChange`` whose results can be controlled.
-    """
-    def __init__(self, result):
-        self.result = result
-        self.called = False
-        self.deployer = None
-
-    def run(self, deployer):
-        self.called = True
-        self.deployer = deployer
-        return self.result
 
 
 class ConvergenceLoopFSMTests(SynchronousTestCase):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -474,9 +474,10 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         A FSM doing convergence that receives a stop input stops when the
         convergence iteration finishes.
         """
-        local_state = object()
-        configuration = object()
-        state = object()
+        local_state = NodeState(hostname=b'192.0.2.123')
+        configuration = Deployment(nodes=frozenset([local_state.to_node()]))
+        state = Deployment(nodes=frozenset([local_state.to_node()]))
+
         # Until this Deferred fires the first iteration won't finish:
         action = ControllableAction(Deferred())
         # Only one discovery result is configured, so a second attempt at

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -400,10 +400,10 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         After a short delay, an FSM completing the changes from one convergence
         iteration starts another iteration.
         """
-        local_state = object()
-        local_state2 = object()
-        configuration = object()
-        state = object()
+        local_state = NodeState(hostname=b'192.0.2.123')
+        local_state2 = NodeState(hostname=b'192.0.2.123')
+        configuration = Deployment(nodes=frozenset([local_state.to_node()]))
+        state = Deployment(nodes=frozenset([local_state.to_node()]))
         action = ControllableAction(succeed(None))
         # Because the second action result is unfired Deferred, the second
         # iteration will never finish; applying its changes waits for this

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -334,6 +334,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
             local_node_state.to_node()
         )
         [calculate_necessary_state_changes_inputs] = deployer.calculate_inputs
+
         (actual_local_state,
          actual_desired_configuration,
          actual_cluster_state) = calculate_necessary_state_changes_inputs

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -293,9 +293,8 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
 
     def test_convergence_done_update_local_state(self):
         """
-        An FSM doing convergence that gets a discovery result updates the local
-        representation of the cluster state before calculating necessary state
-        changes.
+        An FSM doing convergence that gets a discovery result supplies an
+        updated ``cluster_state`` to ``calculate_necessary_state_changes``.
         """
         local_node_hostname = u'192.0.2.123'
         # Control service reports that this node has no manifestations.

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -432,10 +432,10 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         client, desired configuration and cluster state, which are then
         used in next convergence iteration.
         """
-        local_state = object()
-        local_state2 = object()
-        configuration = object()
-        state = object()
+        local_state = NodeState(hostname=b'192.0.2.123')
+        local_state2 = NodeState(hostname=b'192.0.2.123')
+        configuration = Deployment(nodes=frozenset([local_state.to_node()]))
+        state = Deployment(nodes=frozenset([local_state.to_node()]))
         # Until this Deferred fires the first iteration won't finish:
         action = ControllableAction(Deferred())
         # Until this Deferred fires the second iteration won't finish:
@@ -452,8 +452,8 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         # Calculating actions happened, action is run, but waits for
         # Deferred to be fired... Meanwhile a new status update appears!
         client2 = self.successful_amp_client([local_state2])
-        configuration2 = object()
-        state2 = object()
+        configuration2 = Deployment(nodes=frozenset([local_state.to_node()]))
+        state2 = Deployment(nodes=frozenset([local_state.to_node()]))
         loop.receive(_ClientStatusUpdate(
             client=client2, configuration=configuration2, state=state2))
         # Action finally finishes, and we can move on to next iteration,

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -20,7 +20,8 @@ from .._loop import (
     ConvergenceLoopStates, build_convergence_loop_fsm, AgentLoopService,
     ClusterStatus, ConvergenceLoop,
     )
-from .._deploy import IDeployer, IStateChange
+from .._deploy import IStateChange
+from ..testtools import ControllableDeployer
 from ...control import NodeState, Deployment, Node, Manifestation, Dataset
 from ...control._protocol import NodeStateCommand, _AgentLocator, AgentAMP
 from ...control.test.test_protocol import iconvergence_agent_tests_factory
@@ -241,27 +242,6 @@ class ControllableAction(object):
         self.called = True
         self.deployer = deployer
         return self.result
-
-
-@implementer(IDeployer)
-class ControllableDeployer(object):
-    """
-    ``IDeployer`` whose results can be controlled.
-    """
-    def __init__(self, local_states, calculated_actions):
-        self.local_states = local_states
-        self.calculated_actions = calculated_actions
-        self.calculate_inputs = []
-
-    def discover_local_state(self):
-        return self.local_states.pop(0)
-
-    def calculate_necessary_state_changes(self, local_state,
-                                          desired_configuration,
-                                          cluster_state):
-        self.calculate_inputs.append(
-            (local_state, desired_configuration, cluster_state))
-        return self.calculated_actions.pop(0)
 
 
 class ConvergenceLoopFSMTests(SynchronousTestCase):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -274,7 +274,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         """
         local_state = NodeState(hostname=b'192.0.2.123')
         client = self.successful_amp_client([local_state])
-        action = ControllableAction(Deferred())
+        action = ControllableAction(result=Deferred())
         deployer = ControllableDeployer([succeed(local_state)], [action])
         loop = build_convergence_loop_fsm(Clock(), deployer)
         loop.receive(_ClientStatusUpdate(client=client,
@@ -308,7 +308,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
             manifestations=[discovered_manifestation]
         )
         client = self.successful_amp_client([local_node_state])
-        action = ControllableAction(Deferred())
+        action = ControllableAction(result=Deferred())
         deployer = ControllableDeployer([succeed(local_node_state)], [action])
 
         fsm = build_convergence_loop_fsm(Clock(), deployer)
@@ -340,7 +340,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         # Since this Deferred is unfired we never proceed to next
         # iteration; if we did we'd get exception from discovery since we
         # only configured one discovery result.
-        action = ControllableAction(Deferred())
+        action = ControllableAction(result=Deferred())
         deployer = ControllableDeployer([succeed(local_state)], [action])
         loop = build_convergence_loop_fsm(Clock(), deployer)
         loop.receive(_ClientStatusUpdate(
@@ -361,7 +361,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         local_state = NodeState(hostname=b'192.0.2.123')
         configuration = object()
         received_state = Deployment(nodes=frozenset())
-        action = ControllableAction(succeed(None))
+        action = ControllableAction(result=succeed(None))
         deployer = ControllableDeployer([succeed(local_state)], [action])
         client = self.successful_amp_client([local_state])
         reactor = Clock()
@@ -386,11 +386,11 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         local_state2 = NodeState(hostname=b'192.0.2.123')
         configuration = Deployment(nodes=frozenset([local_state.to_node()]))
         state = Deployment(nodes=frozenset([local_state.to_node()]))
-        action = ControllableAction(succeed(None))
+        action = ControllableAction(result=succeed(None))
         # Because the second action result is unfired Deferred, the second
         # iteration will never finish; applying its changes waits for this
         # Deferred to fire.
-        action2 = ControllableAction(Deferred())
+        action2 = ControllableAction(result=Deferred())
         deployer = ControllableDeployer(
             [succeed(local_state), succeed(local_state2)],
             [action, action2])
@@ -419,9 +419,9 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         configuration = Deployment(nodes=frozenset([local_state.to_node()]))
         state = Deployment(nodes=frozenset([local_state.to_node()]))
         # Until this Deferred fires the first iteration won't finish:
-        action = ControllableAction(Deferred())
+        action = ControllableAction(result=Deferred())
         # Until this Deferred fires the second iteration won't finish:
-        action2 = ControllableAction(Deferred())
+        action2 = ControllableAction(result=Deferred())
         deployer = ControllableDeployer(
             [succeed(local_state), succeed(local_state2)],
             [action, action2])
@@ -461,7 +461,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         state = Deployment(nodes=frozenset([local_state.to_node()]))
 
         # Until this Deferred fires the first iteration won't finish:
-        action = ControllableAction(Deferred())
+        action = ControllableAction(result=Deferred())
         # Only one discovery result is configured, so a second attempt at
         # discovery would fail:
         deployer = ControllableDeployer([succeed(local_state)],
@@ -510,9 +510,9 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         state = Deployment(nodes=frozenset([local_state.to_node()]))
 
         # Until this Deferred fires the first iteration won't finish:
-        action = ControllableAction(Deferred())
+        action = ControllableAction(result=Deferred())
         # Until this Deferred fires the second iteration won't finish:
-        action2 = ControllableAction(Deferred())
+        action2 = ControllableAction(result=Deferred())
         deployer = ControllableDeployer(
             [succeed(local_state), succeed(local_state2)],
             [action, action2])

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -299,9 +299,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         local_node_hostname = u'192.0.2.123'
         # Control service reports that this node has no manifestations.
         received_node = Node(hostname=local_node_hostname)
-        received_cluster_state = Deployment(
-            nodes=frozenset([received_node])
-        )
+        received_cluster_state = Deployment(nodes=[received_node])
         discovered_manifestation = Manifestation(
             dataset=Dataset(dataset_id=uuid4()),
             primary=True

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -313,9 +313,17 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         deployer = ControllableDeployer([succeed(local_node_state)], [action])
 
         fsm = build_convergence_loop_fsm(Clock(), deployer)
-        fsm.receive(_ClientStatusUpdate(client=client,
-                                        configuration=object(),
-                                        state=received_cluster_state))
+        fsm.receive(
+            _ClientStatusUpdate(
+                client=client,
+                # Configuration is unimportant here, but we are recreating a
+                # situation where the local state now matches the desired
+                # configuration but the control service is not yet aware that
+                # convergence has been reached.
+                configuration=Deployment(nodes=[local_node_state.to_node()]),
+                state=received_cluster_state
+            )
+        )
 
         expected_local_cluster_state = received_cluster_state.update_node(
             local_node_state.to_node()

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -522,10 +522,11 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         update continues on to to next convergence iteration (i.e. stop
         ends up being ignored).
         """
-        local_state = object()
-        local_state2 = object()
-        configuration = object()
-        state = object()
+        local_state = NodeState(hostname=b'192.0.2.123')
+        local_state2 = NodeState(hostname=b'192.0.2.123')
+        configuration = Deployment(nodes=frozenset([local_state.to_node()]))
+        state = Deployment(nodes=frozenset([local_state.to_node()]))
+
         # Until this Deferred fires the first iteration won't finish:
         action = ControllableAction(Deferred())
         # Until this Deferred fires the second iteration won't finish:
@@ -542,8 +543,8 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         # Calculating actions happened, action is run, but waits for
         # Deferred to be fired... Meanwhile a new status update appears!
         client2 = self.successful_amp_client([local_state2])
-        configuration2 = object()
-        state2 = object()
+        configuration2 = Deployment(nodes=frozenset([local_state.to_node()]))
+        state2 = Deployment(nodes=frozenset([local_state.to_node()]))
         loop.receive(ConvergenceLoopInputs.STOP)
         # And then another status update!
         loop.receive(_ClientStatusUpdate(

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -277,13 +277,17 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         action = ControllableAction(result=Deferred())
         deployer = ControllableDeployer([succeed(local_state)], [action])
         loop = build_convergence_loop_fsm(Clock(), deployer)
-        loop.receive(_ClientStatusUpdate(client=client,
-                                         configuration=Deployment(
-                                             nodes=frozenset([local_state.to_node()])
-                                         ),
-                                         state=Deployment(
-                                             nodes=frozenset([local_state.to_node()])
-                                         )))
+        loop.receive(
+            _ClientStatusUpdate(
+                client=client,
+                configuration=Deployment(
+                    nodes=frozenset([local_state.to_node()])
+                ),
+                state=Deployment(
+                    nodes=frozenset([local_state.to_node()])
+                )
+            )
+        )
         self.assertEqual(client.calls, [(NodeStateCommand,
                                          dict(node_state=local_state))])
 
@@ -327,7 +331,6 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
 
         self.assertEqual(expected_local_cluster_state, actual_cluster_state)
 
-
     def test_convergence_done_changes(self):
         """
         A FSM doing convergence that gets a discovery result starts applying
@@ -347,7 +350,9 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
             client=self.successful_amp_client([local_state]),
             configuration=configuration, state=received_state))
 
-        expected_local_state = received_state.update_node(local_state.to_node())
+        expected_local_state = received_state.update_node(
+            local_state.to_node()
+        )
         # Calculating actions happened, and result was run:
         self.assertEqual(
             (deployer.calculate_inputs, action.called),
@@ -369,7 +374,9 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         loop.receive(_ClientStatusUpdate(
             client=client, configuration=configuration, state=received_state))
 
-        expected_local_state = received_state.update_node(local_state.to_node())
+        expected_local_state = received_state.update_node(
+            local_state.to_node()
+        )
         # Calculating actions happened and the result was run.
         self.assertEqual(
             (deployer.calculate_inputs, client.calls),

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -13,7 +13,7 @@ from unittest import skipUnless
 from zope.interface import implementer
 
 from ._docker import BASE_DOCKER_API_URL
-from . import IDeployer
+from . import IDeployer, IStateChange
 from ..testtools import loop_until
 
 DOCKER_SOCKET_PATH = BASE_DOCKER_API_URL.split(':/')[-1]
@@ -70,6 +70,22 @@ def wait_for_unit_state(docker_client, unit_name, expected_activation_states):
         return responded
 
     return loop_until(check_if_in_states)
+
+
+@implementer(IStateChange)
+class ControllableAction(object):
+    """
+    ``IStateChange`` whose results can be controlled.
+    """
+    def __init__(self, result):
+        self.result = result
+        self.called = False
+        self.deployer = None
+
+    def run(self, deployer):
+        self.called = True
+        self.deployer = deployer
+        return self.result
 
 
 @implementer(IDeployer)

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -12,6 +12,8 @@ from unittest import skipUnless
 
 from zope.interface import implementer
 
+from characteristic import attributes
+
 from ._docker import BASE_DOCKER_API_URL
 from . import IDeployer, IStateChange
 from ..testtools import loop_until
@@ -73,14 +75,13 @@ def wait_for_unit_state(docker_client, unit_name, expected_activation_states):
 
 
 @implementer(IStateChange)
+@attributes(['result'])
 class ControllableAction(object):
     """
     ``IStateChange`` whose results can be controlled.
     """
-    def __init__(self, result):
-        self.result = result
-        self.called = False
-        self.deployer = None
+    called = False
+    deployer = None
 
     def run(self, deployer):
         self.called = True


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1535

We'd also planned to remove the `local_state` argument of `calculate_necessary_state_changes`, thinking that the `cluster_state` would have all the required information. But actually, the `NodeState` attributes `running` and `not_running` and `used_ports` are not available from `cluster_state`. It is a `Deployment` and  only has `Node` records. 

There should probably be a followup issue to create a `DeploymentState` record which has `NodeStates` rather than `Nodes` and a corresponding update to the control service and AMP protocol to broadcast `DeploymentState` records.