### PR TITLE
[FLOC-1590] Acceptance move container

### DIFF
--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -355,6 +355,15 @@ class ContainerAPITests(TestCase):
         return d
 
     @require_mongo
+    def test_move_container_with_dataset(self):
+        """
+        Create a mongodb container with an attached dataset, issue API call
+        to move the container. Wait until we can connect to the running
+        container on the new host and verify the data has moved with it.
+        """
+        self.fail("not implemented yet")
+
+    @require_mongo
     def test_create_container_with_dataset(self):
         """
         Create a mongodb container with an attached dataset, insert some data,


### PR DESCRIPTION
Fixes FLOC-1590

Creates a MongoDB container on node 1 and writes some data. Moves the container with its associated dataset via the API move container endpoint to node 2. Then after moving, shuts down the container on node 2 and launches a new container on node 2 with a different exposed external port, then connects to that container and ensures the data written by the first container is mounted and can be re-read. This approach ensures the container has actually moved; we don't want the acceptance test to pass by accident, which could happen if the first container on node 1 hasn't moved, but we can still read the data because of the proxy layer when connecting to the originally open port on node 2's IP.