### PR TITLE
Fix default Docker client version used by Flocker testtools.

### DIFF
--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -619,7 +619,7 @@ class DockerImageBuilder(PRecord):
         run_process(command)
         if self.cleanup:
             def remove_image():
-                client = DockerClient()
+                client = DockerClient(version="1.15")
                 for container in client.containers():
                     if container[u"Image"] == tag + ":latest":
                         client.remove_container(container[u"Names"][0])


### PR DESCRIPTION
flocker-ubuntu-14.04 builder has test failures due to Docker client/server version mismatch:
docker.errors.APIError: 404 Client Error: Not Found ("client and server don't have same version (client : 1.16, server: 1.15)")

This is caused because of missing client version (1.15) in the following test code:
__________
From flocker/testtools/__init__.py:
from docker import Client as DockerClient
...
def build(self, dockerfile_variables=None):
...
def remove_image():
client = DockerClient() 
__________

Since default docker version is 1.16 (from py27/lib/python2.7/site-packages/docker/client.py:
DEFAULT_DOCKER_API_VERSION = '1.16'), and our Docker server version is 1.15, we run into version mismatch.

We need to create DockerClient(version="1.15") to fix the test issues on Ubuntu.