### PR TITLE
[FLOC-2400] Remove useless return of `Cluster` from `Cluster` methods

### DIFF
--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -72,8 +72,8 @@ class ContainerAPITests(TestCase):
         """
         Create a container listening on port 8080.
 
-        :return: ``Deferred`` firing with a tuple of ``Cluster`` instance
-        and container dictionary once the container is up and running.
+        :return: ``Deferred`` firing with a container dictionary once the
+            container is up and running.
         """
         data = {
             u"name": random_name(self),

--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -85,8 +85,7 @@ class ContainerAPITests(TestCase):
 
         d = cluster.create_container(data)
 
-        def check_result(result):
-            cluster, response = result
+        def check_result(response):
             self.addCleanup(cluster.remove_container, data[u"name"])
 
             self.assertEqual(response, data)
@@ -121,7 +120,7 @@ class ContainerAPITests(TestCase):
         data[u"node_uuid"] = cluster.nodes[0].uuid
         d = cluster.create_container(data)
 
-        def check_result((cluster, response)):
+        def check_result(response):
             self.addCleanup(cluster.remove_container, data[u"name"])
             self.assertEqual(response, data)
             return cluster

--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -164,8 +164,7 @@ class ContainerAPITests(TestCase):
         """
         creating_dataset = create_dataset(self, cluster)
 
-        def created_dataset(result):
-            cluster, dataset = result
+        def created_dataset(dataset):
             mongodb = {
                 u"name": random_name(self),
                 u"node_uuid": cluster.nodes[0].uuid,
@@ -239,8 +238,7 @@ class ContainerAPITests(TestCase):
         """
         creating_dataset = create_dataset(self, cluster)
 
-        def created_dataset(result):
-            cluster, dataset = result
+        def created_dataset(dataset):
             mongodb = {
                 u"name": random_name(self),
                 u"node_uuid": cluster.nodes[0].uuid,
@@ -356,8 +354,7 @@ nc -ll -p 8080 -e /data/script.sh
 
         creating_dataset = create_dataset(self, cluster)
 
-        def created_dataset(result):
-            cluster, dataset = result
+        def created_dataset(dataset):
             container[u"volumes"][0][u"dataset_id"] = dataset[u"dataset_id"]
             return cluster.create_container(container)
         creating_dataset.addCallback(created_dataset)
@@ -479,7 +476,7 @@ class DatasetAPITests(TestCase):
         waiting_for_create = create_dataset(self, cluster)
 
         # Once created, request to move the dataset to node2
-        def move_dataset((cluster, dataset)):
+        def move_dataset(dataset):
             moved_dataset = {
                 u'primary': cluster.nodes[1].uuid
             }
@@ -500,8 +497,7 @@ class DatasetAPITests(TestCase):
         """
         created = create_dataset(self, cluster)
 
-        def delete_dataset(result):
-            cluster, dataset = result
+        def delete_dataset(dataset):
             deleted = cluster.delete_dataset(dataset["dataset_id"])
 
             def not_exists():

--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -450,7 +450,7 @@ def create_dataset(test_case, cluster,
 
     # Wait for the dataset to be created
     waiting_for_create = configuring_dataset.addCallback(
-        lambda (cluster, dataset): cluster.wait_for_dataset(dataset)
+        lambda dataset: cluster.wait_for_dataset(dataset)
     )
 
     return waiting_for_create

--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -485,7 +485,7 @@ class DatasetAPITests(TestCase):
 
         # Wait for the dataset to be moved
         waiting_for_move = dataset_moving.addCallback(
-            lambda (cluster, dataset): cluster.wait_for_dataset(dataset)
+            lambda dataset: cluster.wait_for_dataset(dataset)
         )
 
         return waiting_for_move

--- a/flocker/acceptance/test_deployment.py
+++ b/flocker/acceptance/test_deployment.py
@@ -133,8 +133,7 @@ class DeploymentTests(TestCase):
         waiting_for_container_1 = cluster.wait_for_container(
             expected_container_1)
 
-        def got_container_1(result):
-            cluster, actual_container = result
+        def got_container_1(actual_container):
             self.assertTrue(actual_container['running'])
             waiting_for_dataset = cluster.wait_for_dataset(
                 {
@@ -160,8 +159,7 @@ class DeploymentTests(TestCase):
         waiting_for_container_2 = waiting_for_container_1.addCallback(
             got_container_1)
 
-        def got_container_2(result):
-            cluster, actual_container = result
+        def got_container_2(actual_container):
             waiting_for_dataset = cluster.wait_for_dataset(
                 {
                     u"dataset_id": mongo_dataset_id,

--- a/flocker/acceptance/test_deployment.py
+++ b/flocker/acceptance/test_deployment.py
@@ -146,8 +146,7 @@ class DeploymentTests(TestCase):
                 }
             )
 
-            def got_dataset(result):
-                cluster, dataset = result
+            def got_dataset(dataset):
                 self.assertEqual(
                     (dataset[u"dataset_id"], dataset[u"maximum_size"]),
                     (mongo_dataset_id, REALISTIC_BLOCKDEVICE_SIZE)
@@ -173,8 +172,7 @@ class DeploymentTests(TestCase):
                 }
             )
 
-            def got_dataset(result):
-                cluster, dataset = result
+            def got_dataset(dataset):
                 self.assertEqual(
                     (dataset[u"dataset_id"], dataset[u"maximum_size"]),
                     (mongo_dataset_id, REALISTIC_BLOCKDEVICE_SIZE)

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -353,9 +353,8 @@ class Cluster(PRecord):
 
         :param dict dataset_properties: The attributes of the dataset that
             we're waiting for.
-        :returns: A ``Deferred`` which fires with a 2-tuple of ``Cluster`` and
-            API response when a dataset with the supplied properties appears in
-            the cluster.
+        :returns: A ``Deferred`` which fires with an API response when a
+            dataset with the supplied properties appears in the cluster.
         """
         def created():
             """
@@ -380,7 +379,7 @@ class Cluster(PRecord):
             return request
 
         waiting = loop_until(created)
-        waiting.addCallback(lambda ignored: (self, dataset_properties))
+        waiting.addCallback(lambda ignored: dataset_properties)
         return waiting
 
     @log_method

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -477,7 +477,8 @@ class Cluster(PRecord):
         :param unicode name: The name of the container to move.
         :param unicode node_uuid: The UUID to which the container should
             be moved.
-        :returns: A tuple of (cluster, api_response)
+        :returns: A ``Deferred`` which fires with an API response when the
+            container move has been persisted to the cluster configuration.
         """
         request = self.treq.post(
             self.base_url + b"/configuration/containers/" +
@@ -488,7 +489,6 @@ class Cluster(PRecord):
         )
 
         request.addCallback(check_and_decode_json, OK)
-        request.addCallback(lambda response: (self, response))
         return request
 
     @log_method

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -455,7 +455,9 @@ class Cluster(PRecord):
         :param dict properties: A ``dict`` mapping to the API request fields
             to create a container.
 
-        :returns: A tuple of (cluster, api_response)
+        :returns: A ``Deferred`` which fires with an API response when the
+            container with the supplied properties has been persisted to the
+            cluster configuration.
         """
         request = self.treq.post(
             self.base_url + b"/configuration/containers",
@@ -465,7 +467,6 @@ class Cluster(PRecord):
         )
 
         request.addCallback(check_and_decode_json, CREATED)
-        request.addCallback(lambda response: (self, response))
         return request
 
     @log_method

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -433,7 +433,8 @@ class Cluster(PRecord):
 
         :param unicode dataset_id: The uuid of the dataset to be modified.
 
-        :returns: A 2-tuple of (cluster, api_response)
+        :returns: A ``Deferred`` which fires with an API response when the
+            dataset deletion has been persisted to the cluster configuration.
         """
         request = self.treq.delete(
             self.base_url + b"/configuration/datasets/%s" % (
@@ -444,8 +445,6 @@ class Cluster(PRecord):
         )
 
         request.addCallback(check_and_decode_json, OK)
-        # Return cluster and API response
-        request.addCallback(lambda response: (self, response))
         return request
 
     @log_method

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -551,9 +551,8 @@ class Cluster(PRecord):
         :param dict container_properties: The attributes of the container that
             we're waiting for. All the keys, values and those of nested
             dictionaries must match.
-        :returns: A ``Deferred`` which fires with a 2-tuple of ``Cluster`` and
-            API response when a container with the supplied properties appears
-            in the cluster.
+        :returns: A ``Deferred`` which fires with an API response when a
+            container with the supplied properties appears in the cluster.
         """
         def created():
             """
@@ -571,7 +570,7 @@ class Cluster(PRecord):
                         for item in expected_container.items()
                     ]):
                         # Return cluster and container state
-                        return self, container
+                        return container
                 return False
             request.addCallback(got_response)
             return request

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -411,7 +411,8 @@ class Cluster(PRecord):
         :param unicode dataset_id: The uuid of the dataset to be modified.
         :param dict dataset_properties: The properties of the dataset to
             create.
-        :returns: A 2-tuple of (cluster, api_response)
+        :returns: A ``Deferred`` which fires with an API response when the
+            dataset update has been persisted to the cluster configuration.
         """
         request = self.treq.post(
             self.base_url + b"/configuration/datasets/%s" % (
@@ -423,8 +424,6 @@ class Cluster(PRecord):
         )
 
         request.addCallback(check_and_decode_json, OK)
-        # Return cluster and API response
-        request.addCallback(lambda response: (self, response))
         return request
 
     @log_method

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -498,7 +498,8 @@ class Cluster(PRecord):
 
         :param unicode name: The name of the container to remove.
 
-        :returns: A tuple of (cluster, api_response)
+        :returns: A ``Deferred`` which fires with an API response when the
+            container removal has been persisted to the cluster configuration.
         """
         request = self.treq.delete(
             self.base_url + b"/configuration/containers/" +
@@ -507,7 +508,6 @@ class Cluster(PRecord):
         )
 
         request.addCallback(check_and_decode_json, OK)
-        request.addCallback(lambda response: (self, response))
         return request
 
     @log_method

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -389,9 +389,9 @@ class Cluster(PRecord):
 
         :param dict dataset_properties: The properties of the dataset to
             create.
-        :returns: A ``Deferred`` which fires with a 2-tuple of ``Cluster`` and
-            API response when a dataset with the supplied properties has been
-            persisted to the cluster configuration.
+        :returns: A ``Deferred`` which fires with an API response when a
+            dataset with the supplied properties has been persisted to the
+            cluster configuration.
         """
         request = self.treq.post(
             self.base_url + b"/configuration/datasets",
@@ -401,8 +401,6 @@ class Cluster(PRecord):
         )
 
         request.addCallback(check_and_decode_json, CREATED)
-        # Return cluster and API response
-        request.addCallback(lambda response: (self, response))
         return request
 
     @log_method


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-2400

This is in preparation for getting proper eliot logs from the acceptance tests.