### PR TITLE
[FLOC-1729] Ensure the container has reached State/Running in DockerClient.add

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -461,6 +461,11 @@ class DockerClient(object):
                 sleep(0.001)
                 continue
             self._client.start(container_name)
+            # Ensure the container has reached State/Running True before going on.
+            # see https://clusterhq.atlassian.net/browse/FLOC-1729
+            while not self._blocking_container_runs(container_name):
+                sleep(0.001)
+
         d = deferToThread(_add)
 
         def _extract_error(failure):

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -160,6 +160,20 @@ class GenericDockerClientTests(TestCase):
         name = random_name(self)
         return self.start_container(name)
 
+    def test_add_starts_container_ensure_running(self):
+        """
+        ``DockerClient.add`` starts the container and ensure it's in running state
+        """
+        name = random_name(self)
+        d = self.start_container(name)
+
+        def started_and_running(_):
+            docker = Client()
+            data = docker.inspect_container(self.namespacing_prefix + name)
+            self.assertTrue(data[u"State"][u"Running"])
+        d.addCallback(started_and_running)
+        return d
+
     def test_correct_image_used(self):
         """
         ``DockerClient.add`` creates a container with the specified image.


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-1729

This is my first contribution here so sorry in advance for any mistake :)
I opened this to fix that nasty problem where docker container start api returns before the container is actually running (we know this from docker/docker project itself)
I plan to add a regression test here as soon as this patch is ok for you

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1446)
<!-- Reviewable:end -->
