### PR TITLE
[FLOC-1607] Encode subjectAltName correctly when given hostname is actually an IP

### DIFF
--- a/flocker/ca/test/test_ca.py
+++ b/flocker/ca/test/test_ca.py
@@ -352,13 +352,23 @@ class ControlCredentialTests(
         self.assertEqual(
             subject.CN, b"control-service")
 
-    def test_subjectAltName(self):
+    def test_subjectAltName_dns(self):
         """
         The generated certificate has a subjectAltName containing the given
-        hostname.
+        hostname as a DNS record.
         """
         assert_has_extension(self, self.credential.credential,
                              b"subjectAltName", b"DNS:control.example.com")
+
+    def test_subjectAltName_ipv4(self):
+        """
+        The generated certificate has a subjectAltName containing the given
+        IPv4 address as a IP record.
+        """
+        credential = ControlCredential.initialize(
+            self.path, self.ca, begin=self.start_date, hostname=b"127.0.0.1")
+        assert_has_extension(self, credential.credential,
+                             b"subjectAltName", b"IP:127.0.0.1")
 
 
 class RootCredentialTests(SynchronousTestCase):

--- a/flocker/ca/test/test_ca.py
+++ b/flocker/ca/test/test_ca.py
@@ -354,16 +354,16 @@ class ControlCredentialTests(
 
     def test_subjectAltName_dns(self):
         """
-        The generated certificate has a subjectAltName containing the given
-        hostname as a DNS record.
+        If given a domain name as hostname, the generated certificate has a
+        subjectAltName containing the given hostname as a DNS record.
         """
         assert_has_extension(self, self.credential.credential,
                              b"subjectAltName", b"DNS:control.example.com")
 
     def test_subjectAltName_ipv4(self):
         """
-        The generated certificate has a subjectAltName containing the given
-        IPv4 address as a IP record.
+        If given a IPv4 address as the hostname, the generated certificate has
+        a subjectAltName containing with a IP record.
         """
         credential = ControlCredential.initialize(
             self.path, self.ca, begin=self.start_date, hostname=b"127.0.0.1")

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,10 @@ install_requirements = [
     "pytz",
     "characteristic >= 14.1.0",
     "Twisted == 15.1.0",
+    # TLS support libraries for Twisted:
+    "service_identity == 14.0.0",
+    "idna == 2.0",
+    "pyOpenSSL == 0.15.1",
 
     "PyYAML == 3.10",
 
@@ -103,7 +107,6 @@ install_requirements = [
     "klein == 0.2.3",
     "pyrsistent == 0.9.1",
     "pycrypto == 2.6.1",
-    "pyOpenSSL == 0.14",
     "effect==0.1a13",
     "bitmath==1.2.3-4",
     "boto==2.38.0",


### PR DESCRIPTION
And add dependency on `service_identity`.