### PR TITLE
[FLOC-2113] flocker/acceptance/vagrant/centos-7/zfs fails with a KeyError

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -539,7 +539,9 @@ class RunOptions(Options):
         Get the configuration corresponding to storage driver chosen by the
         command line options.
         """
-        return self['config']['storage-drivers'][self['dataset-backend']]
+        drivers = self['config'].get('storage-drivers', {})
+        configuration = drivers.get(self['dataset-backend'], {})
+        return configuration
 
     def dataset_backend(self):
         """


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2113

This makes the storage drivers section of the acceptance testing configuration file optional as it was intended to be.  Since the Vagrant runner doesn't accept any configuration, this fixes the issue (which seems to be that the slave is deployed with an old version of the configuration file).

Obsoletes #1518