### PR TITLE
[FLOC-1949] Choose dataset backend in acceptance test runner.

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -308,7 +308,7 @@ class RunOptions(Options):
          'The target provider to test against. '
          'One of {}.'.format(', '.join(PROVIDERS))],
         ['dataset-backend', None, 'loopback',
-         'The dataset backend to testt against. '
+         'The dataset backend to test against. '
          'One of {}'.format(', '.join(backend.name for backend
                                       in DatasetBackend.iterconstants()))],
         ['config-file', None, None,

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -464,13 +464,14 @@ def main(reactor, args, base_path, top_level):
         )
 
         control_node = nodes[0]
+        dataset_backend = options['dataset-backend']
 
         yield perform(
             make_dispatcher(reactor),
             configure_cluster(control_node=control_node, agent_nodes=nodes,
-                              certificates=certificates))
+                              certificates=certificates,
+                              dataset_backend=dataset_backend))
 
-        dataset_backend = options['dataset-backend']
         result = yield run_tests(
             reactor=reactor,
             nodes=nodes,

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -307,7 +307,7 @@ class RunOptions(Options):
         ['provider', None, 'vagrant',
          'The target provider to test against. '
          'One of {}.'.format(', '.join(PROVIDERS))],
-        ['dataset-backend', None, 'loopback',
+        ['dataset-backend', None, 'zfs',
          'The dataset backend to test against. '
          'One of {}'.format(', '.join(backend.name for backend
                                       in DatasetBackend.iterconstants()))],

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -32,7 +32,7 @@ from flocker.provision._ca import Certificates
 from effect import parallel
 from effect.twisted import perform
 from flocker.provision._ssh._conch import make_dispatcher
-from flocker.acceptance.testtools import VolumeBackend
+from flocker.acceptance.testtools import DatasetBackend
 
 from .runner import run
 
@@ -61,7 +61,7 @@ def remove_known_host(reactor, hostname):
     return run(reactor, ['ssh-keygen', '-R', hostname])
 
 
-def run_tests(reactor, nodes, control_node, agent_nodes, volume_backend,
+def run_tests(reactor, nodes, control_node, agent_nodes, dataset_backend,
               trial_args, certificates_path):
     """
     Run the acceptance tests.
@@ -72,7 +72,7 @@ def run_tests(reactor, nodes, control_node, agent_nodes, volume_backend,
         tests against.
     :param list agent_nodes: The list of INode nodes running flocker
         agent, to run API acceptance tests against.
-    :param VolumeBackend volume_backend: The volume backend the nodes are
+    :param DatasetBackend dataset_backend: The volume backend the nodes are
         configured with.
     :param list trial_args: Arguments to pass to trial. If not
         provided, defaults to ``['flocker.acceptance']``.
@@ -100,7 +100,7 @@ def run_tests(reactor, nodes, control_node, agent_nodes, volume_backend,
             FLOCKER_ACCEPTANCE_AGENT_NODES=':'.join(
                 node.address for node in agent_nodes),
             FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH=certificates_path.path,
-            FLOCKER_ACCEPTANCE_VOLUME_BACKEND=volume_backend.name,
+            FLOCKER_ACCEPTANCE_VOLUME_BACKEND=dataset_backend.name,
         )).addCallbacks(
             callback=lambda _: 0,
             errback=check_result,
@@ -207,7 +207,7 @@ class VagrantRunner(object):
 
 @attributes(RUNNER_ATTRIBUTES + [
     'provisioner',
-    'volume_backend',
+    'dataset_backend',
 ], apply_immutable=True)
 class LibcloudRunner(object):
     """
@@ -215,7 +215,7 @@ class LibcloudRunner(object):
 
     :ivar LibcloudProvioner provisioner: The provisioner to use to create the
         nodes.
-    :ivar VolumeBackend volume_backend: The volume backend the nodes are
+    :ivar DatasetBackend dataset_backend: The volume backend the nodes are
         configured with.
     """
     def __init__(self):
@@ -270,7 +270,7 @@ class LibcloudRunner(object):
                            variants=self.variants)
             for node in self.nodes
         ])
-        if self.volume_backend == VolumeBackend.zfs:
+        if self.dataset_backend == DatasetBackend.zfs:
             zfs_commands = parallel([
                 configure_zfs(node, variants=self.variants)
                 for node in self.nodes
@@ -331,7 +331,7 @@ class RunOptions(Options):
         Options.__init__(self)
         self.top_level = top_level
         self['variants'] = []
-        self['volume-backend'] = VolumeBackend.zfs
+        self['dataset-backend'] = DatasetBackend.zfs
 
     def opt_variant(self, arg):
         """
@@ -392,7 +392,7 @@ class RunOptions(Options):
                 distribution=self['distribution'],
                 package_source=package_source,
                 provisioner=provisioner,
-                volume_backend=self['volume-backend'],
+                dataset_backend=self['dataset-backend'],
                 variants=self['variants'],
             )
         else:
@@ -470,13 +470,13 @@ def main(reactor, args, base_path, top_level):
             configure_cluster(control_node=control_node, agent_nodes=nodes,
                               certificates=certificates))
 
-        volume_backend = options['volume-backend']
+        dataset_backend = options['dataset-backend']
         result = yield run_tests(
             reactor=reactor,
             nodes=nodes,
             control_node=control_node,
             agent_nodes=nodes,
-            volume_backend=volume_backend,
+            dataset_backend=dataset_backend,
             trial_args=options['trial-args'],
             certificates_path=ca_directory)
     except:
@@ -498,7 +498,7 @@ def main(reactor, args, base_path, top_level):
                 'FLOCKER_ACCEPTANCE_CONTROL_NODE': control_node.address,
                 'FLOCKER_ACCEPTANCE_AGENT_NODES':
                     ':'.join(node.address for node in nodes),
-                'FLOCKER_ACCEPTANCE_VOLUME_BACKEND': volume_backend.name,
+                'FLOCKER_ACCEPTANCE_VOLUME_BACKEND': dataset_backend.name,
                 'FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH': ca_directory.path,
             }
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -24,6 +24,10 @@ The :program:`admin/run-acceptance-tests` script has several options:
 
    Specifies what provider to use to create the nodes.
 
+.. option:: --dataset-backend <dataset-backend>
+
+   Specifies what dataset backend to use for the cluster.
+
 .. option:: --flocker-version <version>
 
    Specifies the version of flocker to install.
@@ -63,6 +67,7 @@ Vagrant
 -------
 
 A configuration file is not required for the vagrant provider.
+The default dataset backend is the ZFS backend.
 
 You will need a ssh agent running with access to the insecure vagrant private key:
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -67,7 +67,6 @@ Vagrant
 -------
 
 A configuration file is not required for the vagrant provider.
-The default dataset backend is the ZFS backend.
 
 You will need a ssh agent running with access to the insecure vagrant private key:
 

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -206,20 +206,20 @@ def _clean_node(test_case, node):
         pass
 
 
-class VolumeBackend(Names):
+class DatasetBackend(Names):
     loopback = NamedConstant()
     zfs = NamedConstant()
     aws = NamedConstant()
     openstack = NamedConstant()
 
 
-def get_volume_backend(test_case):
+def get_dataset_backend(test_case):
     """
     Get the volume backend the acceptance tests are running as.
 
     :param test_case: The ``TestCase`` running this unit test.
 
-    :return VolumeBackend: The configured backend.
+    :return DatasetBackend: The configured backend.
     :raise SkipTest: if the backend is specified.
     """
     backend = environ.get("FLOCKER_ACCEPTANCE_VOLUME_BACKEND")
@@ -227,7 +227,7 @@ def get_volume_backend(test_case):
         raise SkipTest(
             "Set acceptance testing volume backend using the " +
             "FLOCKER_ACCEPTANCE_VOLUME_BACKEND environment variable.")
-    return VolumeBackend.lookupByName(backend)
+    return DatasetBackend.lookupByName(backend)
 
 
 def skip_backend(unsupported, reason):
@@ -244,7 +244,7 @@ def skip_backend(unsupported, reason):
         """
         @wraps(test_method)
         def wrapper(test_case, *args, **kwargs):
-            backend = get_volume_backend(test_case)
+            backend = get_dataset_backend(test_case)
 
             if backend in unsupported:
                 raise SkipTest(
@@ -258,7 +258,7 @@ def skip_backend(unsupported, reason):
     return decorator
 
 require_moving_backend = skip_backend(
-    unsupported={VolumeBackend.loopback},
+    unsupported={DatasetBackend.loopback},
     reason="doesn't support moving")
 
 
@@ -348,7 +348,7 @@ def get_nodes(test_case, num_nodes):
     def clean_zfs(_):
         for node in reachable_nodes:
             _clean_node(test_case, node)
-    if get_volume_backend(test_case) == b'zfs':
+    if get_dataset_backend(test_case) == b'zfs':
         getting.addCallback(clean_zfs)
     getting.addCallback(lambda _: reachable_nodes)
     return getting

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -13,6 +13,7 @@ import yaml
 
 from characteristic import attributes
 
+from flocker.acceptance.testtools import DatasetBackend
 from ._common import PackageSource, Variants
 from ._ssh import (
     run, run_from_args,
@@ -274,13 +275,14 @@ def task_open_control_firewall(distribution):
     ])
 
 
-def task_enable_flocker_agent(distribution, control_node, dataset_backend):
+def task_enable_flocker_agent(distribution, control_node,
+                              dataset_backend=DatasetBackend.zfs):
     """
     Configure and enable the flocker agents.
 
     :param bytes control_node: The address of the control agent.
     :param DatasetBackend dataset_backend: The volume backend the nodes are
-        configured with.
+        configured with. (This has a default for use in the documentation).
     """
     put_config_file = put(
         path='/etc/flocker/agent.yml',

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -610,8 +610,6 @@ def configure_cluster(control_node, agent_nodes,
         ),
         sequence([
             sequence([
-                Effect(
-                    Func(lambda node=node: configure_ssh(node.address, 22))),
                 run_remotely(
                     username='root',
                     address=node.address,


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1949

This will need to be refined to support cloud backends (passing credentials).

I also wonder if having `DatasetBackend` is worthwhile, if we expect people writing out-of-tree backends to use our acceptance tests.

There are some failures in the postgres tests that I haven't investigated yet.

This (temporarily) removes the ZFS acceptance tests, until after https://github.com/ClusterHQ/build.clusterhq.com/pull/91 lands