### PR TITLE
[FLOC-1787] Make functional cloud testing variables explict.

### DIFF
--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -166,12 +166,12 @@ The configuration stanza for the EBS backend looks as follows:
      secret_access_token: <aws secret access token>
 
 The AWS backend also requires that the availability zone the test are running in be specified in the  ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` environment variable.
-This is specified seperately from the credential file, so that the file can be reused in different regions.
+This is specified separately from the credential file, so that the file can be reused in different regions.
 
 Rackspace
 ---------
 
-The configuration stanza for the openstack backend running on rackspace looks as follows:
+The configuration stanza for the OpenStack backend running on Rackspace looks as follows:
 
 .. code:: yaml
 
@@ -183,7 +183,7 @@ The configuration stanza for the openstack backend running on rackspace looks as
 OpenStack
 ---------
 
-The configuration stanza for an private openstack deployment looks as follows:
+The configuration stanza for an private OpenStack deployment looks as follows:
 
 .. code:: yaml
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -135,3 +135,61 @@ You will need a ssh agent running with access to the corresponding private key.
 .. prompt:: bash $
 
   admin/run-acceptance-tests --distribution fedora-20 --provider aws --config-file config.yml
+
+
+Functional Testing
+==================
+
+The tests for the various cloud block device backends depend on access to credentials supplied from the environment.
+
+The tests look for two environment variables:
+
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This points at a yaml file with the credentials.
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This is the name of a top-level key in the configuration file.
+
+The credentials are read from the stanza specified by the ``CLOUD_PROVIDER`` environment variable.
+The supported block-device backend is specified by a ``provider`` key in the stanza,
+or the name of the stanza, if the ``provider`` key is missing.
+
+If the environment variables aren't present, the tests will be skipped.
+The tests that do not correspond to the configured provider will also be skipped.
+
+AWS
+---
+
+The configuration stanza for the EBS backend looks as follows:
+
+.. code:: yaml
+
+   aws:
+     access_key: <aws access key>
+     secret_access_token: <aws secret access token>
+
+The AWS backend also requires that the availability zone the test are running in be specified in the  ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` environment variable.
+This is specified seperately from the credential file, so that the file can be reused in different regions.
+
+Rackspace
+---------
+
+The configuration stanza for the openstack backend running on rackspace looks as follows:
+
+.. code:: yaml
+
+   rackspace:
+     region: <rackspace region, e.g. "iad">
+     username: <rackspace username>
+     key: <access key>
+
+OpenStack
+---------
+
+The configuration stanza for an private openstack deployment looks as follows:
+
+.. code:: yaml
+
+   private-cloud:
+     provider: openstack
+     auth_plugin: plugin_name
+     plugin_option: value
+
+``auth_plugin`` refers to an authentication plugin provided by ``python-keystoneclient``.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -2,6 +2,7 @@ admin
 app
 apps
 backend
+backends
 behaviour
 blog
 Btrfs

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -25,7 +25,7 @@ from ..test.test_blockdevice import (
     make_iblockdeviceapi_tests,
 )
 from ..test.blockdevicefactory import (
-    ConfigMissing, ProviderType, get_blockdeviceapi_args,
+    InvalidConfig, ProviderType, get_blockdeviceapi_args,
     get_blockdeviceapi_with_cleanup,
 )
 from ....testtools import REALISTIC_BLOCKDEVICE_SIZE
@@ -65,7 +65,7 @@ class CinderBlockDeviceAPIInterfaceTests(
         """
         try:
             cls, kwargs = get_blockdeviceapi_args(ProviderType.openstack)
-        except ConfigMissing as e:
+        except InvalidConfig as e:
             raise SkipTest(str(e))
         cinder_volumes = kwargs["cinder_volume_manager"]
         requested_volume = cinder_volumes.create(

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -9,7 +9,7 @@ from twisted.trial.unittest import SkipTest, SynchronousTestCase
 
 from ..cinder import wait_for_volume
 from ..test.blockdevicefactory import (
-    ConfigMissing,
+    InvalidConfig,
     ProviderType, get_blockdeviceapi_args,
 )
 from ....testtools import random_name
@@ -23,7 +23,7 @@ def cinder_volume_manager():
     """
     try:
         cls, kwargs = get_blockdeviceapi_args(ProviderType.openstack)
-    except ConfigMissing as e:
+    except InvalidConfig as e:
         raise SkipTest(str(e))
     return kwargs["cinder_volume_manager"]
 

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -19,7 +19,7 @@ from ..test.test_blockdevice import (
 )
 
 from ..test.blockdevicefactory import (
-    ConfigMissing, ProviderType, get_blockdeviceapi_args,
+    InvalidConfig, ProviderType, get_blockdeviceapi_args,
     get_blockdeviceapi_with_cleanup,
 )
 
@@ -67,7 +67,7 @@ class EBSBlockDeviceAPIInterfaceTests(
         """
         try:
             cls, kwargs = get_blockdeviceapi_args(ProviderType.aws)
-        except ConfigMissing as e:
+        except InvalidConfig as e:
             raise SkipTest(str(e))
         ec2_client = kwargs["ec2_client"]
         requested_volume = ec2_client.connection.create_volume(

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -139,6 +139,7 @@ def get_blockdeviceapi_args(provider):
 from keystoneclient.auth import get_plugin_class
 # from keystoneclient.exceptions import NoMatchingPlugin
 
+
 def _openstack_auth_from_config(**config):
     auth_plugin_name = config.pop('auth_plugin', 'password')
 
@@ -152,7 +153,8 @@ def _openstack_auth_from_config(**config):
     plugin_options = plugin_class.get_options()
     plugin_kwargs = {}
     for option in plugin_options:
-        # option.dest is the python compatible attribute name in the plugin implementation.
+        # option.dest is the python compatible attribute name in the plugin
+        # implementation.
         # option.dest is option.name with hyphens replaced with underscores.
         if option.dest in config:
             plugin_kwargs[option.dest] = config[option.dest]

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -226,7 +226,8 @@ def _aws(**config):
         ),
     }
 
-
+# Map provider labels to IBlockDeviceAPI factory and a corresponding argument
+# factory.
 _BLOCKDEVICE_TYPES = {
     ProviderType.openstack: (CinderBlockDeviceAPI, _openstack),
     ProviderType.aws: (EBSBlockDeviceAPI, _aws),

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -40,7 +40,7 @@ from ..test.test_blockdevice import detach_destroy_volumes
 
 class InvalidConfig(Exception):
     """
-    The cloud configuration could not be found, or is not compatible with the
+    The cloud configuration could not be found or is not compatible with the
     running environment.
     """
 
@@ -137,7 +137,6 @@ def get_blockdeviceapi_args(provider):
 
 
 from keystoneclient.auth import get_plugin_class
-# from keystoneclient.exceptions import NoMatchingPlugin
 
 
 def _openstack_auth_from_config(**config):
@@ -146,8 +145,6 @@ def _openstack_auth_from_config(**config):
     if auth_plugin_name == 'rackspace':
         plugin_class = RackspaceAuth
     else:
-        # XXX May raise NoMatchingPlugin...shall we handle that and return a
-        # nicer error?
         plugin_class = get_plugin_class(auth_plugin_name)
 
     plugin_options = plugin_class.get_options()
@@ -195,7 +192,7 @@ def _aws(**config):
     ``EBSBlockDeviceAPI``.
 
     :param bytes access_key: "access_key" credential for EC2.
-    :param str secret_access_key: "secret_access_token" EC2 credential.
+    :param bytes secret_access_key: "secret_access_token" EC2 credential.
     """
     # We just get the credentials from the config file.
     # We ignore the region specified in acceptance test configuration,

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -37,11 +37,6 @@ from ..ebs import EBSBlockDeviceAPI, ec2_client
 from ..test.test_blockdevice import detach_destroy_volumes
 
 
-# The Rackspace authentication endpoint
-# See http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/Authentication-d1e647.html # noqa
-RACKSPACE_AUTH_URL = "https://identity.api.rackspacecloud.com/v2.0"
-
-
 class InvalidConfig(Exception):
     """
     The cloud configuration could not be found, or is not compatible with the

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -173,7 +173,7 @@ def _aws(**config):
 
 _BLOCKDEVICE_TYPES = {
     ProviderType.openstack: (CinderBlockDeviceAPI, _openstack),
-    ProviderType.aws: (_aws, EBSBlockDeviceAPI),
+    ProviderType.aws: (EBSBlockDeviceAPI, _aws),
 }
 
 # ^^^^^^^^^^^^^^^^^^^^ generally useful implementation code, put it somewhere


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1787

This is based on #1347 since the code this is touching is refactored there. ([relative diff](https://github.com/ClusterHQ/flocker/compare/openstack-attach-FLOC-1485...explict-cloud-testing-variables-FLOC-1787))
