### PR TITLE
Control service yml floc 1801

### DIFF
--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -32,11 +32,15 @@ On AWS, an external firewall is used instead, which will need to be configured s
 To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
 This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node:
 
+# TODO document what the port variable is, here and in Ubuntu section
+# TODO maybe make port an option to
+
 .. code-block:: yaml
 
    "version": 1
    "control-service":
       "hostname": "${CONTROL_NODE}"
+      "port": 4524
 
 .. task:: enable_flocker_agent fedora-20 ${CONTROL_NODE}
    :prompt: [root@agent-node]#
@@ -67,6 +71,7 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
    "version": 1
    "control-service":
       "hostname": "${CONTROL_NODE}"
+      "port": 4524
 
 .. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}
    :prompt: [root@agent-node]#

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -30,10 +30,8 @@ For more details on configuring the firewall, see Fedora's `firewalld documentat
 On AWS, an external firewall is used instead, which will need to be configured similarly.
 
 To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
-This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node:
-
-# TODO document what the port variable is, here and in Ubuntu section
-# TODO maybe make port an option to
+This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node.
+The ``port`` variable is the port on the control node to connect to:
 
 .. code-block:: yaml
 
@@ -64,7 +62,8 @@ For more details on configuring the firewall, see Ubuntu's `UFW documentation <h
 On AWS, an external firewall is used instead, which will need to be configured similarly.
 
 To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
-This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node:
+This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node.
+The ``port`` variable is the port on the control node to connect to:
 
 .. code-block:: yaml
 

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -31,7 +31,7 @@ On AWS, an external firewall is used instead, which will need to be configured s
 
 To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
 This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node.
-The ``port`` variable is the port on the control node to connect to:
+The optional ``port`` variable is the port on the control node to connect to:
 
 .. code-block:: yaml
 
@@ -63,7 +63,7 @@ On AWS, an external firewall is used instead, which will need to be configured s
 
 To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
 This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node.
-The ``port`` variable is the port on the control node to connect to:
+The optional ``port`` variable is the port on the control node to connect to:
 
 .. code-block:: yaml
 

--- a/docs/advanced/api.rst
+++ b/docs/advanced/api.rst
@@ -35,7 +35,8 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 .. code-block:: yaml
 
    "version": 1
-   "control-service-hostname": "${CONTROL_NODE}"
+   "control-service":
+      "hostname": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent fedora-20 ${CONTROL_NODE}
    :prompt: [root@agent-node]#
@@ -64,7 +65,8 @@ This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the
 .. code-block:: yaml
 
    "version": 1
-   "control-service-hostname": "${CONTROL_NODE}"
+   "control-service":
+      "hostname": "${CONTROL_NODE}"
 
 .. task:: enable_flocker_agent ubuntu-14.04 ${CONTROL_NODE}
    :prompt: [root@agent-node]#

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -105,7 +105,7 @@ def agent_config_from_file(path):
             "version": {"type": "number"},
             "control-service": {
                 "type": "object",
-                "required": ["hostname", "port"],
+                "required": ["hostname"],
                 "properties": {
                     "hostname": {
                         "type": "string",
@@ -128,10 +128,15 @@ def agent_config_from_file(path):
         raise ConfigurationError(
             "Configuration has an error. Incorrect version specified.")
 
+    try:
+        port = options['control-service']['port']
+    except KeyError:
+        port = 4524
+
     return {
         'control-service': {
             'hostname': options['control-service']['hostname'],
-            'port': options['control-service']['port'],
+            'port': port,
         },
     }
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -103,15 +103,23 @@ def agent_config_from_file(path):
     schema = {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
-        "required": ["version", "control-service-hostname"],
+        "required": ["version", "control-service"],
         "properties": {
             "version": {"type": "number"},
-            "control-service-hostname": {
-                "type": "string",
-                "format": "hostname",
+            "control-service": {
+                "type": "object",
+                "required": ["hostname"],
+                "properties": {
+                      "hostname": {
+                          "type": "string",
+                          "format": "hostname",
+                      },
+                }
             }
         }
     }
+
+#
 
     try:
         validate(options, schema, format_checker=FormatChecker())
@@ -125,7 +133,9 @@ def agent_config_from_file(path):
             "Configuration has an error. Incorrect version specified.")
 
     return {
-        'control-service-hostname': options[u'control-service-hostname'],
+        'control-service': {
+            'hostname': options[u'control-service']['hostname'],
+        },
     }
 
 
@@ -137,7 +147,7 @@ class ZFSAgentScript(object):
     """
     def main(self, reactor, options, volume_service):
         configuration = agent_config_from_file(path=options[u'agent-config'])
-        host = configuration['control-service-hostname']
+        host = configuration['control-service']['hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
         # Soon we'll extract this from TLS certificate for node.  Until then
@@ -251,7 +261,7 @@ class AgentServiceFactory(PRecord):
         :return: The ``AgentLoopService`` instance.
         """
         configuration = agent_config_from_file(path=options[u'agent-config'])
-        host = configuration['control-service-hostname']
+        host = configuration['control-service']['hostname']
         port = options["destination-port"]
         ip = _get_external_ip(host, port)
         return AgentLoopService(

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -107,11 +107,11 @@ def agent_config_from_file(path):
                 "type": "object",
                 "required": ["hostname", "port"],
                 "properties": {
-                      "hostname": {
-                          "type": "string",
-                          "format": "hostname",
-                      },
-                      "port": {"type": "integer"},
+                    "hostname": {
+                        "type": "string",
+                        "format": "hostname",
+                    },
+                    "port": {"type": "integer"},
                 }
             }
         }

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -336,12 +336,12 @@ class AgentConfigFromFileTests(SynchronousTestCase):
 
         :param Exception exception: The exception type which
             :func:`agent_config_from_file` should fail with.
-        :param unicode configuration: The contents of the agent configuration
+        :param dict configuration: The contents of the agent configuration
             file. If ``None`` then the file will not exist.
         :param bytes message: The expected exception message.
         """
         if configuration is not None:
-            self.config.setContent(configuration)
+            self.config.setContent(yaml.safe_dump(configuration))
 
         exception = self.assertRaises(
             exception,
@@ -365,7 +365,7 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         as a dictionary.
         """
         self.assertErrorForConfig(
-            configuration=yaml.safe_dump("INVALID"),
+            configuration="INVALID",
             exception=ConfigurationError,
             message=("Configuration has an error: "
                      "'INVALID' is not of type 'object'."),
@@ -377,10 +377,10 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         hostname is not a valid hostname.
         """
         self.assertErrorForConfig(
-            configuration=yaml.safe_dump({
+            configuration={
                 "control-service-hostname": "-1",
                 "version": 1,
-            }),
+            },
             exception=ConfigurationError,
             message=("Configuration has an error: '-1' is not a 'hostname'."),
         )
@@ -391,7 +391,7 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         contain a ``u"control-service-hostname"`` key.
         """
         self.assertErrorForConfig(
-            configuration=yaml.safe_dump({"version": 1}),
+            configuration={"version": 1},
             exception=ConfigurationError,
             message=("Configuration has an error: "
                      "'control-service-hostname' is a required property."),
@@ -403,8 +403,8 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         a ``u"version"`` key.
         """
         self.assertErrorForConfig(
-            configuration=yaml.safe_dump({
-                "control-service-hostname": "192.0.2.1"}),
+            configuration={
+                "control-service-hostname": "192.0.2.1"},
             exception=ConfigurationError,
             message=("Configuration has an error: "
                      "'version' is a required property."),
@@ -415,10 +415,10 @@ class AgentConfigFromFileTests(SynchronousTestCase):
         A ``ConfigurationError`` is raised if the version specified is not 1.
         """
         self.assertErrorForConfig(
-            configuration=yaml.safe_dump({
+            configuration={
                 "control-service-hostname": "192.0.2.1",
                 "version": 2,
-            }),
+            },
             exception=ConfigurationError,
             message=("Configuration has an error. "
                      "Incorrect version specified."),

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -87,6 +87,9 @@ class ZFSAgentScriptTests(SynchronousTestCase):
                           P2PManifestationDeployer, service, True))
 
 
+# TODO change put, change docs
+# TODO put port in the dictionary
+
 def get_all_ips():
     """
     Find all IPs for this machine.

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -87,7 +87,6 @@ class ZFSAgentScriptTests(SynchronousTestCase):
                           P2PManifestationDeployer, service, True))
 
 
-# TODO change put, change docs
 # TODO put port in the dictionary
 
 def get_all_ips():

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -444,10 +444,10 @@ class AgentConfigFromFileTests(SynchronousTestCase):
                      "Incorrect version specified."),
         )
 
-    def test_error_on_missing_port(self):
+    def test_default_port(self):
         """
-        A ``ConfigurationError`` is raised if the config file does not contain
-        a port in the ``u"control-service"`` key.
+        If the config file does not contain a port in the
+        ``u"control-service"`` key, the default is 4524.
         """
         configuration = {
             u"control-service": {
@@ -456,12 +456,9 @@ class AgentConfigFromFileTests(SynchronousTestCase):
             "version": 1,
         }
 
-        self.assertErrorForConfig(
-            configuration=configuration,
-            exception=ConfigurationError,
-            message=("Configuration has an error: "
-                     "'port' is a required property."),
-        )
+        self.config.setContent(yaml.safe_dump(configuration))
+        parsed = agent_config_from_file(path=self.config)
+        self.assertEqual(parsed['control-service']['port'], 4524)
 
     def test_error_on_invalid_port(self):
         """

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -231,6 +231,7 @@ def task_enable_flocker_agent(distribution, control_node):
                 "version": 1,
                 "control-service": {
                     "hostname": control_node,
+                    "port": 4524,
                 },
             },
         ),

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -229,10 +229,10 @@ def task_enable_flocker_agent(distribution, control_node):
         content=yaml.safe_dump(
             {
                 "version": 1,
-                "control-service-hostname": control_node,
+                "control-service": {
+                    "hostname": control_node,
+                },
             },
-            # Don't wrap the whole thing in braces
-            default_flow_style=False,
         ),
     )
     if distribution in ('centos-7', 'fedora-20'):


### PR DESCRIPTION
Unlike the design at https://github.com/ClusterHQ/flocker/pull/1338 this does not specify TCP. It is possible to have a "protocol" key and just make sure that it is TCP but I think that it is better to just leave it and add an option later if necessary.

As per the previous PR, there is some documentation duplication and the documentation is not in the best place. However David Oliver is looking into restructuring the documentation and will look at this story in particular before submission so I don't think that should be solved here.