### PR TITLE
[FLOC-1870] Flocker CA tests

### DIFF
--- a/flocker/ca/_ca.py
+++ b/flocker/ca/_ca.py
@@ -133,7 +133,10 @@ def create_certificate_authority(keypair, dn, request, serial,
     expire = expire.strftime(b"%Y%m%d%H%M%SZ")
     req = request.original
     cert = crypto.X509()
-    dn._copyInto(cert.get_issuer())
+    name = cert.get_issuer()
+    name.commonName = dn["commonName"]
+    name.organizationalUnitName = dn["organizationalUnitName"]
+    cert.set_issuer(name)
     cert.set_subject(req.get_subject())
     cert.set_pubkey(req.get_pubkey())
     cert.set_notBefore(start)
@@ -192,7 +195,10 @@ def sign_certificate_request(keypair, dn, request, serial,
     expire = expire.strftime(b"%Y%m%d%H%M%SZ")
     req = request.original
     cert = crypto.X509()
-    dn._copyInto(cert.get_issuer())
+    name = cert.get_issuer()
+    name.commonName = dn["commonName"]
+    name.organizationalUnitName = dn["organizationalUnitName"]
+    cert.set_issuer(name)
     cert.set_subject(req.get_subject())
     cert.set_pubkey(req.get_pubkey())
     cert.set_notBefore(start)

--- a/flocker/ca/functional/test_ca.py
+++ b/flocker/ca/functional/test_ca.py
@@ -5,6 +5,7 @@ Functional tests for ``flocker-ca`` CLI.
 """
 
 import re
+import sys
 from subprocess import CalledProcessError
 from unittest import skipUnless
 
@@ -35,6 +36,9 @@ def flocker_ca(command, *args):
         output = result.output
         status = 0
     except CalledProcessError as e:
+        Message.new(
+            message_type="flocker.ca.functional:ca_initialize_error",
+            error=str(e)).write(Logger())
         output = e.output
         status = e.returncode
     return (status, output)
@@ -59,6 +63,8 @@ def openssl_verify(cafile, certificatefile):
         Message.new(
             message_type="flocker.ca.functional:openssl_verify_error",
             error=str(e)).write(Logger())
+        # XXX temporary, remove this
+        sys.stderr.write("OpenSSL flocker.ca.functional: " + str(e))
         return False
 
 

--- a/flocker/ca/functional/test_ca.py
+++ b/flocker/ca/functional/test_ca.py
@@ -51,7 +51,7 @@ def openssl_verify(cafile, certificatefile):
     :return: A ``bool`` that is True if the certificate was verified,
         otherwise False if verification failed or an error occurred.
     """
-    command = [b"openssl", b"verify", b"-CAfile", cafile+"x", certificatefile]
+    command = [b"openssl", b"verify", b"-CAfile", cafile, certificatefile]
     try:
         result = run_process(command)
         return result.output.strip() == b"{}: OK".format(certificatefile)

--- a/flocker/ca/functional/test_ca.py
+++ b/flocker/ca/functional/test_ca.py
@@ -60,10 +60,11 @@ def openssl_verify(cafile, certificatefile, **kwargs):
         result = run_process(command, **kwargs)
         return result.output.strip() == b"{}: OK".format(certificatefile)
     except CalledProcessError as e:
-        result = run_process(["openssl", "x509", "-text", "-in", cafile])
+        result = run_process([
+            "openssl", "x509", "-text", "-in", cafile], **kwargs)
         cafile_info = result.output
         result = run_process([
-            "openssl", "x509", "-text", "-in", certificatefile])
+            "openssl", "x509", "-text", "-in", certificatefile], **kwargs)
         certificate_info = result.output
         error = str(e)
         error = error + "\n" + cafile_info + "\n" + certificate_info

--- a/flocker/ca/functional/test_ca.py
+++ b/flocker/ca/functional/test_ca.py
@@ -8,6 +8,8 @@ import re
 from subprocess import CalledProcessError
 from unittest import skipUnless
 
+from eliot import Message, Logger
+
 from twisted.python.procutils import which
 
 from .._script import CAOptions
@@ -49,11 +51,14 @@ def openssl_verify(cafile, certificatefile):
     :return: A ``bool`` that is True if the certificate was verified,
         otherwise False if verification failed or an error occurred.
     """
-    command = [b"openssl", b"verify", b"-CAfile", cafile, certificatefile]
+    command = [b"openssl", b"verify", b"-CAfile", cafile+"x", certificatefile]
     try:
         result = run_process(command)
         return result.output.strip() == b"{}: OK".format(certificatefile)
-    except CalledProcessError:
+    except CalledProcessError as e:
+        Message.new(
+            message_type="flocker.ca.functional:openssl_verify_error",
+            error=str(e)).write(Logger())
         return False
 
 

--- a/flocker/ca/functional/test_ca.py
+++ b/flocker/ca/functional/test_ca.py
@@ -63,8 +63,6 @@ def openssl_verify(cafile, certificatefile):
         Message.new(
             message_type="flocker.ca.functional:openssl_verify_error",
             error=str(e)).write(Logger())
-        # XXX temporary, remove this
-        sys.stderr.write("OpenSSL flocker.ca.functional: " + str(e))
         return False
 
 


### PR DESCRIPTION
Fixes FLOC-1870

Prevents differing order of distinguished name components in generated certificates due to inconsistent dict iteration order.

Note: There are a couple of unrelated test failures
```
flocker.provision.test.test_ssh_conch.Tests.test_run_logs_stderr
flocker.provision.test.test_ssh_conch.Tests.test_run_logs_stdout
```