### PR TITLE
Yml startup floc 1790

### DIFF
--- a/admin/package-files/systemd/flocker-agent.service
+++ b/admin/package-files/systemd/flocker-agent.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Flocker ZFS Agent
+AssertFileNotEmpty=/etc/flocker/agent.yml
 
 [Service]
-ExecStart=/usr/sbin/flocker-zfs-agent $FLOCKER_CONTROL_NODE
-EnvironmentFile=/etc/sysconfig/flocker-agent
+ExecStart=/usr/sbin/flocker-zfs-agent
 
 # We can't have a private mount namespace, since we need to see ZFS created mounts.
 

--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Flocker Container Agent
+AssertFileNotEmpty=/etc/flocker/agent.yml
 
 [Service]
-ExecStart=/usr/sbin/flocker-container-agent $FLOCKER_CONTROL_NODE
-EnvironmentFile=/etc/sysconfig/flocker-agent
+ExecStart=/usr/sbin/flocker-container-agent
 
 [Install]
 WantedBy=multi-user.target

--- a/admin/package-files/upstart/flocker-agent.conf
+++ b/admin/package-files/upstart/flocker-agent.conf
@@ -8,7 +8,10 @@ stop on runlevel [016]
 
 respawn
 
+pre-start script
+  [ -r /etc/flocker/agent.yml ]
+end script
+
 script
-	. /etc/default/flocker-agent.conf
-	exec /usr/sbin/flocker-zfs-agent $FLOCKER_CONTROL_NODE
+	exec /usr/sbin/flocker-zfs-agent
 end script

--- a/admin/package-files/upstart/flocker-agent.conf
+++ b/admin/package-files/upstart/flocker-agent.conf
@@ -9,7 +9,10 @@ stop on runlevel [016]
 respawn
 
 pre-start script
-  [ -r /etc/flocker/agent.yml ]
+	if [ ! -r /etc/flocker/agent.yml ]; then
+		echo "Cannot read configuration file '/etc/flocker/agent.yml'."
+		exit 1
+	fi
 end script
 
 script

--- a/admin/package-files/upstart/flocker-container-agent.conf
+++ b/admin/package-files/upstart/flocker-container-agent.conf
@@ -8,7 +8,10 @@ stop on runlevel [016]
 
 respawn
 
+pre-start script
+  [ -r /etc/flocker/agent.yml ]
+end script
+
 script
-	. /etc/default/flocker-agent.conf
-	exec /usr/sbin/flocker-container-agent $FLOCKER_CONTROL_NODE
+	exec /usr/sbin/flocker-container-agent
 end script

--- a/admin/package-files/upstart/flocker-container-agent.conf
+++ b/admin/package-files/upstart/flocker-container-agent.conf
@@ -9,7 +9,10 @@ stop on runlevel [016]
 respawn
 
 pre-start script
-  [ -r /etc/flocker/agent.yml ]
+	if [ ! -r /etc/flocker/agent.yml ]; then
+		echo "Cannot read configuration file '/etc/flocker/agent.yml'."
+		exit 1
+	fi
 end script
 
 script

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -43,6 +43,10 @@ Ubuntu
 
 TODO
 
+TODO? Move most of this document somewhere?
+TODO? Make the service file assert the file exists
+TODO? Make the provision code use the config?
+
 API Details
 ===========
 

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -69,8 +69,6 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 .. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}
    :prompt: [root@agent-node]#
 
-TODO port option
-TODO version
 
 API Details
 ===========

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -41,10 +41,9 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 Ubuntu
 ------
 
-TODO
+TODO (including changing upstart file)
 
 TODO? Move most of this document somewhere?
-TODO Make the service file assert the file exists
 
 API Details
 ===========

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -44,8 +44,11 @@ Ubuntu
 TODO
 
 TODO? Move most of this document somewhere?
-TODO? Make the service file assert the file exists
-TODO? Make the provision code use the config?
+TODO? Change the name of the file?
+TODO Make the service file assert the file exists
+TODO Make the provision._install code use the config
+
+
 
 API Details
 ===========

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -67,9 +67,8 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 .. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}
    :prompt: [root@agent-node]#
 
-TODO Change upstart file
-
-TODO? Move most of this document somewhere?
+- Quotes around yml - looks bad with option
+- We're not moving this document but agree that it should be moved and have asked David to look into this for before the story is submitted
 
 API Details
 ===========

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -11,8 +11,8 @@ While this API is not yet directly accessible in a standard Flocker setup, the d
 Installation
 ============
 
-Fedora/CentOS
--------------
+Fedora / CentOS
+---------------
 
 To enable the Flocker control service.
 
@@ -28,10 +28,20 @@ To configure firewalld to allow access to the control service REST API, and for 
 (On AWS, an external firewall is used instead, which will need to be configured similarity).
 For more details on configuring the firewall, see Fedora's `firewalld documentation <https://fedoraproject.org/wiki/FirewallD>`_.
 
-To start the agents on a node, where ``${CONTROL_NODE}`` is the address of the control node:
+To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/dataset-agent.yml``.
+This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node:
+
+.. code-block:: yaml
+
+   "control-service-endpoint": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent fedora-20 ${CONTROL_NODE}
    :prompt: [root@agent-node]#
+
+Ubuntu
+------
+
+TODO
 
 API Details
 ===========

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -14,19 +14,20 @@ Installation
 Fedora / CentOS
 ---------------
 
-To enable the Flocker control service.
+To enable the Flocker control service:
 
 .. task:: enable_flocker_control fedora-20
    :prompt: [root@control-node]#
 
 The control service needs to accessible remotely.
-To configure firewalld to allow access to the control service REST API, and for agent connections,
+To configure firewalld to allow access to the control service REST API, and for agent connections:
 
 .. task:: open_control_firewall fedora-20
    :prompt: [root@control-node]#
 
-(On AWS, an external firewall is used instead, which will need to be configured similarity).
 For more details on configuring the firewall, see Fedora's `firewalld documentation <https://fedoraproject.org/wiki/FirewallD>`_.
+
+On AWS, an external firewall is used instead, which will need to be configured similarly.
 
 To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
 This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node:

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -45,9 +45,6 @@ TODO
 
 TODO? Move most of this document somewhere?
 TODO Make the service file assert the file exists
-TODO Make the provision._install code use the config
-
-
 
 API Details
 ===========

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -34,7 +34,7 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 
 .. code-block:: yaml
 
-   "version": "0.1"
+   "version": 1
    "control-service-endpoint": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent fedora-20 ${CONTROL_NODE}
@@ -63,7 +63,7 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 
 .. code-block:: yaml
 
-   "version": "0.1"
+   "version": 1
    "control-service-endpoint": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -35,7 +35,7 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 .. code-block:: yaml
 
    "version": 1
-   "control-service-endpoint": "${CONTROL_NODE}"
+   "control-service-hostname": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent fedora-20 ${CONTROL_NODE}
    :prompt: [root@agent-node]#
@@ -64,7 +64,7 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 .. code-block:: yaml
 
    "version": 1
-   "control-service-endpoint": "${CONTROL_NODE}"
+   "control-service-hostname": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}
    :prompt: [root@agent-node]#

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -28,7 +28,7 @@ To configure firewalld to allow access to the control service REST API, and for 
 (On AWS, an external firewall is used instead, which will need to be configured similarity).
 For more details on configuring the firewall, see Fedora's `firewalld documentation <https://fedoraproject.org/wiki/FirewallD>`_.
 
-To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/dataset-agent.yml``.
+To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
 This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node:
 
 .. code-block:: yaml
@@ -44,7 +44,6 @@ Ubuntu
 TODO
 
 TODO? Move most of this document somewhere?
-TODO? Change the name of the file?
 TODO Make the service file assert the file exists
 TODO Make the provision._install code use the config
 

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -34,6 +34,7 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 
 .. code-block:: yaml
 
+   "version": "0.1"
    "control-service-endpoint": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent fedora-20 ${CONTROL_NODE}
@@ -62,13 +63,14 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 
 .. code-block:: yaml
 
+   "version": "0.1"
    "control-service-endpoint": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}
    :prompt: [root@agent-node]#
 
-- Quotes around yml - looks bad with option
-- We're not moving this document but agree that it should be moved and have asked David to look into this for before the story is submitted
+TODO port option
+TODO version
 
 API Details
 ===========

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -42,7 +42,32 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 Ubuntu
 ------
 
-TODO (including changing upstart file)
+To enable the Flocker control service:
+
+.. task:: enable_flocker_control ubuntu-14.04
+   :prompt: [root@control-node]#
+
+The control service needs to accessible remotely.
+To configure ``UFW`` to allow access to the control service REST API, and for agent connections:
+
+.. task:: open_control_firewall ubuntu-14.04
+   :prompt: [root@control-node]#
+
+For more details on configuring the firewall, see Ubuntu's `UFW documentation <https://help.ubuntu.com/community/UFW>`_.
+
+On AWS, an external firewall is used instead, which will need to be configured similarly.
+
+To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
+This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node:
+
+.. code-block:: yaml
+
+   "control-service-endpoint": "${CONTROL_NODE}"
+
+.. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}
+   :prompt: [root@agent-node]#
+
+TODO Change upstart file
 
 TODO? Move most of this document somewhere?
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -104,11 +104,29 @@ def agent_config_from_file(path):
 
     :return dict: Dictionary containing the desired configuration.
     """
+    from jsonschema import validate
+    from jsonschema.exceptions import ValidationError
+
     try:
         options = yaml.safe_load(path.getContent())
     except IOError:
         raise ConfigurationError(
             "Configuration file does not exist at '{}'.".format(path.path))
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "version": {"type" : "number"},
+            "control-service-hostname": {"type": "string"},
+        }
+    }
+
+    try:
+        validate(options, schema)
+    except ValidationError:
+        raise ConfigurationError(
+            "Configuration has an error. It is not in a valid format.")
+
 
     if _lookup_key(configuration=options, key=u'version') != 1:
         raise ConfigurationError(

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -7,6 +7,7 @@ The command-line ``flocker-*-agent`` tools.
 
 from functools import partial
 from socket import socket
+import yaml
 
 from pyrsistent import PRecord, field
 
@@ -49,8 +50,8 @@ class ZFSAgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
-         # TODO we actually have --config from flocker_volume_options
-         # TODO also change the tests to use this
+         # TODO we actually have --config from flocker_volume_options,
+         # maybe that is confusing
         ["config-file", "c", "/etc/flocker/dataset-agent.yml",
          "The configuration file for the dataset agent."],
     ]
@@ -86,7 +87,6 @@ class ZFSAgentScript(object):
     a Flocker cluster.
     """
     def main(self, reactor, options, volume_service):
-        import yaml
         config = yaml.safe_load(options['config-file'].getContent())
         host = config['control-service-hostname']
         port = options["destination-port"]
@@ -200,7 +200,8 @@ class AgentServiceFactory(PRecord):
 
         :return: The ``AgentLoopService`` instance.
         """
-        host = options["destination-host"]
+        config = yaml.safe_load(options['config-file'].getContent())
+        host = config['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
         return AgentLoopService(

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -12,6 +12,7 @@ from pyrsistent import PRecord, field
 
 from zope.interface import implementer
 
+from twisted.python.filepath import FilePath
 from twisted.python.usage import Options
 
 from ..volume.service import (
@@ -113,15 +114,17 @@ class _AgentOptions(Options):
     common options with ``ZFSAgentOptions``.
     """
     # Use as basis for subclass' synopsis:
-    synopsis = "Usage: {} [OPTIONS] <control-service-hostname>"
+    synopsis = "Usage: {} [OPTIONS]"
 
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
+        ["config-file", "c", "/etc/flocker/dataset-agent.yml",
+         "The configuration file for the dataset agent."],
     ]
 
-    def parseArgs(self, host):
-        self["destination-host"] = unicode(host, "ascii")
+    def parseArgs(self):
+        self['config-file'] = FilePath(self['config-file'])
 
 
 class DatasetAgentOptions(_AgentOptions):

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -86,7 +86,9 @@ class ZFSAgentScript(object):
     a Flocker cluster.
     """
     def main(self, reactor, options, volume_service):
-        host = options["destination-host"]
+        import yaml
+        config = yaml.safe_load(options['config-file'].getContent())
+        host = config['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
         # Soon we'll extract this from TLS certificate for node.  Until then

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -95,22 +95,20 @@ def _lookup_key(configuration, key):
             "Configuration has an error. Missing '{}' key.".format(key))
 
 
-def configuration_from_options(options):
+def agent_config_from_file(path):
     """
     Extract configuration from provided options.
 
-    :param dict options: Dictionary containing command line options.
+    :param FilePath path: Path to a file containing specified options for an
+        agent.
 
     :return dict: Dictionary containing the desired configuration.
     """
-    control_service_options_file = options[u'agent-config']
-
     try:
-        options_content = control_service_options_file.getContent()
+        options_content = path.getContent()
     except IOError:
         raise ConfigurationError(
-            "Configuration file does not exist at '{}'.".format(
-                control_service_options_file.path))
+            "Configuration file does not exist at '{}'.".format(path.path))
 
     options_yaml = yaml.safe_load(options_content)
 
@@ -130,7 +128,7 @@ class ZFSAgentScript(object):
     a Flocker cluster.
     """
     def main(self, reactor, options, volume_service):
-        configuration = configuration_from_options(options)
+        configuration = agent_config_from_file(path=options[u'agent-config'])
         host = configuration['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
@@ -244,7 +242,7 @@ class AgentServiceFactory(PRecord):
 
         :return: The ``AgentLoopService`` instance.
         """
-        configuration = configuration_from_options(options)
+        configuration = agent_config_from_file(path=options[u'agent-config'])
         host = configuration['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -105,20 +105,18 @@ def agent_config_from_file(path):
     :return dict: Dictionary containing the desired configuration.
     """
     try:
-        options_content = path.getContent()
+        options = yaml.safe_load(path.getContent())
     except IOError:
         raise ConfigurationError(
             "Configuration file does not exist at '{}'.".format(path.path))
 
-    options_yaml = yaml.safe_load(options_content)
-
-    if _lookup_key(configuration=options_yaml, key=u'version') != 1:
+    if _lookup_key(configuration=options, key=u'version') != 1:
         raise ConfigurationError(
             "Configuration has an error. Incorrect version specified.")
 
     return {
         'control-service-hostname': _lookup_key(
-            configuration=options_yaml, key=u'control-service-hostname')
+            configuration=options, key=u'control-service-hostname')
     }
 
 @implementer(ICommandLineVolumeScript)

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -82,7 +82,7 @@ def _get_external_ip(host, port):
 def configuration_from_options(options):
     """
     """
-    options_file = options['control-service-config']
+    options_file = options[u'control-service-config']
     # handle if this load doesn't work
     try:
         options_content = options_file.getContent()
@@ -95,7 +95,19 @@ def configuration_from_options(options):
     # check version
     configuration = {}
     # nice error message if this fails
-    configuration['control-service-hostname'] = options_yaml['control-service-hostname']
+    try:
+        configuration['control-service-hostname'] = options_yaml[u'control-service-hostname']
+    except (TypeError, KeyError):
+        raise ConfigurationError("Configuration has an error. "
+            "Missing 'control-service-hostname' key.")
+
+    try:
+        if  options_yaml[u'version'] != 1:
+            raise ConfigurationError(
+                "Configuration has an error. Incorrect version specified.")
+    except KeyError:
+        raise ConfigurationError("Configuration has an error. "
+            "Missing 'version' key.")
 
     return configuration
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -9,7 +9,7 @@ from functools import partial
 from socket import socket
 import yaml
 
-from jsonschema import validate
+from jsonschema import FormatChecker, validate
 from jsonschema.exceptions import ValidationError
 
 from pyrsistent import PRecord, field
@@ -99,16 +99,20 @@ def agent_config_from_file(path):
             "Configuration file does not exist at '{}'.".format(path.path))
 
     schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "required": ["version", "control-service-hostname"],
         "properties": {
-            "version": {"type" : "number"},
-            "control-service-hostname": {"type": "string"},
+            "version": {"type": "number"},
+            "control-service-hostname": {
+                "type": "string",
+                "format": "hostname",
+            }
         }
     }
 
     try:
-        validate(options, schema)
+        validate(options, schema, format_checker=FormatChecker())
     except ValidationError as e:
         raise ConfigurationError(
             "Configuration has an error: {}.".format(e.message,)
@@ -121,6 +125,7 @@ def agent_config_from_file(path):
     return {
         'control-service-hostname': options[u'control-service-hostname'],
     }
+
 
 @implementer(ICommandLineVolumeScript)
 class ZFSAgentScript(object):

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -56,7 +56,8 @@ class ZFSAgentOptions(Options):
     ]
 
     def postOptions(self):
-        self['control-service-config'] = FilePath(self['control-service-config'])
+        self['control-service-config'] = FilePath(
+            self['control-service-config'])
 
 
 def _get_external_ip(host, port):
@@ -96,7 +97,8 @@ def configuration_from_options(options):
     configuration = {}
     # nice error message if this fails
     try:
-        configuration['control-service-hostname'] = options_yaml[u'control-service-hostname']
+        configuration['control-service-hostname'] = options_yaml[
+            u'control-service-hostname']
     except (TypeError, KeyError):
         raise ConfigurationError("Configuration has an error. "
             "Missing 'control-service-hostname' key.")

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -55,8 +55,13 @@ class ZFSAgentOptions(Options):
     ]
 
     def postOptions(self):
-        self['control-service-config'] = FilePath(
-            self['control-service-config'])
+        config_file = yaml.safe_load(FilePath(self['control-service-config']).getContent())
+        try:
+            self['control-service-endpoint'] = config_file[
+                'control-service-endpoint']
+        except KeyError:
+            raise ValueError("foo")
+            #raise ConfigurationError("message")
 
 
 def _get_external_ip(host, port):

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -51,13 +51,13 @@ class ZFSAgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
-        ["control-service-config", "c", "/etc/flocker/agent.yml",
+        ["agent-config", "c", "/etc/flocker/agent.yml",
          "The configuration file to set the control service."],
     ]
 
     def postOptions(self):
-        self['control-service-config'] = FilePath(
-            self['control-service-config'])
+        self['agent-config'] = FilePath(
+            self['agent-config'])
 
 
 def _get_external_ip(host, port):
@@ -88,7 +88,7 @@ def configuration_from_options(options):
 
     :return dict: Dictionary containing the desired configuration.
     """
-    control_service_options_file = options[u'control-service-config']
+    control_service_options_file = options[u'agent-config']
 
     try:
         options_content = control_service_options_file.getContent()
@@ -163,13 +163,13 @@ class _AgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
-        ["control-service-config", "c", "/etc/flocker/agent.yml",
+        ["agent-config", "c", "/etc/flocker/agent.yml",
          "The configuration file to set the control service."],
     ]
 
     def postOptions(self):
-        self['control-service-config'] = FilePath(
-            self['control-service-config'])
+        self['agent-config'] = FilePath(
+            self['agent-config'])
 
 
 class DatasetAgentOptions(_AgentOptions):

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -82,20 +82,25 @@ def _get_external_ip(host, port):
 
 def configuration_from_options(options):
     """
+    Extract configuration from provided options.
+
+    :param dict options: Dictionary containing command line options.
+
+    :return dict: Dictionary containing the desired configuration.
     """
-    options_file = options[u'control-service-config']
-    # handle if this load doesn't work
+    control_service_options_file = options[u'control-service-config']
+
     try:
-        options_content = options_file.getContent()
+        options_content = control_service_options_file.getContent()
     except IOError:
         raise ConfigurationError(
             "Configuration file does not exist at '{}'.".format(
-                options_file.path))
+                control_service_options_file.path))
 
     options_yaml = yaml.safe_load(options_content)
-    # check version
+
     configuration = {}
-    # nice error message if this fails
+
     try:
         configuration['control-service-hostname'] = options_yaml[
             u'control-service-hostname']

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -84,6 +84,9 @@ def _get_external_ip(host, port):
         sock.close()
 
 
+def configuration_from_options(options):
+    # TODO this can be tested to check for version, incorrect yml etc
+
 @implementer(ICommandLineVolumeScript)
 class ZFSAgentScript(object):
     """
@@ -91,8 +94,8 @@ class ZFSAgentScript(object):
     a Flocker cluster.
     """
     def main(self, reactor, options, volume_service):
-        config = yaml.safe_load(options['control-service-config'].getContent())
-        host = config['control-service-hostname']
+        configuration = configuration_from_options(options)
+        host = configuration['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
         # Soon we'll extract this from TLS certificate for node.  Until then

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -43,16 +43,17 @@ class ZFSAgentOptions(Options):
     flocker-zfs-agent runs a ZFS-backed convergence agent on a node.
     """
 
-    synopsis = (
-        "Usage: flocker-zfs-agent [OPTIONS] <control-service-hostname>")
+    synopsis = ("Usage: flocker-zfs-agent [OPTIONS]")
 
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
+        ["config-file", "c", "/etc/flocker/dataset-agent.yml",
+         "The configuration file for the dataset agent."],
     ]
 
-    def parseArgs(self, host):
-        self["destination-host"] = unicode(host, "ascii")
+    def parseArgs(self):
+        self['config-file'] = FilePath(self['config-file'])
 
 
 def _get_external_ip(host, port):

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -49,11 +49,13 @@ class ZFSAgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
+         # TODO we actually have --config from flocker_volume_options
+         # TODO also change the tests to use this
         ["config-file", "c", "/etc/flocker/dataset-agent.yml",
          "The configuration file for the dataset agent."],
     ]
 
-    def parseArgs(self):
+    def postOptions(self):
         self['config-file'] = FilePath(self['config-file'])
 
 
@@ -123,7 +125,7 @@ class _AgentOptions(Options):
          "The configuration file for the dataset agent."],
     ]
 
-    def parseArgs(self):
+    def postOptions(self):
         self['config-file'] = FilePath(self['config-file'])
 
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -44,8 +44,7 @@ class ZFSAgentOptions(Options):
     """
 
     synopsis = (
-        "Usage: flocker-zfs-agent [OPTIONS] <local-hostname> "
-        "<control-service-hostname>")
+        "Usage: flocker-zfs-agent [OPTIONS] <control-service-hostname>")
 
     optParameters = [
         ["destination-port", "p", 4524,

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -50,7 +50,7 @@ class ZFSAgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
-        ["control-service-config", "c", "/etc/flocker/dataset-agent.yml",
+        ["control-service-config", "c", "/etc/flocker/agent.yml",
          "The configuration file to set the control service."],
     ]
 
@@ -122,7 +122,7 @@ class _AgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
-        ["control-service-config", "c", "/etc/flocker/dataset-agent.yml",
+        ["control-service-config", "c", "/etc/flocker/agent.yml",
          "The configuration file to set the control service."],
     ]
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -240,8 +240,8 @@ class AgentServiceFactory(PRecord):
 
         :return: The ``AgentLoopService`` instance.
         """
-        config = yaml.safe_load(options['control-service-config'].getContent())
-        host = config['control-service-hostname']
+        configuration = configuration_from_options(options)
+        host = configuration['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
         return AgentLoopService(

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -50,14 +50,13 @@ class ZFSAgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
-         # TODO we actually have --config from flocker_volume_options,
-         # maybe that is confusing
-        ["config-file", "c", "/etc/flocker/dataset-agent.yml",
-         "The configuration file for the dataset agent."],
+        ["control-service-config", "c", "/etc/flocker/dataset-agent.yml",
+         "The configuration file to set the control service."],
     ]
 
     def postOptions(self):
-        self['config-file'] = FilePath(self['config-file'])
+        self['control-service-config'] = FilePath(
+            self['control-service-config'])
 
 
 def _get_external_ip(host, port):
@@ -87,7 +86,7 @@ class ZFSAgentScript(object):
     a Flocker cluster.
     """
     def main(self, reactor, options, volume_service):
-        config = yaml.safe_load(options['config-file'].getContent())
+        config = yaml.safe_load(options['control-service-config'].getContent())
         host = config['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
@@ -123,12 +122,13 @@ class _AgentOptions(Options):
     optParameters = [
         ["destination-port", "p", 4524,
          "The port on the control service to connect to.", int],
-        ["config-file", "c", "/etc/flocker/dataset-agent.yml",
-         "The configuration file for the dataset agent."],
+        ["control-service-config", "c", "/etc/flocker/dataset-agent.yml",
+         "The configuration file to set the control service."],
     ]
 
     def postOptions(self):
-        self['config-file'] = FilePath(self['config-file'])
+        self['control-service-config'] = FilePath(
+            self['control-service-config'])
 
 
 class DatasetAgentOptions(_AgentOptions):
@@ -200,7 +200,7 @@ class AgentServiceFactory(PRecord):
 
         :return: The ``AgentLoopService`` instance.
         """
-        config = yaml.safe_load(options['config-file'].getContent())
+        config = yaml.safe_load(options['control-service-config'].getContent())
         host = config['control-service-hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -105,16 +105,17 @@ def configuration_from_options(options):
         configuration['control-service-hostname'] = options_yaml[
             u'control-service-hostname']
     except (TypeError, KeyError):
-        raise ConfigurationError("Configuration has an error. "
+        raise ConfigurationError(
+            "Configuration has an error. "
             "Missing 'control-service-hostname' key.")
 
     try:
-        if  options_yaml[u'version'] != 1:
+        if options_yaml[u'version'] != 1:
             raise ConfigurationError(
                 "Configuration has an error. Incorrect version specified.")
     except KeyError:
-        raise ConfigurationError("Configuration has an error. "
-            "Missing 'version' key.")
+        raise ConfigurationError(
+            "Configuration has an error. Missing 'version' key.")
 
     return configuration
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -45,7 +45,7 @@ class ZFSAgentScriptTests(SynchronousTestCase):
         """
         service = Service()
         options = ZFSAgentOptions()
-        options.parseOptions([b"--control-service-config", self.config.path])
+        options.parseOptions([b"--agent-config", self.config.path])
         ZFSAgentScript().main(MemoryCoreReactor(), options, service)
         self.assertTrue(service.running)
 
@@ -55,7 +55,7 @@ class ZFSAgentScriptTests(SynchronousTestCase):
         """
         script = ZFSAgentScript()
         options = ZFSAgentOptions()
-        options.parseOptions([b"--control-service-config", self.config.path])
+        options.parseOptions([b"--agent-config", self.config.path])
         self.assertNoResult(script.main(MemoryCoreReactor(), options,
                                         Service()))
 
@@ -67,7 +67,7 @@ class ZFSAgentScriptTests(SynchronousTestCase):
         options = ZFSAgentOptions()
         options.parseOptions(
             [b"--destination-port", b"1234",
-             b"--control-service-config", self.config.path])
+             b"--agent-config", self.config.path])
         test_reactor = MemoryCoreReactor()
         ZFSAgentScript().main(test_reactor, options, service)
         parent_service = service.parent
@@ -134,7 +134,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
         options = DatasetAgentOptions()
         options.parseOptions([
             b"--destination-port", b"1234",
-            b"--control-service-config", self.config.path,
+            b"--agent-config", self.config.path,
         ])
         service_factory = AgentServiceFactory(
             deployer_factory=factory
@@ -162,7 +162,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
 
         reactor = MemoryCoreReactor()
         options = DatasetAgentOptions()
-        options.parseOptions([b"--control-service-config", self.config.path])
+        options.parseOptions([b"--agent-config", self.config.path])
         agent = AgentServiceFactory(deployer_factory=deployer_factory)
         agent.get_service(reactor, options)
         self.assertIn(spied[0], get_all_ips())
@@ -301,7 +301,7 @@ def make_amp_agent_options_tests(options_type):
             """
             self.options.parseOptions([])
             self.assertEqual(
-                self.options["control-service-config"],
+                self.options["agent-config"],
                 FilePath("/etc/flocker/agent.yml"))
 
         def test_custom_config_file(self):
@@ -310,9 +310,9 @@ def make_amp_agent_options_tests(options_type):
             the config file.
             """
             self.options.parseOptions(
-                [b"--control-service-config", b"/etc/foo.yml"])
+                [b"--agent-config", b"/etc/foo.yml"])
             self.assertEqual(
-                self.options["control-service-config"],
+                self.options["agent-config"],
                 FilePath("/etc/foo.yml"))
 
     return Tests
@@ -328,7 +328,7 @@ class ConfigurationFromOptionsTests(SynchronousTestCase):
         self.scratch_directory.makedirs()
         self.config = self.scratch_directory.child('config.yml')
         self.options = {
-            'control-service-config': self.config,
+            'agent-config': self.config,
         }
 
     def assertErrorForConfig(self, exception, configuration=None, message=None):
@@ -339,8 +339,8 @@ class ConfigurationFromOptionsTests(SynchronousTestCase):
 
         :param Exception exception: The exception type which
             :func:`configuration_from_options` should fail with.
-        :param unicode configuration: The contents of the control service
-            configuration file. If ``None`` then the file will not exist.
+        :param unicode configuration: The contents of the agent configuration
+            file. If ``None`` then the file will not exist.
         :param bytes message: The expected exception message. If ``None`` then
             this will not be checked.
         """

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -260,6 +260,16 @@ def make_amp_agent_options_tests(options_type):
     class Tests(SynchronousTestCase):
         def setUp(self):
             self.options = options_type()
+            scratch_directory = FilePath(self.mktemp())
+            scratch_directory.makedirs()
+            self.sample_content = yaml.safe_dump(
+                {
+                    b"control-service-hostname": b"10.0.0.1",
+                    b"version": 1,
+                }
+            )
+            self.config = scratch_directory.child('dataset-config.yml')
+            self.config.setContent(self.sample_content)
 
         def test_default_port(self):
             """
@@ -297,6 +307,82 @@ def make_amp_agent_options_tests(options_type):
             self.assertEqual(
                 self.options["control-service-config"],
                 FilePath("/etc/foo.yml"))
+
+        def test_error_on_file_does_not_exist(self):
+            """
+            A ``ConfigurationError`` is raised if the config file does not
+            contain a ``u"control-service-endpoint"`` key.
+            """
+            config = dict()
+            parser = FlockerConfiguration(config)
+            exception = self.assertRaises(ConfigurationError,
+                                          parser.applications)
+            self.assertEqual(
+                "Application configuration has an error. "
+                "Missing 'applications' key.",
+                exception.message
+            )
+
+        def test_error_on_invalid_yaml(self):
+            """
+            A ``ConfigurationError`` is raised if the config file does not
+            contain a ``u"control-service-endpoint"`` key.
+            """
+            config = dict()
+            parser = FlockerConfiguration(config)
+            exception = self.assertRaises(ConfigurationError,
+                                          parser.applications)
+            self.assertEqual(
+                "Application configuration has an error. "
+                "Missing 'applications' key.",
+                exception.message
+            )
+
+        def test_error_on_missing_endpoint_key(self):
+            """
+            A ``ConfigurationError`` is raised if the config file does not
+            contain a ``u"control-service-endpoint"`` key.
+            """
+            config = dict()
+            parser = FlockerConfiguration(config)
+            exception = self.assertRaises(ConfigurationError,
+                                          parser.applications)
+            self.assertEqual(
+                "Application configuration has an error. "
+                "Missing 'applications' key.",
+                exception.message
+            )
+
+        def test_error_on_missing_version_key(self):
+            """
+            ``Configuration.applications`` raises a
+            ``ConfigurationError`` if the application_configuration does not
+            contain an ``u"version"`` key.
+            """
+            config = dict(applications={})
+            parser = FlockerConfiguration(config)
+            exception = self.assertRaises(ConfigurationError,
+                                          parser.applications)
+            self.assertEqual(
+                "Application configuration has an error. "
+                "Missing 'version' key.",
+                exception.message
+            )
+
+        def test_error_on_incorrect_version(self):
+            """
+            ``Configuration.applications`` raises a
+            ``ConfigurationError`` if the version specified is not 1.
+            """
+            config = dict(applications={}, version=2)
+            parser = FlockerConfiguration(config)
+            exception = self.assertRaises(ConfigurationError,
+                                          parser.applications)
+            self.assertEqual(
+                "Application configuration has an error. "
+                "Incorrect version specified.",
+                exception.message
+            )
 
     return Tests
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -337,7 +337,8 @@ class ConfigurationFromOptionsTests(SynchronousTestCase):
             configuration_from_options, self.options)
 
         self.assertEqual(
-            "Configuration file does not exist at '{}'.".format(self.config.path),
+            "Configuration file does not exist at '{}'.".format(
+                self.config.path),
             exception.message
         )
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -112,7 +112,10 @@ class AgentServiceFactoryTests(SynchronousTestCase):
         scratch_directory.makedirs()
         self.config = scratch_directory.child('dataset-config.yml')
         self.config.setContent(
-            yaml.safe_dump({u"control-service-hostname": u"10.0.0.2"}))
+            yaml.safe_dump({
+                u"control-service-hostname": u"10.0.0.2",
+                u"version": 1,
+        }))
 
     def test_get_service(self):
         """

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -41,7 +41,7 @@ class ZFSAgentScriptTests(SynchronousTestCase):
         """
         service = Service()
         options = ZFSAgentOptions()
-        options.parseOptions([b"--config-file", self.config.path])
+        options.parseOptions([b"--control-service-config", self.config.path])
         ZFSAgentScript().main(MemoryCoreReactor(), options, service)
         self.assertTrue(service.running)
 
@@ -51,7 +51,7 @@ class ZFSAgentScriptTests(SynchronousTestCase):
         """
         script = ZFSAgentScript()
         options = ZFSAgentOptions()
-        options.parseOptions([b"--config-file", self.config.path])
+        options.parseOptions([b"--control-service-config", self.config.path])
         self.assertNoResult(script.main(MemoryCoreReactor(), options,
                                         Service()))
 
@@ -63,7 +63,7 @@ class ZFSAgentScriptTests(SynchronousTestCase):
         options = ZFSAgentOptions()
         options.parseOptions(
             [b"--destination-port", b"1234",
-             b"--config-file", self.config.path])
+             b"--control-service-config", self.config.path])
         test_reactor = MemoryCoreReactor()
         ZFSAgentScript().main(test_reactor, options, service)
         parent_service = service.parent
@@ -126,7 +126,8 @@ class AgentServiceFactoryTests(SynchronousTestCase):
         reactor = MemoryCoreReactor()
         options = DatasetAgentOptions()
         options.parseOptions([
-            b"--destination-port", b"1234", b"--config-file", self.config.path,
+            b"--destination-port", b"1234",
+            b"--control-service-config", self.config.path,
         ])
         service_factory = AgentServiceFactory(
             deployer_factory=factory
@@ -154,7 +155,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
 
         reactor = MemoryCoreReactor()
         options = DatasetAgentOptions()
-        options.parseOptions([b"--config-file", self.config.path])
+        options.parseOptions([b"--control-service-config", self.config.path])
         agent = AgentServiceFactory(deployer_factory=deployer_factory)
         agent.get_service(reactor, options)
         self.assertIn(spied[0], get_all_ips())
@@ -283,7 +284,7 @@ def make_amp_agent_options_tests(options_type):
             """
             self.options.parseOptions([])
             self.assertEqual(
-                self.options["config-file"],
+                self.options["control-service-config"],
                 FilePath("/etc/flocker/dataset-agent.yml"))
 
         def test_custom_config_file(self):
@@ -291,9 +292,10 @@ def make_amp_agent_options_tests(options_type):
             The ``--config-file`` command-line option allows configuring
             the config file.
             """
-            self.options.parseOptions([b"--config-file", b"/etc/foo.yml"])
+            self.options.parseOptions(
+                [b"--control-service-config", b"/etc/foo.yml"])
             self.assertEqual(
-                self.options["config-file"],
+                self.options["control-service-config"],
                 FilePath("/etc/foo.yml"))
 
     return Tests

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -331,7 +331,8 @@ class ConfigurationFromOptionsTests(SynchronousTestCase):
             'agent-config': self.config,
         }
 
-    def assertErrorForConfig(self, exception, configuration=None, message=None):
+    def assertErrorForConfig(self, exception, configuration=None,
+                             message=None):
         """
         Assert that given a particular configuration,
         :func:`configuration_from_options` will fail with an expected exception

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -103,10 +103,18 @@ class AgentServiceFactoryTests(SynchronousTestCase):
     """
     Tests for ``AgentServiceFactory``.
     """
+    def setUp(self):
+        scratch_directory = FilePath(self.mktemp())
+        scratch_directory.makedirs()
+        self.config = scratch_directory.child('dataset-config.yml')
+        self.config.setContent(
+            yaml.safe_dump({b"control-service-hostname": b"10.0.0.2"}))
+
     def test_get_service(self):
         """
         ``AgentServiceFactory.get_service`` creates ``AgentLoopService``
-        configured with the destination given by the options.
+        configured with the destination given in the config file given by the
+        options.
         """
         deployer = object()
 
@@ -118,7 +126,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
         reactor = MemoryCoreReactor()
         options = DatasetAgentOptions()
         options.parseOptions([
-            b"--destination-port", b"1234", b"10.0.0.2",
+            b"--destination-port", b"1234", b"--config-file", self.config.path,
         ])
         service_factory = AgentServiceFactory(
             deployer_factory=factory
@@ -146,7 +154,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
 
         reactor = MemoryCoreReactor()
         options = DatasetAgentOptions()
-        options.parseOptions([b"10.0.0.2"])
+        options.parseOptions([b"--config-file", self.config.path])
         agent = AgentServiceFactory(deployer_factory=deployer_factory)
         agent.get_service(reactor, options)
         self.assertIn(spied[0], get_all_ips())
@@ -314,7 +322,7 @@ class ZFSAgentOptionsTests(make_amp_agent_options_tests(ZFSAgentOptions)):
 
 
 class ZFSAgentOptionsVolumeTests(make_volume_options_tests(
-        ZFSAgentOptions, [b"1.2.3.4"])):
+        ZFSAgentOptions, [])):
     """
     Tests for the volume configuration arguments of ``ZFSAgentOptions``.
     """

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -260,15 +260,15 @@ def make_amp_agent_options_tests(options_type):
     class Tests(SynchronousTestCase):
         def setUp(self):
             self.options = options_type()
-            scratch_directory = FilePath(self.mktemp())
-            scratch_directory.makedirs()
+            self.scratch_directory = FilePath(self.mktemp())
+            self.scratch_directory.makedirs()
             self.sample_content = yaml.safe_dump(
                 {
                     b"control-service-hostname": b"10.0.0.1",
                     b"version": 1,
                 }
             )
-            self.config = scratch_directory.child('dataset-config.yml')
+            self.config = self.scratch_directory.child('dataset-config.yml')
             self.config.setContent(self.sample_content)
 
         def test_default_port(self):

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -328,8 +328,7 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         self.scratch_directory.makedirs()
         self.config = self.scratch_directory.child('config.yml')
 
-    def assertErrorForConfig(self, exception, configuration=None,
-                             message=None):
+    def assertErrorForConfig(self, exception, message, configuration=None):
         """
         Assert that given a particular configuration,
         :func:`agent_config_from_file` will fail with an expected exception
@@ -339,8 +338,7 @@ class AgentConfigFromFileTests(SynchronousTestCase):
             :func:`agent_config_from_file` should fail with.
         :param unicode configuration: The contents of the agent configuration
             file. If ``None`` then the file will not exist.
-        :param bytes message: The expected exception message. If ``None`` then
-            this will not be checked.
+        :param bytes message: The expected exception message.
         """
         if configuration is not None:
             self.config.setContent(configuration)
@@ -349,8 +347,7 @@ class AgentConfigFromFileTests(SynchronousTestCase):
             exception,
             agent_config_from_file, self.config)
 
-        if message is not None:
-            self.assertEqual(exception.message, message)
+        self.assertEqual(exception.message, message)
 
     def test_error_on_file_does_not_exist(self):
         """
@@ -370,6 +367,7 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         self.assertErrorForConfig(
             configuration=yaml.safe_dump("INVALID"),
             exception=ConfigurationError,
+            message="Configuration has an error. It is not in a valid format.",
         )
 
     def test_error_on_missing_hostname(self):

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -8,6 +8,7 @@ import netifaces
 from zope.interface.verify import verifyObject
 
 from twisted.internet.defer import Deferred
+from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.application.service import Service
 
@@ -246,7 +247,7 @@ def make_amp_agent_options_tests(options_type):
             The default AMP destination port configured by the command line
             options is 4524.
             """
-            self.options.parseOptions([b"127.0.0.1"])
+            self.options.parseOptions([])
             self.assertEqual(self.options["destination-port"], 4524)
 
         def test_custom_port(self):
@@ -254,19 +255,28 @@ def make_amp_agent_options_tests(options_type):
             The ``--destination-port`` command-line option allows configuring
             the destination port.
             """
-            self.options.parseOptions([b"--destination-port", b"1234",
-                                       b"127.0.0.1"])
+            self.options.parseOptions([b"--destination-port", b"1234"])
             self.assertEqual(self.options["destination-port"], 1234)
 
-        def test_host(self):
+        def test_default_config_file(self):
             """
-            The second required command-line argument allows configuring the
-            destination host.
+            The default config file is a FilePath with path
+            ``/etc/flocker/dataset-agent.yml``.
             """
-            self.options.parseOptions([b"10.0.0.1"])
+            self.options.parseOptions([])
             self.assertEqual(
-                self.options["destination-host"], u"10.0.0.1",
-            )
+                self.options["config-file"],
+                FilePath("/etc/flocker/dataset-agent.yml"))
+
+        def test_custom_config_file(self):
+            """
+            The ``--config-file`` command-line option allows configuring
+            the config file.
+            """
+            self.options.parseOptions([b"--config-file", b"/etc/foo.yml"])
+            self.assertEqual(
+                self.options["config-file"],
+                FilePath("/etc/foo.yml"))
 
     return Tests
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -280,12 +280,12 @@ def make_amp_agent_options_tests(options_type):
         def test_default_config_file(self):
             """
             The default config file is a FilePath with path
-            ``/etc/flocker/dataset-agent.yml``.
+            ``/etc/flocker/agent.yml``.
             """
             self.options.parseOptions([])
             self.assertEqual(
                 self.options["control-service-config"],
-                FilePath("/etc/flocker/dataset-agent.yml"))
+                FilePath("/etc/flocker/agent.yml"))
 
         def test_custom_config_file(self):
             """

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -371,6 +371,20 @@ class AgentConfigFromFileTests(SynchronousTestCase):
                      "'INVALID' is not of type 'object'."),
         )
 
+    def test_error_on_invalid_hostname(self):
+        """
+        A ``ConfigurationError`` is raised if the given control service
+        hostname is not a valid hostname.
+        """
+        self.assertErrorForConfig(
+            configuration=yaml.safe_dump({
+                "control-service-hostname": "-1",
+                "version": 1,
+            }),
+            exception=ConfigurationError,
+            message=("Configuration has an error: '-1' is not a 'hostname'."),
+        )
+
     def test_error_on_missing_hostname(self):
         """
         A ``ConfigurationError`` is raised if the config file does not

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -367,7 +367,8 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         self.assertErrorForConfig(
             configuration=yaml.safe_dump("INVALID"),
             exception=ConfigurationError,
-            message="Configuration has an error. It is not in a valid format.",
+            message=("Configuration has an error: "
+                     "'INVALID' is not of type 'object'."),
         )
 
     def test_error_on_missing_hostname(self):
@@ -378,8 +379,8 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         self.assertErrorForConfig(
             configuration=yaml.safe_dump({"version": 1}),
             exception=ConfigurationError,
-            message=("Configuration has an error. "
-                     "Missing 'control-service-hostname' key."),
+            message=("Configuration has an error: "
+                     "'control-service-hostname' is a required property."),
         )
 
     def test_error_on_missing_version(self):
@@ -391,8 +392,8 @@ class AgentConfigFromFileTests(SynchronousTestCase):
             configuration=yaml.safe_dump({
                 "control-service-hostname": "192.0.2.1"}),
             exception=ConfigurationError,
-            message=("Configuration has an error. "
-                     "Missing 'version' key."),
+            message=("Configuration has an error: "
+                     "'version' is a required property."),
         )
 
     def test_error_on_incorrect_version(self):

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -18,7 +18,7 @@ from ...common.script import ICommandLineScript
 
 from ..script import (
     ZFSAgentOptions, ZFSAgentScript, AgentScript, ContainerAgentOptions,
-    AgentServiceFactory, DatasetAgentOptions, configuration_from_options)
+    AgentServiceFactory, DatasetAgentOptions, agent_config_from_file)
 from .._loop import AgentLoopService
 from .._deploy import P2PManifestationDeployer
 from ...control import ConfigurationError
@@ -318,28 +318,25 @@ def make_amp_agent_options_tests(options_type):
     return Tests
 
 
-class ConfigurationFromOptionsTests(SynchronousTestCase):
+class AgentConfigFromFileTests(SynchronousTestCase):
     """
-    Tests for :func:`configuration_from_options`.
+    Tests for :func:`agent_config_from_file`.
     """
 
     def setUp(self):
         self.scratch_directory = FilePath(self.mktemp())
         self.scratch_directory.makedirs()
         self.config = self.scratch_directory.child('config.yml')
-        self.options = {
-            'agent-config': self.config,
-        }
 
     def assertErrorForConfig(self, exception, configuration=None,
                              message=None):
         """
         Assert that given a particular configuration,
-        :func:`configuration_from_options` will fail with an expected exception
+        :func:`agent_config_from_file` will fail with an expected exception
         and message.
 
         :param Exception exception: The exception type which
-            :func:`configuration_from_options` should fail with.
+            :func:`agent_config_from_file` should fail with.
         :param unicode configuration: The contents of the agent configuration
             file. If ``None`` then the file will not exist.
         :param bytes message: The expected exception message. If ``None`` then
@@ -350,7 +347,7 @@ class ConfigurationFromOptionsTests(SynchronousTestCase):
 
         exception = self.assertRaises(
             exception,
-            configuration_from_options, self.options)
+            agent_config_from_file, self.config)
 
         if message is not None:
             self.assertEqual(exception.message, message)

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -115,7 +115,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
             yaml.safe_dump({
                 u"control-service-hostname": u"10.0.0.2",
                 u"version": 1,
-        }))
+            }))
 
     def test_get_service(self):
         """

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -233,6 +233,7 @@ def task_enable_flocker_agent(distribution, control_node):
         path='/etc/flocker/agent.yml',
         content=yaml.safe_dump(
             {
+                "version": 1,
                 "control-service-endpoint": control_node,
             },
             # Don't wrap the whole thing in braces

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -249,8 +249,14 @@ def task_enable_flocker_agent(distribution, control_node):
     elif distribution == 'ubuntu-14.04':
         return sequence([
             put(
-                path='/etc/default/flocker-agent.conf',
-                content=AGENT_CONFIG % {'control_node': control_node},
+                path='/etc/flocker/agent.yml',
+                content=yaml.safe_dump(
+                    {
+                        "control-service-endpoint": control_node,
+                    },
+                    # Don't wrap the whole thing in braces
+                    default_flow_style=False,
+                ),
             ),
             run_from_args(['service', 'flocker-agent', 'start']),
             run_from_args(['service', 'flocker-container-agent', 'start']),

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -232,7 +232,7 @@ def task_enable_flocker_agent(distribution, control_node):
     if distribution in ('centos-7', 'fedora-20'):
         return sequence([
             put(
-                path='/etc/flocker/dataset-agent.yml',
+                path='/etc/flocker/agent.yml',
                 content=yaml.safe_dump(
                     {
                         "control-service-endpoint": control_node,

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -229,7 +229,7 @@ def task_enable_flocker_agent(distribution, control_node):
         content=yaml.safe_dump(
             {
                 "version": 1,
-                "control-service-endpoint": control_node,
+                "control-service-hostname": control_node,
             },
             # Don't wrap the whole thing in braces
             default_flow_style=False,

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -218,11 +218,6 @@ def task_open_control_firewall(distribution):
     ])
 
 
-AGENT_CONFIG = """\
-FLOCKER_CONTROL_NODE=%(control_node)s
-"""
-
-
 def task_enable_flocker_agent(distribution, control_node):
     """
     Configure and enable the flocker agents.

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -229,18 +229,19 @@ def task_enable_flocker_agent(distribution, control_node):
 
     :param bytes control_node: The address of the control agent.
     """
+    put_config_file = put(
+        path='/etc/flocker/agent.yml',
+        content=yaml.safe_dump(
+            {
+                "control-service-endpoint": control_node,
+            },
+            # Don't wrap the whole thing in braces
+            default_flow_style=False,
+        ),
+    )
     if distribution in ('centos-7', 'fedora-20'):
         return sequence([
-            put(
-                path='/etc/flocker/agent.yml',
-                content=yaml.safe_dump(
-                    {
-                        "control-service-endpoint": control_node,
-                    },
-                    # Don't wrap the whole thing in braces
-                    default_flow_style=False,
-                ),
-            ),
+            put_config_file,
             run_from_args(['systemctl', 'enable', 'flocker-agent']),
             run_from_args(['systemctl', 'start', 'flocker-agent']),
             run_from_args(['systemctl', 'enable', 'flocker-container-agent']),
@@ -248,16 +249,7 @@ def task_enable_flocker_agent(distribution, control_node):
         ])
     elif distribution == 'ubuntu-14.04':
         return sequence([
-            put(
-                path='/etc/flocker/agent.yml',
-                content=yaml.safe_dump(
-                    {
-                        "control-service-endpoint": control_node,
-                    },
-                    # Don't wrap the whole thing in braces
-                    default_flow_style=False,
-                ),
-            ),
+            put_config_file,
             run_from_args(['service', 'flocker-agent', 'start']),
             run_from_args(['service', 'flocker-container-agent', 'start']),
         ])

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -9,6 +9,7 @@ import posixpath
 from textwrap import dedent
 from urlparse import urljoin
 from effect import Func, Effect
+import yaml
 
 from ._common import PackageSource, Variants
 from ._ssh import (
@@ -231,8 +232,14 @@ def task_enable_flocker_agent(distribution, control_node):
     if distribution in ('centos-7', 'fedora-20'):
         return sequence([
             put(
-                path='/etc/sysconfig/flocker-agent',
-                content=AGENT_CONFIG % {'control_node': control_node},
+                path='/etc/flocker/dataset-agent.yml',
+                content=yaml.safe_dump(
+                    {
+                        "control-service-endpoint": control_node,
+                    },
+                    # Don't wrap the whole thing in braces
+                    default_flow_style=False,
+                ),
             ),
             run_from_args(['systemctl', 'enable', 'flocker-agent']),
             run_from_args(['systemctl', 'start', 'flocker-agent']),


### PR DESCRIPTION
Where we stray from [the design](https://github.com/ClusterHQ/flocker/pull/1338/files):

* For now the config option is called "control-service-config" instead of "config-options". This is because the "flocker-zfs-agent" script already has a "--config" option. The option name and description matches what this is now but a follow-up branch can change that when what it does changes.

* @exarkun asked for quotes around yml strings. We have done this in the documentation example but in the task we found one way to do this with `yaml.safe_dump` and that was to use `default_style='"'` param. However this looked bad with different types.

* The example yml used to be wrapped by braces but that changed because it looked odd to us.

* We agree that this documentation should be moved but have not done it here. We have asked David to look into this and will likely move these docs before the story is submitted.

Also:

* There is duplication between the agent options but the next branch (as in the design) will reduce the two sets of options to one.

* We have kept the assertion in the `service` files from the design. We have also added a similar assertion to the Ubuntu upstart file. However we aren't sure what this adds over error handling in the node script.

* We think when we want more details, the yaml should contain a dictionary like:

```yaml
control-service: {
  "hostname": "192.168.1.1",
  "port": 4252,
  "protocol": "tcp",
}
```

but this is a direct replacement for the existing parameter and so we have not done this. We think that changes before the next release can probably continue to use version 1.