### PR TITLE
Fix doc tests floc 1913

### DIFF
--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -19,8 +19,6 @@ from twisted.web.http import OK, INTERNAL_SERVER_ERROR
 from eliot import Logger, writeFailure
 from eliot.twisted import DeferredContext
 
-from sphinx.errors import SphinxError
-
 from ._error import (
     ILLEGAL_CONTENT_TYPE, DECODING_ERROR, BadRequest, InvalidRequestJSON)
 from ._logging import LOG_SYSTEM, REQUEST, JSON_REQUEST

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -243,11 +243,7 @@ def user_documentation(doc, examples=None, header=None):
     """
     def deco(f):
         f.userDocumentation = doc
-        if header is None:
-            raise SphinxError(
-                'No API header provided in user_documentation decorator')
-        else:
-            f.header = header
+        f.header = header
         f.examples = examples
         return f
     return deco

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -183,7 +183,7 @@ def _introspectRoute(route, exampleByIdentifier, schema_store):
     """
     result = {}
 
-    result['header'] = route.attributes['header']
+    result['header'] = route.attributes.get('header')
 
     userDocumentation = route.attributes.get(
         "userDocumentation", "Undocumented.")
@@ -365,9 +365,10 @@ def makeRst(prefix, app, exampleByIdentifier, schema_store):
     for route in sorted(getRoutes(app)):
         data = _introspectRoute(route, exampleByIdentifier, schema_store)
         for method in route.methods:
-            yield data['header']
-            yield '=' * len(data['header'])
-            yield ''
+            if data['header'] is not None:
+                yield data['header']
+                yield '=' * len(data['header'])
+                yield ''
             body = _formatRouteBody(data, schema_store)
             for line in http_directive(method, prefix + route.path, body):
                 yield line

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -81,9 +81,6 @@ class MakeRstTests(SynchronousTestCase):
         rest = list(makeRst(b"/prefix", app, None, {}))
 
         self.assertEqual(rest, [
-            'No header!',
-            '==========',
-            '',
             '',
             '.. http:get:: /prefix/',
             '',
@@ -135,9 +132,7 @@ class MakeRstTests(SynchronousTestCase):
 
         rest = list(makeRst(b"/prefix", app, examples.get, {}))
         self.assertEqual(
-            ['No header!',
-             '==========',
-             '',
+            [
              '',
              # This line introduces the endpoint
              '.. http:get:: /prefix/',
@@ -210,9 +205,6 @@ class MakeRstTests(SynchronousTestCase):
         rest = list(makeRst(b"/prefix", app, None, self.INPUT_SCHEMAS))
 
         self.assertEqual(rest, [
-            'No header!',
-            '==========',
-            '',
             '',
             '.. http:get:: /prefix/',
             '',
@@ -296,9 +288,6 @@ class MakeRstTests(SynchronousTestCase):
         rest = list(makeRst(b"/prefix", app, None, self.INPUT_ARRAY_SCHEMAS))
 
         self.assertListEqual(rest, [
-            'No header!',
-            '==========',
-            '',
             '',
             '.. http:get:: /prefix/',
             '',
@@ -370,9 +359,6 @@ class MakeRstTests(SynchronousTestCase):
         rest = list(makeRst(b"/prefix", app, None, self.OUTPUT_SCHEMAS))
 
         self.assertEqual(rest, [
-            'No header!',
-            '==========',
-            '',
             '',
             '.. http:get:: /prefix/',
             '',
@@ -446,9 +432,6 @@ class MakeRstTests(SynchronousTestCase):
         rest = list(makeRst(b"/prefix", app, None, self.OUTPUT_ARRAY_SCHEMAS))
 
         self.assertListEqual(rest, [
-            'No header!',
-            '==========',
-            '',
             '',
             '.. http:get:: /prefix/',
             '',
@@ -520,9 +503,6 @@ class MakeRstTests(SynchronousTestCase):
         rest = list(makeRst(b"/prefix", app, None, self.OUTPUT_SCHEMAS))
 
         self.assertEqual(rest, [
-            'No header!',
-            '==========',
-            '',
             '',
             '.. http:get:: /prefix/',
             '',
@@ -686,9 +666,7 @@ class VariableInterpolationTests(SynchronousTestCase):
         self.assertEqual(
             # Unfortunately a lot of stuff that's not relevant to this test
             # comes back from makeRst.
-            [u'No header!',
-             u'==========',
-             u'',
+            [
              u'',
              u'.. http:get:: /prefix/',
              u'',

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -132,8 +132,7 @@ class MakeRstTests(SynchronousTestCase):
 
         rest = list(makeRst(b"/prefix", app, examples.get, {}))
         self.assertEqual(
-            [
-             '',
+            ['',
              # This line introduces the endpoint
              '.. http:get:: /prefix/',
              '',
@@ -666,8 +665,7 @@ class VariableInterpolationTests(SynchronousTestCase):
         self.assertEqual(
             # Unfortunately a lot of stuff that's not relevant to this test
             # comes back from makeRst.
-            [
-             u'',
+            [u'',
              u'.. http:get:: /prefix/',
              u'',
              u'   **Example:** Documentation of some example.',


### PR DESCRIPTION
This undoes the constraint introduced in PR #1412 that `header` is a required field in `user_documentation` decorator. Several tests do not include the `user_documentation` decorator at all, and it is possibly reasonable for this to happen for real operations ("private" operations, for example).