### PR TITLE
Move run logic floc 1667

### DIFF
--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -75,6 +75,9 @@ def run_state_change(change, deployer):
     return change.run(deployer)
 
 
+# run_state_change doesn't use the IStateChange implementation provided by
+# _InParallel and _Sequentially but those types provide it anyway because
+# certain other areas of the test suite depend on it.
 @implementer(IStateChange)
 class _InParallel(PRecord):
     changes = field(type=PVector, factory=pvector, mandatory=True)
@@ -92,6 +95,7 @@ def in_parallel(changes):
     return _InParallel(changes=changes)
 
 
+# See comment above _InParallel.
 @implementer(IStateChange)
 class _Sequentially(PRecord):
     changes = field(type=PVector, factory=pvector, mandatory=True)

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -64,12 +64,17 @@ def run_state_change(change, deployer):
     """
     if isinstance(change, _InParallel):
         return gather_deferreds(list(
-            subchange.run(deployer) for subchange in change.changes
+            run_state_change(subchange, deployer)
+            for subchange in change.changes
         ))
     if isinstance(change, _Sequentially):
         d = succeed(None)
         for subchange in change.changes:
-            d.addCallback(lambda _, change=subchange: change.run(deployer))
+            d.addCallback(
+                lambda _, subchange=subchange: run_state_change(
+                    subchange, deployer
+                )
+            )
         return d
 
     return change.run(deployer)

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -98,6 +98,27 @@ class SequentiallyTests(SynchronousTestCase):
                        self.failureResultOf(result).value])
         self.assertEqual(called, [False, False, exception])
 
+    def test_nested_sequentially(self):
+        """
+        ``run_state_changes`` executes all of the changes in a ``sequentially``
+        nested within another ``sequentially``.
+        """
+        actions = list(
+            ControllableAction(result=succeed(None))
+            for i in range(3)
+        )
+        subchanges = [
+            actions[0],
+            sequentially(changes=[actions[1]]),
+            actions[2],
+        ]
+        change = sequentially(changes=subchanges)
+        run_state_change(change, DEPLOYER)
+        self.assertEqual(
+            [True, True, True],
+            list(action.called for action in actions)
+        )
+
 
 class InParallelTests(SynchronousTestCase):
     """

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -22,6 +22,36 @@ InParallelIStateChangeTests = make_istatechange_tests(
     in_parallel, dict(changes=[1]), dict(changes=[2]))
 
 
+def _test_nested_change(case, outer_factory, inner_factory):
+    """
+    Assert that ``IChangeState`` providers wrapped inside ``inner_factory``
+    wrapped inside ``outer_factory`` are run with the same deployer argument as
+    is passed to ``run_state_change``.
+
+    :param TestCase case: A running test.
+    :param outer_factory: Either ``sequentially`` or ``in_parallel`` to
+        construct the top-level change to pass to ``run_state_change``.
+    :param inner_factory: Either ``sequentially`` or ``in_parallel`` to
+        construct a change to include the top-level change passed to
+        ``run_state_change``.
+
+    :raise: A test failure if the inner change is not run with the same
+        deployer as is passed to ``run_state_change``.
+    """
+    inner_action = ControllableAction(result=succeed(None))
+    subchanges = [
+        ControllableAction(result=succeed(None)),
+        inner_factory(changes=[inner_action]),
+        ControllableAction(result=succeed(None))
+    ]
+    change = outer_factory(changes=subchanges)
+    run_state_change(change, DEPLOYER)
+    case.assertEqual(
+        (True, DEPLOYER),
+        (inner_action.called, inner_action.deployer)
+    )
+
+
 class SequentiallyTests(SynchronousTestCase):
     """
     Tests for handling of ``sequentially`` by ``run_state_changes``.
@@ -103,21 +133,14 @@ class SequentiallyTests(SynchronousTestCase):
         ``run_state_changes`` executes all of the changes in a ``sequentially``
         nested within another ``sequentially``.
         """
-        actions = list(
-            ControllableAction(result=succeed(None))
-            for i in range(3)
-        )
-        subchanges = [
-            actions[0],
-            sequentially(changes=[actions[1]]),
-            actions[2],
-        ]
-        change = sequentially(changes=subchanges)
-        run_state_change(change, DEPLOYER)
-        self.assertEqual(
-            [True, True, True],
-            list(action.called for action in actions)
-        )
+        _test_nested_change(self, sequentially, sequentially)
+
+    def test_nested_in_parallel(self):
+        """
+        ``run_state_changes`` executes all of the changes in an ``in_parallel``
+        nested within a ``sequentially``.
+        """
+        _test_nested_change(self, sequentially, in_parallel)
 
 
 class InParallelTests(SynchronousTestCase):
@@ -200,3 +223,17 @@ class InParallelTests(SynchronousTestCase):
             len(subchanges),
             len(self.flushLoggedErrors(ZeroDivisionError))
         )
+
+    def test_nested_in_parallel(self):
+        """
+        ``run_state_changes`` executes all of the changes in an ``in_parallel``
+        nested within another ``in_parallel``.
+        """
+        _test_nested_change(self, in_parallel, in_parallel)
+
+    def test_nested_sequentially(self):
+        """
+        ``run_state_changes`` executes all of the changes in a ``sequentially``
+        nested within an ``in_parallel``.
+        """
+        _test_nested_change(self, in_parallel, sequentially)


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1667

Depends on FLOC-1666 / #1285, review that first.

This is the second step towards FLOC-1591.  It centralizes `IStateChange.run` calls in one place so it is easy to manipulate them (eg by logging them all).