### PR TITLE
[FLOC-1984] Fix bug where pvector blew up docker-py

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -431,10 +431,16 @@ class DockerClient(object):
                 port_bindings=port_bindings,
                 restart_policy=restart_policy_dict,
             )
+            # We're likely to get e.g. pvector, so make sure we're passing
+            # in something JSON serializable:
+            command_line_values = command_line
+            if command_line_values is not None:
+                command_line_values = list(command_line_values)
+
             self._client.create_container(
                 name=container_name,
                 image=image_name,
-                command=command_line,
+                command=command_line_values,
                 environment=environment,
                 ports=[p.internal_port for p in ports],
                 mem_limit=mem_limit,

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -23,6 +23,8 @@ from twisted.web.client import ResponseNeverReceived
 
 from treq import request, content
 
+from pyrsistent import pvector
+
 from ...testtools import (
     loop_until, find_free_port, DockerImageBuilder, assertContainsAll,
     random_name)
@@ -726,13 +728,15 @@ CMD sh -c "trap \"\" 2; sleep 3"
         name = random_name(self)
         d = self.start_container(
             name, image_name=u"busybox",
-            command_line=[u"sh", u"-c", u"""\
+            # Pass in pvector since this likely to be what caller actually
+            # passes in:
+            command_line=pvector([u"sh", u"-c", u"""\
 echo -n '#!/bin/sh
 echo -n "HTTP/1.1 200 OK\r\n\r\nhi"
 ' > /tmp/script.sh;
 chmod +x /tmp/script.sh;
 nc -ll -p 8080 -e /tmp/script.sh
-"""],
+"""]),
             ports=[PortMap(internal_port=8080,
                            external_port=external_port)])
 


### PR DESCRIPTION
This will also be covered by end-to-end acceptance test (the reason I discovered it) in FLOC-1976. In master there are no acceptance tests using `command_line` which is why this wasn't caught.