### PR TITLE
[FLOC-1803] Rely on Docker restart policies; no longer restart stopped containers ourselves.

### DIFF
--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -757,22 +757,16 @@ class ApplicationNodeDeployer(object):
         if desired_open_ports != set(self.network.enumerate_open_ports()):
             phases.append(OpenPorts(ports=desired_open_ports))
 
-        running_applications = set(
-            app for app in current_node_state.applications if app.running)
         all_applications = current_node_state.applications
 
         # Compare the applications being changed by name only.  Other
         # configuration changes aren't important at this point.
-        running = {app.name for app in running_applications}
+        local_application_names = {app.name for app in all_applications}
         desired_local_state = {app.name for app in
                                desired_node_applications}
-        not_running = {
-            app.name for app
-            in all_applications.difference(running_applications)}
-
         # Don't start applications that exist on this node but aren't
         # running; Docker is in charge of restarts:
-        start_names = desired_local_state.difference(running | not_running)
+        start_names = desired_local_state.difference(local_application_names)
         stop_names = {app.name for app in all_applications}.difference(
             desired_local_state)
 

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -14,12 +14,11 @@ from twisted.python.filepath import FilePath
 from .. import P2PManifestationDeployer, ApplicationNodeDeployer, sequentially
 from ...control._model import (
     Deployment, Application, DockerImage, Node, AttachedVolume, Link,
-    Manifestation, Dataset, DeploymentState, NodeState, RestartAlways)
+    Manifestation, Dataset, DeploymentState, NodeState)
 from .._docker import DockerClient
 from ..testtools import wait_for_unit_state, if_docker_configured
 from ...testtools import (
-    random_name, DockerImageBuilder, assertContainsAll, loop_until,
-    run_process)
+    random_name, DockerImageBuilder, assertContainsAll, loop_until)
 from ...volume.testtools import create_volume_service
 from ...route import make_memory_network
 

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -14,7 +14,7 @@ from twisted.python.filepath import FilePath
 from .. import P2PManifestationDeployer, ApplicationNodeDeployer, sequentially
 from ...control._model import (
     Deployment, Application, DockerImage, Node, AttachedVolume, Link,
-    Manifestation, Dataset, DeploymentState, NodeState)
+    Manifestation, Dataset, DeploymentState, NodeState, RestartAlways)
 from .._docker import DockerClient
 from ..testtools import wait_for_unit_state, if_docker_configured
 from ...testtools import (
@@ -104,50 +104,6 @@ class DeployerTests(TestCase):
     """
     Functional tests for ``Deployer``.
     """
-    @if_docker_configured
-    def test_restart(self):
-        """
-        Stopped applications that are supposed to be running are restarted
-        when the calcualted actions are run.
-        """
-        name = random_name(self)
-        docker_client = DockerClient()
-        deployer = ApplicationNodeDeployer(
-            u"localhost", docker_client, make_memory_network(),
-            node_uuid=uuid4())
-        self.addCleanup(docker_client.remove, name)
-
-        desired_state = Deployment(nodes=frozenset([
-            Node(uuid=deployer.node_uuid,
-                 applications=frozenset([Application(
-                     name=name,
-                     image=DockerImage.from_string(
-                         u"openshift/busybox-http-app"),
-                     links=frozenset(),
-                     )]))]))
-
-        d = change_node_state(deployer, desired_state)
-        d.addCallback(lambda _: wait_for_unit_state(docker_client, name,
-                                                    [u'active']))
-
-        def started(_):
-            # Now that it's running, stop it behind our back:
-            run_process([b"docker", b"stop",
-                         docker_client._to_container_name(name)])
-            return wait_for_unit_state(docker_client, name,
-                                       [u'inactive', u'failed'])
-        d.addCallback(started)
-
-        def stopped(_):
-            # Redeploy, which should restart it:
-            return change_node_state(deployer, desired_state)
-        d.addCallback(stopped)
-        d.addCallback(lambda _: wait_for_unit_state(docker_client, name,
-                                                    [u'active']))
-
-        # Test will timeout if unit was not restarted:
-        return d
-
     @if_docker_configured
     def test_environment(self):
         """


### PR DESCRIPTION
Question for reviewer: perhaps our default policy should be restart always, instead of restart never?

*Update:* Rob has stated this is the desired default.