### PR TITLE
[FLOC-2256] Removed / changed broken links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ We're looking forward to working on this project with you.
 Documentation
 -------------
 
-You can read more about `installing Flocker`_, follow a `tutorial`_ and learn about the `features of Flocker and its architecture`_ or `areas for potential future development`_ in the docs.
+You can read more about `installing Flocker`_, follow a `tutorial`_ and learn about the `features of Flocker and its architecture`_ in the docs.
 
 
 Tests
@@ -44,10 +44,9 @@ Flocker is also tested using `continuous integration`_.
 
 .. _ClusterHQ: https://clusterhq.com/
 .. _Twisted: https://twistedmatrix.com
-.. _installing Flocker: https://docs.clusterhq.com/en/latest/indepth/installation.html
+.. _installing Flocker: https://docs.clusterhq.com/en/latest/using/installing/index.html
 .. _tutorial: https://docs.clusterhq.com/en/latest/gettingstarted/index.html
-.. _features of Flocker and its architecture: https://docs.clusterhq.com/en/latest/introduction.html
-.. _areas for potential future development: https://docs.clusterhq.com/en/latest/roadmap/
+.. _features of Flocker and its architecture: https://docs.clusterhq.com/en/latest/introduction/index.html
 .. _unittest: https://docs.python.org/2/library/unittest.html
 .. _Twisted Trial: https://twistedmatrix.com/trac/wiki/TwistedTrial
 .. _tox: https://tox.readthedocs.org/


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2256

Done by testing the Flocker links, changing those which have moved, removing one which has gone from the docs it seems.