### PR TITLE
Cannot make filesystem on device that has one

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -421,7 +421,11 @@ class CreateFilesystem(PRecord):
 
 def _ensure_no_filesystem(device):
     """
-    Raises an error if there's already a filesystem on 'device'.
+    Raises an error if there's already a filesystem on ``device``.
+
+    :raises: ``FilesystemExists`` if there is already a filesystem on
+        ``device``.
+    :return: ``None``
     """
     try:
         check_output(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -424,7 +424,7 @@ def _ensure_no_filesystem(device):
     Raises an error if there's already a filesystem on 'device'.
     """
     try:
-        output = check_output(
+        check_output(
             [b"blkid", b"-p", b"-u", b"filesystem", device.path],
             stderr=STDOUT,
         )

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -8,7 +8,7 @@ devices.
 """
 
 from uuid import UUID, uuid4
-from subprocess import check_output
+from subprocess import CalledProcessError, check_output, STDOUT
 from stat import S_IRWXU, S_IRWXG, S_IRWXO
 from errno import EEXIST
 
@@ -103,6 +103,16 @@ class DatasetExists(Exception):
     def __init__(self, blockdevice):
         Exception.__init__(self, blockdevice)
         self.blockdevice = blockdevice
+
+
+class FilesystemExists(Exception):
+    """
+    A failed attempt to create a filesystem on a block device that already has
+    one.
+    """
+    def __init__(self, device):
+        Exception.__init__(self, device)
+        self.device = device
 
 
 DATASET = Field(
@@ -394,6 +404,7 @@ class CreateFilesystem(PRecord):
             self.volume.blockdevice_id
         )
         try:
+            _ensure_no_filesystem(device)
             check_output([
                 b"mkfs", b"-t", self.filesystem.encode("ascii"),
                 # This is ext4 specific, and ensures mke2fs doesn't ask
@@ -406,6 +417,30 @@ class CreateFilesystem(PRecord):
         except:
             return fail()
         return succeed(None)
+
+
+def _ensure_no_filesystem(device):
+    """
+    Raises an error if there's already a filesystem on 'device'.
+    """
+    try:
+        output = check_output(
+            [b"blkid", b"-p", b"-u", b"filesystem", device.path],
+            stderr=STDOUT,
+        )
+    except CalledProcessError as e:
+        # According to the man page:
+        #   the specified token was not found, or no (specified) devices
+        #   could be identified
+        #
+        # Experimentation shows that there is no output in the case of the
+        # former, and an error printed to stderr in the case of the
+        # latter.
+        if e.returncode == 2 and not e.output:
+            # There is no filesystem on this device.
+            return
+        raise
+    raise FilesystemExists(device)
 
 
 def _valid_size(size):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -440,6 +440,9 @@ def _ensure_no_filesystem(device):
         # Experimentation shows that there is no output in the case of the
         # former, and an error printed to stderr in the case of the
         # latter.
+        #
+        # FLOC-2388: We're assuming an interface. We should test this
+        # assumption.
         if e.returncode == 2 and not e.output:
             # There is no filesystem on this device.
             return

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -58,6 +58,7 @@ from ..blockdevice import (
     get_blockdevice_volume,
     _backing_file_name,
     ProcessLifetimeCache,
+    FilesystemExists,
 )
 
 from ... import run_state_change, in_parallel
@@ -2701,7 +2702,7 @@ class MountBlockDeviceTests(
         afile = mountpoint.child(b"file")
         afile.setContent(b"data")
         # Try recreating mounted filesystem; this should fail.
-        self.failureResultOf(scenario.create(), CalledProcessError)
+        self.failureResultOf(scenario.create(), FilesystemExists)
         # Unmounting and remounting, but our data still exists:
         check_output([b"umount", mountpoint.path])
         self.successResultOf(run_state_change(
@@ -2709,6 +2710,24 @@ class MountBlockDeviceTests(
                              mountpoint=mountpoint),
             scenario.deployer))
         self.assertEqual(afile.getContent(), b"data")
+
+    def test_create_fails_on_existing_filesystem(self):
+        """
+        Running ``CreateFilesystem`` on a block device that already has a file
+        system fails with an exception and preserves the data.
+
+        This is because mkfs is a destructive operation that will destroy any
+        existing filesystem on that block device.
+        """
+        mountroot = mountroot_for_test(self)
+        mountpoint = mountroot.child(b"mount-test")
+        scenario = self._run_success_test(mountpoint)
+        afile = mountpoint.child(b"file")
+        afile.setContent(b"data")
+        # Unmount the filesystem
+        run_process([b"umount", mountpoint.path])
+        # Try recreating filesystem; this should fail.
+        self.failureResultOf(scenario.create(), FilesystemExists)
 
     def test_mountpoint_exists(self):
         """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -9,9 +9,7 @@ from functools import partial
 from os import getuid
 import time
 from uuid import UUID, uuid4
-from subprocess import (
-    STDOUT, PIPE, Popen, check_output, check_call, CalledProcessError,
-)
+from subprocess import STDOUT, PIPE, Popen, check_output, check_call
 
 from bitmath import Byte, MB, MiB, GB, GiB
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2727,6 +2727,12 @@ class MountBlockDeviceTests(
         run_process([b"umount", mountpoint.path])
         # Try recreating filesystem; this should fail.
         self.failureResultOf(scenario.create(), FilesystemExists)
+        # Remounting should succeed.
+        self.successResultOf(run_state_change(
+            MountBlockDevice(dataset_id=scenario.dataset_id,
+                             mountpoint=mountpoint),
+            scenario.deployer))
+        self.assertEqual(afile.getContent(), b"data")
 
     def test_mountpoint_exists(self):
         """


### PR DESCRIPTION
`mkfs` will blindly run and make a filesystem on a device that already
has one, and it won't even tell you about it.

Look before we leap by running `blkid` to see what's there.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1650)
<!-- Reviewable:end -->
