### PR TITLE
Automatically log IStateChanges

### DIFF
--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -75,6 +75,9 @@ def run_state_change(change, deployer):
     return change.run(deployer)
 
 
+# run_state_change doesn't use the IStateChange implementation provided by
+# _InParallel and _Sequentially but those types provide it anyway because
+# certain other areas of the test suite depend on it.
 @implementer(IStateChange)
 class _InParallel(PRecord):
     changes = field(type=PVector, factory=pvector, mandatory=True)
@@ -92,6 +95,7 @@ def in_parallel(changes):
     return _InParallel(changes=changes)
 
 
+# See comment above _InParallel.
 @implementer(IStateChange)
 class _Sequentially(PRecord):
     changes = field(type=PVector, factory=pvector, mandatory=True)

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -64,12 +64,17 @@ def run_state_change(change, deployer):
     """
     if isinstance(change, _InParallel):
         return gather_deferreds(list(
-            subchange.run(deployer) for subchange in change.changes
+            run_state_change(subchange, deployer)
+            for subchange in change.changes
         ))
     if isinstance(change, _Sequentially):
         d = succeed(None)
         for subchange in change.changes:
-            d.addCallback(lambda _, change=subchange: change.run(deployer))
+            d.addCallback(
+                lambda _, subchange=subchange: run_state_change(
+                    subchange, deployer
+                )
+            )
         return d
 
     return change.run(deployer)

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -149,6 +149,11 @@ class StartApplication(PRecord):
     application = field(type=Application, mandatory=True)
     node_state = field(type=NodeState, mandatory=True)
 
+    # This (and other eliot_action implementations) uses `start_action` because
+    # it was easier than defining a new `ActionType` with a bunch of fields.
+    # It might be worth doing that work eventually, though.  Also, this can
+    # turn into a regular attribute when the `_logger` argument is no longer
+    # required by Eliot.
     @property
     def eliot_action(self):
         return start_action(

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -13,7 +13,7 @@ from characteristic import attributes
 
 from pyrsistent import PRecord, field
 
-from eliot import write_failure, Logger
+from eliot import write_failure, Logger, start_action
 
 from twisted.internet.defer import gatherResults, fail, succeed
 
@@ -131,6 +131,10 @@ class _OldToNewDeployer(object):
             local_state, configuration, cluster_state)
 
 
+def _eliot_system(part):
+    return u"flocker:p2pdeployer:" + part
+
+
 @implementer(IStateChange)
 @attributes(["application", "node_state"])
 class StartApplication(object):
@@ -143,6 +147,14 @@ class StartApplication(object):
     :ivar NodeState node_state: The state of the node the ``Application``
         is running on.
     """
+
+    @property
+    def eliot_action(self):
+        return start_action(
+            _logger, _eliot_system(u"startapplication"),
+            name=self.application.name,
+        )
+
     def run(self, deployer):
         application = self.application
 
@@ -225,6 +237,13 @@ class StopApplication(object):
 
     :ivar Application application: The ``Application`` to stop.
     """
+    @property
+    def eliot_action(self):
+        return start_action(
+            _logger, _eliot_system(u"stopapplication"),
+            name=self.application.name,
+        )
+
     def run(self, deployer):
         application = self.application
         unit_name = application.name
@@ -239,6 +258,14 @@ class CreateDataset(object):
 
     :ivar Dataset dataset: Dataset to create.
     """
+    @property
+    def eliot_action(self):
+        return start_action(
+            _logger, _eliot_system(u"createdataset"),
+            dataset_id=self.dataset.dataset_id,
+            maximum_size=self.dataset.maximum_size,
+        )
+
     def run(self, deployer):
         volume = deployer.volume_service.get(
             name=_to_volume_name(self.dataset.dataset_id),
@@ -255,6 +282,14 @@ class ResizeDataset(object):
 
     :ivar Dataset dataset: Dataset to resize.
     """
+    @property
+    def eliot_action(self):
+        return start_action(
+            _logger, _eliot_system(u"createdataset"),
+            dataset_id=self.dataset.dataset_id,
+            maximum_size=self.dataset.maximum_size,
+        )
+
     def run(self, deployer):
         volume = deployer.volume_service.get(
             name=_to_volume_name(self.dataset.dataset_id),

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -10,7 +10,7 @@ devices.
 from uuid import UUID
 from subprocess import check_output
 
-from eliot import ActionType, Field, Logger
+from eliot import MessageType, ActionType, Field, Logger
 from eliot.serializers import identity
 
 from zope.interface import implementer, Interface
@@ -120,9 +120,15 @@ BLOCK_DEVICE_HOST = Field(
 CREATE_BLOCK_DEVICE_DATASET = ActionType(
     u"agent:blockdevice:create",
     [DATASET, MOUNTPOINT],
+    [],
+    u"A block-device-backed dataset is being created.",
+)
+
+BLOCK_DEVICE_DATASET_CREATED = MessageType(
+    u"agent:blockdevice:created",
     [DEVICE_PATH, BLOCK_DEVICE_ID, DATASET_ID, BLOCK_DEVICE_SIZE,
      BLOCK_DEVICE_HOST],
-    u"A block-device-backed dataset is being created.",
+    u"A block-device-backed dataset has been created.",
 )
 
 DESTROY_BLOCK_DEVICE_DATASET = ActionType(
@@ -354,13 +360,13 @@ class CreateBlockDeviceDataset(PRecord):
         self.mountpoint.makedirs()
         check_output(["mount", device.path, self.mountpoint.path])
 
-        # action.add_success_fields(
-        #     block_device_path=device,
-        #     block_device_id=volume.blockdevice_id,
-        #     dataset_id=volume.dataset_id,
-        #     block_device_size=volume.size,
-        #     block_device_host=volume.host,
-        # )
+        BLOCK_DEVICE_DATASET_CREATED(
+            block_device_path=device,
+            block_device_id=volume.blockdevice_id,
+            dataset_id=volume.dataset_id,
+            block_device_size=volume.size,
+            block_device_host=volume.host,
+        ).write(_logger)
         return succeed(None)
 
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -196,6 +196,8 @@ class DestroyBlockDeviceDataset(PRecord):
     """
     dataset_id = field(type=UUID, mandatory=True)
 
+    # This can be replaced with a regular attribute when the `_logger` argument
+    # is no longer required by Eliot.
     @property
     def eliot_action(self):
         return DESTROY_BLOCK_DEVICE_DATASET(

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -33,7 +33,7 @@ from ..blockdevice import (
     DESTROY_VOLUME,
 )
 
-from ... import IStateChange, in_parallel
+from ... import IStateChange, run_state_change, in_parallel
 from ...testtools import ideployer_tests_factory, to_node
 from ....testtools import run_process
 from ....control import (
@@ -1468,7 +1468,7 @@ class DestroyBlockDeviceDatasetTests(
             mountroot=mountroot,
         )
         change = DestroyBlockDeviceDataset(dataset_id=dataset_id)
-        self.successResultOf(change.run(deployer))
+        self.successResultOf(run_state_change(change, deployer))
 
         # It's only possible to destroy a volume that's been detached.  It's
         # only possible to detach a volume that's been unmounted.  If the

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -21,9 +21,11 @@ DEPLOYER = ControllableDeployer(u"192.168.1.1", (), ())
 
 
 SequentiallyIStateChangeTests = make_istatechange_tests(
-    sequentially, dict(changes=[1]), dict(changes=[2]))
+    sequentially, dict(changes=[1]), dict(changes=[2])
+)
 InParallelIStateChangeTests = make_istatechange_tests(
-    in_parallel, dict(changes=[1]), dict(changes=[2]))
+    in_parallel, dict(changes=[1]), dict(changes=[2])
+)
 
 
 def _test_nested_change(case, outer_factory, inner_factory):

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -58,36 +58,6 @@ def _test_nested_change(case, outer_factory, inner_factory):
     )
 
 
-def _test_nested_change(case, outer_factory, inner_factory):
-    """
-    Assert that ``IChangeState`` providers wrapped inside ``inner_factory``
-    wrapped inside ``outer_factory`` are run with the same deployer argument as
-    is passed to ``run_state_change``.
-
-    :param TestCase case: A running test.
-    :param outer_factory: Either ``sequentially`` or ``in_parallel`` to
-        construct the top-level change to pass to ``run_state_change``.
-    :param inner_factory: Either ``sequentially`` or ``in_parallel`` to
-        construct a change to include the top-level change passed to
-        ``run_state_change``.
-
-    :raise: A test failure if the inner change is not run with the same
-        deployer as is passed to ``run_state_change``.
-    """
-    inner_action = ControllableAction(result=succeed(None))
-    subchanges = [
-        ControllableAction(result=succeed(None)),
-        inner_factory(changes=[inner_action]),
-        ControllableAction(result=succeed(None))
-    ]
-    change = outer_factory(changes=subchanges)
-    run_state_change(change, DEPLOYER)
-    case.assertEqual(
-        (True, DEPLOYER),
-        (inner_action.called, inner_action.deployer)
-    )
-
-
 class SequentiallyTests(SynchronousTestCase):
     """
     Tests for handling of ``sequentially`` by ``run_state_changes``.

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -98,6 +98,27 @@ class SequentiallyTests(SynchronousTestCase):
                        self.failureResultOf(result).value])
         self.assertEqual(called, [False, False, exception])
 
+    def test_nested_sequentially(self):
+        """
+        ``run_state_changes`` executes all of the changes in a ``sequentially``
+        nested within another ``sequentially``.
+        """
+        actions = list(
+            ControllableAction(result=succeed(None))
+            for i in range(3)
+        )
+        subchanges = [
+            actions[0],
+            sequentially(changes=[actions[1]]),
+            actions[2],
+        ]
+        change = sequentially(changes=subchanges)
+        run_state_change(change, DEPLOYER)
+        self.assertEqual(
+            [True, True, True],
+            list(action.called for action in actions)
+        )
+
 
 class InParallelTests(SynchronousTestCase):
     """

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -22,6 +22,36 @@ InParallelIStateChangeTests = make_istatechange_tests(
     in_parallel, dict(changes=[1]), dict(changes=[2]))
 
 
+def _test_nested_change(case, outer_factory, inner_factory):
+    """
+    Assert that ``IChangeState`` providers wrapped inside ``inner_factory``
+    wrapped inside ``outer_factory`` are run with the same deployer argument as
+    is passed to ``run_state_change``.
+
+    :param TestCase case: A running test.
+    :param outer_factory: Either ``sequentially`` or ``in_parallel`` to
+        construct the top-level change to pass to ``run_state_change``.
+    :param inner_factory: Either ``sequentially`` or ``in_parallel`` to
+        construct a change to include the top-level change passed to
+        ``run_state_change``.
+
+    :raise: A test failure if the inner change is not run with the same
+        deployer as is passed to ``run_state_change``.
+    """
+    inner_action = ControllableAction(result=succeed(None))
+    subchanges = [
+        ControllableAction(result=succeed(None)),
+        inner_factory(changes=[inner_action]),
+        ControllableAction(result=succeed(None))
+    ]
+    change = outer_factory(changes=subchanges)
+    run_state_change(change, DEPLOYER)
+    case.assertEqual(
+        (True, DEPLOYER),
+        (inner_action.called, inner_action.deployer)
+    )
+
+
 class SequentiallyTests(SynchronousTestCase):
     """
     Tests for handling of ``sequentially`` by ``run_state_changes``.
@@ -103,21 +133,14 @@ class SequentiallyTests(SynchronousTestCase):
         ``run_state_changes`` executes all of the changes in a ``sequentially``
         nested within another ``sequentially``.
         """
-        actions = list(
-            ControllableAction(result=succeed(None))
-            for i in range(3)
-        )
-        subchanges = [
-            actions[0],
-            sequentially(changes=[actions[1]]),
-            actions[2],
-        ]
-        change = sequentially(changes=subchanges)
-        run_state_change(change, DEPLOYER)
-        self.assertEqual(
-            [True, True, True],
-            list(action.called for action in actions)
-        )
+        _test_nested_change(self, sequentially, sequentially)
+
+    def test_nested_in_parallel(self):
+        """
+        ``run_state_changes`` executes all of the changes in an ``in_parallel``
+        nested within a ``sequentially``.
+        """
+        _test_nested_change(self, sequentially, in_parallel)
 
 
 class InParallelTests(SynchronousTestCase):
@@ -200,3 +223,17 @@ class InParallelTests(SynchronousTestCase):
             len(subchanges),
             len(self.flushLoggedErrors(ZeroDivisionError))
         )
+
+    def test_nested_in_parallel(self):
+        """
+        ``run_state_changes`` executes all of the changes in an ``in_parallel``
+        nested within another ``in_parallel``.
+        """
+        _test_nested_change(self, in_parallel, in_parallel)
+
+    def test_nested_sequentially(self):
+        """
+        ``run_state_changes`` executes all of the changes in a ``sequentially``
+        nested within an ``in_parallel``.
+        """
+        _test_nested_change(self, in_parallel, sequentially)

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -7,7 +7,11 @@ Tests for ``flocker.node._change``.
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import FirstError, Deferred, succeed, fail
 
-from ..testtools import ControllableAction, ControllableDeployer
+from eliot.testing import validate_logging, assertHasAction
+
+from ..testtools import (
+    CONTROLLABLE_ACTION_TYPE, ControllableAction, ControllableDeployer
+)
 
 from .. import sequentially, in_parallel, run_state_change
 
@@ -237,3 +241,51 @@ class InParallelTests(SynchronousTestCase):
         nested within an ``in_parallel``.
         """
         _test_nested_change(self, in_parallel, sequentially)
+
+
+class RunStateChangeTests(SynchronousTestCase):
+    """
+    Direct unit tests for ``run_state_change``.
+    """
+    def test_run(self):
+        """
+        ``run_state_change`` calls the ``run`` method of the ``IStateChange``
+        passed to it and passes along the same deployer it was called with.
+        """
+        action = ControllableAction(result=succeed(None))
+        run_state_change(action, DEPLOYER)
+        self.assertTrue(
+            (True, DEPLOYER),
+            (action.called, action.deployer)
+        )
+
+    @validate_logging(
+        assertHasAction, CONTROLLABLE_ACTION_TYPE, succeeded=True,
+    )
+    def test_succeed(self, logger):
+        """
+        If the change passed to ``run_state_change`` returns a ``Deferred``
+        that succeeds, the ``Deferred`` returned by ``run_state_change``
+        succeeds.
+        """
+        action = ControllableAction(result=succeed(None))
+        action._logger = logger
+        self.assertIs(
+            None, self.successResultOf(run_state_change(action, DEPLOYER))
+        )
+
+    @validate_logging(
+        assertHasAction, CONTROLLABLE_ACTION_TYPE, succeeded=False,
+    )
+    def test_failed(self, logger):
+        """
+        If the change passed to ``run_state_change`` returns a ``Deferred``
+        that fails, the ``Deferred`` returned by ``run_state_change`` fails the
+        same way.
+        """
+        action = ControllableAction(result=fail(Exception("Oh no")))
+        action._logger = logger
+        failure = self.failureResultOf(run_state_change(action, DEPLOYER))
+        self.assertEqual(failure.getErrorMessage(), "Oh no")
+
+

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -18,6 +18,8 @@ from twisted.trial.unittest import TestCase
 
 from zope.interface.verify import verifyObject
 
+from eliot import Logger, ActionType
+
 from ._deploy import _OldToNewDeployer
 from ._docker import BASE_DOCKER_API_URL
 from . import IDeployer, IStateChange
@@ -81,6 +83,9 @@ def wait_for_unit_state(docker_client, unit_name, expected_activation_states):
     return loop_until(check_if_in_states)
 
 
+CONTROLLABLE_ACTION_TYPE = ActionType(u"test:controllableaction", [], [])
+
+
 @implementer(IStateChange)
 @attributes(['result'])
 class ControllableAction(object):
@@ -89,6 +94,12 @@ class ControllableAction(object):
     """
     called = False
     deployer = None
+
+    _logger = Logger()
+
+    @property
+    def eliot_action(self):
+        return CONTROLLABLE_ACTION_TYPE(self._logger)
 
     def run(self, deployer):
         self.called = True


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1591

This is the last step.  Logging is added to the new `run_state_change` API and existing `IStateChange` implementations are augmented with the necessary Eliot logging information.
