### PR TITLE
[FLOC-2420] Additional get_device_for_dataset_id change

### DIFF
--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -569,6 +569,7 @@ class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
             unmounted.blockdevice_id,
             attach_to=self.this_node,
         )
+        create_filesystem(self, self.deployer, unmounted)
 
         assert_discovered_state(
             self, self.deployer,


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2420

This is basically a follow-up to https://clusterhq.atlassian.net/browse/FLOC-2374 where we missed one `IBlockDeviceAPI.get_device_path` caller.