### PR TITLE
[FLOC-1229] Allow passing arguments to trial run by tox

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -80,6 +80,12 @@ You can run all unit tests by doing:
 
    $ tox
 
+You can also run specific tests in a specific environment:
+
+.. code-block:: console
+
+   $ tox -e py27 flocker.control.test.test_httpapi
+
 Functional tests require ``ZFS`` and ``Docker`` to be installed and in the case of the latter running as well.
 In addition, ``tox`` needs to be run as root:
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ changedir = {envtmpdir}
 commands =
     pip install Flocker[dev]
     pip install Flocker[doc] # necessary for flocker.restapi.docs tests
-    trial --rterrors flocker
+    trial --rterrors {posargs:flocker}
 setenv =
     PYTHONHASHSEED=random
 


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1229

Now you can do `tox -e py27 flocker.control.test.test_httpapi` or whatever. Lack of this was constant annoyance for me.