### PR TITLE
[FLOC-2055] "Managed" acceptance test node provider/runner

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -385,8 +385,11 @@ class RunOptions(Options):
 
     def dataset_backend(self):
         """
-        Get the name of the storage driver the acceptance testing nodes will be
-        confused to use.
+        Get the storage driver the acceptance testing nodes will be confused to
+        use.
+
+        :return: A constant from ``DatasetBackend`` matching the name of the
+            backend chosen by the command-line options.
         """
         try:
             return DatasetBackend.lookupByName(self['dataset-backend'])

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -576,7 +576,6 @@ class RunOptions(Options):
             self._provider_config_missing(provider)
 
         cloud_config = provider_config.copy()
-        cloud_config.pop('dataset')
         provisioner = CLOUD_PROVIDERS[provider](**cloud_config)
         return LibcloudRunner(
             config=self['config'],

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -428,8 +428,7 @@ class RunOptions(Options):
 
     def _get_provider_names(self):
         """
-        Find the names of all supported "providers" (eg Vagrant, Rackspace,
-        etc).
+        Find the names of all supported "providers" (eg Vagrant, Rackspace).
 
         :return: A ``list`` of ``str`` giving all such names.
         """
@@ -448,8 +447,7 @@ class RunOptions(Options):
 
     def dataset_backend(self):
         """
-        Get the storage driver the acceptance testing nodes will be confused to
-        use.
+        Get the storage driver the acceptance testing nodes will use.
 
         :return: A constant from ``DatasetBackend`` matching the name of the
             backend chosen by the command-line options.
@@ -510,6 +508,7 @@ class RunOptions(Options):
 
     def _provider_config_missing(self, provider):
         """
+        :param str provider: The name of the missing provider.
         :raise: ``UsageError`` indicating which provider configuration was
                 missing.
         """
@@ -518,11 +517,15 @@ class RunOptions(Options):
             "{!r} config stanza.".format(provider)
         )
 
-    def _runner_VAGRANT(self, package_source, dataset_backend, provider_config):
+    def _runner_VAGRANT(self, package_source,
+                        dataset_backend, provider_config):
         """
+        :param PackageSource package_source: The source of omnibus packages.
+        :param DatasetBackend dataset_backend: A ``DatasetBackend`` constant.
         :param provider_config: The ``vagrant`` section of the acceptance
             testing configuration file.  Since the Vagrant runner accepts no
             configuration, this is ignored.
+        :returns: ``VagrantRunner``
         """
         return VagrantRunner(
             config=self['config'],
@@ -535,6 +538,8 @@ class RunOptions(Options):
     def _runner_MANAGED(self, package_source, dataset_backend,
                         provider_config):
         """
+        :param PackageSource package_source: The source of omnibus packages.
+        :param DatasetBackend dataset_backend: A ``DatasetBackend`` constant.
         :param provider_config: The ``managed`` section of the acceptance
             testing configuration file.  The section of the configuration
             file should look something like:
@@ -544,6 +549,7 @@ class RunOptions(Options):
                     - "172.16.255.240"
                     - "172.16.255.241"
                   distribution: "centos-7"
+        :returns: ``ManagedRunner``.
         """
         if provider_config is None:
             self._provider_config_missing("managed")
@@ -551,7 +557,7 @@ class RunOptions(Options):
         return ManagedRunner(
             node_addresses=provider_config['addresses'],
             # TODO LATER Might be nice if this were part of
-            # provider_config
+            # provider_config. See FLOC-2078.
             distribution=self['distribution'],
         )
 
@@ -559,6 +565,12 @@ class RunOptions(Options):
                          provider, provider_config):
         """
         Run some nodes using ``libcloud``.
+
+        :param PackageSource package_source: The source of omnibus packages.
+        :param DatasetBackend dataset_backend: A ``DatasetBackend`` constant.
+        :param provider: The name of the cloud provider of nodes for the tests.
+        :param provider_config: The ``managed`` section of the acceptance
+        :returns: ``LibcloudRunner``.
         """
         if provider_config is None:
             self._provider_config_missing(provider)
@@ -579,6 +591,8 @@ class RunOptions(Options):
     def _runner_RACKSPACE(self, package_source, dataset_backend,
                           provider_config):
         """
+        :param PackageSource package_source: The source of omnibus packages.
+        :param DatasetBackend dataset_backend: A ``DatasetBackend`` constant.
         :param provider_config: The ``rackspace`` section of the acceptance
             testing configuration file.  The section of the configuration
             file should look something like:
@@ -598,6 +612,8 @@ class RunOptions(Options):
     def _runner_AWS(self, package_source, dataset_backend,
                     provider_config):
         """
+        :param PackageSource package_source: The source of omnibus packages.
+        :param DatasetBackend dataset_backend: A ``DatasetBackend`` constant.
         :param provider_config: The ``aws`` section of the acceptance testing
             configuration file.  The section of the configuration file should
             look something like:

--- a/admin/test/test_acceptance.py
+++ b/admin/test/test_acceptance.py
@@ -1,3 +1,8 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+"""
+Tests for ``admin.acceptance``.
+"""
+
 from zope.interface.verify import verifyObject
 from twisted.trial.unittest import SynchronousTestCase
 

--- a/admin/test/test_acceptance.py
+++ b/admin/test/test_acceptance.py
@@ -1,0 +1,21 @@
+from zope.interface.verify import verifyObject
+from twisted.trial.unittest import SynchronousTestCase
+
+from ..acceptance import IClusterRunner, ManagedRunner
+
+
+class ManagedRunnerTests(SynchronousTestCase):
+    """
+    Tests for ``ManagedRunner``.
+    """
+    def test_interface(self):
+        """
+        ``ManagedRunner`` provides ``IClusterRunner``.
+        """
+        runner = ManagedRunner(
+            node_addresses=[b'192.0.2.1'],
+            distribution=b'centos-7'
+        )
+        self.assertTrue(
+            verifyObject(IClusterRunner, runner)
+        )

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -160,6 +160,31 @@ You will need a ssh agent running with access to the corresponding private key.
 
   admin/run-acceptance-tests --distribution fedora-20 --provider aws --config-file config.yml
 
+.. _acceptance-testing-managed-config:
+
+Managed
+-------
+
+You can also run acceptance tests on existing "managed" nodes.
+In this case the configuration file should include:
+
+- **addresses**: The IP addresses of two running nodes.
+
+.. code-block:: yaml
+
+   managed:
+     addresses:
+       - "192.0.2.101"
+       - "192.0.2.102"
+   metadata:
+     creator: <your-name>
+
+The nodes should be configured to allow key based SSH connections as user ``root`` and the ``root``.
+
+.. prompt:: bash $
+
+   admin/run-acceptance-tests --distribution centos-7 --provider managed --config-file config.yml
+
 
 .. _client-acceptance-tests:
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -132,7 +132,7 @@ You will need a ssh agent running with access to the corresponding private key.
   admin/run-acceptance-tests --distribution fedora-20 --provider rackspace --config-file config.yml
 
 
-.. _acceptance-testing-rackspace-config:
+.. _acceptance-testing-aws-config:
 
 AWS
 ---

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -102,6 +102,9 @@ Ensure that they all pass, with no skips:
 
   admin/run-acceptance-tests --distribution fedora-20 --provider vagrant
 
+
+.. _acceptance-testing-rackspace-config:
+
 Rackspace
 ---------
 
@@ -128,6 +131,8 @@ You will need a ssh agent running with access to the corresponding private key.
 
   admin/run-acceptance-tests --distribution fedora-20 --provider rackspace --config-file config.yml
 
+
+.. _acceptance-testing-rackspace-config:
 
 AWS
 ---

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -28,6 +28,12 @@ from ._effect import sequence
 
 from flocker.cli import configure_ssh
 
+# A systemctl sub-command to start or restart a service.  We use restart here
+# so that if it is already running it gets restart (possibly necessary to
+# respect updated configuration) and because restart will also start it if it
+# is not running.
+START = "restart"
+
 ZFS_REPO = {
     'fedora-20': "https://s3.amazonaws.com/archive.zfsonlinux.org/"
                  "fedora/zfs-release$(rpm -E %dist).noarch.rpm",
@@ -420,7 +426,7 @@ def task_enable_flocker_control(distribution):
     if distribution in ('centos-7', 'fedora-20'):
         return sequence([
             run_from_args(['systemctl', 'enable', 'flocker-control']),
-            run_from_args(['systemctl', 'start', 'flocker-control']),
+            run_from_args(['systemctl', START, 'flocker-control']),
         ])
     elif distribution == 'ubuntu-14.04':
         # Since the flocker-control service is currently installed
@@ -488,9 +494,9 @@ def task_enable_flocker_agent(distribution, control_node,
         return sequence([
             put_config_file,
             run_from_args(['systemctl', 'enable', 'flocker-dataset-agent']),
-            run_from_args(['systemctl', 'start', 'flocker-dataset-agent']),
+            run_from_args(['systemctl', START, 'flocker-dataset-agent']),
             run_from_args(['systemctl', 'enable', 'flocker-container-agent']),
-            run_from_args(['systemctl', 'start', 'flocker-container-agent']),
+            run_from_args(['systemctl', START, 'flocker-container-agent']),
         ])
     elif distribution == 'ubuntu-14.04':
         return sequence([

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -11,9 +11,12 @@ from urlparse import urljoin, urlparse
 from effect import Func, Effect
 import yaml
 
+from zope.interface import implementer
+
 from characteristic import attributes
 
 from flocker.acceptance.testtools import DatasetBackend
+from ._libcloud import INode
 from ._common import PackageSource, Variants
 from ._ssh import (
     run, run_from_args,
@@ -61,6 +64,15 @@ class DistributionNotSupported(NotImplementedError):
     """
     def __str__(self):
         return "Distribution not supported: %s" % (self.distribution,)
+
+
+@implementer(INode)
+@attributes(['address', 'distribution'], apply_immutable=True)
+class ManagedNode(object):
+    """
+    A node managed by some other system (eg by hand or by another piece of
+    orchestration software).
+    """
 
 
 def task_client_installation_test():


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2055

This changes the factoring of the acceptance test "runner" setup to make it easier to extend and it extends it to support a "managed" provider which just points at some already-running nodes.

The new provider isn't 100% feature complete (eg you have to install packages on it yourself).  Further enhancements would make this more usable but just being able to re-use some already-running nodes is already a big win.