### PR TITLE
[FLOC-2243] Remove Alpha and replace with Experimental

### DIFF
--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -559,8 +559,8 @@ AWS must be able to attach volumes created in that availability zone to your Flo
 
 .. _zfs-dataset-backend:
 
-ZFS Peer-to-Peer Backend Configuration (ALPHA)
-..............................................
+ZFS Peer-to-Peer Backend Configuration (Experimental)
+.....................................................
 
 The ZFS backend uses node-local storage and ZFS filesystems as the storage for datasets.
 The ZFS backend remains under development,


### PR DESCRIPTION
Only one occurrence in the docs on master (installation doc). This is changed.

Definition of Stable and Experimental will be covered on FLOC 2045