### PR TITLE
[FLOC-1979] Client certificate instructions that work on OS X

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -24,9 +24,12 @@
     <script type="text/javascript" src="https://fast.fonts.net/jsapi/b20e6cd5-c1a4-4878-9d69-da3806cb86b8.js"></script>
     <link href='https://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 
+    <!--
+         Enable Bootstrap tabs in the documentation. There's probably a better
+         way to get these dependencies loaded.  FLOC-2248.
+    -->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="{{ pathto('_static/js/vendor/jquery-1.11.1.min.js', 1) }}"><\/script>')</script>
-
     <script src="{{ pathto('_static/js/vendor/bootstrap.min.js', 1)}}"></script>
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -24,14 +24,6 @@
     <script type="text/javascript" src="https://fast.fonts.net/jsapi/b20e6cd5-c1a4-4878-9d69-da3806cb86b8.js"></script>
     <link href='https://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 
-    <!--
-         Enable Bootstrap tabs in the documentation. There's probably a better
-         way to get these dependencies loaded.  FLOC-2248.
-    -->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="{{ pathto('_static/js/vendor/jquery-1.11.1.min.js', 1) }}"><\/script>')</script>
-    <script src="{{ pathto('_static/js/vendor/bootstrap.min.js', 1)}}"></script>
-
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -24,6 +24,11 @@
     <script type="text/javascript" src="https://fast.fonts.net/jsapi/b20e6cd5-c1a4-4878-9d69-da3806cb86b8.js"></script>
     <link href='https://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="{{ pathto('_static/js/vendor/jquery-1.11.1.min.js', 1) }}"><\/script>')</script>
+
+    <script src="{{ pathto('_static/js/vendor/bootstrap.min.js', 1)}}"></script>
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/docs/reference/authentication.rst
+++ b/docs/reference/authentication.rst
@@ -72,6 +72,6 @@ Linux
 .. code-block:: console
 
     $ curl --cacert $PWD/cluster.crt --cert $PWD/user.crt --key $PWD/user.key \
-        https://172.16.255.250:4523/v1/configuration/containers
+         https://172.16.255.250:4523/v1/configuration/containers
 
 You can read more about how Flocker's authentication layer works in the :ref:`security and authentication guide <security>`.

--- a/docs/reference/authentication.rst
+++ b/docs/reference/authentication.rst
@@ -43,37 +43,35 @@ An example of performing this authentication with ``cURL`` is given below.
 In this example, ``172.16.255.250`` represents the IP address of the control service.
 The following is an example of an authenticated request to create a new container on a cluster.
 
-.. tabs::
+OS X
+^^^^
 
-  OS X
-  ^^^^
+Make sure you know the common name of the client certificate you will use.
+If you just generated the certificate following the `instructions above <generate-api>`_,
+the common name is ``user-<username>`` where ``<username>`` is whatever argument you passed to ``flocker-ca generate-api-certificate``.
+If you're not sure what the username is, you can find the common name like this:
 
-  Make sure you know the common name of the client certificate you will use.
-  If you just generated the certificate following the `instructions above <generate-api>`_,
-  the common name is ``user-<username>`` where ``<username>`` is whatever argument you passed to ``flocker-ca generate-api-certificate``.
-  If you're not sure what the username is, you can find the common name like this:
+.. code-block:: console
 
-  .. code-block:: console
+    $ openssl x509 -in user.crt -noout -subject
+    subject= /OU=164b81dd-7e5d-4570-99c7-8baf1ffb49d3/CN=user-allison
 
-      $ openssl x509 -in user.crt -noout -subject
-      subject= /OU=164b81dd-7e5d-4570-99c7-8baf1ffb49d3/CN=user-allison
+In this example, ``user-allison`` is the common name.
+Import the client certificate into the ``Keychain`` and then refer to it by its common name:
 
-  In this example, ``user-allison`` is the common name.
-  Import the client certificate into the ``Keychain`` and then refer to it by its common name:
+.. code-block:: console
 
-  .. code-block:: console
+    $ openssl pkcs12 -export -in user.crt -inkey user.key -out user.p12
+    $ security import user.p12 -k ~/Library/Keychains/login.keychain
+    $ curl --cacert $PWD/cluster.crt --cert "<common name>" \
+         https://172.16.255.250:4523/v1/configuration/containers
 
-      $ openssl pkcs12 -export -in user.crt -inkey user.key -out user.p12
-      $ security import user.p12 -k ~/Library/Keychains/login.keychain
-      $ curl --cacert $PWD/cluster.crt --cert "<common name>" \
-           https://172.16.255.250:4523/v1/configuration/containers
+Linux
+^^^^^
 
-  Linux
-  ^^^^^
+.. code-block:: console
 
-  .. code-block:: console
-
-      $ curl --cacert $PWD/cluster.crt --cert $PWD/user.crt --key $PWD/user.key \
-          https://172.16.255.250:4523/v1/configuration/containers
+    $ curl --cacert $PWD/cluster.crt --cert $PWD/user.crt --key $PWD/user.key \
+        https://172.16.255.250:4523/v1/configuration/containers
 
 You can read more about how Flocker's authentication layer works in the :ref:`security and authentication guide <security>`.

--- a/docs/reference/authentication.rst
+++ b/docs/reference/authentication.rst
@@ -27,10 +27,10 @@ Run ``flocker-ca create-api-certificate <username>``, where ``<username>`` is a 
 
 .. code-block:: console
 
-   $ flocker-ca create-api-certificate alice
-   Created alice.crt and alice.key. You can now give these to your API end user so they can access the control service API.
+   $ flocker-ca create-api-certificate allison
+   Created allison.crt and allison.key. You can now give these to your API end user so they can access the control service API.
 
-The two files generated will correspond to the username you specified in the command, in this example ``alice.crt`` and ``alice.key``.
+The two files generated will correspond to the username you specified in the command, in this example ``allison.crt`` and ``allison.key``.
 You should securely provide a copy of these files to the API end user, as well as a copy of the cluster's public certificate, the ``cluster.crt`` file.
 
 Using an API certificate to authenticate

--- a/docs/reference/authentication.rst
+++ b/docs/reference/authentication.rst
@@ -43,9 +43,37 @@ An example of performing this authentication with ``cURL`` is given below.
 In this example, ``172.16.255.250`` represents the IP address of the control service.
 The following is an example of an authenticated request to create a new container on a cluster.
 
-.. code-block:: console
+.. tabs::
 
-   $ curl --cacert $PWD/cluster.crt --cert $PWD/user.crt --key $PWD/user.key \
+  OS X
+  ^^^^
+
+  Make sure you know the common name of the client certificate you will use.
+  If you just generated the certificate following the `instructions above <generate-api>`_,
+  the common name is ``user-<username>`` where ``<username>`` is whatever argument you passed to ``flocker-ca generate-api-certificate``.
+  If you're not sure what the username is, you can find the common name like this:
+
+  .. code-block:: console
+
+      $ openssl x509 -in user.crt -noout -subject
+      subject= /OU=164b81dd-7e5d-4570-99c7-8baf1ffb49d3/CN=user-allison
+
+  In this example, ``user-allison`` is the common name.
+  Import the client certificate into the ``Keychain`` and then refer to it by its common name:
+
+  .. code-block:: console
+
+      $ openssl pkcs12 -export -in user.crt -inkey user.key -out user.p12
+      $ security import user.p12 -k ~/Library/Keychains/login.keychain
+      $ curl --cacert $PWD/cluster.crt --cert "<common name>" \
+           https://172.16.255.250:4523/v1/configuration/containers
+
+  Linux
+  ^^^^^
+
+  .. code-block:: console
+
+      $ curl --cacert $PWD/cluster.crt --cert $PWD/user.crt --key $PWD/user.key \
           https://172.16.255.250:4523/v1/configuration/containers
 
 You can read more about how Flocker's authentication layer works in the :ref:`security and authentication guide <security>`.

--- a/docs/reference/authentication.rst
+++ b/docs/reference/authentication.rst
@@ -36,8 +36,11 @@ You should securely provide a copy of these files to the API end user, as well a
 Using an API certificate to authenticate
 ========================================
 
-Once in possession of an API user certificate and the cluster certificate, an end user must authenticate with those certificates in every request to the cluster REST API - the cluster certificate ensures the user is connecting to the genuine API of their cluster, while the client certificate allows the API server to ensure the request is from a genuine, authorised user.
-An example of performing this authentication with ``cURL`` is given below, where ``172.16.255.250`` represents the IP address of the control service.
+Once in possession of an API user certificate and the cluster certificate an end user must authenticate with those certificates in every request to the cluster REST API.
+The cluster certificate ensures the user is connecting to the genuine API of their cluster.
+The client certificate allows the API server to ensure the request is from a genuine, authorised user.
+An example of performing this authentication with ``cURL`` is given below.
+In this example, ``172.16.255.250`` represents the IP address of the control service.
 The following is an example of an authenticated request to create a new container on a cluster.
 
 .. code-block:: console

--- a/docs/reference/authentication.rst
+++ b/docs/reference/authentication.rst
@@ -44,5 +44,5 @@ The following is an example of an authenticated request to create a new containe
 
    $ curl --cacert $PWD/cluster.crt --cert $PWD/user.crt --key $PWD/user.key \
           https://172.16.255.250:4523/v1/configuration/containers
-   
+
 You can read more about how Flocker's authentication layer works in the :ref:`security and authentication guide <security>`.

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -410,6 +410,8 @@ The Flocker CLI package includes the ``flocker-ca`` tool that is used to generat
 
 You should now have :file:`cluster.crt`, :file:`node.crt`, and :file:`node.key` on each of your agent nodes, and :file:`cluster.crt`, :file:`control-service.crt`, and :file:`control-service.key` on your control node.
 
+Before you can use Flocker's API you will also need to `generate a client certificate <generate-api>`_.
+
 You can read more about how Flocker's authentication layer works in the :ref:`security and authentication guide <security>`.
 
 .. _post-installation-configuration:

--- a/flocker/docs/bootstrap/__init__.py
+++ b/flocker/docs/bootstrap/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
 """
-Sphinx extensions exposing bootstrap constructs.
+Sphinx extensions exposing Bootstrap.js constructs.
 """
 
 from ._extension import setup, HTMLWriter


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1979

The tabs appear to **not** render correctly in the branch as-is.  If someone knows how to fix that, I'd love to know (or just check it into the branch).  If not, then I guess we'll drop the tabs and just have one section after the other.

I also added a link to this section of the docs from the other section about certificates since the other section leaves the user hanging.

I also didn't add any instructions about the pkcs12 export password.  Possibly I should have?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1567)
<!-- Reviewable:end -->
