### PR TITLE
[FLOC-2372] Remember discovered device path in EBSBlockDeviceAPI instead of relying on EBS volume metadata

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -8,7 +8,7 @@ devices.
 """
 
 from uuid import UUID, uuid4
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 from stat import S_IRWXU, S_IRWXG, S_IRWXO
 from errno import EEXIST
 
@@ -396,6 +396,7 @@ class CreateFilesystem(PRecord):
         try:
             check_output([
                 b"mkfs", b"-t", self.filesystem.encode("ascii"),
+                b"-U", bytes(self.volume.dataset_id),
                 # This is ext4 specific, and ensures mke2fs doesn't ask
                 # user interactively about whether they really meant to
                 # format whole device rather than partition. It will be
@@ -1780,3 +1781,22 @@ class ProcessLifetimeCache(proxyForInterface(IBlockDeviceAPI, "_api")):
         except KeyError:
             pass
         return self._api.detach_volume(blockdevice_id)
+
+
+def get_device_for_dataset_id(dataset_id):
+    """
+    Lookup the path of the device for an attached dataset on this machine.
+
+    :param UUID dataset_id: The dataset we're looking up.
+
+    :return: ``FilePath`` of device where the dataset is attached.
+    """
+    try:
+        result = check_output([b"blkid", b"-U", bytes(dataset_id)])
+    except CalledProcessError as e:
+        if e.returncode == 2:
+            raise KeyError(dataset_id)
+        else:
+            # This code path is untested, unfortunately.
+            raise
+    return FilePath(result.strip())

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -569,15 +569,6 @@ class EBSBlockDeviceAPI(object):
                     break
                 # end lock scope
 
-        # Stamp EBS volume with attached device name tag.
-        # If OS fails to see new block device in 60 seconds,
-        # `new_device` is `None`, indicating the volume failed
-        # to attach to the compute instance.
-        metadata = {
-            ATTACHED_DEVICE_LABEL: unicode(new_device),
-        }
-        if new_device is not None:
-            self.connection.create_tags([ebs_volume.id], metadata)
         _wait_for_volume(ebs_volume,
                          start_status=u'available',
                          transient_status=u'attaching',
@@ -613,10 +604,7 @@ class EBSBlockDeviceAPI(object):
                          transient_status=u'detaching',
                          end_status=u'available')
 
-        # XXX Clear _device_paths here?
-
-        # Delete attached device metadata from EBS Volume
-        self.connection.delete_tags([ebs_volume.id], [ATTACHED_DEVICE_LABEL])
+        self._device_paths = self._device_paths.discard(blockdevice_id)
 
     def destroy_volume(self, blockdevice_id):
         """

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -663,7 +663,7 @@ class EBSBlockDeviceAPI(object):
             # Maybe we screwed up.  Do a sanity check instead of just claiming
             # the caller screwed up?
             #
-            # ebs_volume = self._get_ebs_volume(blockdevice_id)
+            ebs_volume = self._get_ebs_volume(blockdevice_id)
             # volume = _blockdevicevolume_from_ebs_volume(ebs_volume)
             # if volume.attached_to is None:
             #     raise UnattachedVolume(blockdevice_id)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -584,7 +584,7 @@ class EBSBlockDeviceAPI(object):
                          end_status=u'in-use')
 
         attached_volume = volume.set('attached_to', attach_to)
-        self._device_paths = self._devices_path.set(
+        self._device_paths = self._device_paths.set(
             blockdevice_id, FilePath(new_device)
         )
         return attached_volume

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -13,7 +13,7 @@ from uuid import UUID
 
 from bitmath import Byte, GiB
 
-from pyrsistent import PRecord, field, pset
+from pyrsistent import PRecord, field, pset, pmap
 from zope.interface import implementer
 from boto import ec2
 from boto import config
@@ -366,8 +366,12 @@ def _is_cluster_volume(cluster_id, ebs_volume):
 @implementer(IBlockDeviceAPI)
 class EBSBlockDeviceAPI(object):
     """
-    An EBS implementation of ``IBlockDeviceAPI`` which creates
-    block devices in an EC2 cluster using Boto APIs.
+    An EBS implementation of ``IBlockDeviceAPI`` which creates block devices in
+    an EC2 cluster using Boto APIs.
+
+    :ivar pmap _device_paths: A mapping with keys of ``blockdevice_id``\ s of
+        volumes attached to this node and values of ``FilePath`` instances
+        giving the OS device path where those volumes are accessible.
     """
     def __init__(self, ec2_client, cluster_id):
         """
@@ -381,6 +385,7 @@ class EBSBlockDeviceAPI(object):
         self.zone = ec2_client.zone
         self.cluster_id = cluster_id
         self.lock = threading.Lock()
+        self._device_paths = pmap()
 
     def allocation_unit(self):
         """
@@ -579,6 +584,7 @@ class EBSBlockDeviceAPI(object):
                          end_status=u'in-use')
 
         attached_volume = volume.set('attached_to', attach_to)
+        self._device_paths[blockdevice_id] = FilePath(new_device)
         return attached_volume
 
     def detach_volume(self, blockdevice_id):
@@ -604,6 +610,8 @@ class EBSBlockDeviceAPI(object):
                          start_status=u'in-use',
                          transient_status=u'detaching',
                          end_status=u'available')
+
+        # XXX Clear _device_paths here?
 
         # Delete attached device metadata from EBS Volume
         self.connection.delete_tags([ebs_volume.id], [ATTACHED_DEVICE_LABEL])
@@ -647,18 +655,17 @@ class EBSBlockDeviceAPI(object):
         :raises UnattachedVolume: If the supplied ``blockdevice_id`` is
             not attached to a host.
         """
-        ebs_volume = self._get_ebs_volume(blockdevice_id)
-        volume = _blockdevicevolume_from_ebs_volume(ebs_volume)
-        if volume.attached_to is None:
-            raise UnattachedVolume(blockdevice_id)
-
         try:
-            device = ebs_volume.tags[ATTACHED_DEVICE_LABEL]
+            return self._device_paths[blockdevice_id]
         except KeyError:
+            # Maybe we screwed up.  Do a sanity check instead of just claiming
+            # the caller screwed up?
+            #
+            # ebs_volume = self._get_ebs_volume(blockdevice_id)
+            # volume = _blockdevicevolume_from_ebs_volume(ebs_volume)
+            # if volume.attached_to is None:
+            #     raise UnattachedVolume(blockdevice_id)
             raise UnattachedVolume(blockdevice_id)
-        if device is None:
-            raise UnattachedVolume(blockdevice_id)
-        return FilePath(device)
 
 
 def aws_from_configuration(region, zone, access_key_id, secret_access_key,

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -584,7 +584,9 @@ class EBSBlockDeviceAPI(object):
                          end_status=u'in-use')
 
         attached_volume = volume.set('attached_to', attach_to)
-        self._device_paths[blockdevice_id] = FilePath(new_device)
+        self._device_paths = self._devices_path.set(
+            blockdevice_id, FilePath(new_device)
+        )
         return attached_volume
 
     def detach_volume(self, blockdevice_id):

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -89,27 +89,6 @@ class EBSBlockDeviceAPIInterfaceTests(
         )
         self.assert_foreign_volume(flocker_volume)
 
-    def test_attached_volume_missing_device_tag(self):
-        """
-        Test that missing ATTACHED_DEVICE_LABEL on an EBS
-        volume causes `UnattacheVolume` while attempting
-        `get_device_path()`.
-        """
-        volume = self.api.create_volume(
-            dataset_id=uuid4(),
-            size=self.minimum_allocatable_size,
-        )
-        self.api.attach_volume(
-            volume.blockdevice_id,
-            attach_to=self.this_node,
-        )
-
-        self.api.connection.delete_tags([volume.blockdevice_id],
-                                        [ATTACHED_DEVICE_LABEL])
-
-        self.assertRaises(UnattachedVolume, self.api.get_device_path,
-                          volume.blockdevice_id)
-
     @capture_logging(lambda self, logger: None)
     def test_boto_ec2response_error(self, logger):
         """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1723,6 +1723,28 @@ class IBlockDeviceAPITestsMixin(object):
         )
         self.assertEqual(new_volume.blockdevice_id, exception.blockdevice_id)
 
+    def test_get_device_path_detached_volume(self):
+        """
+        ``get_device_path`` raises ``UnattachedVolume`` if the supplied
+        ``blockdevice_id`` corresponds to a volume that was attached to the
+        node but has been detached from it.
+        """
+        volume = self.api.create_volume(
+            dataset_id=uuid4(),
+            size=self.minimum_allocatable_size
+        )
+        self.api.attach_volume(
+            volume.blockdevice_id,
+            attach_to=self.this_node,
+        )
+        self.api.detach_volume(volume.blockdevice_id)
+        exception = self.assertRaises(
+            UnattachedVolume,
+            self.api.get_device_path,
+            volume.blockdevice_id,
+        )
+        self.assertEqual(volume.blockdevice_id, exception.blockdevice_id)
+
     def test_get_device_path_device(self):
         """
         ``get_device_path`` returns a ``FilePath`` to the device representing


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2372 for the 1.0.0 release branch.

Stacked on https://github.com/ClusterHQ/flocker/pull/1653 so review that first.
