### PR TITLE
[FLOC-1571] Build package logging

### DIFF
--- a/admin/build_targets/centos-7/Dockerfile
+++ b/admin/build_targets/centos-7/Dockerfile
@@ -12,7 +12,7 @@ RUN ["yum", "install", "--assumeyes", "git", "ruby-devel", "python-devel", "pyth
 # See https://github.com/jordansissel/fpm/issues/611
 RUN ["gem", "install", "fpm"]
 
-RUN ["pip", "install", "twisted==15.0.0", "characteristic==14.1.0", "virtualenv==12.0.5", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11"]
+RUN ["pip", "install", "twisted==15.0.0", "characteristic==14.1.0", "virtualenv==12.0.5", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0"]
 VOLUME /flocker
 WORKDIR /
 ENTRYPOINT ["/flocker/admin/build-package-entrypoint", "--destination-path=/output"]

--- a/admin/build_targets/fedora-20/Dockerfile
+++ b/admin/build_targets/fedora-20/Dockerfile
@@ -10,6 +10,6 @@ RUN ["yum", "install", "--assumeyes", "@buildsys-build", "git", "ruby-devel", "p
 # See https://github.com/jordansissel/fpm/issues/611
 RUN ["gem", "install", "fpm"]
 
-RUN ["pip", "install", "twisted==15.0.0", "characteristic==14.1.0", "virtualenv==12.0.5", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11"]
+RUN ["pip", "install", "twisted==15.0.0", "characteristic==14.1.0", "virtualenv==12.0.5", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0"]
 VOLUME /flocker
 ENTRYPOINT ["/flocker/admin/build-package-entrypoint", "--destination-path=/output"]

--- a/admin/build_targets/ubuntu-14.04/Dockerfile
+++ b/admin/build_targets/ubuntu-14.04/Dockerfile
@@ -13,6 +13,6 @@ RUN ["apt-get", "install", "--no-install-recommends", "-y", "git", "ruby-dev", "
 # https://github.com/jordansissel/fpm/issues/657
 RUN ["gem", "install", "fpm"]
 
-RUN ["pip", "install", "twisted==15.0.0", "characteristic==14.1.0", "virtualenv==12.0.5", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11"]
+RUN ["pip", "install", "twisted==15.0.0", "characteristic==14.1.0", "virtualenv==12.0.5", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0"]
 VOLUME /flocker
 ENTRYPOINT ["/flocker/admin/build-package-entrypoint", "--destination-path=/output"]

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -1081,6 +1081,8 @@ class DockerBuildScript(object):
         :param FilePath top_level: The top-level of the flocker repository.
         :param base_path: ignored.
         """
+        to_file(self.sys_module.stderr)
+
         options = DockerBuildOptions()
 
         try:

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -13,6 +13,8 @@ from subprocess import check_output, check_call, CalledProcessError, call
 from tempfile import mkdtemp
 from textwrap import dedent, fill
 
+from eliot import Logger, start_action, to_file
+
 from twisted.python.constants import ValueConstant, Values
 from twisted.python.filepath import FilePath
 from twisted.python import usage, log
@@ -117,9 +119,13 @@ class BuildSequence(object):
 
     :ivar tuple steps: A sequence of steps.
     """
+    logger = Logger()
+    _system = u"packaging:buildsequence:run"
+
     def run(self):
         for step in self.steps:
-            step.run()
+            with start_action(self.logger, self._system, step=step):
+                step.run()
 
 
 def run_command(args, added_env=None, cwd=None):
@@ -1160,6 +1166,8 @@ class BuildScript(object):
             directory.
         :param base_path: ignored.
         """
+        to_file(self.sys_module.stderr)
+
         options = BuildOptions()
 
         try:

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -124,7 +124,7 @@ class BuildSequence(object):
 
     def run(self):
         for step in self.steps:
-            with start_action(self.logger, self._system, step=step):
+            with start_action(self.logger, self._system, step=repr(step)):
                 step.run()
 
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-1571

Adds eliot logging to admin/build-package.  Logs the steps run by `BuildSequence` so some kind of package build progress is apparent.

Excludes actual eliot action or message type definitions and excludes unit tests for the logging behavior because:

  * this isn't production code
  * the exact information being logged here is pretty haphazard (repr of an object).  maybe we'll think of something more useful to log later.
  * the code being modified to do logging does have unit tests
  * this is as much as I could implement while waiting for vagrant to download a flocker-tutorial box that I needed for other more important work
