### PR TITLE
Make tag instance instructions not ambiguous any more.

### DIFF
--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -182,7 +182,8 @@ Using Amazon Web Services
    * Choose instance type. We recommend at least the ``m3.large`` instance size.
    * Configure instance details. You will need to configure a minimum of 2 instances.
    * Add storage. It is important to note that the default storage of an AWS image can be too small to store popular Docker images, so we recommend choosing at least 16GB to avoid potential disk space problems.
-   * Tag instance. No tags are required, but you may wish to add your own.
+   * Tag instance.
+     No tags are required, but you may wish to add your own.
    * Configure security group.
 
      * If you wish to customize the instance's security settings, make sure to permit SSH access from the administrators machine (for example, your laptop).

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -177,14 +177,14 @@ Using Amazon Web Services
    * `US West (Oregon) <https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#LaunchInstanceWizard:ami=ami-cc8de6fc>`_
 
 #. Configure the instance.
-   Complete the configuration wizard; in general the default configuration should suffice.   
+   Complete the configuration wizard; in general the default configuration should suffice.
 
    * Choose instance type. We recommend at least the ``m3.large`` instance size.
    * Configure instance details. You will need to configure a minimum of 2 instances.
    * Add storage. It is important to note that the default storage of an AWS image can be too small to store popular Docker images, so we recommend choosing at least 16GB to avoid potential disk space problems.
-   * Tag instance.
+   * Tag instance. No tags are required, but you may wish to add your own.
    * Configure security group.
-      
+
      * If you wish to customize the instance's security settings, make sure to permit SSH access from the administrators machine (for example, your laptop).
      * To enable Flocker agents to communicate with the control service and for external access to the API, add a custom TCP security rule enabling access to ports 4523-4524.
      * Keep in mind that (quite reasonably) the default security settings firewall off all ports other than SSH.


### PR DESCRIPTION
The AWS instructions mention "Tag instance." as one of the steps, but do not give further instruction.

Clarify that there is nothing specific for the administrator to do here.