### PR TITLE
[FLOC-2289] Don't use world-writeable permissions if dataset has been modified with files

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -465,21 +465,24 @@ class MountBlockDevice(PRecord):
         # This should be asynchronous.  FLOC-1797
         check_output([b"mount", device.path, self.mountpoint.path])
 
-        # Mounted filesystem is world writeable/readable/executable since
-        # we can't predict what user a container will run as.  Make sure
-        # we change mounted filesystem's root directory permissions, so we
-        # only do this after the filesystem is mounted.
-        self.mountpoint.chmod(S_IRWXU | S_IRWXG | S_IRWXO)
-        self.mountpoint.restat()
-
         # Remove lost+found to ensure filesystems always start out empty.
-        # If other files exist we don't bother, since at that point user
-        # has modified the volume and we don't want to delete their data
-        # by mistake. A better way is described in
+        # Mounted filesystem is also made world
+        # writeable/readable/executable since we can't predict what user a
+        # container will run as.  We make sure we change mounted
+        # filesystem's root directory permissions, so we only do this
+        # after the filesystem is mounted.  If other files exist we don't
+        # bother with either change, since at that point user has modified
+        # the volume and we don't want to undo their changes by mistake
+        # (e.g. postgres doesn't like world-writeable directories once
+        # it's initialized).
+
+        # A better way is described in
         # https://clusterhq.atlassian.net/browse/FLOC-2074
         lostfound = self.mountpoint.child(b"lost+found")
         if self.mountpoint.children() == [lostfound]:
             lostfound.remove()
+            self.mountpoint.chmod(S_IRWXU | S_IRWXG | S_IRWXO)
+            self.mountpoint.restat()
 
         return succeed(None)
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 from subprocess import (
     STDOUT, PIPE, Popen, check_output, check_call, CalledProcessError,
 )
+from stat import S_IRWXU
 
 from bitmath import Byte, MB, MiB, GB, GiB
 
@@ -2798,6 +2799,24 @@ class MountBlockDeviceTests(
         self.assertItemsEqual(mountpoint.children(),
                               [mountpoint.child(b"file"),
                                mountpoint.child(b"lost+found")])
+
+    def test_world_permissions_not_reset_if_other_files_exist(self):
+        """
+        If files exist in the filesystem, permissions are not reset when the
+        filesystem is remounted.
+        """
+        mountpoint = mountroot_for_test(self).child(b"mount-test")
+        scenario = self._run_success_test(mountpoint)
+        mountpoint.child(b"file").setContent(b"stuff")
+        check_call([b"umount", mountpoint.path])
+        mountpoint.chmod(S_IRWXU)
+        mountpoint.restat()
+        self.successResultOf(run_state_change(
+            MountBlockDevice(dataset_id=scenario.dataset_id,
+                             mountpoint=scenario.mountpoint),
+            scenario.deployer))
+        self.assertEqual(mountpoint.getPermissions().shorthand(),
+                         'rwx------')
 
 
 class UnmountBlockDeviceInitTests(


### PR DESCRIPTION
Builds on #1605.

In theory this should fix postgres acceptance tests on AWS.