### PR TITLE
[FLOC-2330] Release maintenance/flocker 1.0.0pre1/ - in_parallel error handling

### DIFF
--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -18,7 +18,7 @@ from zope.interface import Interface, Attribute, implementer
 
 from pyrsistent import PVector, PRecord, pvector, field
 
-from twisted.internet.defer import succeed
+from twisted.internet.defer import maybeDeferred, succeed
 
 from eliot.twisted import DeferredContext
 
@@ -85,7 +85,7 @@ def run_state_change(change, deployer):
         return d
 
     with change.eliot_action.context():
-        context = DeferredContext(change.run(deployer))
+        context = DeferredContext(maybeDeferred(change.run, deployer))
         context.addActionFinish()
         return context.result
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2330 (sub-task of https://clusterhq.atlassian.net/browse/FLOC-2327) in the 1.0.0 release branch (which will become 1.0.1).

