### PR TITLE
[FLOC-1884] Fix conch tests 

### DIFF
--- a/admin/test/test_runner.py
+++ b/admin/test/test_runner.py
@@ -47,7 +47,7 @@ class RunTests(TestCase):
              CommandProtocol])
 
     @capture_logging(
-        assertHasMessage, RUN_OUTPUT_MESSAGE, {'line': 'hello'})
+        assertHasMessage, RUN_OUTPUT_MESSAGE, {'line': 'hello:test_runner.py'})
     def test_writes_output(self, logger):
         """
         Output of the spawned process is written to standard output.
@@ -55,7 +55,7 @@ class RunTests(TestCase):
         reactor = ProcessCoreReactor()
         run(reactor, ['command', 'and', 'args'])
         [process] = reactor.processes
-        process.processProtocol.childDataReceived(1, "hello\n")
+        process.processProtocol.childDataReceived(1, "hello:test_runner.py\n")
 
     def test_registers_killer(self):
         """

--- a/flocker/provision/test/test_ssh_conch.py
+++ b/flocker/provision/test/test_ssh_conch.py
@@ -76,7 +76,8 @@ class Tests(TestCase):
         return d
 
     @capture_logging(
-        assertHasMessage, RUN_OUTPUT_MESSAGE, {'line': 'hello'})
+        assertHasMessage, RUN_OUTPUT_MESSAGE,
+        {'line': 'test_ssh_conch:test_run_logs_stdout'})
     def test_run_logs_stdout(self, logger):
         """
         The ``Run`` intent logs the standard output of the specified command.
@@ -85,7 +86,7 @@ class Tests(TestCase):
             username="root",
             address=str(self.server.ip),
             port=self.server.port,
-            commands=run("echo hello 1>&2"),
+            commands=run("echo test_ssh_conch:test_run_logs_stdout 1>&2"),
         )
 
         d = perform(
@@ -95,7 +96,8 @@ class Tests(TestCase):
         return d
 
     @capture_logging(
-        assertHasMessage, RUN_OUTPUT_MESSAGE, {'line': 'hello'})
+        assertHasMessage, RUN_OUTPUT_MESSAGE,
+        {'line': 'test_ssh_conch:test_run_logs_stderr'})
     def test_run_logs_stderr(self, logger):
         """
         The ``Run`` intent logs the standard output of the specified command.
@@ -104,7 +106,7 @@ class Tests(TestCase):
             username="root",
             address=str(self.server.ip),
             port=self.server.port,
-            commands=run("echo hello 1>&2"),
+            commands=run("echo test_ssh_conch:test_run_logs_stderr 1>&2"),
         )
 
         d = perform(

--- a/flocker/testtools/ssh.py
+++ b/flocker/testtools/ssh.py
@@ -13,14 +13,19 @@ from zope.interface import implementer
 
 from ipaddr import IPAddress
 
+from twisted.python.components import registerAdapter
 from twisted.internet import reactor
 from twisted.cred.portal import IRealm, Portal
 
 try:
     from twisted.conch.ssh.keys import Key
     from twisted.conch.checkers import SSHPublicKeyDatabase
+    from twisted.conch.interfaces import ISession
     from twisted.conch.openssh_compat.factory import OpenSSHFactory
-    from twisted.conch.unix import UnixConchUser
+    from twisted.conch.unix import (
+        SSHSessionForUnixConchUser,
+        UnixConchUser,
+    )
     _have_conch = True
 except ImportError:
     SSHPublicKeyDatabase = UnixConchUser = object
@@ -79,6 +84,23 @@ class _FixedHomeConchUser(UnixConchUser):
         switch IDs (which it can't do if it is not running as root).
         """
         return None, None
+
+
+@implementer(ISession)
+class _EnvironmentSSHSessionForUnixConchUser(SSHSessionForUnixConchUser):
+    """
+    SSH Session that correctly sets HOMe.
+
+    Work-around for https://twistedmatrix.com/trac/ticket/7936.
+    """
+
+    def execCommand(self, proto, cmd):
+        self.environ['HOME'] = self.avatar.getHomeDir()
+        return SSHSessionForUnixConchUser.execCommand(self, proto, cmd)
+
+
+registerAdapter(
+    _EnvironmentSSHSessionForUnixConchUser, _FixedHomeConchUser, ISession)
 
 
 @implementer(IRealm)

--- a/flocker/testtools/ssh.py
+++ b/flocker/testtools/ssh.py
@@ -89,7 +89,7 @@ class _FixedHomeConchUser(UnixConchUser):
 @implementer(ISession)
 class _EnvironmentSSHSessionForUnixConchUser(SSHSessionForUnixConchUser):
     """
-    SSH Session that correctly sets HOMe.
+    SSH Session that correctly sets HOME.
 
     Work-around for https://twistedmatrix.com/trac/ticket/7936.
     """


### PR DESCRIPTION
In lieu of actually fixing [the actual bug in conch](https://twistedmatrix.com/trac/ticket/7936), this changes the `ISession` implementation that we use so that it sets `HOME` to the avatar's configured home directory.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1580)
<!-- Reviewable:end -->
