### PR TITLE
[FLOC-1959] Have more informative pyrsistence type errors

### DIFF
--- a/admin/build_targets/centos-7/Dockerfile
+++ b/admin/build_targets/centos-7/Dockerfile
@@ -12,7 +12,7 @@ RUN ["yum", "install", "--assumeyes", "git", "ruby-devel", "python-devel", "libf
 # See https://github.com/jordansissel/fpm/issues/611
 RUN ["gem", "install", "fpm"]
 
-RUN ["pip", "install", "Twisted==15.1.0", "characteristic==14.1.0", "pyOpenSSL==0.14", "pycrypto==2.6.1", "virtualenv==12.1.1", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0", "pyrsistent==0.9.1", "python-cinderclient==1.1.1", "python-novaclient==2.24.1", "python-keystoneclient-rackspace==0.1.3"]
+RUN ["pip", "install", "Twisted==15.1.0", "characteristic==14.1.0", "pyOpenSSL==0.14", "pycrypto==2.6.1", "virtualenv==12.1.1", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0", "pyrsistent==0.9.2", "python-cinderclient==1.1.1", "python-novaclient==2.24.1", "python-keystoneclient-rackspace==0.1.3"]
 VOLUME /flocker
 WORKDIR /
 ENTRYPOINT ["/flocker/admin/build-package-entrypoint", "--destination-path=/output"]

--- a/admin/build_targets/fedora-20/Dockerfile
+++ b/admin/build_targets/fedora-20/Dockerfile
@@ -10,6 +10,6 @@ RUN ["yum", "install", "--assumeyes", "@buildsys-build", "git", "ruby-devel", "l
 # See https://github.com/jordansissel/fpm/issues/611
 RUN ["gem", "install", "fpm"]
 
-RUN ["pip", "install", "Twisted==15.1.0", "characteristic==14.1.0", "pyOpenSSL==0.14", "pycrypto==2.6.1", "virtualenv==12.1.1", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0", "pyrsistent==0.9.1", "python-cinderclient==1.1.1", "python-novaclient==2.24.1", "python-keystoneclient-rackspace==0.1.3"]
+RUN ["pip", "install", "Twisted==15.1.0", "characteristic==14.1.0", "pyOpenSSL==0.14", "pycrypto==2.6.1", "virtualenv==12.1.1", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0", "pyrsistent==0.9.2", "python-cinderclient==1.1.1", "python-novaclient==2.24.1", "python-keystoneclient-rackspace==0.1.3"]
 VOLUME /flocker
 ENTRYPOINT ["/flocker/admin/build-package-entrypoint", "--destination-path=/output"]

--- a/admin/build_targets/ubuntu-14.04/Dockerfile
+++ b/admin/build_targets/ubuntu-14.04/Dockerfile
@@ -13,6 +13,6 @@ RUN ["apt-get", "install", "--no-install-recommends", "-y", "git", "ruby-dev", "
 # https://github.com/jordansissel/fpm/issues/657
 RUN ["gem", "install", "fpm"]
 
-RUN ["pip", "install", "Twisted==15.1.0", "characteristic==14.1.0", "pyOpenSSL==0.14", "pycrypto==2.6.1", "virtualenv==12.1.1", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0", "pyrsistent==0.9.1", "python-cinderclient==1.1.1", "python-novaclient==2.24.1", "python-keystoneclient-rackspace==0.1.3"]
+RUN ["pip", "install", "Twisted==15.1.0", "characteristic==14.1.0", "pyOpenSSL==0.14", "pycrypto==2.6.1", "virtualenv==12.1.1", "effect==0.1a13" , "boto==2.30.0", "requests==2.4.3", "requests-file==1.0", "ipaddr==2.1.11", "eliot==0.6.0", "pyrsistent==0.9.2", "python-cinderclient==1.1.1", "python-novaclient==2.24.1", "python-keystoneclient-rackspace==0.1.3"]
 VOLUME /flocker
 ENTRYPOINT ["/flocker/admin/build-package-entrypoint", "--destination-path=/output"]

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ install_requirements = [
     "docker-py == 0.7.1",
     "jsonschema == 2.4.0",
     "klein == 0.2.3",
-    "pyrsistent == 0.9.1",
+    "pyrsistent == 0.9.2",
     "pycrypto == 2.6.1",
     "effect==0.1a13",
     "bitmath==1.2.3-4",


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1959

The newer version of pyrsistent has better exceptions.

0.9.1 has exceptions like:

```
  File "/home/exarkun/Environments/flocker/local/lib/python2.7/site-packages/pyrsistent.py", line 2721, in _check_types
    raise TypeError
exceptions.TypeError: 
```

0.9.2 has exceptions like:

```
    File \"/home/exarkun/Environments/flocker/local/lib/python2.7/site-packages/pyrsistent.py\", line 2761, in _check_types
    raise exception_type(expected_types, actual_type, e, source_class, msg)
pyrsistent.CheckedValueTypeError: Type UuidFilepathPMap can only be used with ('FilePath',), not NoneType
```
