### PR TITLE
Swap tabs and noscript content, to make prompt styles work

### DIFF
--- a/docs/gettingstarted/index.rst
+++ b/docs/gettingstarted/index.rst
@@ -74,7 +74,7 @@ Getting started with Flocker
 
          Local
 
-      .. noscript-content::
+      .. tabs::
 
          OS X
          ^^^^
@@ -84,8 +84,6 @@ Getting started with Flocker
          .. task:: test_homebrew flocker-|latest-installable|
             :prompt: you@laptop:~$
 
-      .. noscript-content::
-
          Ubuntu 14.04
          ^^^^^^^^^^^^
 
@@ -93,7 +91,6 @@ Getting started with Flocker
 
          .. task:: install_cli ubuntu-14.04
             :prompt: you@laptop:~$
-
 
          Fedora 20
          ^^^^^^^^^
@@ -107,8 +104,7 @@ Getting started with Flocker
               sh linux-install.sh && \
               source flocker-tutorial/bin/activate
 
-
-      .. tabs::
+      .. noscript-content::
 
          OS X
          ^^^^

--- a/docs/gettingstarted/index.rst
+++ b/docs/gettingstarted/index.rst
@@ -145,7 +145,7 @@ Getting started with Flocker
 
          Live
 
-      .. noscript-content::
+      .. tabs::
 
          Vagrant
          ^^^^^^^
@@ -167,7 +167,10 @@ Getting started with Flocker
 
          Please see our separate :ref:`AWS install instructions <aws-install>` to get started.
 
-      .. tabs::
+      .. noscript-content::
+
+         .. The noscript content must come after the tabs, because the prompt
+            command defines CSS styles on the first use of a prompt. See FLOC-2104.
 
          Vagrant
          ^^^^^^^


### PR DESCRIPTION
A quick patch to make Getting Started Guide work with modified `sphinx-prompt`. Swaps the order of the `noscript` section with the normal tabbed section.

In `master`, the prompts are missing from the OS X and Ubuntu tabs since #1502  was merged. In this branch, the prompts should be back.