### PR TITLE
[FLOC-1490, FLOC-1494] Initial IBlockDeviceAPI and an initial Loopback implementation for creating, attaching and listing block devices

### DIFF
--- a/flocker/node/agents/__init__.py
+++ b/flocker/node/agents/__init__.py
@@ -1,0 +1,3 @@
+"""
+This package contains backend-specific agent implementations.
+"""

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -244,7 +244,8 @@ class LoopbackBlockDeviceAPI(object):
 
     def create_volume(self, size):
         """
-        Create a file of some size and put it in the ``unattached`` directory.
+        Create a "sparse" file of some size and put it in the ``unattached``
+        directory.
 
         See ``IBlockDeviceAPI.create_volume`` for parameter and return type
         documentation.
@@ -253,9 +254,10 @@ class LoopbackBlockDeviceAPI(object):
             blockdevice_id=unicode(uuid4()),
             size=size,
         )
-        self._unattached_directory.child(
+        with self._unattached_directory.child(
             volume.blockdevice_id.encode('ascii')
-        ).setContent(b'\0' * volume.size)
+        ).open('wb') as f:
+            f.truncate(size)
         return volume
 
     def _get(self, blockdevice_id):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -261,7 +261,9 @@ class LoopbackBlockDeviceAPI(object):
                 host_directory.makedirs()
             except OSError:
                 pass
-            old_path.moveTo(host_directory.child(blockdevice_id))
+            new_path = host_directory.child(blockdevice_id)
+            old_path.moveTo(new_path)
+            check_output(["losetup", "--find", new_path.path])
             attached_volume = volume.set(host=host)
             return attached_volume
 
@@ -304,7 +306,5 @@ class LoopbackBlockDeviceAPI(object):
         volume_path = self._attached_directory.descendant(
             [volume.host, volume.blockdevice_id]
         )
-        device_path = device_for_path(volume_path)
-
-        if device_path is not None:
-            return FilePath(device_path)
+        # May be None if the file hasn't been used for a loop device.
+        return device_for_path(volume_path)

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -284,7 +284,9 @@ class LoopbackBlockDeviceAPI(object):
         volume = self._get(blockdevice_id)
         if volume.host is None:
             old_path = self._unattached_directory.child(blockdevice_id)
-            host_directory = self._attached_directory.child(host.encode("utf-8"))
+            host_directory = self._attached_directory.child(
+                host.encode("utf-8")
+            )
             try:
                 host_directory.makedirs()
             except OSError:

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -240,12 +240,12 @@ class LoopbackBlockDeviceAPI(object):
         if volume.host is None:
             old_path = self._unattached_directory.child(blockdevice_id)
             host_directory = self._attached_directory.child(host)
-            attached_volume = volume.set(host=host)
             try:
                 host_directory.makedirs()
             except OSError:
                 pass
             old_path.moveTo(host_directory.child(blockdevice_id))
+            attached_volume = volume.set(host=host)
             return attached_volume
 
         raise AlreadyAttachedVolume(blockdevice_id)

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -47,6 +47,13 @@ class AlreadyAttachedVolume(VolumeException):
     """
 
 
+class UnattachedVolume(VolumeException):
+    """
+    An attempt was made to operate on an unattached volume but the operation
+    requires the volume to be attached.
+    """
+
+
 class IBlockDeviceAPI(Interface):
     """
     Common operations provided by all block device backends.
@@ -78,6 +85,16 @@ class IBlockDeviceAPI(Interface):
         List all the block devices available via the back end API.
 
         :returns: A ``list`` of ``BlockDeviceVolume``s.
+        """
+
+    def get_device_path(blockdevice_id):
+        """
+        Calculate the path at which ``blockdevice_id`` will be exposed on the
+        host when attached.
+
+        :param unicode blockdevice_id: The unique identifier for the block
+            device.
+        :returns: A ``FilePath`` for the device.
         """
 
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -81,7 +81,7 @@ class IBlockDeviceAPI(Interface):
 
         :param unicode blockdevice_id: The unique identifier for the block
             device being attached.
-        :param bytes host: The IP address of a host to attach the volume to.
+        :param unicode host: The IP address of a host to attach the volume to.
         :raises UnknownVolume: If the supplied ``blockdevice_id`` does not
             exist.
         :raises AlreadyAttachedVolume: If the supplied ``blockdevice_id`` is
@@ -118,12 +118,12 @@ class BlockDeviceVolume(PRecord):
 
     :ivar unicode blockdevice_id: The unique identifier of the block device.
     :ivar int size: The size, in bytes, of the block device.
-    :ivar bytes host: The IP address of the host to which the block device is
+    :ivar unicode host: The IP address of the host to which the block device is
         attached or ``None`` if it is currently unattached.
     """
     blockdevice_id = field(type=unicode, mandatory=True)
     size = field(type=int, mandatory=True)
-    host = field(type=(bytes, type(None)), initial=None)
+    host = field(type=(unicode, type(None)), initial=None)
 
 
 def _losetup_list_parse(output):
@@ -284,7 +284,7 @@ class LoopbackBlockDeviceAPI(object):
         volume = self._get(blockdevice_id)
         if volume.host is None:
             old_path = self._unattached_directory.child(blockdevice_id)
-            host_directory = self._attached_directory.child(host)
+            host_directory = self._attached_directory.child(host.encode("utf-8"))
             try:
                 host_directory.makedirs()
             except OSError:
@@ -316,7 +316,7 @@ class LoopbackBlockDeviceAPI(object):
             volumes.append(volume)
 
         for host_directory in self._root_path.child('attached').children():
-            host_name = host_directory.basename().encode('ascii')
+            host_name = host_directory.basename().decode('ascii')
             for child in host_directory.children():
 
                 volume = BlockDeviceVolume(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -82,6 +82,7 @@ class IBlockDeviceAPI(Interface):
 
         :param unicode blockdevice_id: The unique identifier for the block
             device being attached.
+        :param bytes host: The IP address of a host to attach the volume to.
         :raises UnknownVolume: If the supplied ``blockdevice_id`` does not
             exist.
         :raises AlreadyAttachedVolume: If the supplied ``blockdevice_id`` is

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -268,7 +268,15 @@ class LoopbackBlockDeviceAPI(object):
 
     def attach_volume(self, blockdevice_id, host):
         """
-        Move an existing ``unattached`` file into a per-host directory.
+        Move an existing ``unattached`` file into a per-host directory and
+        create a loopback device backed by that file.
+
+        Note: Although `mkfs` can format files directly and `mount` can mount
+        files directly (with the `-o loop` option), we want to simulate a real
+        block device which will be allocated a real block device file on the
+        host to which it is attached. This allows the consumer of this API to
+        perform formatting and mount operations exactly the same as for a real
+        block device.
 
         See ``IBlockDeviceAPI.attach_volume`` for parameter and return type
         documentation.
@@ -283,6 +291,8 @@ class LoopbackBlockDeviceAPI(object):
                 pass
             new_path = host_directory.child(blockdevice_id)
             old_path.moveTo(new_path)
+            # The --find option allocates the next available /dev/loopX device
+            # name to the device.
             check_output(["losetup", "--find", new_path.path])
             attached_volume = volume.set(host=host)
             return attached_volume

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -54,6 +54,9 @@ class UnattachedVolume(VolumeException):
     """
 
 
+# TODO: Introduce a non-blocking version of this interface and an automatic
+# thread-based wrapper for adapting this to the other.  Use that interface
+# anywhere being non-blocking is important (which is probably lots of places).
 class IBlockDeviceAPI(Interface):
     """
     Common operations provided by all block device backends.

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -123,11 +123,15 @@ def device_for_path(file_path):
     :returns: A ``FilePath`` to the loopback device if one is found, or
         ``None`` if no device exists.
     """
-    device_path = check_output(
-        ["losetup", "--noheadings", "--output", "name", "--associated",
+    # Omit the heading line.
+    # losetup from util-linux 2.24.2 provides a --noheadings option, but it's
+    # not available on Centos7 or Ubuntu 14.04.
+    device_paths = check_output(
+        ["losetup", "--output", "name", "--associated",
          file_path.path]
-    ).strip()
-    if device_path != b"":
+    ).splitlines()[1:]
+    if device_paths:
+        [device_path] = device_paths
         return FilePath(device_path.strip())
     return None
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -100,8 +100,8 @@ class IBlockDeviceAPI(Interface):
 
     def get_device_path(blockdevice_id):
         """
-        Return the path of the device through which ``blockdevice_id`` is
-        exposed on the host when attached.
+        Return the device path that has been allocated to the block device on
+        the host to which it is currently attached.
 
         :param unicode blockdevice_id: The unique identifier for the block
             device.

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -57,6 +57,7 @@ class UnattachedVolume(VolumeException):
 # TODO: Introduce a non-blocking version of this interface and an automatic
 # thread-based wrapper for adapting this to the other.  Use that interface
 # anywhere being non-blocking is important (which is probably lots of places).
+# See https://clusterhq.atlassian.net/browse/FLOC-1549
 class IBlockDeviceAPI(Interface):
     """
     Common operations provided by all block device backends.

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -89,14 +89,12 @@ class IBlockDeviceAPI(Interface):
 
     def get_device_path(blockdevice_id):
         """
-        Calculate the path at which ``blockdevice_id`` will be mounted on the
+        Calculate the path at which ``blockdevice_id`` will be exposed on the
         host when attached.
 
         :param unicode blockdevice_id: The unique identifier for the block
             device.
-        :returns: A ``BlockDeviceVolume`` with a ``host`` attribute set to
-            ``host``.
-
+        :returns: A ``FilePath`` for the device.
         """
 
 
@@ -180,6 +178,11 @@ class LoopbackBlockDeviceAPI(object):
             pass
 
     def get_device_path(self, blockdevice_id):
+        """
+        For this loopback implementation, we create a new loop device if one
+        does not already exist or return the loop device that is already
+        associated with the block device backing file.
+        """
         volume = self._get(blockdevice_id)
 
         if volume.host is not None:

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -127,7 +127,7 @@ class BlockDeviceVolume(PRecord):
     host = field(type=(bytes, type(None)), initial=None)
 
 
-def losetup_list_parse(output):
+def _losetup_list_parse(output):
     """
     Parse the output of ``losetup --all`` which varies depending on the
     privileges of the user.
@@ -168,7 +168,7 @@ def losetup_list_parse(output):
     return devices
 
 
-def losetup_list():
+def _losetup_list():
     """
     List all the loopback devices on the system.
 
@@ -178,17 +178,17 @@ def losetup_list():
     output = check_output(
         ["losetup", "--all"]
     ).decode('utf8')
-    return losetup_list_parse(output)
+    return _losetup_list_parse(output)
 
 
-def device_for_path(expected_backing_file):
+def _device_for_path(expected_backing_file):
     """
     :param FilePath backing_file: A path which may be associated with a
         loopback device.
     :returns: A ``FilePath`` to the loopback device if one is found, or
         ``None`` if no device exists.
     """
-    for device_file, backing_file in losetup_list():
+    for device_file, backing_file in _losetup_list():
         if expected_backing_file == backing_file:
             return device_file
     return None
@@ -320,4 +320,4 @@ class LoopbackBlockDeviceAPI(object):
             [volume.host, volume.blockdevice_id]
         )
         # May be None if the file hasn't been used for a loop device.
-        return device_for_path(volume_path)
+        return _device_for_path(volume_path)

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -137,23 +137,23 @@ def _losetup_list_parse(output):
     """
     devices = []
     for line in output.splitlines():
-        parts = line.split(':', 2)
+        parts = line.split(u":", 2)
         if len(parts) != 3:
             continue
         device_file, attributes, backing_file = parts
-        device_file = FilePath(device_file.strip())
+        device_file = FilePath(device_file.strip().encode("utf-8"))
 
         # Trim everything from the first left bracket, skipping over the
         # possible inode number which appears only when run as root.
-        left_bracket_offset = backing_file.find('(')
-        backing_file = backing_file[left_bracket_offset+1:]
+        left_bracket_offset = backing_file.find(b"(")
+        backing_file = backing_file[left_bracket_offset + 1:]
 
         # Trim everything from the right most right bracket
-        right_bracket_offset = backing_file.rfind(')')
+        right_bracket_offset = backing_file.rfind(b")")
         backing_file = backing_file[:right_bracket_offset]
 
         # Trim a possible embedded deleted flag
-        expected_suffix_list = ['(deleted)']
+        expected_suffix_list = [b"(deleted)"]
         for suffix in expected_suffix_list:
             offset = backing_file.rfind(suffix)
             if offset > -1:
@@ -162,7 +162,7 @@ def _losetup_list_parse(output):
         # Remove the space that may have been between the path and the deleted
         # flag.
         backing_file = backing_file.rstrip()
-        backing_file = FilePath(backing_file)
+        backing_file = FilePath(backing_file.encode("utf-8"))
         devices.append((device_file, backing_file))
     return devices
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -61,10 +61,16 @@ class UnattachedVolume(VolumeException):
 class IBlockDeviceAPI(Interface):
     """
     Common operations provided by all block device backends.
+
+    Note: This is an early sketch of the interface and it'll be refined as we
+    real blockdevice providers are implemented.
     """
     def create_volume(size):
         """
         Create a new block device.
+
+        XXX: Probably needs to be some checking of valid sizes for different
+        backends. Perhaps the allowed sizes should be defined as constants?
 
         :param int size: The size of the new block device in bytes.
         :returns: A ``BlockDeviceVolume``.

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -100,11 +100,15 @@ class IBlockDeviceAPI(Interface):
 
     def get_device_path(blockdevice_id):
         """
-        Calculate the path at which ``blockdevice_id`` will be exposed on the
-        host when attached.
+        Return the path of the device through which ``blockdevice_id`` is
+        exposed on the host when attached.
 
         :param unicode blockdevice_id: The unique identifier for the block
             device.
+        :raises UnknownVolume: If the supplied ``blockdevice_id`` does not
+            exist.
+        :raises UnattachedVolume: If the supplied ``blockdevice_id`` is
+            not attached to a host.
         :returns: A ``FilePath`` for the device.
         """
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1,0 +1,263 @@
+# -*- test-case-name: flocker.node.agents.test.test_blockdevice -*-
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+This module implements the parts of a block-device based dataset
+convergence agent that can be re-used against many different kinds of block
+devices.
+"""
+
+from uuid import uuid4
+from subprocess import check_output
+
+from zope.interface import implementer, Interface
+
+from characteristic import attributes
+from pyrsistent import PRecord, field
+
+from twisted.python.filepath import FilePath
+
+
+class VolumeException(Exception):
+    """
+    A base class for exceptions raised by  ``IBlockDeviceAPI`` operations.
+
+    :param unicode blockdevice_id: The unique identifier of the block device.
+    """
+    def __init__(self, blockdevice_id):
+        if not isinstance(blockdevice_id, unicode):
+            raise TypeError(
+                'Unexpected blockdevice_id type. '
+                'Expected unicode. '
+                'Got {!r}.'.format(blockdevice_id)
+            )
+        Exception.__init__(self, blockdevice_id)
+        self.blockdevice_id = blockdevice_id
+
+
+class UnknownVolume(VolumeException):
+    """
+    The block device could not be found.
+    """
+
+
+class AlreadyAttachedVolume(VolumeException):
+    """
+    A failed attempt to attach a block device that is already attached.
+    """
+
+
+class UnattachedVolume(VolumeException):
+    """
+    An attempt was made to operate on an unattached volume but the operation
+    requires the volume to be attached.
+    """
+
+
+class IBlockDeviceAPI(Interface):
+    """
+    Common operations provided by all block device backends.
+    """
+    def create_volume(size):
+        """
+        Create a new block device.
+
+        :param int size: The size of the new block device in bytes.
+        :returns: A ``BlockDeviceVolume``.
+        """
+
+    def attach_volume(blockdevice_id, host):
+        """
+        Attach ``blockdevice_id`` to ``host``.
+
+        :param unicode blockdevice_id: The unique identifier for the block
+            device being attached.
+        :raises UnknownVolume: If the supplied ``blockdevice_id`` does not
+            exist.
+        :raises AlreadyAttachedVolume: If the supplied ``blockdevice_id`` is
+            already attached.
+        :returns: A ``BlockDeviceVolume`` with a ``host`` attribute set to
+            ``host``.
+        """
+
+    def list_volumes():
+        """
+        List all the block devices available via the back end API.
+
+        :returns: A ``list`` of ``BlockDeviceVolume``s.
+        """
+
+    def get_device_path(blockdevice_id):
+        """
+        Calculate the path at which ``blockdevice_id`` will be mounted on the
+        host when attached.
+
+        :param unicode blockdevice_id: The unique identifier for the block
+            device.
+        :returns: A ``BlockDeviceVolume`` with a ``host`` attribute set to
+            ``host``.
+
+        """
+
+
+class BlockDeviceVolume(PRecord):
+    """
+    A block device that may be attached to a host.
+
+    :ivar unicode blockdevice_id: The unique identifier of the block device.
+    :ivar int size: The size of the block device.
+    :ivar bytes host: The IP address of the host to which the block device is
+        attached or ``None`` if it is currently unattached.
+    """
+    blockdevice_id = field(type=unicode, mandatory=True)
+    size = field(type=int, mandatory=True)
+    # XXX: Should be hostname, for consistency of is host a better name since
+    # we currently only expect IP addresses?
+    host = field(type=(bytes, type(None)), initial=None)
+
+
+def device_for_path(file_path):
+    """
+    :param FilePath file_path: A path which may be associated with a loopback
+        device.
+    :returns: A ``FilePath`` to the loopback device if one is found, or
+        ``None`` if no device exists.
+    """
+    device_path = check_output(
+        ["losetup", "--noheadings", "--output", "name", "--associated",
+         file_path.path]
+    ).strip()
+    if device_path != b"":
+        return FilePath(device_path.strip())
+    return None
+
+
+@implementer(IBlockDeviceAPI)
+@attributes(['root_path'])
+class LoopbackBlockDeviceAPI(object):
+    """
+    A simulated ``IBlockDeviceAPI`` which creates loopback devices backed by
+    files located beneath the supplied ``root_path``.
+    """
+    _attached_directory_name = 'attached'
+    _unattached_directory_name = 'unattached'
+
+    @classmethod
+    def from_path(cls, root_path):
+        """
+        :param bytes root_path: The path to a directory in which loop back
+            backing files will be created. The directory is created if it does
+            not already exist.
+        :returns: A ``LoopbackBlockDeviceAPI`` with the supplied ``root_path``.
+        """
+        api = cls(root_path=FilePath(root_path))
+        api._initialise_directories()
+        return api
+
+    def _initialise_directories(self):
+        """
+        Create the root and sub-directories in which loopback files will be
+        created.
+        """
+        self._unattached_directory = self.root_path.child(
+            self._unattached_directory_name)
+
+        try:
+            self._unattached_directory.makedirs()
+        except OSError:
+            pass
+
+        self._attached_directory = self.root_path.child(
+            self._attached_directory_name)
+
+        try:
+            self._attached_directory.makedirs()
+        except OSError:
+            pass
+
+    def get_device_path(self, blockdevice_id):
+        volume = self._get(blockdevice_id)
+
+        if volume.host is not None:
+            volume_path = self._attached_directory.descendant(
+                [volume.host, volume.blockdevice_id]
+            )
+            device_path = device_for_path(volume_path)
+            if device_path is None:
+                check_output(["losetup", "--find", volume_path.path])
+
+            return device_for_path(volume_path)
+
+        raise UnattachedVolume(blockdevice_id)
+
+    def create_volume(self, size):
+        """
+        Create a file of some size and put it in the ``unattached`` directory.
+
+        See ``IBlockDeviceAPI.create_volume`` for parameter and return type
+        documentation.
+        """
+        volume = BlockDeviceVolume(
+            blockdevice_id=unicode(uuid4()),
+            size=size,
+        )
+        self._unattached_directory.child(
+            volume.blockdevice_id.encode('ascii')
+        ).setContent(b'\0' * volume.size)
+        return volume
+
+    def _get(self, blockdevice_id):
+        for volume in self.list_volumes():
+            if volume.blockdevice_id == blockdevice_id:
+                return volume
+        raise UnknownVolume(blockdevice_id)
+
+    def attach_volume(self, blockdevice_id, host):
+        """
+        Move an existing ``unattached`` file into a per-host directory.
+
+        See ``IBlockDeviceAPI.attach_volume`` for parameter and return type
+        documentation.
+        """
+        volume = self._get(blockdevice_id)
+        if volume.host is None:
+            old_path = self._unattached_directory.child(blockdevice_id)
+            host_directory = self._attached_directory.child(host)
+            attached_volume = volume.set(host=host)
+            try:
+                host_directory.makedirs()
+            except OSError:
+                pass
+            old_path.moveTo(host_directory.child(blockdevice_id))
+            return attached_volume
+
+        raise AlreadyAttachedVolume(blockdevice_id)
+
+    def list_volumes(self):
+        """
+        Return ``BlockDeviceVolume`` instances for all the files in the
+        ``unattached`` directory and all per-host directories.
+
+        See ``IBlockDeviceAPI.list_volumes`` for parameter and return type
+        documentation.
+        """
+        volumes = []
+        for child in self.root_path.child('unattached').children():
+            volume = BlockDeviceVolume(
+                blockdevice_id=child.basename().decode('ascii'),
+                size=child.getsize(),
+            )
+            volumes.append(volume)
+
+        for host_directory in self.root_path.child('attached').children():
+            host_name = host_directory.basename().encode('ascii')
+            for child in host_directory.children():
+
+                volume = BlockDeviceVolume(
+                    blockdevice_id=child.basename().decode('ascii'),
+                    size=child.getsize(),
+                    host=host_name,
+                )
+                volumes.append(volume)
+
+        return volumes

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -124,8 +124,6 @@ class BlockDeviceVolume(PRecord):
     """
     blockdevice_id = field(type=unicode, mandatory=True)
     size = field(type=int, mandatory=True)
-    # XXX: Should be hostname, for consistency of is host a better name since
-    # we currently only expect IP addresses?
     host = field(type=(bytes, type(None)), initial=None)
 
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -118,7 +118,7 @@ class BlockDeviceVolume(PRecord):
     A block device that may be attached to a host.
 
     :ivar unicode blockdevice_id: The unique identifier of the block device.
-    :ivar int size: The size of the block device.
+    :ivar int size: The size, in bytes, of the block device.
     :ivar bytes host: The IP address of the host to which the block device is
         attached or ``None`` if it is currently unattached.
     """

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -47,13 +47,6 @@ class AlreadyAttachedVolume(VolumeException):
     """
 
 
-class UnattachedVolume(VolumeException):
-    """
-    An attempt was made to operate on an unattached volume but the operation
-    requires the volume to be attached.
-    """
-
-
 class IBlockDeviceAPI(Interface):
     """
     Common operations provided by all block device backends.
@@ -85,16 +78,6 @@ class IBlockDeviceAPI(Interface):
         List all the block devices available via the back end API.
 
         :returns: A ``list`` of ``BlockDeviceVolume``s.
-        """
-
-    def get_device_path(blockdevice_id):
-        """
-        Calculate the path at which ``blockdevice_id`` will be exposed on the
-        host when attached.
-
-        :param unicode blockdevice_id: The unique identifier for the block
-            device.
-        :returns: A ``FilePath`` for the device.
         """
 
 
@@ -223,26 +206,6 @@ class LoopbackBlockDeviceAPI(object):
             self._attached_directory.makedirs()
         except OSError:
             pass
-
-    def get_device_path(self, blockdevice_id):
-        """
-        For this loopback implementation, we create a new loop device if one
-        does not already exist or return the loop device that is already
-        associated with the block device backing file.
-        """
-        volume = self._get(blockdevice_id)
-
-        if volume.host is not None:
-            volume_path = self._attached_directory.descendant(
-                [volume.host, volume.blockdevice_id]
-            )
-            device_path = device_for_path(volume_path)
-            if device_path is None:
-                check_output(["losetup", "--find", volume_path.path])
-
-            return device_for_path(volume_path)
-
-        raise UnattachedVolume(blockdevice_id)
 
     def create_volume(self, size):
         """

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -295,3 +295,16 @@ class LoopbackBlockDeviceAPI(object):
                 volumes.append(volume)
 
         return volumes
+
+    def get_device_path(self, blockdevice_id):
+        volume = self._get(blockdevice_id)
+        if volume.host is None:
+            raise UnattachedVolume(blockdevice_id)
+
+        volume_path = self._attached_directory.descendant(
+            [volume.host, volume.blockdevice_id]
+        )
+        device_path = device_for_path(volume_path)
+
+        if device_path is not None:
+            return FilePath(device_path)

--- a/flocker/node/agents/test/__init__.py
+++ b/flocker/node/agents/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.node.agents``.
+"""

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -6,7 +6,6 @@ Tests for ``flocker.node.agents.blockdevice``.
 
 import os
 from uuid import uuid4
-from operator import attrgetter
 from subprocess import check_output
 
 from zope.interface.verify import verifyObject

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -4,6 +4,7 @@
 Tests for ``flocker.node.agents.blockdevice``.
 """
 
+import os
 from uuid import uuid4
 
 from zope.interface.verify import verifyObject
@@ -15,7 +16,7 @@ from ..blockdevice import (
 )
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SynchronousTestCase
+from twisted.trial.unittest import SynchronousTestCase, SkipTest
 
 
 class IBlockDeviceAPITestsMixin(object):
@@ -212,7 +213,7 @@ class IBlockDeviceAPITestsMixin(object):
 
 def make_iblockdeviceapi_tests(blockdevice_api_factory):
     """
-    :returns: A ``TestCase`` for with tests that will be performed on the
+    :returns: A ``TestCase`` with tests that will be performed on the
        supplied ``IBlockDeviceAPI`` provider.
     """
     class Tests(IBlockDeviceAPITestsMixin, SynchronousTestCase):
@@ -227,6 +228,14 @@ def loopbackblockdeviceapi_for_test(test_case):
     :returns: A ``LoopbackBlockDeviceAPI`` with a temporary root directory
     created for the supplied ``test_case``.
     """
+    user_id = os.getuid()
+    if user_id != 0:
+        raise SkipTest(
+            "``LoopbackBlockDeviceAPI`` uses ``losetup``, "
+            "which requires root privileges. "
+            "Required UID: 0, Found UID: {!r}".format(user_id)
+        )
+
     root_path = test_case.mktemp()
     return LoopbackBlockDeviceAPI.from_path(root_path=root_path)
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -435,8 +435,7 @@ class LosetupListTests(SynchronousTestCase):
         self.assertEqual(
             [(FilePath('/dev/loop0'), FilePath('/tmp/rjw')),
              (FilePath('/dev/loop1'),
-              FilePath('/usr/share/virtualbox/VBoxGuestAdditions.iso'),)
-         ],
+              FilePath('/usr/share/virtualbox/VBoxGuestAdditions.iso'))],
             losetup_list_parse(input_text)
         )
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -14,7 +14,7 @@ from zope.interface.verify import verifyObject
 from ..blockdevice import (
     LoopbackBlockDeviceAPI, IBlockDeviceAPI,
     BlockDeviceVolume, UnknownVolume, AlreadyAttachedVolume,
-    losetup_list_parse, losetup_list, UnattachedVolume
+    _losetup_list_parse, _losetup_list, UnattachedVolume
 )
 
 from twisted.python.filepath import FilePath
@@ -260,7 +260,7 @@ def losetup_detach_all(root_path):
         backing files.
     :param list backing_files: A ``list`` of all loopback backing files.
     """
-    for device_file, backing_file in losetup_list():
+    for device_file, backing_file in _losetup_list():
         try:
             backing_file.segmentsFrom(root_path)
         except ValueError:
@@ -395,13 +395,13 @@ class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
 
 class LosetupListTests(SynchronousTestCase):
     """
-    Tests for ``losetup_list_parse``.
+    Tests for ``_losetup_list_parse``.
     """
     def test_parse_empty(self):
         """
         An empty list is returned if there are no devices listed.
         """
-        self.assertEqual([], losetup_list_parse('\n'))
+        self.assertEqual([], _losetup_list_parse('\n'))
 
     def test_parse_one_line(self):
         """
@@ -413,7 +413,7 @@ class LosetupListTests(SynchronousTestCase):
         ])
         self.assertEqual(
             [(FilePath('/dev/loop0'), FilePath('/tmp/rjw'))],
-            losetup_list_parse(input_text)
+            _losetup_list_parse(input_text)
         )
 
     def test_parse_multiple_lines(self):
@@ -430,7 +430,7 @@ class LosetupListTests(SynchronousTestCase):
             [(FilePath('/dev/loop0'), FilePath('/tmp/rjw')),
              (FilePath('/dev/loop1'),
               FilePath('/usr/share/virtualbox/VBoxGuestAdditions.iso'))],
-            losetup_list_parse(input_text)
+            _losetup_list_parse(input_text)
         )
 
     def test_remove_deleted_suffix(self):
@@ -443,7 +443,7 @@ class LosetupListTests(SynchronousTestCase):
         ])
         self.assertEqual(
             [(FilePath('/dev/loop0'), FilePath('/tmp/rjw'))],
-            losetup_list_parse(input_text)
+            _losetup_list_parse(input_text)
         )
 
     def test_remove_inode(self):
@@ -455,5 +455,5 @@ class LosetupListTests(SynchronousTestCase):
         ])
         self.assertEqual(
             [(FilePath('/dev/loop0'), FilePath('/tmp/rjw'))],
-            losetup_list_parse(input_text)
+            _losetup_list_parse(input_text)
         )

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -226,7 +226,7 @@ def make_iblockdeviceapi_tests(blockdevice_api_factory):
 def loopbackblockdeviceapi_for_test(test_case):
     """
     :returns: A ``LoopbackBlockDeviceAPI`` with a temporary root directory
-    created for the supplied ``test_case``.
+        created for the supplied ``test_case``.
     """
     user_id = os.getuid()
     if user_id != 0:

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -362,7 +362,7 @@ class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
             size=expected_size,
         )
         (api
-         .root_path.child('unattached')
+         ._root_path.child('unattached')
          .child(blockdevice_volume.blockdevice_id)
          .setContent(b'x' * expected_size))
         self.assertEqual([blockdevice_volume], api.list_volumes())
@@ -378,7 +378,7 @@ class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
 
         blockdevice_id = unicode(uuid4())
 
-        host_dir = api.root_path.child('attached').child(expected_host)
+        host_dir = api._root_path.child('attached').child(expected_host)
         host_dir.makedirs()
         (host_dir
          .child(blockdevice_id)

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -350,6 +350,27 @@ class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
         unattached_directory.makedirs()
         self.assertDirectoryStructure(directory)
 
+    def test_create_sparse(self):
+        """
+        ``create_volume`` creates sparse files.
+        """
+        api = loopbackblockdeviceapi_for_test(test_case=self)
+        # 1GB
+        apparent_size = 1024 * 1000 * 1000 * 1000
+        volume = api.create_volume(apparent_size)
+        backing_file = api._root_path.descendant(
+            ['unattached', volume.blockdevice_id]
+        )
+        # Get actual number of 512 byte blocks used by the file.
+        # See http://stackoverflow.com/a/3212102
+        actual_size = os.stat(backing_file.path).st_blocks * 512
+        reported_size = backing_file.getsize()
+
+        self.assertEqual(
+            (0, apparent_size),
+            (actual_size, reported_size)
+        )
+
     def test_list_unattached_volumes(self):
         """
         ``list_volumes`` returns a ``BlockVolume`` for each unattached volume

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -6,6 +6,7 @@ Tests for ``flocker.node.agents.blockdevice``.
 
 import os
 from uuid import uuid4
+from operator import attrgetter
 
 from zope.interface.verify import verifyObject
 
@@ -17,6 +18,15 @@ from ..blockdevice import (
 
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase, SkipTest
+
+
+def sorted_by_blockdevice_id(blockdevices):
+    """
+    :param list blockdevices: The ``BlockDeviceVolume`` instances to sort.
+    :returns: A ``list`` of ``BlockDeviceVolume``s sorted by their
+        ``blockdevice_id``.
+    """
+    return sorted(blockdevices, key=attrgetter('blockdevice_id'))
 
 
 class IBlockDeviceAPITestsMixin(object):
@@ -140,8 +150,8 @@ class IBlockDeviceAPITestsMixin(object):
             host=expected_host
         )
         self.assertEqual(
-            sorted([new_volume1, attached_volume]),
-            sorted(self.api.list_volumes())
+            sorted_by_blockdevice_id([new_volume1, attached_volume]),
+            sorted_by_blockdevice_id(self.api.list_volumes())
         )
 
     def test_multiple_volumes_attached_to_host(self):
@@ -159,8 +169,8 @@ class IBlockDeviceAPITestsMixin(object):
         )
 
         self.assertEqual(
-            sorted([attached_volume1, attached_volume2]),
-            sorted(self.api.list_volumes())
+            sorted_by_blockdevice_id([attached_volume1, attached_volume2]),
+            sorted_by_blockdevice_id(self.api.list_volumes())
         )
 
     # def test_get_attached_volume_device(self):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -14,7 +14,7 @@ from zope.interface.verify import verifyObject
 from ..blockdevice import (
     LoopbackBlockDeviceAPI, IBlockDeviceAPI,
     BlockDeviceVolume, UnknownVolume, AlreadyAttachedVolume,
-    UnattachedVolume, losetup_list_parse, losetup_list
+    losetup_list_parse, losetup_list
 )
 
 from twisted.python.filepath import FilePath
@@ -179,64 +179,6 @@ class IBlockDeviceAPITestsMixin(object):
 
     # def test_get_unattached_volume_device(self):
     #     1/0
-
-    def test_get_device_path_unknown_volume(self):
-        """
-        ``get_device_path`` raises ``UnknownVolume`` if the supplied
-        ``blockdevice_id`` has not been created.
-        """
-        unknown_blockdevice_id = unicode(uuid4())
-        exception = self.assertRaises(
-            UnknownVolume,
-            self.api.get_device_path,
-            unknown_blockdevice_id
-        )
-        self.assertEqual(unknown_blockdevice_id, exception.blockdevice_id)
-
-    def test_get_device_path_unattached_volume(self):
-        """
-        ``get_device_path`` raises ``UnattachedVolume`` if the supplied
-        ``blockdevice_id`` corresponds to an unattached volume.
-        """
-        new_volume = self.api.create_volume(size=1000)
-        exception = self.assertRaises(
-            UnattachedVolume,
-            self.api.get_device_path,
-            new_volume.blockdevice_id
-        )
-        self.assertEqual(new_volume.blockdevice_id, exception.blockdevice_id)
-
-    def test_get_device_path_device(self):
-        """
-        ``get_device_path`` returns a ``FilePath`` to the device representing
-        the attached volume.
-        """
-        new_volume = self.api.create_volume(size=1024 * 50)
-        attached_volume = self.api.attach_volume(
-            new_volume.blockdevice_id,
-            b'192.0.2.123'
-        )
-        device_path = self.api.get_device_path(attached_volume.blockdevice_id)
-        self.assertTrue(
-            device_path.isBlockDevice(),
-            u"Not a block device. Path: {!r}".format(device_path)
-        )
-
-    def test_get_device_path_device_exists(self):
-        """
-        ``get_device_path`` returns the same ``FilePath`` for the volume device
-        when called multiple times.
-        """
-        new_volume = self.api.create_volume(size=1024 * 50)
-        attached_volume = self.api.attach_volume(
-            new_volume.blockdevice_id,
-            b'192.0.2.123'
-        )
-
-        device_path1 = self.api.get_device_path(attached_volume.blockdevice_id)
-        device_path2 = self.api.get_device_path(attached_volume.blockdevice_id)
-
-        self.assertEqual(device_path1, device_path2)
 
 
 def make_iblockdeviceapi_tests(blockdevice_api_factory):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -24,15 +24,6 @@ GIBIBYTE = 2**30
 REALISTIC_BLOCKDEVICE_SIZE = 4 * GIBIBYTE
 
 
-def sorted_by_blockdevice_id(blockdevices):
-    """
-    :param list blockdevices: The ``BlockDeviceVolume`` instances to sort.
-    :returns: A ``list`` of ``BlockDeviceVolume``s sorted by their
-        ``blockdevice_id``.
-    """
-    return sorted(blockdevices, key=attrgetter('blockdevice_id'))
-
-
 class IBlockDeviceAPITestsMixin(object):
     """
     Tests to perform on ``IBlockDeviceAPI`` providers.
@@ -156,9 +147,9 @@ class IBlockDeviceAPITestsMixin(object):
             blockdevice_id=new_volume2.blockdevice_id,
             host=expected_host
         )
-        self.assertEqual(
-            sorted_by_blockdevice_id([new_volume1, attached_volume]),
-            sorted_by_blockdevice_id(self.api.list_volumes())
+        self.assertItemsEqual(
+            [new_volume1, attached_volume],
+            self.api.list_volumes()
         )
 
     def test_multiple_volumes_attached_to_host(self):
@@ -175,9 +166,9 @@ class IBlockDeviceAPITestsMixin(object):
             volume2.blockdevice_id, host=expected_host
         )
 
-        self.assertEqual(
-            sorted_by_blockdevice_id([attached_volume1, attached_volume2]),
-            sorted_by_blockdevice_id(self.api.list_volumes())
+        self.assertItemsEqual(
+            [attached_volume1, attached_volume2],
+            self.api.list_volumes()
         )
 
     def test_get_device_path_unknown_volume(self):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -127,6 +127,23 @@ class IBlockDeviceAPITestsMixin(object):
         )
         self.assertEqual([expected_volume], self.api.list_volumes())
 
+    def test_list_attached_and_unattached(self):
+        """
+        ``list_volumes`` returns both attached and unattached
+        ``BlockDeviceVolume``s.
+        """
+        expected_host = b'192.0.2.123'
+        new_volume1 = self.api.create_volume(size=1000)
+        new_volume2 = self.api.create_volume(size=1000)
+        attached_volume = self.api.attach_volume(
+            blockdevice_id=new_volume2.blockdevice_id,
+            host=expected_host
+        )
+        self.assertEqual(
+            sorted([new_volume1, attached_volume]),
+            sorted(self.api.list_volumes())
+        )
+
     def test_multiple_volumes_attached_to_host(self):
         """
         ``attach_volume`` can attach multiple block devices to a single host.

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1,0 +1,337 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.node.agents.blockdevice``.
+"""
+
+from uuid import uuid4
+
+from zope.interface.verify import verifyObject
+
+from ..blockdevice import (
+    LoopbackBlockDeviceAPI, IBlockDeviceAPI,
+    BlockDeviceVolume, UnknownVolume, AlreadyAttachedVolume,
+    UnattachedVolume
+)
+
+from twisted.python.filepath import FilePath
+from twisted.trial.unittest import SynchronousTestCase
+
+
+class IBlockDeviceAPITestsMixin(object):
+    """
+    Tests to perform on ``IBlockDeviceAPI`` providers.
+    """
+    def test_interface(self):
+        """
+        ``api`` instances provide ``IBlockDeviceAPI``.
+        """
+        self.assertTrue(
+            verifyObject(IBlockDeviceAPI, self.api)
+        )
+
+    def test_list_volume_empty(self):
+        """
+        ``list_volumes`` returns an empty ``list`` if no block devices have
+        been created.
+        """
+        self.assertEqual([], self.api.list_volumes())
+
+    def test_created_is_listed(self):
+        """
+        ``create_volume`` returns a ``BlockVolume`` that is returned by
+        ``list_volumes``.
+        """
+        new_volume = self.api.create_volume(size=1000)
+        self.assertIn(new_volume, self.api.list_volumes())
+
+    def test_attach_unknown_volume(self):
+        """
+        An attempt to attach an unknown ``BlockDeviceVolume`` raises
+        ``UnknownVolume``.
+        """
+        self.assertRaises(
+            UnknownVolume,
+            self.api.attach_volume,
+            blockdevice_id=unicode(uuid4()),
+            host=b'192.0.2.123'
+        )
+
+    def test_attach_attached_volume(self):
+        """
+        An attempt to attach an already attached ``BlockDeviceVolume`` raises
+        ``AlreadyAttachedVolume``.
+        """
+        host = b'192.0.2.123'
+        new_volume = self.api.create_volume(size=1234)
+        attached_volume = self.api.attach_volume(
+            new_volume.blockdevice_id, host=host
+        )
+
+        self.assertRaises(
+            AlreadyAttachedVolume,
+            self.api.attach_volume,
+            blockdevice_id=attached_volume.blockdevice_id,
+            host=host
+        )
+
+    def test_attach_elsewhere_attached_volume(self):
+        """
+        An attempt to attach a ``BlockDeviceVolume`` already attached to
+        another host raises ``AlreadyAttachedVolume``.
+        """
+        new_volume = self.api.create_volume(size=1234)
+        attached_volume = self.api.attach_volume(
+            new_volume.blockdevice_id, host=b'192.0.2.123'
+        )
+
+        self.assertRaises(
+            AlreadyAttachedVolume,
+            self.api.attach_volume,
+            blockdevice_id=attached_volume.blockdevice_id,
+            host=b'192.0.2.124'
+        )
+
+    def test_attach_unattached_volume(self):
+        """
+        An unattached ``BlockDeviceVolume`` can be attached.
+        """
+        expected_host = b'192.0.2.123'
+        new_volume = self.api.create_volume(size=1000)
+        expected_volume = BlockDeviceVolume(
+            blockdevice_id=new_volume.blockdevice_id,
+            size=new_volume.size,
+            host=expected_host,
+        )
+        attached_volume = self.api.attach_volume(
+            blockdevice_id=new_volume.blockdevice_id,
+            host=expected_host
+        )
+        self.assertEqual(expected_volume, attached_volume)
+
+    def test_attached_volume_listed(self):
+        """
+        An attached ``BlockDeviceVolume`` is listed.
+        """
+        expected_host = b'192.0.2.123'
+        new_volume = self.api.create_volume(size=1000)
+        expected_volume = BlockDeviceVolume(
+            blockdevice_id=new_volume.blockdevice_id,
+            size=new_volume.size,
+            host=expected_host,
+        )
+        self.api.attach_volume(
+            blockdevice_id=new_volume.blockdevice_id,
+            host=expected_host
+        )
+        self.assertEqual([expected_volume], self.api.list_volumes())
+
+    def test_multiple_volumes_attached_to_host(self):
+        """
+        ``attach_volume`` can attach multiple block devices to a single host.
+        """
+        expected_host = b'192.0.2.123'
+        volume1 = self.api.create_volume(size=1234)
+        volume2 = self.api.create_volume(size=1234)
+        attached_volume1 = self.api.attach_volume(
+            volume1.blockdevice_id, host=expected_host
+        )
+        attached_volume2 = self.api.attach_volume(
+            volume2.blockdevice_id, host=expected_host
+        )
+
+        self.assertEqual(
+            [attached_volume1, attached_volume2],
+            self.api.list_volumes()
+        )
+
+    # def test_get_attached_volume_device(self):
+    #     1/0
+
+    # def test_get_unattached_volume_device(self):
+    #     1/0
+
+    def test_get_device_path_unknown_volume(self):
+        """
+        ``get_device_path`` raises ``UnknownVolume`` if the supplied
+        ``blockdevice_id`` has not been created.
+        """
+        unknown_blockdevice_id = unicode(uuid4())
+        exception = self.assertRaises(
+            UnknownVolume,
+            self.api.get_device_path,
+            unknown_blockdevice_id
+        )
+        self.assertEqual(unknown_blockdevice_id, exception.blockdevice_id)
+
+    def test_get_device_path_unattached_volume(self):
+        """
+        ``get_device_path`` raises ``UnattachedVolume`` if the supplied
+        ``blockdevice_id`` corresponds to an unattached volume.
+        """
+        new_volume = self.api.create_volume(size=1000)
+        exception = self.assertRaises(
+            UnattachedVolume,
+            self.api.get_device_path,
+            new_volume.blockdevice_id
+        )
+        self.assertEqual(new_volume.blockdevice_id, exception.blockdevice_id)
+
+    def test_get_device_path_device(self):
+        """
+        ``get_device_path`` returns a ``FilePath`` to the device representing
+        the attached volume.
+        """
+        new_volume = self.api.create_volume(size=1024 * 50)
+        attached_volume = self.api.attach_volume(
+            new_volume.blockdevice_id,
+            b'192.0.2.123'
+        )
+        device_path = self.api.get_device_path(attached_volume.blockdevice_id)
+        self.assertTrue(
+            device_path.isBlockDevice(),
+            u"Not a block device. Path: {!r}".format(device_path)
+        )
+
+    def test_get_device_path_device_exists(self):
+        """
+        ``get_device_path`` returns the same ``FilePath`` for the volume device
+        when called multiple times.
+        """
+        new_volume = self.api.create_volume(size=1024 * 50)
+        attached_volume = self.api.attach_volume(
+            new_volume.blockdevice_id,
+            b'192.0.2.123'
+        )
+
+        device_path1 = self.api.get_device_path(attached_volume.blockdevice_id)
+        device_path2 = self.api.get_device_path(attached_volume.blockdevice_id)
+
+        self.assertEqual(device_path1, device_path2)
+
+
+def make_iblockdeviceapi_tests(blockdevice_api_factory):
+    """
+    :returns: A ``TestCase`` for with tests that will be performed on the
+       supplied ``IBlockDeviceAPI`` provider.
+    """
+    class Tests(IBlockDeviceAPITestsMixin, SynchronousTestCase):
+        def setUp(self):
+            self.api = blockdevice_api_factory(test_case=self)
+
+    return Tests
+
+
+def loopbackblockdeviceapi_for_test(test_case):
+    """
+    :returns: A ``LoopbackBlockDeviceAPI`` with a temporary root directory
+    created for the supplied ``test_case``.
+    """
+    root_path = test_case.mktemp()
+    return LoopbackBlockDeviceAPI.from_path(root_path=root_path)
+
+
+class LoopbackBlockDeviceAPITests(
+        make_iblockdeviceapi_tests(
+            blockdevice_api_factory=loopbackblockdeviceapi_for_test
+        )
+):
+    """
+    Interface adherence Tests for ``LoopbackBlockDeviceAPI``.
+    """
+
+
+class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
+    """
+    Implementation specific tests for ``LoopbackBlockDeviceAPI``.
+    """
+    def assertDirectoryStructure(self, directory):
+        """
+        Assert that the supplied ``directory`` has all the sub-directories
+        required by ``LoopbackBlockDeviceAPI``.
+        """
+        attached_directory = directory.child(
+            LoopbackBlockDeviceAPI._attached_directory_name
+        )
+        unattached_directory = directory.child(
+            LoopbackBlockDeviceAPI._unattached_directory_name
+        )
+
+        LoopbackBlockDeviceAPI.from_path(directory.path)
+
+        self.assertTrue(
+            (True, True),
+            (attached_directory.exists(), unattached_directory.exists())
+        )
+
+    def test_initialise_directories(self):
+        """
+        ``from_path`` creates a directory structure if it doesn't already
+        exist.
+        """
+        directory = FilePath(self.mktemp()).child('loopback')
+        self.assertDirectoryStructure(directory)
+
+    def test_initialise_directories_attached_exists(self):
+        """
+        ``from_path`` uses existing attached directory if present.
+        """
+        directory = FilePath(self.mktemp())
+        attached_directory = directory.child(
+            LoopbackBlockDeviceAPI._attached_directory_name
+        )
+        attached_directory.makedirs()
+        self.assertDirectoryStructure(directory)
+
+    def test_initialise_directories_unattached_exists(self):
+        """
+        ``from_path`` uses existing unattached directory if present.
+        """
+        directory = FilePath(self.mktemp())
+        unattached_directory = directory.child(
+            LoopbackBlockDeviceAPI._unattached_directory_name
+        )
+        unattached_directory.makedirs()
+        self.assertDirectoryStructure(directory)
+
+    def test_list_unattached_volumes(self):
+        """
+        ``list_volumes`` returns a ``BlockVolume`` for each unattached volume
+        file.
+        """
+        expected_size = 1234
+        api = loopbackblockdeviceapi_for_test(test_case=self)
+        blockdevice_volume = BlockDeviceVolume(
+            blockdevice_id=unicode(uuid4()),
+            size=expected_size,
+        )
+        (api
+         .root_path.child('unattached')
+         .child(blockdevice_volume.blockdevice_id)
+         .setContent(b'x' * expected_size))
+        self.assertEqual([blockdevice_volume], api.list_volumes())
+
+    def test_list_attached_volumes(self):
+        """
+        ``list_volumes`` returns a ``BlockVolume`` for each attached volume
+        file.
+        """
+        expected_size = 1234
+        expected_host = b'192.0.2.123'
+        api = loopbackblockdeviceapi_for_test(test_case=self)
+
+        blockdevice_id = unicode(uuid4())
+
+        host_dir = api.root_path.child('attached').child(expected_host)
+        host_dir.makedirs()
+        (host_dir
+         .child(blockdevice_id)
+         .setContent(b'x' * expected_size))
+
+        blockdevice_volume = BlockDeviceVolume(
+            blockdevice_id=blockdevice_id,
+            size=expected_size,
+            host=expected_host,
+        )
+
+        self.assertEqual([blockdevice_volume], api.list_volumes())

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -54,7 +54,7 @@ class IBlockDeviceAPITestsMixin(object):
         ``create_volume`` returns a ``BlockVolume`` that is returned by
         ``list_volumes``.
         """
-        new_volume = self.api.create_volume(size=1000)
+        new_volume = self.api.create_volume(size=1024)
         self.assertIn(new_volume, self.api.list_volumes())
 
     def test_attach_unknown_volume(self):
@@ -75,7 +75,7 @@ class IBlockDeviceAPITestsMixin(object):
         ``AlreadyAttachedVolume``.
         """
         host = b'192.0.2.123'
-        new_volume = self.api.create_volume(size=1234)
+        new_volume = self.api.create_volume(size=1024)
         attached_volume = self.api.attach_volume(
             new_volume.blockdevice_id, host=host
         )
@@ -92,7 +92,7 @@ class IBlockDeviceAPITestsMixin(object):
         An attempt to attach a ``BlockDeviceVolume`` already attached to
         another host raises ``AlreadyAttachedVolume``.
         """
-        new_volume = self.api.create_volume(size=1234)
+        new_volume = self.api.create_volume(size=1024)
         attached_volume = self.api.attach_volume(
             new_volume.blockdevice_id, host=b'192.0.2.123'
         )
@@ -109,7 +109,7 @@ class IBlockDeviceAPITestsMixin(object):
         An unattached ``BlockDeviceVolume`` can be attached.
         """
         expected_host = b'192.0.2.123'
-        new_volume = self.api.create_volume(size=1000)
+        new_volume = self.api.create_volume(size=1024)
         expected_volume = BlockDeviceVolume(
             blockdevice_id=new_volume.blockdevice_id,
             size=new_volume.size,
@@ -126,7 +126,7 @@ class IBlockDeviceAPITestsMixin(object):
         An attached ``BlockDeviceVolume`` is listed.
         """
         expected_host = b'192.0.2.123'
-        new_volume = self.api.create_volume(size=1000)
+        new_volume = self.api.create_volume(size=1024)
         expected_volume = BlockDeviceVolume(
             blockdevice_id=new_volume.blockdevice_id,
             size=new_volume.size,
@@ -144,8 +144,8 @@ class IBlockDeviceAPITestsMixin(object):
         ``BlockDeviceVolume``s.
         """
         expected_host = b'192.0.2.123'
-        new_volume1 = self.api.create_volume(size=1000)
-        new_volume2 = self.api.create_volume(size=1000)
+        new_volume1 = self.api.create_volume(size=1024)
+        new_volume2 = self.api.create_volume(size=1024)
         attached_volume = self.api.attach_volume(
             blockdevice_id=new_volume2.blockdevice_id,
             host=expected_host
@@ -160,8 +160,8 @@ class IBlockDeviceAPITestsMixin(object):
         ``attach_volume`` can attach multiple block devices to a single host.
         """
         expected_host = b'192.0.2.123'
-        volume1 = self.api.create_volume(size=1234)
-        volume2 = self.api.create_volume(size=1234)
+        volume1 = self.api.create_volume(size=1024)
+        volume2 = self.api.create_volume(size=1024)
         attached_volume1 = self.api.attach_volume(
             volume1.blockdevice_id, host=expected_host
         )

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -69,6 +69,9 @@ class IBlockDeviceAPITestsMixin(object):
             UnknownVolume,
             self.api.attach_volume,
             blockdevice_id=unicode(uuid4()),
+            # XXX This IP address and others in following tests need to be
+            # parameterized so that these tests can be run against real cloud
+            # nodes.
             host=b'192.0.2.123'
         )
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -142,8 +142,8 @@ class IBlockDeviceAPITestsMixin(object):
         )
 
         self.assertEqual(
-            [attached_volume1, attached_volume2],
-            self.api.list_volumes()
+            sorted([attached_volume1, attached_volume2]),
+            sorted(self.api.list_volumes())
         )
 
     # def test_get_attached_volume_device(self):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -213,7 +213,7 @@ class IBlockDeviceAPITestsMixin(object):
             u"Not a block device. Path: {!r}".format(device_path)
         )
 
-    def test_get_device_path_device_exists(self):
+    def test_get_device_path_device_repeatable_results(self):
         """
         ``get_device_path`` returns the same ``FilePath`` for the volume device
         when called multiple times.

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -257,9 +257,13 @@ def loopback_devices():
         files.
     """
     output = check_output(
-        ['losetup', '--list', '--output', 'name,back-file', '--noheadings']
+        ['losetup', '--list', '--output', 'name,back-file']
     )
-    for line in output.splitlines():
+    # Omit the heading line.
+    # losetup from util-linux 2.24.2 provides a --noheadings option, but it's
+    # not available on Centos7 or Ubuntu 14.04.
+    lines = output.splitlines()[1:]
+    for line in lines:
         device_file, backing_file = [
             FilePath(f) for f in line.split()[:2]
         ]

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -62,7 +62,7 @@ class IBlockDeviceAPITestsMixin(object):
             # XXX This IP address and others in following tests need to be
             # parameterized so that these tests can be run against real cloud
             # nodes.
-            host=b'192.0.2.123'
+            host=u'192.0.2.123'
         )
 
     def test_attach_attached_volume(self):
@@ -70,7 +70,7 @@ class IBlockDeviceAPITestsMixin(object):
         An attempt to attach an already attached ``BlockDeviceVolume`` raises
         ``AlreadyAttachedVolume``.
         """
-        host = b'192.0.2.123'
+        host = u'192.0.2.123'
         new_volume = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         attached_volume = self.api.attach_volume(
             new_volume.blockdevice_id, host=host
@@ -90,21 +90,21 @@ class IBlockDeviceAPITestsMixin(object):
         """
         new_volume = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         attached_volume = self.api.attach_volume(
-            new_volume.blockdevice_id, host=b'192.0.2.123'
+            new_volume.blockdevice_id, host=u'192.0.2.123'
         )
 
         self.assertRaises(
             AlreadyAttachedVolume,
             self.api.attach_volume,
             blockdevice_id=attached_volume.blockdevice_id,
-            host=b'192.0.2.124'
+            host=u'192.0.2.124'
         )
 
     def test_attach_unattached_volume(self):
         """
         An unattached ``BlockDeviceVolume`` can be attached.
         """
-        expected_host = b'192.0.2.123'
+        expected_host = u'192.0.2.123'
         new_volume = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         expected_volume = BlockDeviceVolume(
             blockdevice_id=new_volume.blockdevice_id,
@@ -121,7 +121,7 @@ class IBlockDeviceAPITestsMixin(object):
         """
         An attached ``BlockDeviceVolume`` is listed.
         """
-        expected_host = b'192.0.2.123'
+        expected_host = u'192.0.2.123'
         new_volume = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         expected_volume = BlockDeviceVolume(
             blockdevice_id=new_volume.blockdevice_id,
@@ -139,7 +139,7 @@ class IBlockDeviceAPITestsMixin(object):
         ``list_volumes`` returns both attached and unattached
         ``BlockDeviceVolume``s.
         """
-        expected_host = b'192.0.2.123'
+        expected_host = u'192.0.2.123'
         new_volume1 = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         new_volume2 = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         attached_volume = self.api.attach_volume(
@@ -155,7 +155,7 @@ class IBlockDeviceAPITestsMixin(object):
         """
         ``attach_volume`` can attach multiple block devices to a single host.
         """
-        expected_host = b'192.0.2.123'
+        expected_host = u'192.0.2.123'
         volume1 = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         volume2 = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         attached_volume1 = self.api.attach_volume(
@@ -204,7 +204,7 @@ class IBlockDeviceAPITestsMixin(object):
         new_volume = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         attached_volume = self.api.attach_volume(
             new_volume.blockdevice_id,
-            b'192.0.2.123'
+            u'192.0.2.123'
         )
         device_path = self.api.get_device_path(attached_volume.blockdevice_id)
         self.assertTrue(
@@ -220,7 +220,7 @@ class IBlockDeviceAPITestsMixin(object):
         new_volume = self.api.create_volume(size=REALISTIC_BLOCKDEVICE_SIZE)
         attached_volume = self.api.attach_volume(
             new_volume.blockdevice_id,
-            b'192.0.2.123'
+            u'192.0.2.123'
         )
 
         device_path1 = self.api.get_device_path(attached_volume.blockdevice_id)
@@ -391,12 +391,14 @@ class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
         file.
         """
         expected_size = REALISTIC_BLOCKDEVICE_SIZE
-        expected_host = b'192.0.2.123'
+        expected_host = u'192.0.2.123'
         api = loopbackblockdeviceapi_for_test(test_case=self)
 
         blockdevice_id = unicode(uuid4())
 
-        host_dir = api._root_path.child('attached').child(expected_host)
+        host_dir = api._root_path.descendant([
+            b'attached', expected_host.encode("utf-8")
+        ])
         host_dir.makedirs()
         with host_dir.child(blockdevice_id).open('wb') as f:
             f.truncate(expected_size)


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1490
Fixes https://clusterhq.atlassian.net/browse/FLOC-1494

This introduces an (incomplete) interface for block-device backends.  It also implements that interface using a local-only loopback block device provider.  This was split out of a larger branch which also includes new `IDeployer` implementation that knows how to use this new interface to provide block-device-based storage for a datasets convergence agent (that code to be up for review shortly, you can see it in https://github.com/ClusterHQ/flocker/tree/iblockdevice-deployer-FLOC-1502 (currently contains all of this code and some more code besides)).

The new interface and implementation also covers the "list existing block devices" functionality that's required but there's no separate JIRA issue for that work.