### PR TITLE
Wait until `host` can resolve `clusterhq.com` before really provisioning.

### DIFF
--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -57,7 +57,7 @@ def task_wait_for_working_network():
     return sequence([
         run("""\
 for count in $(seq 60); do
-    host clusterhq.com
+    ping -n 1 clusterhq.com
     result=$?
     if ${result}; then
         break

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -58,7 +58,7 @@ def task_wait_for_working_network():
         run("""\
 for count in $(seq 60); do
     host clusterhq.com
-    result = $?
+    result=$?
     if ${result}; then
         break
     fi


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1842

(Quite possibly this is not helpful, need to see what happens on buildbot.)