### PR TITLE
Replace hardcoded 14.04 in Ubuntu node instructions

### DIFF
--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -45,7 +45,7 @@ CLUSTERHQ_REPO = {
                     ),
     # FLOC-1828 TODO - use ubuntu rather than ubuntu-testing
     'ubuntu-14.04': 'https://{archive_bucket}.s3.amazonaws.com/ubuntu-testing/'
-                    '$(lsb_release --release --short)/$(ARCH)'.format(
+                    '$(lsb_release --release --short)/\\$(ARCH)'.format(
                         archive_bucket=ARCHIVE_BUCKET
                     ),
 }
@@ -156,10 +156,8 @@ def install_cli_commands_ubuntu(distribution, package_source):
             "apt-get", "-y", "install", "apt-transport-https",
             "software-properties-common"]),
         # Add ClusterHQ repo for installation of Flocker packages.
-        sudo_from_args([
-            'add-apt-repository', '-y',
-            'deb {} /'.format(CLUSTERHQ_REPO[distribution])
-            ])
+        sudo(command='add-apt-repository -y "deb {} /"'.format(
+            CLUSTERHQ_REPO[distribution])),
         ]
 
     if use_development_branch:
@@ -616,11 +614,9 @@ def task_install_flocker(
             run_from_args([
                 "add-apt-repository", "-y", "ppa:james-page/docker"]),
             # Add ClusterHQ repo for installation of Flocker packages.
-            run_from_args([
-                'add-apt-repository', '-y',
-                'deb {} /'.format(CLUSTERHQ_REPO[distribution])
-                ])
-            ]
+            run(command='add-apt-repository -y "deb {} /"'.format(
+                CLUSTERHQ_REPO[distribution])),
+        ]
 
         if use_development_branch:
             # Add BuildBot repo for testing

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -44,6 +44,14 @@ CLUSTERHQ_REPO = {
                     archive_bucket=ARCHIVE_BUCKET,
                     ),
     # FLOC-1828 TODO - use ubuntu rather than ubuntu-testing
+    # This could hardcode the version number instead of using ``lsb_release``
+    # but that allows instructions to be shared between versions, and for
+    # earlier error reporting if you try to install on a separate version.
+    # The $(ARCH) part must be left unevaluated, hence the backslash escapes
+    # (one to make shell ignore the $ as a substitution marker, and then
+    # doubled to make Python ignore the \ as an escape marker).
+    # The output of this value then goes into /etc/apt/sources.list which does
+    # its own substitution on $(ARCH) during a subsequent apt-get update
     'ubuntu-14.04': 'https://{archive_bucket}.s3.amazonaws.com/ubuntu-testing/'
                     '$(lsb_release --release --short)/\\$(ARCH)'.format(
                         archive_bucket=ARCHIVE_BUCKET

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -44,9 +44,9 @@ CLUSTERHQ_REPO = {
                     archive_bucket=ARCHIVE_BUCKET,
                     ),
     # FLOC-1828 TODO - use ubuntu rather than ubuntu-testing
-    'ubuntu-14.04': 'https://{archive_bucket}.s3.amazonaws.com/'
-                'ubuntu-testing/14.04/$(ARCH)'.format(
-                    archive_bucket=ARCHIVE_BUCKET
+    'ubuntu-14.04': 'https://{archive_bucket}.s3.amazonaws.com/ubuntu-testing/'
+                    '$(lsb_release --release --short)/$(ARCH)'.format(
+                        archive_bucket=ARCHIVE_BUCKET
                     ),
 }
 

--- a/flocker/provision/test/test_install.py
+++ b/flocker/provision/test/test_install.py
@@ -58,7 +58,7 @@ class InstallFlockerTests(SynchronousTestCase):
         self.assertEqual(commands, sequence([
             run(command='apt-get -y install apt-transport-https software-properties-common'),  # noqa
             run(command='add-apt-repository -y ppa:james-page/docker'),
-            run(command="add-apt-repository -y 'deb {} /'".format(CLUSTERHQ_REPO[distribution])),  # noqa
+            run(command='add-apt-repository -y "deb {} /"'.format(CLUSTERHQ_REPO[distribution])),  # noqa
             run(command='apt-get update'),
             run(command='apt-get -y --force-yes install clusterhq-flocker-node'),  # noqa
         ]))
@@ -77,7 +77,7 @@ class InstallFlockerTests(SynchronousTestCase):
         self.assertEqual(commands, sequence([
             run(command='apt-get -y install apt-transport-https software-properties-common'),  # noqa
             run(command='add-apt-repository -y ppa:james-page/docker'),
-            run(command="add-apt-repository -y 'deb {} /'".format(CLUSTERHQ_REPO[distribution])),  # noqa
+            run(command='add-apt-repository -y "deb {} /"'.format(CLUSTERHQ_REPO[distribution])),  # noqa
             run(command='apt-get update'),
             run(command='apt-get -y --force-yes install clusterhq-flocker-node=1.2.3-1'),  # noqa
         ]))
@@ -95,7 +95,7 @@ class InstallFlockerTests(SynchronousTestCase):
         self.assertEqual(commands, sequence([
             run(command='apt-get -y install apt-transport-https software-properties-common'),  # noqa
             run(command='add-apt-repository -y ppa:james-page/docker'),
-            run(command="add-apt-repository -y 'deb {} /'".format(CLUSTERHQ_REPO[distribution])),  # noqa
+            run(command='add-apt-repository -y "deb {} /"'.format(CLUSTERHQ_REPO[distribution])),  # noqa
             run(command="add-apt-repository -y "
                         "'deb http://build.clusterhq.com/results/omnibus/branch-FLOC-1234/ubuntu-14.04 /'"),  # noqa
             put(


### PR DESCRIPTION
This has been tested with an Ubuntu 14.04 container, as the output of ``lsb_release --release --short`` is ``14.04``. When the repository doesn't exist (if we change ``$(lsb_release --release --short)`` to ``foo``) then the error is much clearer than the datetime issue shown on the parent:

``sudo apt-get update`` gives:

```
W: Failed to fetch https://clusterhq-archive.s3.amazonaws.com/ubuntu-testing/foo/amd64/Packages  HttpError403

E: Some index files failed to download. They have been ignored, or old ones used instead.
```

at the end. Then:

```
root@3fb2482ad88f:/# sudo apt-get -y --force-yes install clusterhq-flocker-cli
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package clusterhq-flocker-cli
```