### PR TITLE
[FLOC-2244] Require zone when configuring AWS acceptance instances.

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -739,6 +739,7 @@ class RunOptions(Options):
 
                aws:
                  region: <aws region, e.g. "us-west-2">
+                 zone: <aws zone, e.g. "us-west-2a">
                  access_key: <aws access key>
                  secret_access_token: <aws secret access token>
                  keyname: <ssh-key-name>

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -178,6 +178,7 @@ To run the acceptance tests on AWS, you need:
 
    aws:
      region: <aws region, e.g. "us-west-2">
+     zone: <aws zone, e.g. "us-west-2a">
      access_key: <aws access key>
      secret_access_token: <aws secret access token>
      keyname: <ssh-key-name>
@@ -190,6 +191,8 @@ AWS can use these dataset backends:
   * :ref:`AWS<aws-dataset-backend>`.
   * :ref:`ZFS<zfs-dataset-backend>`.
   * :ref:`Loopback<loopback-dataset-backend>`.
+
+If you're using the AWS dataset backend make sure the regions and zones are the same both here and there!
 
 .. prompt:: bash $
 

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -88,13 +88,14 @@ IMAGE_NAMES = {
 
 
 def aws_provisioner(access_key, secret_access_token, keyname,
-                    region, security_groups):
+                    region, zone, security_groups):
     """
     Create a LibCloudProvisioner for provisioning nodes on AWS EC2.
 
     :param bytes access_key: The access_key to connect to AWS with.
     :param bytes secret_access_token: The corresponding secret token.
     :param bytes region: The AWS region in which to launch the instance.
+    :param bytes zone: The AWS zone in which to launch the instance.
     :param bytes keyname: The name of an existing ssh public key configured in
        AWS. The provision step assumes the corresponding private key is
        available from an agent.
@@ -109,8 +110,12 @@ def aws_provisioner(access_key, secret_access_token, keyname,
         secret=secret_access_token,
         region=region)
 
+    location = [loc for loc in driver.list_locations()
+                if loc.availability_zone.name == zone][0]
+
     def create_arguments(disk_size):
         return {
+            "location": location,
             "ex_securitygroup": security_groups,
             "ex_blockdevicemappings": [
                 {"DeviceName": "/dev/sda1",


### PR DESCRIPTION
This has a corresponding config change to Buildbot (already in), so Buildbot will need to be restarted before the AWS acceptance tests will pass. Until this is merged *other* branches will fail to run AWS acceptance tests altogether, but its' not like they were passing before...

I do have a locally passing AWS acceptance test run, though, using this branch.