### PR TITLE
[FLOC-2192] Don't attempt to destroy nonmanifest datasets 

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1604,7 +1604,8 @@ class BlockDeviceDeployer(PRecord):
         detaches = list(self._calculate_detaches(
             local_state.devices, local_state.paths, configured_manifestations,
         ))
-        deletes = self._calculate_deletes(local_state, configured_manifestations)
+        deletes = self._calculate_deletes(
+            local_state, configured_manifestations)
 
         # FLOC-1484 Support resize for block storage backends. See also
         # FLOC-1875.

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1604,7 +1604,7 @@ class BlockDeviceDeployer(PRecord):
         detaches = list(self._calculate_detaches(
             local_state.devices, local_state.paths, configured_manifestations,
         ))
-        deletes = self._calculate_deletes(local_state.paths, configured_manifestations)
+        deletes = self._calculate_deletes(local_state, configured_manifestations)
 
         # FLOC-1484 Support resize for block storage backends. See also
         # FLOC-1875.
@@ -1705,10 +1705,10 @@ class BlockDeviceDeployer(PRecord):
                     dataset_id=UUID(manifestation.dataset_id),
                 )
 
-    def _calculate_deletes(self, paths, configured_manifestations):
+    def _calculate_deletes(self, local_state, configured_manifestations):
         """
-        :param PMap paths: The paths at which datasets' filesystems are mounted
-            on this node.  This is the same as ``NodeState.paths``.
+        :param NodeState: The local state discovered immediately prior to
+            calculation.
 
         :param dict configured_manifestations: The manifestations configured
             for this node (like ``Node.manifestations``).
@@ -1727,12 +1727,11 @@ class BlockDeviceDeployer(PRecord):
             for manifestation in configured_manifestations.values()
             if manifestation.dataset.deleted
         )
-
         return [
             DestroyBlockDeviceDataset(dataset_id=UUID(dataset_id))
             for dataset_id
             in delete_dataset_ids
-#            if dataset_id in paths
+            # if dataset_id in local_state.manifestations
         ]
 
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1604,7 +1604,7 @@ class BlockDeviceDeployer(PRecord):
         detaches = list(self._calculate_detaches(
             local_state.devices, local_state.paths, configured_manifestations,
         ))
-        deletes = self._calculate_deletes(configured_manifestations)
+        deletes = self._calculate_deletes(local_state.paths, configured_manifestations)
 
         # FLOC-1484 Support resize for block storage backends. See also
         # FLOC-1875.
@@ -1705,8 +1705,11 @@ class BlockDeviceDeployer(PRecord):
                     dataset_id=UUID(manifestation.dataset_id),
                 )
 
-    def _calculate_deletes(self, configured_manifestations):
+    def _calculate_deletes(self, paths, configured_manifestations):
         """
+        :param PMap paths: The paths at which datasets' filesystems are mounted
+            on this node.  This is the same as ``NodeState.paths``.
+
         :param dict configured_manifestations: The manifestations configured
             for this node (like ``Node.manifestations``).
 
@@ -1729,6 +1732,7 @@ class BlockDeviceDeployer(PRecord):
             DestroyBlockDeviceDataset(dataset_id=UUID(dataset_id))
             for dataset_id
             in delete_dataset_ids
+#            if dataset_id in paths
         ]
 
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1731,7 +1731,7 @@ class BlockDeviceDeployer(PRecord):
             DestroyBlockDeviceDataset(dataset_id=UUID(dataset_id))
             for dataset_id
             in delete_dataset_ids
-            # if dataset_id in local_state.manifestations
+            if dataset_id in local_state.manifestations
         ]
 
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -894,6 +894,28 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
             in_parallel(changes=[]),
         )
 
+    def test_deleted_dataset_volume_unmounted(self):
+        """
+        ``DestroyBlockDeviceDataset`` is a compound state change that first
+        attempts to unmount the block device.
+        Therefore do not calculate deletion for blockdevices that are attached
+        but unmounted.
+        """
+        local_state = self.ONE_DATASET_STATE
+        local_config = to_node(local_state).transform(
+            ["manifestations", unicode(self.DATASET_ID), "dataset", "deleted"],
+            True
+        )
+        # Remove the mount path for the manifestation.
+        local_state = local_state.transform(
+            ['paths', unicode(self.DATASET_ID)],
+            discard
+        )
+        assert_calculated_changes(
+            self, local_state, local_config, set(),
+            in_parallel(changes=[]),
+        )
+
 
 class BlockDeviceDeployerAttachCalculateChangesTests(
         SynchronousTestCase, ScenarioMixin

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -915,10 +915,19 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
             ['paths', unicode(self.DATASET_ID)],
             discard
         )
-
+        # Local state shows that there is a device for the (now) non-manifest
+        # dataset. i.e it is attached.
+        self.assertEqual([self.DATASET_ID], local_state.devices.keys())
         assert_calculated_changes(
-            self, local_state, local_config, set(),
-            in_parallel(
+            case=self,
+            node_state=local_state,
+            node_config=local_config,
+            # The unmounted dataset has been added back to the non-manifest
+            # datasets by discover_state.
+            nonmanifest_datasets=[
+                self.MANIFESTATION.dataset
+            ],
+            expected_changes=in_parallel(
                 changes=[
                     MountBlockDevice(
                         mountpoint=FilePath('/flocker/').child(


### PR DESCRIPTION
Design / fix for https://clusterhq.atlassian.net/browse/FLOC-2192

There's a test in this branch which demonstrates at least one of the problems we're seeing in the logs attached to FLOC-2192

```
Jun 09 16:41:29 acceptance-test-buildbot-0 flocker-dataset-agent[12516]: {"timestamp": 1433868088.771906, "task_uuid": "3701d26f-b458-407e-914c-5a544f
0d42ad", "message_type": "flocker:agent:converge:actions", "calculated_actions": "_InParallel(changes=pvector([DestroyBlockDeviceDataset(dataset_id=UU
ID('9ea3afb6-c3ca-4bef-8f0a-774a58fc005d')), MountBlockDevice(mountpoint=FilePath('/flocker/9ea3afb6-c3ca-4bef-8f0a-774a58fc005d'), dataset_id=UUID('9
ea3afb6-c3ca-4bef-8f0a-774a58fc005d'))]))", "task_level": [2, 4]}
```

The problem is that ``DestroyBlockDeviceDataset`` is a compound state change which attempts to perform:
 * unmount
 * detach
 * destroy
 ...in series.

Therefore the target dataset must be mounted for this to succeed.

Some ideas:
 1. Change the order of state changes so that ``MountBlockDevice`` always comes before ``DestroyBlockDeviceDataset`` and return an ``_InSeries`` state change collection....but that's probably too slow.

 2. Change the ``_calculate_deletes`` helper to only calculate deletes for fully manifest datasets. (by fully manifest, I mean that the dataset is attached and mounted). I could base this on the presence of a path key matching the deleted dataset ID but actually ``discover_state`` already moves datasets to ``non_manifest_datasets`` if the dataset is attached but not mounted.

 3. Change the ``_calculate_mounts``, ``_calculate_attaches``, ``_calculate_unmounts``, ``_calculate_detaches`` to only consider extant (not deleted) datasets in the configuration.

 4. And probably best of all would be to get rid of all the compound state changes and calculate all the intermediate steps separately.

After discussing with @itamarst I went for No2.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1563)
<!-- Reviewable:end -->
