### PR TITLE
[FLOC-1914] Switch from GB to GiB.

### DIFF
--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -44,11 +44,16 @@ class ICinderVolumeManager(Interface):
     See:
     https://github.com/openstack/python-cinderclient/blob/master/cinderclient/v1/volumes.py#L135
     """
+
+    # The OpenStack Cinder API documentation says the size is in GB (multiples
+    # of 10 ** 9 bytes).  Real world observations indicate size is actually in
+    # GiB (multiples of 2 ** 30).  So this method is documented as accepting
+    # GiB values.  https://bugs.launchpad.net/openstack-api-site/+bug/1456631
     def create(size, metadata=None):
         """
         Creates a volume.
 
-        :param size: Size of volume in GB
+        :param size: Size of volume in GiB
         :param metadata: Optional metadata to set on volume creation
         :rtype: :class:`Volume`
         """
@@ -222,11 +227,6 @@ class CinderBlockDeviceAPI(object):
             # XXX: Address size mistach (see
             # (https://clusterhq.atlassian.net/browse/FLOC-1874).
             requested_volume = self.cinder_volume_manager.create(
-                # The OpenStack Cinder API documentation says the size is in GB
-                # (multiples of 10 ** 9 bytes).  Real world observations
-                # indicate size is actually in GiB (multiples of 2 ** 30).  So
-                # convert the value to GiB here.
-                # https://bugs.launchpad.net/openstack-api-site/+bug/1456631
                 size=Byte(size).to_GiB().value,
                 metadata=metadata,
             )

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -8,7 +8,7 @@ import time
 from uuid import UUID
 from subprocess import check_output
 
-from bitmath import Byte, GB
+from bitmath import Byte, GiB
 
 from eliot import Message, start_action
 
@@ -379,7 +379,7 @@ def _blockdevicevolume_from_cinder_volume(cinder_volume):
 
     return BlockDeviceVolume(
         blockdevice_id=unicode(cinder_volume.id),
-        size=int(GB(cinder_volume.size).to_Byte().value),
+        size=int(GiB(cinder_volume.size).to_Byte().value),
         attached_to=server_id,
         dataset_id=UUID(cinder_volume.metadata[DATASET_ID_LABEL])
     )


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1914

Adjust to the reality that OpenStack Cinder APIs operate in terms of GiB, not GB (as documentation suggests).

Here's a completely green run of the OpenStack functional tests on Rackspace (from this branch): http://build.clusterhq.com/builders/flocker%2Ffunctional%2Frackspace%2Fcentos-7%2Fstorage-driver/builds/54