### PR TITLE
[FLOC-1849] Show stderr from admin.runner too.

### DIFF
--- a/admin/runner.py
+++ b/admin/runner.py
@@ -49,7 +49,7 @@ class CommandProtocol(ProcessProtocol, object):
         Otherwise, errbacks with the reason.
     :ivar file-like output: For logging.
 
-    :ivar defaultdict _fds: Mapping from fds to `_LineParsers`.
+    :ivar defaultdict _fds: Mapping from file descriptors to `_LineParsers`.
     """
     def __init__(self):
         self._fds = defaultdict(lambda: _LineParser(output=self.output))

--- a/admin/runner.py
+++ b/admin/runner.py
@@ -1,25 +1,46 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# -*- test-case-name: admin.test.test_runner -*-
 """
 Tools for running commands.
 """
 import sys
 import os
+from collections import defaultdict
 
 from characteristic import attributes
 
-from twisted.internet.error import ConnectionDone
-from twisted.internet.endpoints import ProcessEndpoint, connectProtocol
+from twisted.internet.error import ProcessDone
 from twisted.internet.defer import Deferred
+from twisted.internet.protocol import ProcessProtocol
 
 from twisted.protocols.basic import LineOnlyReceiver
 
 
 # LineOnlyReceiver is mutable, so can't use pyrsistent
 @attributes([
+    "output",
+])
+class _LineParser(LineOnlyReceiver, object):
+    """
+    Parser that breaks input into lines, and writes it to ouput.
+
+    :ivar file-like output: For logging.
+    """
+    delimiter = b'\n'
+
+    def __init__(self):
+        self.transport = type('', (object,), {})()
+        self.transport.disconnecting = False
+
+    def lineReceived(self, line):
+        self.output.write(line + "\n")
+
+
+@attributes([
     "deferred",
     "output",
 ])
-class CommandProtocol(LineOnlyReceiver, object):
+class CommandProtocol(ProcessProtocol, object):
     """
     Protocol that logs the lines of a remote command.
 
@@ -27,20 +48,20 @@ class CommandProtocol(LineOnlyReceiver, object):
         If the command finished successfully, will fire with ``None``.
         Otherwise, errbacks with the reason.
     :ivar file-like output: For logging.
+
+    :ivar defaultdict _fds: Mapping from fds to `_LineParsers`.
     """
-    delimiter = b'\n'
+    def __init__(self):
+        self._fds = defaultdict(lambda: _LineParser(output=self.output))
 
-    def connectionMade(self):
-        self.transport.disconnecting = False
+    def childDataReceived(self, childFD, data):
+        self._fds[childFD].dataReceived(data)
 
-    def connectionLost(self, reason):
-        if reason.check(ConnectionDone):
+    def processEnded(self, reason):
+        if reason.check(ProcessDone):
             self.deferred.callback(None)
         else:
             self.deferred.errback(reason)
-
-    def lineReceived(self, line):
-        self.output.write(line + "\n")
 
 
 def run(reactor, command, **kwargs):
@@ -54,11 +75,10 @@ def run(reactor, command, **kwargs):
     """
     if 'env' not in kwargs:
         kwargs['env'] = os.environ
-    endpoint = ProcessEndpoint(reactor, command[0], command, **kwargs)
     protocol_done = Deferred()
     protocol = CommandProtocol(deferred=protocol_done, output=sys.stdout)
 
-    connected = connectProtocol(endpoint, protocol)
+    reactor.spawnProcess(protocol, command[0], command, **kwargs)
 
     def unregister_killer(result, trigger_id):
         try:
@@ -69,12 +89,8 @@ def run(reactor, command, **kwargs):
             # if this fails.
             pass
         return result
+    trigger_id = reactor.addSystemEventTrigger(
+        'before', 'shutdown', protocol.transport.signalProcess, 'TERM')
+    protocol_done.addBoth(unregister_killer, trigger_id)
 
-    def register_killer(_):
-        trigger_id = reactor.addSystemEventTrigger(
-            'before', 'shutdown', protocol.transport.signalProcess, 'TERM')
-        protocol_done.addBoth(unregister_killer, trigger_id)
-
-    connected.addCallback(register_killer)
-    connected.addCallback(lambda _: protocol_done)
-    return connected
+    return protocol_done

--- a/admin/test/test_runner.py
+++ b/admin/test/test_runner.py
@@ -43,7 +43,7 @@ class RunTests(TestCase):
         self.assertEqual(
             [process.executable,
              process.args,
-             type(process.processProtocol.protocol)],
+             type(process.processProtocol)],
             ['command',
              ['command', 'and', 'args'],
              CommandProtocol])
@@ -104,6 +104,20 @@ class RunTests(TestCase):
             [])
 
     def test_process_success(self):
+        """
+        If the process ends with a success, the returned deferred fires with
+        the reason.
+        """
+
+        reactor = ProcessCoreReactor()
+        d = run(reactor, ['command', 'and', 'args'])
+        [process] = reactor.processes
+
+        expected_failure = Failure(ProcessDone(0))
+        process.processProtocol.processEnded(expected_failure)
+        self.successResultOf(d),
+
+    def test_process_failure(self):
         """
         If the process ends with a failure, the returned deferred fires with
         the reason.

--- a/admin/test/test_runner.py
+++ b/admin/test/test_runner.py
@@ -106,7 +106,7 @@ class RunTests(TestCase):
     def test_process_success(self):
         """
         If the process ends with a success, the returned deferred fires with
-        the reason.
+        a succesful result.
         """
 
         reactor = ProcessCoreReactor()
@@ -115,7 +115,7 @@ class RunTests(TestCase):
 
         expected_failure = Failure(ProcessDone(0))
         process.processProtocol.processEnded(expected_failure)
-        self.successResultOf(d),
+        self.successResultOf(d)
 
     def test_process_failure(self):
         """


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1849

This doesn't address the underlying issue (which is we don't interact with vagrant and virtualbox in a way that cleans up old images properly). But it does address the regression in #1294, where we stopped showing stderr from vagrant.

(See 
http://build.clusterhq.com/builders/flocker%2Facceptance%2Fvagrant%2Ffedora-20/builds/2059
where it demonstrates the output).