### PR TITLE
make the order of `changes` passed to `in_parallel` irrelevant

### DIFF
--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -97,6 +97,9 @@ def run_state_change(change, deployer):
 class _InParallel(PRecord):
     changes = field(
         type=PVector,
+        # Sort the changes for the benefit of comparison.  Stick with a vector
+        # (rather than, say, a set) in case someone wants to run the same
+        # change multiple times in parallel.
         factory=lambda changes: pvector(sorted(changes)),
         mandatory=True
     )

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -119,6 +119,7 @@ def in_parallel(changes):
     Failures in one change do not prevent other changes from continuing.
 
     The order in which execution of the changes is started is unspecified.
+    Comparison of the resulting object disregards the ordering of the changes.
     """
     return _InParallel(changes=changes)
 

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -95,7 +95,11 @@ def run_state_change(change, deployer):
 # certain other areas of the test suite depend on it.
 @implementer(IStateChange)
 class _InParallel(PRecord):
-    changes = field(type=PVector, factory=pvector, mandatory=True)
+    changes = field(
+        type=PVector,
+        factory=lambda changes: pvector(sorted(changes)),
+        mandatory=True
+    )
 
     # Supplied so we technically conform to the interface.  This won't actually
     # be used.
@@ -110,6 +114,8 @@ def in_parallel(changes):
     Run a series of changes in parallel.
 
     Failures in one change do not prevent other changes from continuing.
+
+    The order in which execution of the changes is started is unspecified.
     """
     return _InParallel(changes=changes)
 

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -83,7 +83,7 @@ class InParallelIStateChangeTests(
     def test_duplicates_run(self):
         """
         If the same change is passed to ``in_parallel`` twice then it is run
-        twice then the resulting ``IStateChange`` is run.
+        twice.
         """
         deployer = DummyDeployer()
         the_change = RunSpyStateChange(value=0)

--- a/flocker/node/test/test_testtools.py
+++ b/flocker/node/test/test_testtools.py
@@ -1,0 +1,46 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.node.testtools``.
+"""
+
+from zope.interface import implementer
+
+from twisted.internet.defer import succeed
+
+from .. import sequentially
+from ..testtools import (
+    DummyDeployer, ControllableDeployer, ideployer_tests_factory,
+)
+from ...control import IClusterStateChange
+
+
+@implementer(IClusterStateChange)
+class DummyClusterStateChange(object):
+    """
+    A non-implementation of ``IClusterStateChange``.
+    """
+    def update_cluster_state(self, cluster_state):
+        return cluster_state
+
+
+class DummyDeployerIDeployerTests(
+    ideployer_tests_factory(lambda case: DummyDeployer())
+):
+    """
+    Tests for the ``IDeployer`` implementation of ``DummyDeployer``.
+    """
+
+
+class ControllableDeployerIDeployerTests(
+    ideployer_tests_factory(
+        lambda case: ControllableDeployer(
+            hostname=u"10.0.0.1",
+            local_states=[succeed(DummyClusterStateChange())],
+            calculated_actions=[sequentially(changes=[])],
+        )
+    )
+):
+    """
+    Tests for the ``IDeployer`` implementation of ``DummyDeployer``.
+    """

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -21,7 +21,7 @@ from zope.interface.verify import verifyObject
 from eliot import Logger, ActionType
 
 from ._docker import BASE_DOCKER_API_URL
-from . import IDeployer, IStateChange
+from . import IDeployer, IStateChange, sequentially
 from ..testtools import loop_until
 from ..control import (
     IClusterStateChange, Node, NodeState, Deployment, DeploymentState)
@@ -102,6 +102,18 @@ class ControllableAction(object):
         self.called = True
         self.deployer = deployer
         return self.result
+
+
+@implementer(IDeployer)
+class DummyDeployer(object):
+    """
+    A non-implementation of ``IDeployer``.
+    """
+    def discover_state(self, node_stat):
+        return ()
+
+    def calculate_changes(self, desired_configuration, cluster_state):
+        return sequentially(changes=[])
 
 
 @implementer(IDeployer)

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -15,6 +15,7 @@ from zope.interface import implementer
 from characteristic import attributes
 
 from twisted.trial.unittest import TestCase
+from twisted.internet.defer import succeed
 
 from zope.interface.verify import verifyObject
 
@@ -109,8 +110,10 @@ class DummyDeployer(object):
     """
     A non-implementation of ``IDeployer``.
     """
+    hostname = u"127.0.0.1"
+
     def discover_state(self, node_stat):
-        return ()
+        return succeed(())
 
     def calculate_changes(self, desired_configuration, cluster_state):
         return sequentially(changes=[])


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1714

I almost made `changes` a `PSet` but I concluded that being able to run the same change twice is probably a legitimate use-case (and at the very least less surprising than having two changes collapsed into one).