### PR TITLE
Implementation sketch for collecting/tracking/using cluster-wide non-manifest dataset information

### DIFF
--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -35,6 +35,12 @@ class ClusterStateService(Service):
         """
         self._deployment_state = self._deployment_state.update_node(node_state)
 
+    # FLOC-1513
+    #
+    # Add a new method, replace_nonmanifest_datasets.
+    # It replaces _deployment_state with a new instance that has a new (not
+    # updated) set of dataset_ids.
+
     def manifestation_path(self, hostname, dataset_id):
         """
         Get the filesystem path of a manifestation on a particular node.

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -507,6 +507,14 @@ class NodeState(PRecord):
     manifestations = pmap_field(unicode, Manifestation, optional=True)
     paths = pmap_field(unicode, FilePath, optional=True)
 
+    # FLOC-1513
+    #
+    # Add an update_cluster_state method that accepts a ``DeploymentState``
+    # instance and just calls ``DeploymentState.update_node(self)``.
+    #
+    # Double-dispatch is in support of letting VisibleClusterState get involved
+    # in the update process too.
+
 
 class DeploymentState(PRecord):
     """
@@ -516,6 +524,28 @@ class DeploymentState(PRecord):
         the state of each cooperating node.
     """
     nodes = pset_field(NodeState)
+
+    # FLOC-1513
+    #
+    # A new mapping from dataset ids to dataset instances.  This represents
+    # information about all datasets that are known to exist but have no
+    # manifestations.  There cannot be any such datasets against a P2P backend.
+    # IaaS agents can discover these datasets by finding unattached volumes.
+    #
+    # This doesn't convey backend-specific information.  Backends are expected
+    # to be able to map a dataset id back onto whatever the backend specific
+    # storage is.  Membership in this map indicates *something* exists.
+    #
+    # The Dataset instances in this pmap are "state" Datasets.  They have a
+    # dataset_id and all the rest of their fields are basically meaningless
+    # (XXX maybe maximum_size should be populated eventually?)  (Huh we should
+    # have a separate type for dataset state vs config).
+    #
+    # nonmanifest_datasets = pmap_field(UUID, Dataset)
+
+    # FLOC-1513
+    #
+    # Add an __invariant__ so keys and values match up.
 
     def update_node(self, node_state):
         """

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -440,6 +440,12 @@ class P2PNodeDeployer(object):
         :returns: A ``Deferred`` which fires with a ``NodeState``
             instance.
         """
+        # FLOC-1513
+        #
+        # Does not require changes.  NodeState already implements the necessary
+        # interface (not formally).  There is no information about nonmanifest
+        # datasets to produce here.
+
         # Add real namespace support in
         # https://clusterhq.atlassian.net/browse/FLOC-737; for now we just
         # strip the namespace since there will only ever be one.

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -283,9 +283,18 @@ class ConvergenceLoop(object):
             # XXX FLOC-1542 will need to deal with partial updates, and
             # make sure there is no duplication with code in
             # flocker.control._clusterstate.
+
+            # FLOC-1513
+            #
+            # Change this to call
+            # local_state.update_cluster_state(self.cluster_state) instead.
+            # This allows ``NodeState`` and ``VisibleClusterState`` to work.
             self.cluster_state = self.cluster_state.update_node(local_state)
             with LOG_SEND_TO_CONTROL_SERVICE(
                     self.fsm.logger, connection=self.client) as context:
+                # FLOC-1513
+                #
+                # Add the nonmanifest dataset_ids to this call.
                 self.client.callRemote(NodeStateCommand,
                                        node_state=local_state,
                                        eliot_context=context)


### PR DESCRIPTION
Design for https://clusterhq.atlassian.net/browse/FLOC-1513

The general idea here is to add a new attribute to `DeploymentState` describing all datasets that are known to exist but are not manifest on any node.  The node->control service protocol is adjusted to allow nodes to tell the control service about this information.  The control service->node protocol is implicitly changed merely by having a new attribute on `DeploymentState`.

Thus, nodes collect the information and report it to the control service and the control service sends it back out to nodes to be used.  Initially all (IaaS) nodes collect and report this information.  Later we can fix things so fewer of them do (perhaps just one) to avoid the redundant work.
