### PR TITLE
File exists floc 1873

### DIFF
--- a/admin/package-files/systemd/flocker-agent.service
+++ b/admin/package-files/systemd/flocker-agent.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Flocker Dataset Agent
-ConditionFileNotEmpty=/etc/flocker/agent.yml
 
 [Service]
 ExecStart=/usr/sbin/flocker-dataset-agent

--- a/admin/package-files/systemd/flocker-agent.service
+++ b/admin/package-files/systemd/flocker-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Flocker Dataset Agent
-AssertFileNotEmpty=/etc/flocker/agent.yml
+ConditionFileNotEmpty=/etc/flocker/agent.yml
 
 [Service]
 ExecStart=/usr/sbin/flocker-dataset-agent

--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Flocker Container Agent
-ConditionFileNotEmpty=/etc/flocker/agent.yml
 
 [Service]
 ExecStart=/usr/sbin/flocker-container-agent

--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Flocker Container Agent
-AssertFileNotEmpty=/etc/flocker/agent.yml
+ConditionFileNotEmpty=/etc/flocker/agent.yml
 
 [Service]
 ExecStart=/usr/sbin/flocker-container-agent


### PR DESCRIPTION
Unfortunately `ConditionFileNotEmpty=` shows the same error. It doesn't seem worth investigating right now, and we can look into it if it ever causes hassle.

For now `journalctl -r -u flocker-agent` shows a traceback:

```
May 18 11:36:43 node1 systemd[1]: Unit flocker-agent.service entered failed state.
May 18 11:36:43 node1 systemd[1]: flocker-agent.service: main process exited, code=exited, status=1/FAILURE
May 18 11:36:43 node1 flocker-dataset-agent[2012]: {"task_uuid": "0e08892a-7221-4396-b6e0-5505061814d4", "error": false, "timestamp": 1431974203.083844, "message": "Main loop terminated.", "message_type": "twisted:log", "task_level": [4]}
May 18 11:36:43 node1 flocker-dataset-agent[2012]: {"task_uuid": "0e08892a-7221-4396-b6e0-5505061814d4", "error": true, "timestamp": 1431974203.083727, "message": "main function encountered error\nTraceback (most recent call last):\n  File \"/opt/flocker/lib/python2.7/site-packages/flocker/node/script.py\", line 275,
...
```