### PR TITLE
[FLOC 2087] Example: Using the API with Python

### DIFF
--- a/docs/using/examples/api-example-python.rst
+++ b/docs/using/examples/api-example-python.rst
@@ -1,0 +1,27 @@
+=========================
+Using the API with Python
+=========================
+
+.. note:: You will need to have a running Flocker cluster set up, and at least `Python 2.7.9`_ to run this example.
+
+#. Download the :file:`example.py` file:
+
+   :download:`example.py`
+
+   .. literalinclude:: example.py
+
+#. Before you run the example, you will need to change the following values (either by editing the source file or by setting environment variables):
+
+   * **CONTROL_SERVICE** - the IP address of the Flocker control service
+   * **CONTROL_PORT** - the port the control service is listening on
+   * **KEY_FILE** - the API key file to use
+   * **CERT_FILE** - the API certificate file to use
+   * **CA_FILE** - the certificate authority file to use
+
+#. Now you can run the example:
+
+   .. prompt:: bash
+
+      python example.py
+
+.. _`Python 2.7.9`: https://www.python.org/downloads/

--- a/docs/using/examples/api-examples.rst
+++ b/docs/using/examples/api-examples.rst
@@ -1,0 +1,14 @@
+:tocdepth: 2
+
+====================
+Flocker API Examples
+====================
+
+You can find below an example of using the :ref:`Flocker REST API<api>` with Python.
+
+Examples of using the Flocker API with languages such as `cURL`, `Go`, and `Ruby` will be available soon.
+
+.. toctree::
+   :maxdepth: 2
+
+   api-example-python

--- a/docs/using/examples/example.py
+++ b/docs/using/examples/example.py
@@ -1,0 +1,60 @@
+import httplib
+import os
+import ssl
+import tempfile
+
+# NOTE - to run this example, you need at least python 2.7.9
+
+# Define the control IP, port, and the certificates for authentication.
+
+CONTROL_SERVICE = os.environ.get(
+    "CONTROL_SERVICE", "54.157.8.57")
+CONTROL_PORT = os.environ.get(
+    "CONTROL_PORT", 4523)
+KEY_FILE = os.environ.get(
+    "KEY_FILE", "/Users/kai/projects/flocker-api-examples/flockerdemo.key")
+CERT_FILE = os.environ.get(
+    "CERT_FILE", "/Users/kai/projects/flocker-api-examples/flockerdemo.crt")
+CA_FILE = os.environ.get(
+    "CA_FILE", "/Users/kai/projects/flocker-api-examples/cluster.crt")
+
+# Create a certificate chain and then pass that into the SSL system.
+
+certtemp = tempfile.NamedTemporaryFile()
+TEMP_CERT_CA_FILE = certtemp.name
+os.chmod(TEMP_CERT_CA_FILE, 0600)
+certtemp.write(open(CERT_FILE).read())
+certtemp.write("\n")
+certtemp.write(open(CA_FILE).read())
+certtemp.seek(0)
+ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+ctx.load_cert_chain(TEMP_CERT_CA_FILE, KEY_FILE)
+
+# Finally, create a HTTP connection.
+
+c = httplib.HTTPSConnection(CONTROL_SERVICE, CONTROL_PORT, context=ctx)
+
+def make_api_request(method, endpoint, data=None):
+    if method in ("GET", "DELETE"):
+        c.request(method, endpoint)
+    elif method == "POST":
+        c.request("POST", endpoint, data, 
+            headers={"Content-type": "application/json"})
+    else:
+        raise Exception("Unknown method %s" % (method,))
+
+    r = c.getresponse()
+    body = r.read()
+    status = r.status
+
+    print body
+
+# Make the first request to check the service is working.
+
+make_api_request("GET", "/v1/version")
+
+# Create a volume.
+
+make_api_request("POST", "/v1/configuration/datasets",
+    data= r'{"primary": "%s", "maximum_size": 107374182400, "metadata": {"name": "example_dataset"}}'
+        % ("5540d6e3-392b-4da0-828a-34b724c5bb80",))

--- a/docs/using/index.rst
+++ b/docs/using/index.rst
@@ -24,3 +24,4 @@ This Getting Started guide will walk you step-by-step through installing Flocker
    tutorial/index
    examples/apps
    examples/features
+   examples/api-examples


### PR DESCRIPTION
These examples (this being the first of 3 currently under development) are currently tested manually in the following repo: https://github.com/ClusterHQ/flocker-api-examples

The README.md file details the process of testing, and the results of the tests can be viewed in the "_output" folder.

The process at the moment is that I run the test manually before copying the example files into the Flocker repo. We have an issue to bring these tests into the automated Buildbot tests post v1. See FLOC 2395.

When designing this example, @itamarst recommended that a good way to do this was using requests libraries. Having discussed this with @binocarlos, we decided the example "as-is" is affective, but we opened an issue to create an improved example using libraries post v1.0. See FLOC 2377.