### PR TITLE
[FLOC-2331] in_parallel error handling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-Flocker 1.0.0pre1 (2015-06-12)
-==============================
+Flocker 1.0.0 (2015-06-15)
+==========================
 
 - It is now necessary to specify a dataset backend for each agent node. (FLOC-1420)
 - Flocker-initiated communication is secured with TLS. (FLOC-1441)

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -18,7 +18,7 @@ from zope.interface import Interface, Attribute, implementer
 
 from pyrsistent import PVector, PRecord, pvector, field
 
-from twisted.internet.defer import succeed
+from twisted.internet.defer import maybeDeferred, succeed
 
 from eliot.twisted import DeferredContext
 
@@ -85,7 +85,7 @@ def run_state_change(change, deployer):
         return d
 
     with change.eliot_action.context():
-        context = DeferredContext(change.run(deployer))
+        context = DeferredContext(maybeDeferred(change.run, deployer))
         context.addActionFinish()
         return context.result
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2331 (sub-task of https://clusterhq.atlassian.net/browse/FLOC-2327) in the master.  Forward-port of #1637.

Has an extra change from the 1.0.0 release since that branch hasn't been merged yet.  Don't merge this until #1634 is merged.