### PR TITLE
[FLOC-1943] Validate openstack credentials

### DIFF
--- a/docs/indepth/installation.rst
+++ b/docs/indepth/installation.rst
@@ -395,6 +395,9 @@ For more details on configuring the firewall, see Fedora's `FirewallD documentat
 
 On AWS, an external firewall is used instead, which will need to be configured similarly.
 
+.. This (and the Ubuntu section below) should link to a new section about starting agents on a node.
+That new section can have subsections for each supported backend.
+
 To start the agents on a node, a configuration file must exist on the node at ``/etc/flocker/agent.yml``.
 This should be as follows, replacing ``${CONTROL_NODE}`` with the address of the control node.
 The optional ``port`` variable is the port on the control node to connect to:

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -131,6 +131,9 @@ def validate_configuration(configuration):
             "dataset": {
                 "type": "object",
                 "oneOf": [
+                    # Add further "oneOf" option for openstack, which itself
+                    # has "oneOf" options for each auth plugin.
+                    # We may use references to split this part of the schema up.
                     {
                         "required": ["backend"],
                         "properties": {

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -130,36 +130,12 @@ def validate_configuration(configuration):
             },
             "dataset": {
                 "type": "object",
-                "oneOf": [
-                    # Add further "oneOf" option for openstack, which itself
-                    # has "oneOf" options for each auth plugin.
-                    # We may use references to split this part of the schema up.
-                    {
-                        "required": ["backend"],
-                        "properties": {
-                            "backend": {
-                                "type": "string",
-                                "pattern": "zfs",
-                            },
-                            "pool": {
-                                "type": "string",
-                            },
-                        }
+                "required": ["backend"],
+                "properties": {
+                    "backend": {
+                        "type": "string",
                     },
-                    {
-                        "required": ["backend"],
-                        "properties": {
-                            "backend": {
-                                "type": "string",
-                                "pattern": "loopback",
-                            },
-                            "pool": {
-                                "type": "string",
-                            },
-                        }
-
-                    },
-                ]
+                }
             }
         }
     }

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -496,9 +496,6 @@ def make_amp_agent_options_tests(options_type):
     return Tests
 
 
-# This is getting large.
-# We will add tests to it, to validate the proposed backends (see PR description).
-# We think it might be best to split this up (e.g. ControlServiceValidationTests, ZFSBackendValidationTests, OpenStackBackendValidationTests)
 class ValidateConfigurationTests(SynchronousTestCase):
     """
     Tests for :func:`validate_configuration`.
@@ -512,8 +509,7 @@ class ValidateConfigurationTests(SynchronousTestCase):
                 u"port": 1234,
             },
             u"dataset": {
-                u"backend": u"zfs",
-                u"pool": u"custom-pool",
+                u"backend": u"backend_example",
             },
             "version": 1,
         }
@@ -526,45 +522,11 @@ class ValidateConfigurationTests(SynchronousTestCase):
         # Nothing is raised
         validate_configuration(self.configuration)
 
-    def test_valid_loopback_configuration(self):
-        """
-        No exception is raised when validating a valid configuration with a
-        loopback backend.
-        """
-        self.configuration['dataset'] = {
-            u"backend": u"loopback",
-            u"pool": u"custom-pool",
-        }
-        # Nothing is raised
-        validate_configuration(self.configuration)
-
     def test_port_optional(self):
         """
         The control service agent's port is optional.
         """
         self.configuration['control-service'].pop('port')
-        # Nothing is raised
-        validate_configuration(self.configuration)
-
-    def test_zfs_pool_optional(self):
-        """
-        No exception is raised when validating a ZFS backend is specified but
-        a ZFS pool is not.
-        """
-        self.configuration['dataset'] = {
-            u"backend": u"zfs",
-        }
-        # Nothing is raised
-        validate_configuration(self.configuration)
-
-    def test_loopback_pool_optional(self):
-        """
-        No exception is raised when validating a loopback backend is specified
-        but a loopback pool is not.
-        """
-        self.configuration['dataset'] = {
-            u"backend": u"loopback",
-        }
         # Nothing is raised
         validate_configuration(self.configuration)
 
@@ -653,14 +615,6 @@ class ValidateConfigurationTests(SynchronousTestCase):
         The dataset key must contain a backend type.
         """
         self.configuration['dataset'] = {}
-        self.assertRaises(
-            ValidationError, validate_configuration, self.configuration)
-
-    def test_error_on_invalid_dataset_type(self):
-        """
-        The dataset key must contain a valid dataset type.
-        """
-        self.configuration['dataset'] = {"backend": "invalid"}
         self.assertRaises(
             ValidationError, validate_configuration, self.configuration)
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -496,6 +496,9 @@ def make_amp_agent_options_tests(options_type):
     return Tests
 
 
+# This is getting large.
+# We will add tests to it, to validate the proposed backends (see PR description).
+# We think it might be best to split this up (e.g. ControlServiceValidationTests, ZFSBackendValidationTests, OpenStackBackendValidationTests)
 class ValidateConfigurationTests(SynchronousTestCase):
     """
     Tests for :func:`validate_configuration`.


### PR DESCRIPTION
Design for: https://clusterhq.atlassian.net/browse/FLOC-1943

We plan to support a third dataset backend option, 'openstack' (after 'zfs' and 'loopback').
This requires:
* Documentation about what is supported,
* Documentation about how to create a valid agent.yml,
* Validation of the currently supported options.

Openstack backends require an auth plugin. For each auth plugin, there are various plugin-specific options.
We currently support two plugins: "rackspace" and "password".
The "password" plugin is used (at least) for PistonCloud.

Supported configs would be something like the following (but `yaml`):

```python
config_rackspace = {
    'control-service': {
        'hostname': '172.16.255.240',
        'port': 4524,
    },
    'dataset': {
        'backend': 'openstack',
        'tenant_id': 'my_id', # required if openstack
        'auth_url': 'https://example.com/rackspace/', # required if openstack, must be a uri
        'auth_plugin': 'rackspace': # required if openstack
        'username': 'adam', # required if rackspace plugin
        'region': 'my_region', # required if rackspace plugin
        'api_key': 'my_username', # required if rackspace
    },
    'version': 1
}

config_piston = {
    'control-service': {
        'hostname': '172.16.255.240',
        'port': 4524,
    },
    'dataset': {
        'backend': 'openstack',
        'tenant_id': 'my_id', # required if openstack
        'auth_url': 'https://example.com/piston/', # required if openstack, must be a uri
        'auth_plugin': 'password', # required if openstack
        'username': 'my_username', # required if 'password' plugin
        'password': 'my_password', # required if 'password' plugin
    },
    'version': 1
}
```