### PR TITLE
[FLOC-2143] Remove host attribute from /state/containers

### DIFF
--- a/docs/reference/api_examples.yml
+++ b/docs/reference/api_examples.yml
@@ -315,7 +315,6 @@
     [
       {
         "node_uuid": "%(NODE_0)s",
-        "host": "10.0.0.3",
         "name": "webserver",
         "image": "nginx:latest",
         "restart_policy": {"name": "never"},
@@ -323,7 +322,6 @@
       },
       {
         "node_uuid": "%(NODE_0)s",
-        "host": "10.0.0.3",
         "name": "database",
         "image": "postgres:latest",
         "restart_policy": {"name": "on-failure", "maximum_retry_count": 5},

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -459,7 +459,6 @@ class ConfigurationAPIUserV1(object):
             for application in node.applications:
                 container = container_configuration_response(
                     application, node.uuid)
-                container[u"host"] = node.hostname
                 container[u"running"] = application.running
                 result.append(container)
         return result

--- a/flocker/control/schema/endpoints.yml
+++ b/flocker/control/schema/endpoints.yml
@@ -87,8 +87,6 @@ definitions:
     properties:
       node_uuid:
         '$ref': 'types.json#/definitions/container_node_uuid'
-      host:
-        '$ref': 'types.json#/definitions/host'
       name:
         '$ref': 'types.json#/definitions/container_name'
       image:
@@ -121,7 +119,6 @@ definitions:
         '$ref': 'types.json#/definitions/running'
     required:
       - node_uuid
-      - host
       - name
       - image
       - running

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -3048,7 +3048,6 @@ class ContainerStateTestsMixin(APITestsMixin):
         ])
         expected_dict = dict(
             name=u"myapp",
-            host=expected_hostname,
             node_uuid=unicode(expected_uuid),
             image=u"busybox:1.2",
             running=True,
@@ -3098,7 +3097,6 @@ class ContainerStateTestsMixin(APITestsMixin):
         ])
         expected_dict = dict(
             name=u"myapp",
-            host=expected_hostname,
             node_uuid=unicode(expected_uuid),
             image=u"busybox:1.2",
             running=True,
@@ -3132,7 +3130,6 @@ class ContainerStateTestsMixin(APITestsMixin):
         ])
         expected_dict = dict(
             name=u"myapp",
-            host=expected_hostname,
             node_uuid=unicode(expected_uuid),
             image=u"busybox:latest",
             running=False,
@@ -3172,7 +3169,6 @@ class ContainerStateTestsMixin(APITestsMixin):
         ])
         expected_dict1 = dict(
             name=u"myapp",
-            host=expected_hostname1,
             node_uuid=unicode(expected_uuid1),
             image=u"busybox:latest",
             running=True,
@@ -3180,7 +3176,6 @@ class ContainerStateTestsMixin(APITestsMixin):
         )
         expected_dict2 = dict(
             name=u"myapp2",
-            host=expected_hostname2,
             node_uuid=unicode(expected_uuid2),
             image=u"busybox2:latest",
             running=True,

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -733,22 +733,20 @@ StateContainersArrayTests = build_schema_test(
         # Wrong item type
         ["string"],
         # Failing dataset type (missing running)
-        [{u"host": u"10.0.0.1", u"node_uuid": a_uuid, u"name": u"lalala",
+        [{u"node_uuid": a_uuid, u"name": u"lalala",
           u"image": u"busybox:latest"}]
     ],
     passing_instances=[
         [],
-        [{u"host": u"10.0.0.1", u"name": u"lalala",
+        [{u"name": u"lalala",
           u"node_uuid": a_uuid,
           u"image": u"busybox:latest", u'running': True}],
         [{
-            u'host': u"10.0.0.1",
             u"node_uuid": a_uuid,
             u'image': u'nginx:latest',
             u'name': u'webserver2',
             u'running': True},
          {
-             u'host': u"10.0.0.2",
              u"node_uuid": unicode(uuid4()),
              u'image': u'nginx:latest',
              u'name': u'webserver',


### PR DESCRIPTION
Probably not *strictly* necessary, but I feel like it'll encourage people to interact badly with the API.