### PR TITLE
[FLOC-2056] Less agent.yml validation

### DIFF
--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -139,6 +139,10 @@ def validate_configuration(configuration):
     """
     Validate a provided configuration.
 
+    XXX: Validation of backend specific parameters was removed in
+    a4d0f0eb4c38ffbfe10085a1cbc3d5ed5cae17c7 and will be re-instated
+    as part of FLOC-2058.
+
     :param dict configuration: A desired configuration for an agent.
 
     :raises: jsonschema.ValidationError if the configuration is invalid.

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -166,42 +166,14 @@ def validate_configuration(configuration):
             },
             "dataset": {
                 "type": "object",
-                "oneOf": [
-                    {
-                        "required": ["backend"],
-                        "properties": {
-                            "backend": {
-                                "type": "string",
-                                "pattern": "zfs",
-                            },
-                            "pool": {
-                                "type": "string",
-                            },
-                            "mount_root": {
-                                "type": "string"
-                            },
-                            "volume_config_path": {
-                                "type": "string"
-                            },
-                        }
+                "properties": {
+                    "backend": {
+                        "type": "string",
                     },
-                    {
-                        "required": ["backend"],
-                        "properties": {
-                            "backend": {
-                                "type": "string",
-                                "pattern": "loopback",
-                            },
-                            "root_path": {
-                                "type": "string",
-                            },
-                            "compute_instance_id": {
-                                "type": "string",
-                            },
-                        }
-
-                    },
-                ]
+                },
+                "required": [
+                    "backend",
+                ],
             }
         }
     }

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -721,40 +721,6 @@ class ValidateConfigurationTests(SynchronousTestCase):
         # Nothing is raised
         validate_configuration(self.configuration)
 
-    def test_zfs_pool_optional(self):
-        """
-        No exception is raised when validating a ZFS backend but a ZFS
-        pool is not specified.
-        """
-        self.configuration['dataset'] = {
-            u"backend": u"zfs",
-        }
-        # Nothing is raised
-        validate_configuration(self.configuration)
-
-    def test_loopback_compute_instance_id_optional(self):
-        """
-        No exception is raised when validating a loopback backend but a
-        compute_instance_id is not specified.
-        """
-        self.configuration['dataset'] = {
-            u"backend": u"loopback",
-            u"root_path": u"/tmp",
-        }
-        # Nothing is raised
-        validate_configuration(self.configuration)
-
-    def test_loopback_root_path_optional(self):
-        """
-        No exception is raised when validating a loopback backend but a
-        root_path is not specified.
-        """
-        self.configuration['dataset'] = {
-            u"backend": u"loopback",
-        }
-        # Nothing is raised
-        validate_configuration(self.configuration)
-
     def test_error_on_invalid_configuration_type(self):
         """
         A ``ValidationError`` is raised if the config file is not formatted
@@ -847,7 +813,7 @@ class ValidateConfigurationTests(SynchronousTestCase):
         """
         The dataset key must contain a valid dataset type.
         """
-        self.configuration['dataset'] = {"backend": "invalid"}
+        self.configuration['dataset'] = "invalid"
         self.assertRaises(
             ValidationError, validate_configuration, self.configuration)
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2056

This removes some of the validation for zfs and loopback backends.  This is the easier option compared to adding proper validation for aws, openstack, and third-party backends (at least for now).  In general this was good validation and we should re-introduce it later in a way that's more friendly to extensions.