### PR TITLE
[FLOC-2135] Only invalidate agent-reported state if the agent really goes away

### DIFF
--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -14,7 +14,7 @@ they match that configuration.
 from ._config import (
     FlockerConfiguration, ConfigurationError, FigConfiguration,
     model_from_configuration,
-    )
+)
 from ._model import (
     IClusterStateChange,
     Application, Deployment, DockerImage, Node, Port, Link, AttachedVolume,

--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -21,7 +21,12 @@ from ._model import (
     NodeState, Manifestation, Dataset, RestartNever, RestartOnFailure,
     RestartAlways, DeploymentState, NonManifestDatasets, same_node,
     IClusterStateWipe,
-    )
+)
+from ._protocol import (
+    IConvergenceAgent,
+    NodeStateCommand,
+    AgentAMP,
+)
 
 __all__ = [
     'same_node',
@@ -46,4 +51,8 @@ __all__ = [
     'RestartOnFailure',
     'RestartAlways',
     'NonManifestDatasets',
+
+    'IConvergenceAgent',
+    'NodeStateCommand',
+    'AgentAMP',
 ]

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -6,6 +6,8 @@ Combine and retrieve current cluster state.
 
 from datetime import datetime, timedelta
 
+from twisted.python.versions import Version
+from twisted.python.deprecate import deprecated
 from twisted.application.service import MultiService
 from twisted.application.internet import TimerService
 
@@ -17,6 +19,7 @@ from ._model import DeploymentState, ChangeSource
 # Allowed inactivity period before updates are expired
 EXPIRATION_TIME = timedelta(seconds=120)
 
+v1_0 = Version("flocker", 1, 0, 0)
 
 class _WiperAndSource(PRecord):
     """
@@ -121,6 +124,7 @@ class ClusterStateService(MultiService):
                 key, _WiperAndSource(wiper=wiper, source=source)
             )
 
+    @deprecated(v1_0, "ClusterStateService.apply_changes_from_source")
     def apply_changes(self, changes):
         """
         Compatibility layer.  See and use ``apply_changes_from_source``.

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -4,18 +4,33 @@
 Combine and retrieve current cluster state.
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from twisted.application.service import MultiService
 from twisted.application.internet import TimerService
 
-from pyrsistent import pmap
+from pyrsistent import PRecord, field, pmap
 
-from ._model import DeploymentState
+from ._model import DeploymentState, ChangeSource
 
 
 # Allowed inactivity period before updates are expired
 EXPIRATION_TIME = timedelta(seconds=120)
+
+
+class _WiperAndSource(PRecord):
+    """
+    :ivar IClusterStateWipe wiper: A change wiper.
+    :ivar IClusterStateSource source: Where the change wiper came from.
+    """
+    wiper = field()
+    source = field()
+
+    def last_activity(self):
+        return self.source.last_activity()
+
+    def update_cluster_state(self, deployment_state):
+        return self.wiper.update_cluster_state(deployment_state)
 
 
 class ClusterStateService(MultiService):
@@ -28,8 +43,8 @@ class ClusterStateService(MultiService):
     https://clusterhq.atlassian.net/browse/FLOC-1896
 
     :ivar DeploymentState _deployment_state: The current known cluster state.
-    :ivar PMap _information_wipers: Map (wiper class, wiper key) to (wiper,
-        added timestamp), where wiper is a ``IClusterStateWipe`` provider.
+    :ivar PMap _information_wipers: Map (wiper class, wiper key) to
+        ``_WiperAndSource``.
     :ivar _clock: ``IReactorTime`` provider.
     """
     def __init__(self, reactor):
@@ -45,12 +60,14 @@ class ClusterStateService(MultiService):
         """
         Clear any expired state from memory.
         """
-        current_time = self._clock.seconds()
+        current_time = datetime.utcfromtimestamp(self._clock.seconds())
         evolver = self._information_wipers.evolver()
-        for key, (wiper, timestamp) in self._information_wipers.items():
-            if current_time - EXPIRATION_TIME.total_seconds() >= timestamp:
-                self._deployment_state = wiper.update_cluster_state(
-                    self._deployment_state)
+        for key, wipe in self._information_wipers.items():
+            last_activity = wipe.last_activity()
+            if current_time - last_activity >= EXPIRATION_TIME:
+                self._deployment_state = wipe.update_cluster_state(
+                    self._deployment_state
+                )
                 evolver.remove(key)
         self._information_wipers = evolver.persistent()
 
@@ -74,10 +91,13 @@ class ClusterStateService(MultiService):
         """
         return self._deployment_state
 
-    def apply_changes(self, changes):
+    def apply_changes_from_source(self, source, changes):
         """
         Apply some changes to the cluster state.
 
+        :param IClusterChangeSource source: An object representing the entity
+            that gave us these changes.  The information in the changes will be
+            kept until they are overwritten or this entity goes away.
         :param list changes: Some ``IClusterStateChange`` providers to use to
             update the internal cluster state.
         """
@@ -92,4 +112,13 @@ class ClusterStateService(MultiService):
             wiper = change.get_information_wipe()
             key = (wiper.__class__, wiper.key())
             self._information_wipers = self._information_wipers.set(
-                key, (wiper, self._clock.seconds()))
+                key, _WiperAndSource(wiper=wiper, source=source)
+            )
+
+    def apply_changes(self, changes):
+        """
+        Compatibility layer.  See and use ``apply_changes_from_source``.
+        """
+        source = ChangeSource()
+        source.set_last_activity(self._clock.seconds())
+        return self.apply_changes_from_source(source, changes)

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -4,6 +4,8 @@
 Combine and retrieve current cluster state.
 """
 
+from datetime import timedelta
+
 from twisted.application.service import MultiService
 from twisted.application.internet import TimerService
 
@@ -12,8 +14,8 @@ from pyrsistent import pmap
 from ._model import DeploymentState
 
 
-# Seconds until updates are expired:
-EXPIRATION_TIME = 120
+# Allowed inactivity period before updates are expired
+EXPIRATION_TIME = timedelta(seconds=120)
 
 
 class ClusterStateService(MultiService):
@@ -46,7 +48,7 @@ class ClusterStateService(MultiService):
         current_time = self._clock.seconds()
         evolver = self._information_wipers.evolver()
         for key, (wiper, timestamp) in self._information_wipers.items():
-            if current_time - EXPIRATION_TIME >= timestamp:
+            if current_time - EXPIRATION_TIME.total_seconds() >= timestamp:
                 self._deployment_state = wiper.update_cluster_state(
                     self._deployment_state)
                 evolver.remove(key)

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -27,9 +27,15 @@ class _WiperAndSource(PRecord):
     source = field()
 
     def last_activity(self):
+        """
+        Return the source's last activity time.
+        """
         return self.source.last_activity()
 
     def update_cluster_state(self, deployment_state):
+        """
+        Update the state according to the wiper.
+        """
         return self.wiper.update_cluster_state(deployment_state)
 
 

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -21,6 +21,7 @@ EXPIRATION_TIME = timedelta(seconds=120)
 
 v1_0 = Version("flocker", 1, 0, 0)
 
+
 class _WiperAndSource(PRecord):
     """
     :ivar IClusterStateWipe wiper: A change wiper.

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -17,6 +17,7 @@ There are different categories of classes:
 from uuid import UUID
 from warnings import warn
 from hashlib import md5
+from datetime import datetime
 
 from characteristic import attributes
 from twisted.python.filepath import FilePath
@@ -681,6 +682,44 @@ class IClusterStateWipe(Interface):
         cover different information, so there is no need for the key to
         express that differentation.
         """
+
+
+class IClusterStateSource(Interface):
+    """
+    Represents where some cluster state (``IClusterStateChange``) came from.
+    This is presently used for activity/inactivity tracking to inform change
+    wiping.
+    """
+    def last_activity():
+        """
+        :return: The point in time at which the last activity was observed from
+            this source.
+        :rtype: ``datetime.datetime`` (in UTC)
+        """
+
+
+@implementer(IClusterStateSource)
+class ChangeSource(object):
+    """
+    An ``IClusterStateSource`` which reports whatever time it was last told to
+    report.
+
+    :ivar float _last_activity: Recorded activity time.
+    """
+    def __init__(self):
+        self.set_last_activity(0)
+
+    def set_last_activity(self, since_epoch):
+        """
+        Set the time of the last activity.
+
+        :param float since_epoch: Number of seconds since the epoch at which
+            point the activity occurred.
+        """
+        self._last_activity = since_epoch
+
+    def last_activity(self):
+        return datetime.utcfromtimestamp(self._last_activity)
 
 
 def ip_to_uuid(ip):

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -849,14 +849,15 @@ class DeploymentState(PRecord):
         """
         Create new ``DeploymentState`` based on this one which updates an
         existing ``NodeState`` with any known information from the given
-        ``NodeState``. Attributes which are set to ``None` on the given
+        ``NodeState``.  Attributes which are set to ``None` on the given
         update, indicating ignorance, will not be changed in the result.
 
-        The given ``NodeState`` will simply be added if no existing ones
-        have matching hostname.
+        The given ``NodeState`` will simply be added if it doesn't represent a
+        node that is already part of the ``DeploymentState`` (based on UUID
+        comparison).
 
-        :param NodeState node: An update for ``NodeState`` with same
-             hostname in this ``DeploymentState``.
+        :param NodeState node: An update for ``NodeState`` with same hostname
+            in this ``DeploymentState``.
 
         :return DeploymentState: Updated with new ``NodeState``.
         """

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -895,8 +895,8 @@ class DeploymentState(PRecord):
         node that is already part of the ``DeploymentState`` (based on UUID
         comparison).
 
-        :param NodeState node: An update for ``NodeState`` with same hostname
-            in this ``DeploymentState``.
+        :param NodeState node: An update for ``NodeState`` with same UUID in
+            this ``DeploymentState``.
 
         :return DeploymentState: Updated with new ``NodeState``.
         """

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -390,6 +390,13 @@ class _AgentLocator(CommandLocator):
         CommandLocator.__init__(self)
         self.agent = agent
 
+    @NoOp.responder
+    def noop(self):
+        """
+        Perform no operation.
+        """
+        return {}
+
     @property
     def logger(self):
         """

--- a/flocker/control/script.py
+++ b/flocker/control/script.py
@@ -69,7 +69,7 @@ class ControlScript(object):
             rest_api_context_factory(ca, control_credential))
         api_service.setServiceParent(top_service)
         amp_service = ControlAMPService(
-            cluster_state, persistence, serverFromString(
+            reactor, cluster_state, persistence, serverFromString(
                 reactor, options["agent-port"]),
             amp_server_context_factory(ca, control_credential))
         amp_service.setServiceParent(top_service)

--- a/flocker/control/test/clusterstatetools.py
+++ b/flocker/control/test/clusterstatetools.py
@@ -1,0 +1,23 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Helpers for testing ``flocker.control._clusterstate`` interactions.
+"""
+
+from .._clusterstate import EXPIRATION_TIME
+
+
+def advance_some(clock):
+    """
+    Move the clock forward by a little time.  Much less than
+    ``EXPIRATION_TIME``.
+    """
+    clock.advance(1)
+
+
+def advance_rest(clock):
+    """
+    Move the clock forward by a lot of time.  Enough to reach
+    ``EXPIRATION_TIME`` if ``advance_some`` is also used.
+    """
+    clock.advance(EXPIRATION_TIME.total_seconds() - 1)

--- a/flocker/control/test/test_clusterstate.py
+++ b/flocker/control/test/test_clusterstate.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 """
 Tests for ``flocker.control._clusterstate``.
@@ -11,11 +11,12 @@ from twisted.python.filepath import FilePath
 from twisted.internet.task import Clock
 
 from .._model import ChangeSource
-from .._clusterstate import EXPIRATION_TIME, ClusterStateService
+from .._clusterstate import ClusterStateService
 from .. import (
     Application, DockerImage, NodeState, DeploymentState, Manifestation,
     Dataset,
 )
+from .clusterstatetools import advance_some, advance_rest
 
 APP1 = Application(
     name=u"webserver", image=DockerImage.from_string(u"apache"))
@@ -23,22 +24,6 @@ APP2 = Application(
     name=u"database", image=DockerImage.from_string(u"postgresql"))
 MANIFESTATION = Manifestation(dataset=Dataset(dataset_id=unicode(uuid4())),
                               primary=True)
-
-
-def advance_some(clock):
-    """
-    Move the clock forward by a little time.  Much less than
-    ``EXPIRATION_TIME``.
-    """
-    clock.advance(1)
-
-
-def advance_rest(clock):
-    """
-    Move the clock forward by a lot of time.  Enough to reach
-    ``EXPIRATION_TIME`` if ``advance_some`` is also used.
-    """
-    clock.advance(EXPIRATION_TIME.total_seconds() - 1)
 
 
 class ClusterStateServiceTests(SynchronousTestCase):

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -29,15 +29,17 @@ from twisted.internet.task import Clock
 from .._protocol import (
     SerializableArgument,
     VersionCommand, ClusterStatusCommand, NodeStateCommand, IConvergenceAgent,
-    AgentAMP, ControlAMPService, ControlAMP, _AgentLocator,
+    NoOp, AgentAMP, ControlAMPService, ControlAMP, _AgentLocator,
     ControlServiceLocator, LOG_SEND_CLUSTER_STATE, LOG_SEND_TO_AGENT,
 )
+from .._model import ChangeSource
 from .._clusterstate import ClusterStateService
 from .. import (
     Deployment, Application, DockerImage, Node, NodeState, Manifestation,
     Dataset, DeploymentState, NonManifestDatasets,
 )
 from .._persistence import ConfigurationPersistenceService
+from .clusterstatetools import advance_some, advance_rest
 
 
 class LoopbackAMPClient(object):
@@ -95,6 +97,14 @@ TEST_DEPLOYMENT = Deployment(nodes=frozenset([
          applications=frozenset([APP1, APP2]))]))
 MANIFESTATION = Manifestation(dataset=Dataset(dataset_id=unicode(uuid4())),
                               primary=True)
+
+# A very simple piece of node state that makes for nice-looking, easily-read
+# test failures.  It arbitrarily supplies only ports because integers have a
+# very simple representation.
+SIMPLE_NODE_STATE = NodeState(
+    hostname=u"192.0.2.17", applications=[], used_ports=[1],
+)
+
 NODE_STATE = NodeState(hostname=u'node1.example.com',
                        applications=[APP1, APP2],
                        used_ports=[1, 2],
@@ -185,7 +195,7 @@ class SerializationTests(SynchronousTestCase):
             TypeError, SerializableArgument(NodeState).fromString, as_bytes)
 
 
-def build_control_amp_service(test):
+def build_control_amp_service(test, reactor=None):
     """
     Create a new ``ControlAMPService``.
 
@@ -193,14 +203,16 @@ def build_control_amp_service(test):
 
     :return ControlAMPService: Not started.
     """
-    cluster_state = ClusterStateService(Clock())
+    if reactor is None:
+        reactor = Clock()
+    cluster_state = ClusterStateService(reactor)
     cluster_state.startService()
     test.addCleanup(cluster_state.stopService)
     persistence_service = ConfigurationPersistenceService(
         None, FilePath(test.mktemp()))
     persistence_service.startService()
     test.addCleanup(persistence_service.stopService)
-    return ControlAMPService(cluster_state, persistence_service,
+    return ControlAMPService(reactor, cluster_state, persistence_service,
                              TCP4ServerEndpoint(MemoryReactor(), 1234),
                              # Easiest TLS context factory to create:
                              ClientContextFactory())
@@ -245,8 +257,11 @@ class ControlAMPTests(ControlTestCase):
     Tests for ``ControlAMP`` and ``ControlServiceLocator``.
     """
     def setUp(self):
-        self.control_amp_service = build_control_amp_service(self)
-        self.protocol = ControlAMP(self.control_amp_service)
+        self.reactor = Clock()
+        self.control_amp_service = build_control_amp_service(
+            self, self.reactor,
+        )
+        self.protocol = ControlAMP(self.reactor, self.control_amp_service)
         self.client = LoopbackAMPClient(self.protocol.locator)
 
     def test_connection_made(self):
@@ -319,6 +334,42 @@ class ControlAMPTests(ControlTestCase):
             self.control_amp_service.cluster_state.as_deployment(),
         )
 
+    def test_activity_refreshes_node_state(self):
+        """
+        Any time commands are dispatched by ``ControlAMP`` its activity
+        timestamp is refreshed to prevent previously applied state from
+        expiring.
+        """
+        cluster_state = self.control_amp_service.cluster_state
+
+        # Deliver some initial state (T1) which can be expected to be
+        # preserved.
+        self.successResultOf(
+            self.client.callRemote(
+                NodeStateCommand,
+                state_changes=(SIMPLE_NODE_STATE,),
+                eliot_context=TEST_ACTION,
+            )
+        )
+        # Let a little time pass (T2) and then cause some activity.
+        advance_some(self.reactor)
+        self.client.callRemote(NoOp)
+
+        # Let enough time pass (T3) to reach EXPIRATION_TIME from T1
+        advance_rest(self.reactor)
+        before_wipe_state = cluster_state.as_deployment()
+
+        # Let enough time pass (T4) to reach EXPIRATION_TIME from T2
+        advance_some(self.reactor)
+        after_wipe_state = cluster_state.as_deployment()
+
+        # The state from T1 should not have been wiped at T3 but it should have
+        # been wiped at T4.
+        self.assertEqual(
+            (before_wipe_state, after_wipe_state),
+            (DeploymentState(nodes={SIMPLE_NODE_STATE}), DeploymentState()),
+        )
+
     def test_nodestate_notifies_all_connected(self):
         """
         ``NodeStateCommand`` results in all connected ``ControlAMP``
@@ -327,7 +378,7 @@ class ControlAMPTests(ControlTestCase):
         """
         self.control_amp_service.configuration_service.save(TEST_DEPLOYMENT)
         self.protocol.makeConnection(StringTransport())
-        another_protocol = ControlAMP(self.control_amp_service)
+        another_protocol = ControlAMP(self.reactor, self.control_amp_service)
         another_protocol.makeConnection(StringTransport())
         sent1 = []
         sent2 = []
@@ -382,7 +433,7 @@ class ControlAMPServiceTests(ControlTestCase):
         """
         service = build_control_amp_service(self)
         service.startService()
-        connections = [ControlAMP(service) for i in range(3)]
+        connections = [ControlAMP(Clock(), service) for i in range(3)]
         initial_disconnecting = []
         for c in connections:
             c.makeConnection(StringTransport())
@@ -416,7 +467,7 @@ class ControlAMPServiceTests(ControlTestCase):
         """
         service = build_control_amp_service(self)
         service.startService()
-        protocol = ControlAMP(service)
+        protocol = ControlAMP(Clock(), service)
         protocol.makeConnection(StringTransport())
         sent = []
         self.patch_call_remote(sent, protocol=protocol)
@@ -645,6 +696,7 @@ class ControlServiceLocatorTests(SynchronousTestCase):
         fake_control_amp_service = build_control_amp_service(self)
         self.patch(fake_control_amp_service, 'logger', logger)
         locator = ControlServiceLocator(
+            reactor=Clock(),
             control_amp_service=fake_control_amp_service
         )
         self.assertIs(logger, locator.logger)
@@ -664,7 +716,7 @@ class SendStateToConnectionsTests(SynchronousTestCase):
         control_amp_service = build_control_amp_service(self)
         self.patch(control_amp_service, 'logger', logger)
 
-        connection_protocol = ControlAMP(control_amp_service)
+        connection_protocol = ControlAMP(Clock(), control_amp_service)
         # Patching is bad.
         # https://clusterhq.atlassian.net/browse/FLOC-1603
         connection_protocol.callRemote = lambda *args, **kwargs: succeed({})
@@ -704,13 +756,13 @@ class SendStateToConnectionsTests(SynchronousTestCase):
         control_amp_service = build_control_amp_service(self)
         self.patch(control_amp_service, 'logger', logger)
 
-        connected_protocol = ControlAMP(control_amp_service)
+        connected_protocol = ControlAMP(Clock(), control_amp_service)
         # Patching is bad.
         # https://clusterhq.atlassian.net/browse/FLOC-1603
         connected_protocol.callRemote = lambda *args, **kwargs: succeed({})
 
         error = ConnectionLost()
-        disconnected_protocol = ControlAMP(control_amp_service)
+        disconnected_protocol = ControlAMP(Clock(), control_amp_service)
         results = [succeed({}), fail(error)]
         # Patching is bad.
         # https://clusterhq.atlassian.net/browse/FLOC-1603
@@ -719,7 +771,10 @@ class SendStateToConnectionsTests(SynchronousTestCase):
 
         control_amp_service.connected(disconnected_protocol)
         control_amp_service.connected(connected_protocol)
-        control_amp_service.node_changed((NodeState(hostname=u"1.2.3.4"),))
+        control_amp_service.node_changed(
+            ChangeSource(),
+            (NodeState(hostname=u"1.2.3.4"),)
+        )
 
         actions = LoggedAction.ofType(logger.messages, LOG_SEND_TO_AGENT)
         self.assertEqual(

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -106,7 +106,7 @@ MANIFESTATION = Manifestation(dataset=Dataset(dataset_id=unicode(uuid4())),
 # test failures.  It arbitrarily supplies only ports because integers have a
 # very simple representation.
 SIMPLE_NODE_STATE = NodeState(
-    hostname=u"192.0.2.17", applications=[], used_ports=[1],
+    hostname=u"192.0.2.17", uuid=uuid4(), applications=[], used_ports=[1],
 )
 
 NODE_STATE = NodeState(hostname=u'node1.example.com',

--- a/flocker/control/test/test_script.py
+++ b/flocker/control/test/test_script.py
@@ -71,9 +71,9 @@ class ControlOptionsTests(StandardOptionsTestsMixin,
         self.assertEqual(options["agent-port"], b"tcp:1234")
 
 
-class ControlScriptEffectsTests(SynchronousTestCase):
+class ControlScriptTests(SynchronousTestCase):
     """
-    Tests for effects ``ControlScript``.
+    Tests for ``ControlScript``.
     """
     def setUp(self):
         """

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -23,7 +23,7 @@ from characteristic import attributes
 from machinist import (
     trivialInput, TransitionTable, constructFiniteStateMachine,
     MethodSuffixOutputer,
-    )
+)
 
 from twisted.application.service import MultiService
 from twisted.python.constants import Names, NamedConstant

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -418,7 +418,8 @@ class AgentLoopService(object, MultiService):
         self.logger = convergence_loop.logger
         self.cluster_status = build_cluster_status_fsm(convergence_loop)
         self.reconnecting_factory = ReconnectingClientFactory.forProtocol(
-            lambda: AgentAMP(self))
+            lambda: AgentAMP(self.reactor, self)
+        )
         self.factory = TLSMemoryBIOFactory(context_factory, True,
                                            self.reconnecting_factory)
 

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -32,9 +32,9 @@ from twisted.protocols.tls import TLSMemoryBIOFactory
 
 from . import run_state_change
 
-from ..control._protocol import (
+from ..control import (
     NodeStateCommand, IConvergenceAgent, AgentAMP,
-    )
+)
 
 
 class ClusterStatusInputs(Names):


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2135

This includes:

  * Changes to both sides of the AMP connection to send "ping" commands periodically.  This forces TCP-level disconnection notification in a timely manner.
  * Changes to use AMP command dispatch as a signal of "activity" and considers this sufficient evidence that the agent is still operating properly.
  * Changes to use "activity" (or inactivity) as the trigger for wiping state instead of using a hard-coded timeout on the age of the state itself.

It's probable this resolves FLOC-1896 as well.  The requirements there just say "do better".  This is probably better.