### PR TITLE
[FLOC-1788] Docker pull timeout

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -290,6 +290,9 @@ class TimeoutClient(Client):
     """
     A subclass of docker.Client that sets any infinite timeouts to the
     provided ``long_timeout`` value.
+
+    This class is hopefully a temporary fix until docker-py with
+    PR/issue TBD merged is released (working on PR, or will submit issue)
     """
 
     def __init__(self, *args, **kw):

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -293,6 +293,8 @@ class TimeoutClient(Client):
 
     This class is a temporary fix until docker-py is released with
     PR #625 or similar. See https://github.com/docker/docker-py/pull/625
+
+    See Flocker JIRA Issue FLOC-2082
     """
 
     def __init__(self, *args, **kw):

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -291,8 +291,8 @@ class TimeoutClient(Client):
     A subclass of docker.Client that sets any infinite timeouts to the
     provided ``long_timeout`` value.
 
-    This class is hopefully a temporary fix until docker-py with
-    PR/issue TBD merged is released (working on PR, or will submit issue)
+    This class is a temporary fix until docker-py is released with
+    PR #625 or similar. See https://github.com/docker/docker-py/pull/625
     """
 
     def __init__(self, *args, **kw):
@@ -322,6 +322,9 @@ class DockerClient(object):
 
     :ivar unicode namespace: A namespace prefix to add to container names
         so we don't clobber other applications interacting with Docker.
+    :ivar str base_url: URL for connection to the Docker server.
+    :ivar int long_timeout: Maximum time in seconds to wait for
+        long-running operations, particularly pulling an image.
     """
     def __init__(
             self, namespace=BASE_NAMESPACE, base_url=BASE_DOCKER_API_URL,

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -286,6 +286,28 @@ BASE_NAMESPACE = u"flocker--"
 BASE_DOCKER_API_URL = u'unix://var/run/docker.sock'
 
 
+class TimeoutClient(Client):
+    """
+    A subclass of docker.Client that sets any infinite timeouts to the
+    provided ``long_timeout`` value.
+    """
+
+    def __init__(self, *args, **kw):
+        self.long_timeout = kw.pop('long_timeout', None)
+        Client.__init__(self, *args, **kw)
+
+    def _set_request_timeout(self, kwargs):
+        """
+        Prepare the kwargs for an HTTP request by inserting the timeout
+        parameter, if not already present.  If the timeout is infinite,
+        set it to the ``long_timeout`` parameter.
+        """
+        kwargs = Client._set_request_timeout(self, kwargs)
+        if kwargs['timeout'] is None:
+            kwargs['timeout'] = self.long_timeout
+        return kwargs
+
+
 @implementer(IDockerClient)
 class DockerClient(object):
     """
@@ -298,10 +320,12 @@ class DockerClient(object):
     :ivar unicode namespace: A namespace prefix to add to container names
         so we don't clobber other applications interacting with Docker.
     """
-    def __init__(self, namespace=BASE_NAMESPACE,
-                 base_url=BASE_DOCKER_API_URL):
+    def __init__(
+            self, namespace=BASE_NAMESPACE, base_url=BASE_DOCKER_API_URL,
+            long_timeout=600):
         self.namespace = namespace
-        self._client = Client(version="1.15", base_url=base_url)
+        self._client = TimeoutClient(
+            version="1.15", base_url=base_url, long_timeout=long_timeout)
 
     def _to_container_name(self, unit_name):
         """

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -425,6 +425,7 @@ CMD sh -c "trap \"\" 2; sleep 3"
         d = client.add(name, image)
         # requests has a TimeoutError, but timeout raises a ConnectionError.
         # Both are subclasses of IOError, so use that for now
+        # https://github.com/kennethreitz/requests/issues/2620
         self.assertFailure(d, IOError)
         return d
 

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -420,13 +420,49 @@ CMD sh -c "trap \"\" 2; sleep 3"
 
         name = random_name(self)
         client = DockerClient(
-            namespace=self.namespacing_prefix, long_timeout=5)
+            namespace=self.namespacing_prefix, long_timeout=1)
         self.addCleanup(client.remove, name)
         d = client.add(name, image)
         # requests has a TimeoutError, but timeout raises a ConnectionError.
         # Both are subclasses of IOError, so use that for now
         # https://github.com/kennethreitz/requests/issues/2620
         self.assertFailure(d, IOError)
+        return d
+
+    def test_pull_timeout_pull(self):
+        """
+        Image pull timeout does not affect subsequent pulls.
+        """
+        # Use an image that isn't likely to be in use by anything, since
+        # it's old, and isn't used by other tests.  Note, this is the
+        # same image as test_pull_image_if_necessary, but they run at
+        # different times.
+        image = u"busybox:ubuntu-12.04"
+        # Make sure image is gone:
+        docker = Client()
+        try:
+            docker.remove_image(image, force=True)
+        except APIError as e:
+            if e.response.status_code != 404:
+                raise
+
+        name = random_name(self)
+        client = DockerClient(
+            namespace=self.namespacing_prefix, long_timeout=1)
+        d = client.add(name, image)
+
+        def unexpected_success(_):
+            self.fail('Image unexpectedly pulled within timeout limit')
+
+        def expected_failure(failure):
+            self.assertIsNotNone(failure.check(IOError))
+            # We got our failure, now try to successfully pull
+            client = DockerClient(
+                namespace=self.namespacing_prefix, long_timeout=600)
+            self.addCleanup(client.remove, name)
+            return client.add(name, image)
+
+        d.addCallbacks(unexpected_success, expected_failure)
         return d
 
     def test_namespacing(self):

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -449,6 +449,7 @@ CMD sh -c "trap \"\" 2; sleep 3"
         name = random_name(self)
         client = DockerClient(
             namespace=self.namespacing_prefix, long_timeout=1)
+        self.addCleanup(client.remove, name)
         d = client.add(name, image)
 
         def unexpected_success(_):
@@ -459,7 +460,6 @@ CMD sh -c "trap \"\" 2; sleep 3"
             # We got our failure, now try to successfully pull
             client = DockerClient(
                 namespace=self.namespacing_prefix, long_timeout=600)
-            self.addCleanup(client.remove, name)
             return client.add(name, image)
 
         d.addCallbacks(unexpected_success, expected_failure)


### PR DESCRIPTION
Does not do anything with streaming, as mentioned in JIRA issue. This PR just prevents requests/urllib3 from using an infinite timeout, swapping it for a 10 minute timeout.