### PR TITLE
[FLOC-1677] Log the port number rather than OpenPort in delete_open_port

### DIFF
--- a/flocker/route/_iptables.py
+++ b/flocker/route/_iptables.py
@@ -251,7 +251,7 @@ def delete_open_port(logger, port):
     :see: ``HostNetwork.delete_open_port``
     """
     action = DELETE_OPEN_PORT(
-        logger=logger, target_port=port)
+        logger=logger, target_port=port.port)
 
     with action:
         encoded_port = unicode(port.port).encode("ascii")

--- a/flocker/route/functional/test_iptables_create.py
+++ b/flocker/route/functional/test_iptables_create.py
@@ -499,8 +499,6 @@ class DeleteOpenPortTests(TestCase):
         action when the requested port has been opened.
         """
         port = self.network.open_port(self.expected_port)
-
-        # Only interested in logging behavior of delete_proxy here.
         self.patch(self.network, "logger", logger)
         self.network.delete_open_port(port)
 
@@ -515,7 +513,6 @@ class DeleteOpenPortTests(TestCase):
         ``HostNetwork.delete_open_port`` logs a failed ``DELETE_OPEN_PORT``
         action when the requested port has not been opened.
         """
-        # Only interested in logging behavior of delete_proxy here.
         self.patch(self.network, "logger", logger)
         self.assertRaises(
             Exception,

--- a/flocker/route/functional/test_iptables_create.py
+++ b/flocker/route/functional/test_iptables_create.py
@@ -20,8 +20,10 @@ from twisted.trial.unittest import TestCase
 from twisted.python.procutils import which
 
 from ...testtools import if_root
-from .. import make_host_network
-from .._logging import CREATE_PROXY_TO, DELETE_PROXY, IPTABLES
+from .. import make_host_network, OpenPort
+from .._logging import (
+    CREATE_PROXY_TO, DELETE_PROXY, IPTABLES, DELETE_OPEN_PORT
+)
 from .networktests import make_network_tests
 
 try:
@@ -471,3 +473,51 @@ class UsedPortsTests(TestCase):
 
         self.assertIn(
             client.getsockname()[1], network.enumerate_used_ports())
+
+
+class DeleteOpenPortTests(TestCase):
+    """
+    Tests for ``HostNetwork.delete_open_port``.
+    """
+    expected_port = 12345
+
+    @_dependency_skip
+    @_environment_skip
+    def setUp(self):
+        self.addCleanup(create_network_namespace().restore)
+        self.network = make_host_network()
+
+    @validateLogging(
+        assertHasAction,
+        DELETE_OPEN_PORT,
+        succeeded=True,
+        startFields={'target_port': expected_port}
+    )
+    def test_success(self, logger):
+        """
+        ``HostNetwork.delete_open_port`` logs a successful ``DELETE_OPEN_PORT``
+        action when the requested port has been opened.
+        """
+        port = self.network.open_port(self.expected_port)
+
+        # Only interested in logging behavior of delete_proxy here.
+        self.patch(self.network, "logger", logger)
+        self.network.delete_open_port(port)
+
+    @validateLogging(
+        assertHasAction,
+        DELETE_OPEN_PORT,
+        succeeded=False,
+        startFields={'target_port': expected_port}
+    )
+    def test_failure(self, logger):
+        """
+        ``HostNetwork.delete_open_port`` logs a failed ``DELETE_OPEN_PORT``
+        action when the requested port has not been opened.
+        """
+        # Only interested in logging behavior of delete_proxy here.
+        self.patch(self.network, "logger", logger)
+        self.assertRaises(
+            Exception,
+            self.network.delete_open_port, OpenPort(port=self.expected_port)
+        )


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-1677

I think the exception I saw in that issue was due to passing `OpenPort` rather than `int` as the `target_port` argument of the `DELETE_OPEN_PORT` Eliot action.

Hopefully, when that's fixed, we'll be able to see what the actual error is.
If this parent action can be serialised by Eliot, I think we'll see a child IPTABLES action fail with a more meaningful error message.