### PR TITLE
[FLOC-2083] Release 0.4.1dev3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Flocker 0.4.1dev1 (2015-05-25)
+Flocker 0.4.1dev3 (2015-06-05)
 ==============================
 
 - It is now necessary to specify a dataset backend for each agent node. (FLOC-1420)
@@ -11,6 +11,9 @@ Flocker 0.4.1dev1 (2015-05-25)
 - There are new systemd units: ``flocker-zfs-agent`` is now ``flocker-container-agent`` and ``flocker-dataset-agent``. (FLOC-1554)
 - ``flocker-reportstate`` and ``flocker-changestate`` have been removed. (FLOC-1663)
 - Updated to Twisted 15.1. (FLOC-1707)
+- Dataset backend support for OpenStack and AWS. (FLOC-1925, FLOC-1743, FLOC-1745)
+- CentOS 7 tutorial environment. (FLOC-1510)
+- Ubuntu CLI installation instructions now use debian packages instead of pip packaging. (FLOC-1742)
 
 Flocker 0.4.0 (2015-04-07)
 ==========================

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -17,6 +17,9 @@ Next Release
 * Docker restart policies are adhered to.
 * New API endpoint: List the hosts currently in the cluster.
   See :ref:`api`.
+* Ubuntu CLI installation instructions now use Debian packages instead of pip packaging. 
+  See :ref:`installing-flocker-cli-ubuntu-14.04`
+* Dataset backend support for OpenStack and AWS.
 
 v0.4
 ====

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -18,7 +18,7 @@ Next Release
 * New API endpoint: List the hosts currently in the cluster.
   See :ref:`api`.
 * Ubuntu CLI installation instructions now use Debian packages instead of pip packaging. 
-  See :ref:`installing-flocker-cli-ubuntu-14.04`
+  See :ref:`installing-flocker-cli-ubuntu-14.04`.
 * Dataset backend support for OpenStack and AWS.
 
 v0.4

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -20,7 +20,7 @@ It contains the services that need to run on each node.
 Installing ``flocker-cli``
 ==========================
 
-.. _installing-flocker-cli-ubuntu-14.04
+.. _installing-flocker-cli-ubuntu-14.04:
 
 Ubuntu 14.04
 ------------

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -20,6 +20,8 @@ It contains the services that need to run on each node.
 Installing ``flocker-cli``
 ==========================
 
+.. _installing-flocker-cli-ubuntu-14.04
+
 Ubuntu 14.04
 ------------
 


### PR DESCRIPTION
It was agreed to ignore failing tests which are not release-specific. That means that the following test failures should be ignored in review:

* Failed tests on ``flocker/acceptance/vagrant/centos-7/zfs`` because of a key error
* Known `flocker.provision.test.test_ssh_conch` tests

If you'd like when reviewing the link redirects here, it might be a good opportunity to review the automation of that: https://clusterhq.atlassian.net/browse/FLOC-1701.

Redirects have been manually tested and do work, but the authors page has moved so the instructions and tool need to be updated.