### PR TITLE
Do not call mkfs on devices that already have filesystems

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -421,7 +421,11 @@ class CreateFilesystem(PRecord):
 
 def _ensure_no_filesystem(device):
     """
-    Raises an error if there's already a filesystem on 'device'.
+    Raises an error if there's already a filesystem on ``device``.
+
+    :raises: ``FilesystemExists`` if there is already a filesystem on
+        ``device``.
+    :return: ``None``
     """
     try:
         check_output(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -424,7 +424,7 @@ def _ensure_no_filesystem(device):
     Raises an error if there's already a filesystem on 'device'.
     """
     try:
-        output = check_output(
+        check_output(
             [b"blkid", b"-p", b"-u", b"filesystem", device.path],
             stderr=STDOUT,
         )

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -8,7 +8,7 @@ devices.
 """
 
 from uuid import UUID, uuid4
-from subprocess import check_output
+from subprocess import CalledProcessError, check_output, STDOUT
 from stat import S_IRWXU, S_IRWXG, S_IRWXO
 from errno import EEXIST
 
@@ -103,6 +103,16 @@ class DatasetExists(Exception):
     def __init__(self, blockdevice):
         Exception.__init__(self, blockdevice)
         self.blockdevice = blockdevice
+
+
+class FilesystemExists(Exception):
+    """
+    A failed attempt to create a filesystem on a block device that already has
+    one.
+    """
+    def __init__(self, device):
+        Exception.__init__(self, device)
+        self.device = device
 
 
 DATASET = Field(
@@ -394,6 +404,7 @@ class CreateFilesystem(PRecord):
             self.volume.blockdevice_id
         )
         try:
+            _ensure_no_filesystem(device)
             check_output([
                 b"mkfs", b"-t", self.filesystem.encode("ascii"),
                 # This is ext4 specific, and ensures mke2fs doesn't ask
@@ -406,6 +417,30 @@ class CreateFilesystem(PRecord):
         except:
             return fail()
         return succeed(None)
+
+
+def _ensure_no_filesystem(device):
+    """
+    Raises an error if there's already a filesystem on 'device'.
+    """
+    try:
+        output = check_output(
+            [b"blkid", b"-p", b"-u", b"filesystem", device.path],
+            stderr=STDOUT,
+        )
+    except CalledProcessError as e:
+        # According to the man page:
+        #   the specified token was not found, or no (specified) devices
+        #   could be identified
+        #
+        # Experimentation shows that there is no output in the case of the
+        # former, and an error printed to stderr in the case of the
+        # latter.
+        if e.returncode == 2 and not e.output:
+            # There is no filesystem on this device.
+            return
+        raise
+    raise FilesystemExists(device)
 
 
 def _valid_size(size):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -440,6 +440,9 @@ def _ensure_no_filesystem(device):
         # Experimentation shows that there is no output in the case of the
         # former, and an error printed to stderr in the case of the
         # latter.
+        #
+        # FLOC-2388: We're assuming an interface. We should test this
+        # assumption.
         if e.returncode == 2 and not e.output:
             # There is no filesystem on this device.
             return

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2727,6 +2727,12 @@ class MountBlockDeviceTests(
         run_process([b"umount", mountpoint.path])
         # Try recreating filesystem; this should fail.
         self.failureResultOf(scenario.create(), FilesystemExists)
+        # Remounting should succeed.
+        self.successResultOf(run_state_change(
+            MountBlockDevice(dataset_id=scenario.dataset_id,
+                             mountpoint=mountpoint),
+            scenario.deployer))
+        self.assertEqual(afile.getContent(), b"data")
 
     def test_mountpoint_exists(self):
         """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -9,10 +9,8 @@ from functools import partial
 from os import getuid
 import time
 from uuid import UUID, uuid4
-from subprocess import (
-    STDOUT, PIPE, Popen, check_output, check_call, CalledProcessError,
-)
 from stat import S_IRWXU
+from subprocess import STDOUT, PIPE, Popen, check_output, check_call
 
 from bitmath import Byte, MB, MiB, GB, GiB
 


### PR DESCRIPTION
This applies the diff at #1650 to the release branch.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1663)
<!-- Reviewable:end -->
