### PR TITLE
[FLOC-1547] Sort the expected logged errors before comparing

### DIFF
--- a/flocker/cli/functional/test_deploy_script.py
+++ b/flocker/cli/functional/test_deploy_script.py
@@ -198,8 +198,8 @@ class FlockerDeployConfigureSSHTests(TestCase):
         def check_logs(ignored_first_error):
             failures = self.flushLoggedErrors(ZeroDivisionError)
             self.assertEqual(
-                expected_errors,
-                [f.value for f in failures]
+                sorted(expected_errors),
+                sorted(f.value for f in failures)
             )
 
         result.addErrback(check_logs)


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1547

I couldn't reproduce the thread ordering problem locally, so introduced some time delays to force the issue.

I should probably remove those delays before merging.

Or alternatively, I could somehow chain the firing of failures so that the errors are logged in predictable order.

But probably not worth spending time on.