### PR TITLE
Tested osx floc 2004

### DIFF
--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -439,6 +439,8 @@ Post-Release Review Process
 
 #. Verify that the client (``flocker-deploy``) can be installed on all supported platforms:
 
+   OS X and Ubuntu 14.04 instructions are tested by BuildBot automatically so they do not need to be manually tested.
+
    Follow the Flocker client installation documentation at ``https://docs.clusterhq.com/en/${VERSION}/indepth/installation.html#installing-flocker-cli``.
 
    XXX: This step should be documented, see :issue:`1622`.

--- a/docs/gettingstarted/index.rst
+++ b/docs/gettingstarted/index.rst
@@ -81,11 +81,8 @@ Getting started with Flocker
 
          Install the Flocker client on your Mac (requires Homebrew):
 
-         .. version-code-block:: console
-
-            you@laptop:~$ brew update && \
-              brew tap clusterhq/flocker && \
-              brew install flocker-|latest-installable|
+         .. task:: test_homebrew flocker-|latest-installable|
+            :prompt: you@laptop:~$
 
       .. noscript-content::
 
@@ -118,11 +115,8 @@ Getting started with Flocker
 
          Install the Flocker client on your Mac (requires Homebrew):
 
-         .. version-code-block:: console
-
-            you@laptop:~$ brew update && \
-              brew tap clusterhq/flocker && \
-              brew install flocker-|latest-installable|
+         .. task:: test_homebrew flocker-|latest-installable|
+            :prompt: you@laptop:~$
 
          Ubuntu 14.04
          ^^^^^^^^^^^^


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2004

Also happens to fix https://clusterhq.atlassian.net/browse/FLOC-1551.

This removes the &&s, but part of the advantage of that is that you can copy in one go - the prompt directive allows this to be done too by not copying the prompt.