### PR TITLE
Shrink block device volumes

### DIFF
--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -218,8 +218,9 @@ definitions:
     # considered more carefully.
     minimum: 67108864
     # Filesystem initialization in the block device backend requires sizes to
-    # be a multiple of 512.
-    multipleOf: 512
+    # be a multiple of 512 and for ease of implementation we'll tighten that
+    # constraint so it's multiples of 1024 (1 KiB).
+    multipleOf: 1024
 
 
   running:

--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -217,8 +217,10 @@ definitions:
     # on what this can be set to for the ZFS backend.  Could probably be
     # considered more carefully.
     minimum: 67108864
-    # This is how you require integers, of course.
-    divisibleBy: 1
+    # Filesystem initialization in the block device backend requires sizes to
+    # be a multiple of 512.
+    multipleOf: 512
+
 
   running:
     title: "Running"

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -2362,13 +2362,13 @@ class UpdateSizeDatasetTestsMixin(APITestsMixin):
         """
         return self.assert_dataset_resize(
             original_size=67108864,
-            new_size=67108864 - 1,
+            new_size=67108864 - 512,
             expected_code=BAD_REQUEST,
             expected_result={
                 u'description':
                 u"The provided JSON doesn't match the required schema.",
                 u'errors':
-                [u'67108863 is less than the minimum of 67108864']
+                [u'67108352 is less than the minimum of 67108864']
             }
         )
 

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -2362,13 +2362,13 @@ class UpdateSizeDatasetTestsMixin(APITestsMixin):
         """
         return self.assert_dataset_resize(
             original_size=67108864,
-            new_size=67108864 - 512,
+            new_size=67108864 - 1024,
             expected_code=BAD_REQUEST,
             expected_result={
                 u'description':
                 u"The provided JSON doesn't match the required schema.",
                 u'errors':
-                [u'67108352 is less than the minimum of 67108864']
+                [u'67107840 is less than the minimum of 67108864']
             }
         )
 

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -528,12 +528,12 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = [
     # wrong numeric type for maximum size
     {u"primary": u"10.0.0.1", u"maximum_size": 1024 * 1024 * 64 + 0.5},
 
-    # too-small (but multiple of 512) value for maximum size
+    # too-small (but multiple of 1024) value for maximum size
     {u"primary": u"10.0.0.1", u"maximum_size": 1024},
 
-    # Value for maximum_size that is not a multiple of 512 (but is larger than
+    # Value for maximum_size that is not a multiple of 1024 (but is larger than
     # the minimum allowed)
-    {u"primary": u"10.0.0.1", u"maximum_size": 1024 * 1024 * 64 + 511},
+    {u"primary": u"10.0.0.1", u"maximum_size": 1024 * 1024 * 64 + 1023},
 
     # wrong type for primary
     {u"primary": 10,

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -525,8 +525,15 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = [
     # wrong type for maximum size
     {u"primary": u"10.0.0.1", u"maximum_size": u"123"},
 
-    # too-small value for maximum size
-    {u"primary": u"10.0.0.1", u"maximum_size": 123},
+    # wrong numeric type for maximum size
+    {u"primary": u"10.0.0.1", u"maximum_size": 1024 * 1024 * 64 + 0.5},
+
+    # too-small (but multiple of 512) value for maximum size
+    {u"primary": u"10.0.0.1", u"maximum_size": 1024},
+
+    # Value for maximum_size that is not a multiple of 512 (but is larger than
+    # the minimum allowed)
+    {u"primary": u"10.0.0.1", u"maximum_size": 1024 * 1024 * 64 + 511},
 
     # wrong type for primary
     {u"primary": 10,

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -413,12 +413,14 @@ class CreateFilesystem(PRecord):
 
 def _valid_size(size):
     """
-    Pyrsistent invariant for filesystem size, which must be a multiple of 512
+    Pyrsistent invariant for filesystem size, which must be a multiple of 1024
     bytes.
     """
-    if size % 512 == 0:
+    if size % 1024 == 0:
         return (True, "")
-    return (False, "Filesystem size must be multiple of 512, not %d" % (size,))
+    return (
+        False, "Filesystem size must be multiple of 1024, not %d" % (size,)
+    )
 
 
 @implementer(IStateChange)

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -423,7 +423,7 @@ class ResizeFilesystem(PRecord):
     """
     volume = _volume_field()
 
-    # FLOC-1503 - Add a size attribute to support the shrinking case.
+    size = field(type=(int, type(None)), initial=None, mandatory=True)
 
     @property
     def eliot_action(self):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -475,6 +475,8 @@ class ResizeFilesystem(PRecord):
         # sizes are in GB - so if you're using that the API should really
         # require multiples of 1000000000).  See FLOC-1579.
         new_size = int(Byte(self.size).to_KiB().value)
+        # The system could fail while this is running.  We don't presently have
+        # recovery logic for this case.  See FLOC-1815.
         check_output([
             b"resize2fs",
             # The path to the device file referring to the filesystem to
@@ -1653,6 +1655,9 @@ class BlockDeviceDeployer(PRecord):
             if dataset_config.deleted:
                 continue
             configured_size = dataset_config.maximum_size
+            # We only inspect volume size here.  A failure could mean the
+            # volume size is correct even though the filesystem size is not.
+            # See FLOC-1815.
             if manifestation.dataset.maximum_size != configured_size:
                 yield ResizeBlockDeviceDataset(
                     dataset_id=UUID(dataset_id),

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -411,6 +411,16 @@ class CreateFilesystem(PRecord):
         return succeed(None)
 
 
+def _valid_size(size):
+    """
+    Pyrsistent invariant for filesystem size, which must be a multiple of 512
+    bytes.
+    """
+    if size % 512 == 0:
+        return (True, "")
+    return (False, "Filesystem size must be multiple of 512, not %d" % (size,))
+
+
 @implementer(IStateChange)
 class ResizeFilesystem(PRecord):
     """
@@ -424,7 +434,11 @@ class ResizeFilesystem(PRecord):
     """
     volume = _volume_field()
 
-    size = field(type=int, mandatory=True)
+    size = field(
+        type=int, mandatory=True,
+        # It would be nice to compute this invariant from the API schema.
+        invariant=_valid_size,
+    )
 
     @property
     def eliot_action(self):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1380,7 +1380,7 @@ class BlockDeviceDeployer(PRecord):
                 paths[dataset_id] = mountpath
             else:
                 del manifestations[dataset_id]
-                # FLOC-1503-x Populate the Dataset's size information from the
+                # FLOC-1806 Populate the Dataset's size information from the
                 # volume object.
                 nonmanifest[dataset_id] = Dataset(dataset_id=dataset_id)
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1641,6 +1641,7 @@ class BlockDeviceDeployer(PRecord):
             and the actual state of volumes (ie which have a size that is
             different to the configuration)
         """
+        # This won't resize nonmanifest datasets.  See FLOC-1806.
         for (dataset_id, manifestation) in local_state.manifestations.items():
             try:
                 manifestation_config = configured_manifestations[dataset_id]

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -492,11 +492,11 @@ class ResizeBlockDeviceDataset(PRecord):
         #
         # If the volume is shrinking, arrange the changes like
         #
-        # unmount, detach, resize volume, attach, resize filesystem, mount
+        # unmount, resize filesystem, detach, resize volume, attach, mount
         #
         # If the volume is growing, arrange the changes like [
         #
-        # unmount, resize filesystem, detach, resize volume, attach, mount
+        # unmount, detach, resize volume, attach, resize filesystem, mount
 
         return run_state_change(
             sequentially(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1369,7 +1369,7 @@ class BlockDeviceDeployer(PRecord):
                 paths[dataset_id] = mountpath
             else:
                 del manifestations[dataset_id]
-                # FLOC-1503 Populate the Dataset's size information from the
+                # FLOC-1503-x Populate the Dataset's size information from the
                 # volume object.
                 nonmanifest[dataset_id] = Dataset(dataset_id=dataset_id)
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -466,6 +466,12 @@ class ResizeFilesystem(PRecord):
         # When passed no explicit size argument, resize2fs resizes the
         # filesystem to the size of the device it lives on.  Be sure to use
         # 1024 byte KiB conversion because that's what "K" means to resize2fs.
+        # This will be come out as an integer because the API schema requires
+        # multiples of 1024 bytes for dataset sizes.  However, it would be nice
+        # the API schema could be informed by the backend somehow so that other
+        # constraints could be applied as well (for example, OpenStack volume
+        # sizes are in GB - so if you're using that the API should really
+        # require multiples of 1000000000).  See FLOC-1579.
         new_size = int(Byte(self.size).to_KiB().value)
         check_output([
             b"resize2fs",

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -423,7 +423,7 @@ class ResizeFilesystem(PRecord):
     """
     volume = _volume_field()
 
-    size = field(type=(int, type(None)), initial=None, mandatory=True)
+    size = field(type=int, mandatory=True)
 
     @property
     def eliot_action(self):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -462,6 +462,8 @@ class ResizeFilesystem(PRecord):
         # -y automatically answers yes to every question.  There should be no
         #     questions since the filesystem isn't corrupt.  Without this,
         #     e2fsck refuses to run non-interactively, though.
+        #
+        # See FLOC-1814
         check_output([b"e2fsck", b"-f", b"-y", device.path])
         # When passed no explicit size argument, resize2fs resizes the
         # filesystem to the size of the device it lives on.  Be sure to use

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -290,6 +290,10 @@ def assert_discovered_state(case,
         ),
     )
     if expected_nonmanifest_datasets is not None:
+        # FLOC-1503 - Make this actually be a dictionary (callers pass a list
+        # instead, despite the docs, and this is used like an iterable) and
+        # construct the ``NonManifestDatasets`` with the ``Dataset`` instances
+        # that are present as values.
         expected += (
             NonManifestDatasets(datasets={
                 unicode(dataset_id):
@@ -339,6 +343,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
+            # FLOC-1503 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unmounted.dataset_id],
             expected_devices={
                 unmounted.dataset_id:
@@ -374,6 +379,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
+            # FLOC-1503 Expect dataset with size LOOPBACK_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unexpected.dataset_id],
             expected_devices={
                 unexpected.dataset_id: device,
@@ -407,6 +413,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
+            # FLOC-1503 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unmounted.dataset_id],
             expected_devices={
                 unmounted.dataset_id:
@@ -474,6 +481,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
+            # FLOC-1503 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[dataset_id],
         )
 
@@ -962,6 +970,8 @@ class BlockDeviceDeployerResizeCalculateChangesTests(
     Tests for ``BlockDeviceDeployer.calculate_changes`` in the cases relating
     to resizing a dataset.
     """
+    # FLOC-1503 Change this to be increase/decrease indifferent.  Calculation
+    # logic is unchanged for grow vs shrink.
     def test_maximum_size_increased(self):
         """
         ``BlockDeviceDeployer.calculate_changes`` returns a
@@ -2657,6 +2667,12 @@ class ResizeBlockDeviceDatasetTests(
             self.assertEqual(REALISTIC_BLOCKDEVICE_SIZE * 2, volume.size)
         resizing.addCallback(resized)
         return resizing
+
+    # FLOC-1503 Add a test like test_run_grow but for shrinking.  Refactor
+    # existing test to share code.  Add more assertions about final state: we
+    # expect it to be resized but also attached and mounted.  In particular, if
+    # it isn't mounted then there's no evidence the filesystem was correctly
+    # resized.
 
 
 class ResizeVolumeInitTests(

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -970,8 +970,6 @@ class BlockDeviceDeployerResizeCalculateChangesTests(
     Tests for ``BlockDeviceDeployer.calculate_changes`` in the cases relating
     to resizing a dataset.
     """
-    # FLOC-1503 Change this to be increase/decrease indifferent.  Calculation
-    # logic is unchanged for grow vs shrink.
     def _maximum_size_change_test(self, size_factor):
         """
         Assert that if the size of an existing dataset is changed by the

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -290,7 +290,7 @@ def assert_discovered_state(case,
         ),
     )
     if expected_nonmanifest_datasets is not None:
-        # FLOC-1503 - Make this actually be a dictionary (callers pass a list
+        # FLOC-1503-x - Make this actually be a dictionary (callers pass a list
         # instead, despite the docs, and this is used like an iterable) and
         # construct the ``NonManifestDatasets`` with the ``Dataset`` instances
         # that are present as values.
@@ -343,7 +343,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
+            # FLOC-1503-x Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unmounted.dataset_id],
             expected_devices={
                 unmounted.dataset_id:
@@ -379,7 +379,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503 Expect dataset with size LOOPBACK_BLOCKDEVICE_SIZE
+            # FLOC-1503-x Expect dataset with size LOOPBACK_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unexpected.dataset_id],
             expected_devices={
                 unexpected.dataset_id: device,
@@ -413,7 +413,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
+            # FLOC-1503-x Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unmounted.dataset_id],
             expected_devices={
                 unmounted.dataset_id:
@@ -481,7 +481,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
+            # FLOC-1503-x Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[dataset_id],
         )
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2820,7 +2820,7 @@ class ResizeFilesystemInitTests(
     make_with_init_tests(
         ResizeFilesystem,
         dict(volume=_ARBITRARY_VOLUME, size=REALISTIC_BLOCKDEVICE_SIZE),
-        dict(size=None),
+        dict(),
     ),
 ):
     """
@@ -2831,8 +2831,11 @@ class ResizeFilesystemInitTests(
 class ResizeFilesystemTests(
     make_istatechange_tests(
         ResizeFilesystem,
-        dict(volume=_ARBITRARY_VOLUME),
-        dict(volume=_ARBITRARY_VOLUME.set(blockdevice_id=u"wxyz")),
+        dict(volume=_ARBITRARY_VOLUME, size=REALISTIC_BLOCKDEVICE_SIZE),
+        dict(
+            volume=_ARBITRARY_VOLUME.set(blockdevice_id=u"wxyz"),
+            size=REALISTIC_BLOCKDEVICE_SIZE
+        ),
     ),
 ):
     """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2660,7 +2660,7 @@ class ResizeBlockDeviceDatasetTests(
     def _run_resize_test(self, logger, size_factor):
         """
         Assert that ``ResizeBlockDeviceDataset`` changes the size of the
-        dataset's volume (and filesystem?  XXX) to the specified size.
+        dataset's volume to the specified size.
         """
         self.patch(blockdevice, "_logger", logger)
 
@@ -2697,6 +2697,8 @@ class ResizeBlockDeviceDatasetTests(
         def resized(ignored):
             [volume] = api.list_volumes()
             self.assertEqual(new_size, volume.size)
+            # FLOC-1807 Make an assertion about filesystem size and mounted
+            # state here, too.
         resizing.addCallback(resized)
         return resizing
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2727,13 +2727,6 @@ class ResizeBlockDeviceDatasetTests(
         return self._run_resize_test(logger, 0.5)
 
 
-    # FLOC-1503 Add a test like test_run_grow but for shrinking.  Refactor
-    # existing test to share code.  Add more assertions about final state: we
-    # expect it to be resized but also attached and mounted.  In particular, if
-    # it isn't mounted then there's no evidence the filesystem was correctly
-    # resized.
-
-
 class ResizeVolumeInitTests(
     make_with_init_tests(
         ResizeVolume,

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2924,16 +2924,19 @@ class ResizeFilesystemTests(
 
         after = get_filesystem_inodes(self, deployer, dataset_id)
 
-        expected_inodes_after = int(size_factor * before)
+        expected_inodes_after = float(size_factor * before)
 
-        self.assertEqual(
-            expected_inodes_after,
-            after,
-            "Unexpected inode count. "
-            "Before: {}, "
-            "After: {}, "
-            "Expected: {}.".format(
-                before, after, expected_inodes_after
+        # The error should be less than one percent.
+        self.assertLess(
+            abs(after - expected_inodes_after) / expected_inodes_after,
+            0.01,
+            msg=(
+                "Unexpected inode count. "
+                "Before: {}, "
+                "After: {}, "
+                "Expected: {}.".format(
+                    before, after, expected_inodes_after
+                )
             )
         )
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2891,6 +2891,16 @@ class ResizeFilesystemTests(
     """
     Tests for ``ResizeFilesystem``\ 's ``IStateChange`` implementation.
     """
+    def test_size_invariant(self):
+        """
+        ``ResizeFilesystem.size`` must be a multiple of 512.
+        """
+        self.assertRaises(
+            InvariantException,
+            ResizeFilesystem,
+            volume=_ARBITRARY_VOLUME, size=513,
+        )
+
     def _resize_test(self, size_factor):
         """
         Assert that ``ResizeFilesystem`` can change the size of an existing

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2954,7 +2954,15 @@ class ResizeFilesystemTests(
 
         expected_inodes_after = float(size_factor * before)
 
-        # The error should be less than one percent.
+        # The error should be less than one percent.  This is not an exact
+        # comparison because it's really hard to accurately measure the size of
+        # a filesystem, as it turns out.  Depending on irrelevant internal ext4
+        # details, we can easily mispredict what it means to "double" the size
+        # of a filesystem by as much as 4096 or 8192 inodes (which is how we're
+        # measuring size because it seems to be the *least* inaccurate).  Maybe
+        # this is because inodes get allocated to backup superblocks (just a
+        # guess).  So: accept some error, as long as it's not much we probably
+        # managed to accomplish the resize we wanted.
         self.assertLess(
             abs(after - expected_inodes_after) / expected_inodes_after,
             0.01,

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -290,7 +290,7 @@ def assert_discovered_state(case,
         ),
     )
     if expected_nonmanifest_datasets is not None:
-        # FLOC-1503-x - Make this actually be a dictionary (callers pass a list
+        # FLOC-1806 - Make this actually be a dictionary (callers pass a list
         # instead, despite the docs, and this is used like an iterable) and
         # construct the ``NonManifestDatasets`` with the ``Dataset`` instances
         # that are present as values.
@@ -343,7 +343,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503-x Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
+            # FLOC-1806 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unmounted.dataset_id],
             expected_devices={
                 unmounted.dataset_id:
@@ -379,7 +379,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503-x Expect dataset with size LOOPBACK_BLOCKDEVICE_SIZE
+            # FLOC-1806 Expect dataset with size LOOPBACK_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unexpected.dataset_id],
             expected_devices={
                 unexpected.dataset_id: device,
@@ -413,7 +413,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503-x Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
+            # FLOC-1806 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[unmounted.dataset_id],
             expected_devices={
                 unmounted.dataset_id:
@@ -481,7 +481,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
         assert_discovered_state(
             self, self.deployer,
             expected_manifestations=[],
-            # FLOC-1503-x Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
+            # FLOC-1806 Expect dataset with size REALISTIC_BLOCKDEVICE_SIZE
             expected_nonmanifest_datasets=[dataset_id],
         )
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2819,8 +2819,8 @@ class AttachVolumeTests(
 class ResizeFilesystemInitTests(
     make_with_init_tests(
         ResizeFilesystem,
-        dict(volume=_ARBITRARY_VOLUME),
-        dict(),
+        dict(volume=_ARBITRARY_VOLUME, size=REALISTIC_BLOCKDEVICE_SIZE),
+        dict(size=None),
     ),
 ):
     """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2893,12 +2893,12 @@ class ResizeFilesystemTests(
     """
     def test_size_invariant(self):
         """
-        ``ResizeFilesystem.size`` must be a multiple of 512.
+        ``ResizeFilesystem.size`` must be a multiple of 1024.
         """
         self.assertRaises(
             InvariantException,
             ResizeFilesystem,
-            volume=_ARBITRARY_VOLUME, size=513,
+            volume=_ARBITRARY_VOLUME, size=1025,
         )
 
     def _resize_test(self, size_factor):

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -55,7 +55,7 @@ from ..common.script import (
 # This is currently set to the minimum size for a SATA based Rackspace Cloud
 # Block Storage volume. See:
 # * http://www.rackspace.com/knowledge_center/product-faq/cloud-block-storage
-REALISTIC_BLOCKDEVICE_SIZE = int(GB(75).to_Byte().value)
+REALISTIC_BLOCKDEVICE_SIZE = int(GB(100).to_Byte().value)
 
 
 @implementer(IProcessTransport)


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1503

Initially I thought this would involve improving state discovery to include the size of non-manifest datasets.  I changed my mind, though.  Resizes are only attempted for datasets that have a manifestation and those datasets already have their size discovered.  I left the design notes for non-manifest dataset size discovered in, though, marked `FLOC-1503-x`.  I may go ahead and implement that stuff here anyway, it's barely an extra code and improves the system.  If the reviewer would prefer me not to, though, I'll split those things off into a separate issue.
