### PR TITLE
Replace gsutil with awsutil

### DIFF
--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -49,8 +49,6 @@ Software
 Access
 ~~~~~~
 
-- Access to `Google Cloud Storage`_.
-
 - Access to Amazon `S3`_ with an `Access Key ID and Secret Access Key <https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html>`_.
   It is possible that you will have an account but not the permissions to create an Access Key ID and Secret Access Key.
 
@@ -58,7 +56,7 @@ Access
 
 - An OS X (most recent release) system.
 
-.. note:: For a maintenance or documentation release, access to Google Cloud Storage and Atlas is not required.
+.. note:: For a maintenance or documentation release, access to Atlas is not required.
 
 .. _preparing-for-a-release:
 
@@ -90,7 +88,7 @@ Preparing For a Release
    This copies your local git configuration from ``~/.gitconfig``.
    If this does not exist, commits made for the release will be associated with the default Vagrant username and email address.
 
-   This copies your local configuration for `gsutil`_ and `S3`_ from ``~/.boto``.
+   This copies your local configuration for `S3`_ from ``~/.aws``.
    If this does not exist, a later step will create it.
 
    .. prompt:: bash $
@@ -99,7 +97,7 @@ Preparing For a Release
       cd flocker-${VERSION}
       vagrant up
       vagrant ssh -c "echo export VERSION=${VERSION} >> .bashrc"
-      if [ -f ~/.boto ]; then vagrant scp "~/.boto" /home/vagrant; fi
+      if [ -d ~/.aws ]; then vagrant scp "~/.aws" /home/vagrant; fi
       vagrant ssh -- -A
 
 #. Create a release branch, and create and activate a virtual environment:
@@ -206,24 +204,14 @@ Preparing For a Release
       git commit -am "Updated Vagrantfile"
       git push --set-upstream origin release/flocker-${VERSION}
 
-#. Set up Google Cloud Storage and Amazon S3 credentials:
+#. Set up ``AWS Access Key ID`` and ``AWS Secret Access Key`` Amazon S3 credentials:
 
-   Creating the Vagrant machine attempts to copy the ``~/.boto`` configuration file from the host machine.
-
-   Run:
-
-   .. prompt:: bash [vagrant@localhost]$
-
-     gsutil ls gs:// s3://
-
-   If the credentials have been set up correctly, you should see ClusterHQ's ``gs://`` and ``s3://`` buckets.
-   If they have not, run:
+   Creating the Vagrant machine attempts to copy the ``~/.aws`` configuration directory from the host machine.
+   This means that ``awsutil`` may have correct defaults.
 
    .. prompt:: bash [vagrant@localhost]$
 
-      gsutil config
-
-   and set ``aws_access_key_id`` and ``aws_secret_access_key`` in the ``[Credentials]`` section of ``~/.boto`` to allow access to Amazon `S3`_ using `gsutil`_.
+      aws configure
 
 #. Update the staging documentation:
 
@@ -509,7 +497,6 @@ Look at `existing issues relating to the release process <https://clusterhq.atla
 The issue(s) for the planned improvements should be put into the next sprint.
 
 
-.. _gsutil: https://developers.google.com/storage/docs/gsutil
 .. _wheel: https://pypi.python.org/pypi/wheel
 .. _Google cloud storage: https://console.developers.google.com/project/apps~hybridcluster-docker/storage/archive.clusterhq.com/
 .. _homebrew-tap: https://github.com/ClusterHQ/homebrew-tap

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -434,15 +434,15 @@ Release
       git merge origin/release/flocker-${VERSION}
       git push
 
-#. Copy the ``boto`` configuration file to your local home directory:
+#. Copy the AWS configuration to your local home directory:
 
-   If the ``boto`` configuration is on your workstation it will not have to be recreated next time you do a release.
+   If the AWS configuration is on your workstation it will not have to be recreated next time you do a release.
 
    .. prompt:: bash [vagrant@localhost]$,$ auto
 
       [vagrant@localhost]$ logout
       Connection to 127.0.0.1 closed.
-      $ vagrant scp default:/home/vagrant/.boto ~/
+      $ vagrant scp default:/home/vagrant/.aws ~/
 
 #. Submit the release pull request for review again.
 

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -207,7 +207,7 @@ Preparing For a Release
 #. Set up ``AWS Access Key ID`` and ``AWS Secret Access Key`` Amazon S3 credentials:
 
    Creating the Vagrant machine attempts to copy the ``~/.aws`` configuration directory from the host machine.
-   This means that ``awsutil`` may have correct defaults.
+   This means that ``awscli`` may have correct defaults.
 
    .. prompt:: bash [vagrant@localhost]$
 

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ setup(
         # environment.
         "release": [
             "gitpython==1.0.0",
-            "gsutil",
+            "awscli==1.7.25",
             "wheel==0.24.0",
             "virtualenv",
             "PyCrypto",


### PR DESCRIPTION
This can be reviewed but should not be merged yet because there is one outstanding use of `gsutil` in the release process. The issue (currently awaiting review) to remove this is https://clusterhq.atlassian.net/browse/FLOC-1718.

There are other uses of gsutil in the docs but some are going away, none already told you to use Flocker's setup.py, and most are very rarely run.