### PR TITLE
[FLOC-1848] Remove resize dataset from API

### DIFF
--- a/docs/advanced/api_examples.yml
+++ b/docs/advanced/api_examples.yml
@@ -209,30 +209,6 @@
 
 -
   id:
-    "update dataset size"
-
-  doc: |
-    Update a dataset with a new maximum_size. This will grow or shrink
-    the filesystem on the dataset.
-
-  requires:
-    - "create dataset with dataset_id"
-
-  request: |
-    POST /v1/configuration/datasets/886ed03a-5606-453a-94a9-a1cbaf35164c HTTP/1.1
-
-    {"maximum_size": 1073741824}
-
-  response: |
-    HTTP/1.1 200 OK
-
-    {"dataset_id": "886ed03a-5606-453a-94a9-a1cbaf35164c",
-     "maximum_size": 1073741824,
-     "primary": "%(NODE_1)s",
-     "deleted": false}
-
--
-  id:
     "delete dataset"
 
   doc: |

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -297,14 +297,12 @@ class ConfigurationAPIUserV1(object):
 
         * Move a dataset from one node to another by changing the
           ``primary`` attribute.
-        * Resize the dataset by modifying the maximum_size attribute.
         * In the future update metadata.
 
         """,
         examples=[
             u"update dataset with primary",
             u"update dataset with unknown dataset id",
-            u"update dataset size"
         ]
     )
     @structured(
@@ -316,8 +314,7 @@ class ConfigurationAPIUserV1(object):
             '/v1/endpoints.json#/definitions/configuration_datasets'},
         schema_store=SCHEMAS
     )
-    def update_dataset(self, dataset_id, primary=None,
-                       maximum_size=_UNDEFINED_MAXIMUM_SIZE):
+    def update_dataset(self, dataset_id, primary=None):
         """
         Update an existing dataset in the cluster configuration.
 
@@ -326,11 +323,6 @@ class ConfigurationAPIUserV1(object):
 
         :param primary: The UUID of the node to which the dataset will be
             moved, or ``None`` indicating no change.
-
-        :param maximum_size: Either the maximum number of bytes the dataset
-            will be capable of storing or ``None`` to make the dataset size
-            unlimited. This may be optional or required depending on the
-            dataset backend.
 
         :return: A ``dict`` describing the dataset which has been added to the
             cluster configuration or giving error information if this is not
@@ -350,11 +342,6 @@ class ConfigurationAPIUserV1(object):
         if primary is not None:
             deployment = _update_dataset_primary(
                 deployment, dataset_id, UUID(hex=primary)
-            )
-
-        if maximum_size is not _UNDEFINED_MAXIMUM_SIZE:
-            deployment = _update_dataset_maximum_size(
-                deployment, dataset_id, maximum_size
             )
 
         saving = self.persistence_service.save(deployment)

--- a/flocker/control/schema/endpoints.yml
+++ b/flocker/control/schema/endpoints.yml
@@ -141,7 +141,7 @@ definitions:
   configuration_datasets_update:
     description: |
       The input schema for the update_dataset endpoint.
-    "$ref": "types.json#/definitions/dataset_configuration"
+    "$ref": "types.json#/definitions/dataset_configuration_update"
 
   configuration_datasets_create:
     # XXX: The publicapi documentation builder currently fails unless the

--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -271,3 +271,19 @@ definitions:
       maximum_size:
         '$ref': '#/definitions/maximum_size'
     additionalProperties: false
+
+  dataset_configuration_update:
+    title: "Dataset Configuration"
+    description: "The configuration for a particular dataset."
+    type: object
+    properties:
+      primary:
+        '$ref': '#/definitions/primary'
+      dataset_id:
+        '$ref': '#/definitions/dataset_id'
+      deleted:
+        '$ref': '#/definitions/deleted'
+      metadata:
+        '$ref': '#/definitions/metadata'
+    additionalProperties: false
+

--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -279,11 +279,5 @@ definitions:
     properties:
       primary:
         '$ref': '#/definitions/primary'
-      dataset_id:
-        '$ref': '#/definitions/dataset_id'
-      deleted:
-        '$ref': '#/definitions/deleted'
-      metadata:
-        '$ref': '#/definitions/metadata'
     additionalProperties: false
 

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -38,7 +38,6 @@ from ..httpapi import (
     ConfigurationAPIUserV1, create_api_service, datasets_from_deployment,
     api_dataset_from_dataset_and_node, container_configuration_response
 )
-from ...node.agents.test.test_blockdevice import REALISTIC_BLOCKDEVICE_SIZE
 from .._persistence import ConfigurationPersistenceService
 from .._clusterstate import ClusterStateService
 from .._config import (
@@ -2278,124 +2277,6 @@ class UpdatePrimaryDatasetTestsMixin(APITestsMixin):
 RealTestsUpdatePrimaryDataset, MemoryTestsUpdatePrimaryDataset = (
     buildIntegrationTests(
         UpdatePrimaryDatasetTestsMixin, "UpdatePrimaryDataset", _build_app)
-)
-
-
-class UpdateSizeDatasetTestsMixin(APITestsMixin):
-    """
-    Tests for the behaviour of the dataset modification endpoint at
-    ``/configuration/datasets/<dataset_id>`` when supplied with a maximum_size
-    value.
-    """
-    def assert_dataset_resize(self, original_size, new_size,
-                              expected_code=OK, expected_result=None):
-        """
-        Check that a request to resize a dataset results in an `OK` response
-        and that the returned dataset has the expected new size.
-
-        This function first creates and persists a deployment containing a
-        dataset with ``original_size``.  It then issues a dataset update
-        request for that dataset with ``new_size`` and checks that the the
-        response code is ``expected_code`` and that the decoded response body
-        is ``expected_result``.
-
-        ``expected_code`` and ``expected_result`` can be overridden to test
-        cases where the supplied ``new_size`` is invalid.
-
-        :param int original_size: The initial size in bytes of the dataset.
-        :param int new_size: The new size in bytes of the dataset.
-        :param int expected_code: The HTTP status code that is expected in the
-            response.
-        :param dict expected_result: The dictionary of dataset attributes that
-            is expected in the response body.
-
-        :returns: A ``Deferred`` which fires when all assertions have been
-            performed on the result of the dataset update request.
-        """
-        expected_manifestation = _manifestation(
-            maximum_size=original_size
-        )
-
-        if expected_result is None:
-            expected_result = {
-                u'dataset_id': expected_manifestation.dataset_id,
-                u'primary': self.NODE_A,
-                u'deleted': False,
-                u'metadata': {},
-                u'maximum_size': new_size,
-            }
-
-            if new_size is None:
-                del expected_result[u'maximum_size']
-
-        current_primary_node = Node(
-            uuid=self.NODE_A_UUID,
-            applications=[],
-            manifestations={expected_manifestation.dataset_id:
-                            expected_manifestation}
-        )
-        deployment = Deployment(nodes=[current_primary_node])
-        saving = self.persistence_service.save(deployment)
-
-        def resize(result):
-            return self.assertResult(
-                method=b"POST",
-                path=b"/configuration/datasets/%s" % (
-                    bytes(expected_manifestation.dataset_id),
-                ),
-                request_body={u'maximum_size': new_size},
-                expected_code=expected_code,
-                expected_result=expected_result,
-            )
-        return saving.addCallback(resize)
-
-    def test_grow(self):
-        """
-        A dataset maximum_size can be increased.
-        """
-        return self.assert_dataset_resize(
-            original_size=REALISTIC_BLOCKDEVICE_SIZE,
-            new_size=REALISTIC_BLOCKDEVICE_SIZE * 2
-        )
-
-    def test_shrink(self):
-        """
-        A dataset maximum_size can be decreased.
-        """
-        return self.assert_dataset_resize(
-            original_size=REALISTIC_BLOCKDEVICE_SIZE * 2,
-            new_size=REALISTIC_BLOCKDEVICE_SIZE
-        )
-
-    def test_too_small(self):
-        """
-        A dataset must be at least 67108864 bytes.
-        """
-        return self.assert_dataset_resize(
-            original_size=67108864,
-            new_size=67108864 - 1024,
-            expected_code=BAD_REQUEST,
-            expected_result={
-                u'description':
-                u"The provided JSON doesn't match the required schema.",
-                u'errors':
-                [u'67107840 is less than the minimum of 67108864']
-            }
-        )
-
-    def test_remove_limit(self):
-        """
-        A dataset maximum_size can be removed.
-        """
-        return self.assert_dataset_resize(
-            original_size=REALISTIC_BLOCKDEVICE_SIZE,
-            new_size=None
-        )
-
-
-RealTestsUpdateSizeDataset, MemoryTestsUpdateSizeDataset = (
-    buildIntegrationTests(
-        UpdateSizeDatasetTestsMixin, "UpdateSizeDataset", _build_app)
 )
 
 

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -564,21 +564,20 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = [
 CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES = [
     # everything optional except primary
     {u"primary": a_uuid},
-
-    # metadata is an object with a handful of short string key/values
-    {u"primary": a_uuid,
-     u"metadata":
-         dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256)},
-
-    # dataset_id is a string of 36 characters
-    {u"primary": a_uuid, u"dataset_id": u"x" * 36},
-
-    # deleted is a boolean
-    {u"primary": a_uuid, u"deleted": False},
 ]
 
 CONFIGURATION_DATASETS_PASSING_INSTANCES = (
     CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES + [
+        # metadata is an object with a handful of short string key/values
+        {u"primary": a_uuid,
+         u"metadata":
+             dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256)},
+
+        # dataset_id is a string of 36 characters
+        {u"primary": a_uuid, u"dataset_id": u"x" * 36},
+
+        # deleted is a boolean
+        {u"primary": a_uuid, u"deleted": False},
         # maximum_size is an integer of at least 64MiB
         {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64},
 

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -561,7 +561,7 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = [
      u"deleted": u"hello"},
 ]
 
-CONFIGURATION_DATASETS_PASSING_INSTANCES = [
+CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES = [
     # everything optional except primary
     {u"primary": a_uuid},
 
@@ -570,26 +570,30 @@ CONFIGURATION_DATASETS_PASSING_INSTANCES = [
      u"metadata":
          dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256)},
 
-    # maximum_size is an integer of at least 64MiB
-    {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64},
-
-    # maximum_size may be null, which means no size limit
-    {u"primary": a_uuid, u"maximum_size": None},
-
     # dataset_id is a string of 36 characters
     {u"primary": a_uuid, u"dataset_id": u"x" * 36},
 
     # deleted is a boolean
     {u"primary": a_uuid, u"deleted": False},
-
-    # All of them can be combined.
-    {u"primary": a_uuid,
-     u"metadata":
-         dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256),
-     u"maximum_size": 1024 * 1024 * 64,
-     u"dataset_id": u"x" * 36,
-     u"deleted": True},
 ]
+
+CONFIGURATION_DATASETS_PASSING_INSTANCES = (
+    CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES + [
+        # maximum_size is an integer of at least 64MiB
+        {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64},
+
+        # maximum_size may be null, which means no size limit
+        {u"primary": a_uuid, u"maximum_size": None},
+
+        # All of them can be combined.
+        {u"primary": a_uuid,
+         u"metadata":
+             dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256),
+         u"maximum_size": 1024 * 1024 * 64,
+         u"dataset_id": u"x" * 36,
+         u"deleted": True},
+    ]
+)
 
 ConfigurationDatasetsSchemaTests = build_schema_test(
     name="ConfigurationDatasetsSchemaTests",
@@ -607,7 +611,7 @@ ConfigurationDatasetsUpdateSchemaTests = build_schema_test(
             '/v1/endpoints.json#/definitions/configuration_datasets_update'},
     schema_store=SCHEMAS,
     failing_instances=CONFIGURATION_DATASETS_FAILING_INSTANCES,
-    passing_instances=CONFIGURATION_DATASETS_PASSING_INSTANCES,
+    passing_instances=CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES,
 )
 
 


### PR DESCRIPTION
Fixes:
 * https://clusterhq.atlassian.net/browse/FLOC-1848

Removes the maximum_size change capabilities from the update dataset API endpoint.