### PR TITLE
Use a helper that captures all output instead of only some.

### DIFF
--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -4,7 +4,6 @@
 Functional tests for ``flocker.node._deploy``.
 """
 
-from subprocess import check_call
 from uuid import uuid4
 
 from pyrsistent import pmap
@@ -19,7 +18,8 @@ from ...control._model import (
 from .._docker import DockerClient
 from ..testtools import wait_for_unit_state, if_docker_configured
 from ...testtools import (
-    random_name, DockerImageBuilder, assertContainsAll, loop_until)
+    random_name, DockerImageBuilder, assertContainsAll, loop_until,
+    run_process)
 from ...volume.testtools import create_volume_service
 from ...route import make_memory_network
 
@@ -58,8 +58,8 @@ class DeployerTests(TestCase):
 
         def started(_):
             # Now that it's running, stop it behind our back:
-            check_call([b"docker", b"stop",
-                        docker_client._to_container_name(name)])
+            run_process([b"docker", b"stop",
+                         docker_client._to_container_name(name)])
             return wait_for_unit_state(docker_client, name,
                                        [u'inactive', u'failed'])
         d.addCallback(started)

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -827,7 +827,7 @@ def run_process(command, *args, **kwargs):
     """
     Run a child process, capturing its stdout and stderr.
 
-    :param list command: An ``argv`` to use to launch the child process.
+    :param list command: An argument list to use to launch the child process.
 
     :raise CalledProcessError: If the child process has a non-zero exit status.
 

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -21,7 +21,7 @@ from unittest import skipIf, skipUnless
 
 from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 
-from pyrsistent import PRecord, field, optional
+from pyrsistent import PRecord, field
 
 from zope.interface import implementer
 from zope.interface.verify import verifyClass, verifyObject

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -1,6 +1,8 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
-"""Various utilities to help with unit and functional testing."""
+"""
+Various utilities to help with unit and functional testing.
+"""
 
 from __future__ import absolute_import
 
@@ -14,17 +16,19 @@ from collections import namedtuple
 from contextlib import contextmanager
 from random import random
 import shutil
-from subprocess import check_call, check_output
 from functools import wraps
-from unittest import skipIf
-from unittest import skipUnless
+from unittest import skipIf, skipUnless
+
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen
+
+from pyrsistent import PRecord, field, optional
 
 from zope.interface import implementer
 from zope.interface.verify import verifyClass, verifyObject
 
 from twisted.internet.interfaces import (
     IProcessTransport, IReactorProcess, IReactorCore,
-    )
+)
 from twisted.python.filepath import FilePath, Permissions
 from twisted.internet.task import Clock, deferLater
 from twisted.internet.defer import maybeDeferred, Deferred, succeed
@@ -592,11 +596,11 @@ class DockerImageBuilder(object):
             b'--tag=%s' % (tag,),
             docker_dir.path
         ]
-        check_call(command)
+        run_process(command)
         # XXX until https://clusterhq.atlassian.net/browse/FLOC-409 is
         # fixed we will often have a container lying around which is still
         # using the new image, so removing the image will fail.
-        # self.test.addCleanup(check_call, [b"docker", b"rmi", tag])
+        # self.test.addCleanup(run_process, [b"docker", b"rmi", tag])
         return tag
 
 
@@ -725,16 +729,16 @@ def make_script_tests(executable):
             """
             The script is a command available on the system path.
             """
-            result = check_output([executable] + [b"--version"])
-            self.assertEqual(result, b"%s\n" % (__version__,))
+            result = run_process([executable] + [b"--version"])
+            self.assertEqual(result.output, b"%s\n" % (__version__,))
 
         @skipUnless(which(executable), executable + " not installed")
         def test_identification(self):
             """
             The script identifies itself as what it is.
             """
-            result = check_output([executable] + [b"--help"])
-            self.assertIn(executable, result)
+            result = run_process([executable] + [b"--help"])
+            self.assertIn(executable, result.output)
     return ScriptTests
 
 
@@ -807,3 +811,35 @@ class CustomException(Exception):
     An exception that will never be raised by real code, useful for
     testing.
     """
+
+
+class _ProcessResult(PRecord):
+    """
+    The return type for ``run_process`` representing the outcome of the process
+    that was run.
+    """
+    command = field(type=list, mandatory=True)
+    output = field(type=bytes, mandatory=True)
+    status = field(type=int, mandatory=True)
+
+
+def run_process(command, *args, **kwargs):
+    """
+    Run a child process, capturing its stdout and stderr.
+
+    :param list command: An ``argv`` to use to launch the child process.
+
+    :raise CalledProcessError: If the child process has a non-zero exit status.
+
+    :return: A ``_ProcessResult`` instance describing the result of the child
+         process.
+    """
+    kwargs["stdout"] = PIPE
+    kwargs["stderr"] = STDOUT
+    process = Popen(command, *args, **kwargs)
+    output = process.stdout.read()
+    status = process.wait()
+    result = _ProcessResult(command=command, output=output, status=status)
+    if result.status:
+        raise CalledProcessError(command=command, status=status, output=output)
+    return result

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -597,10 +597,7 @@ class DockerImageBuilder(object):
             docker_dir.path
         ]
         run_process(command)
-        # XXX until https://clusterhq.atlassian.net/browse/FLOC-409 is
-        # fixed we will often have a container lying around which is still
-        # using the new image, so removing the image will fail.
-        # self.test.addCleanup(run_process, [b"docker", b"rmi", tag])
+        self.test.addCleanup(run_process, [b"docker", b"rmi", tag])
         return tag
 
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-167

Still a little bit of junk output but this gets rid of a about 99% of it.