### PR TITLE
[FLOC-2376] Upgrade ext4 filesystems created by Flocker 1.0.0 to carry dataset identifying information

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+Flocker 1.0.1 (2015-06-XX)
+==========================
+
+- Flocker-created filesystems now include information identifying the dataset they belong to.
+  Filesystems created by Flocker 1.0.0 will be upgraded to include this information automatically if and only if they are not in use.
+  See the upgrade documentation for details. (FLOC-2369, FLOC-2372, FLOC-2374, FLOC-2376)
+
 Flocker 1.0.0 (2015-06-15)
 ==========================
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,6 +9,14 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.0.1
+======
+
+* The on-disk representation of filesystems for the AWS EBS and OpenStack Cinder storage drivers has changed.
+  An upgrade, mostly automatic, of filesystems created using Flocker 1.0.0 is required.
+  See :ref:`upgrading-flocker-1.0.1` for details.
+* The EBS storage driver now more reliably selects the correct OS device file corresponding to an EBS volume being used.
+
 v1.0
 ====
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,7 +14,7 @@ v1.0.1
 
 * The on-disk representation of filesystems for the AWS EBS and OpenStack Cinder storage drivers has changed.
   An upgrade, mostly automatic, of filesystems created using Flocker 1.0.0 is required.
-  See :ref:`upgrading-flocker-1.0.1` for details.
+  See :ref:`upgrading-flocker` for details.
 * The EBS storage driver now more reliably selects the correct OS device file corresponding to an EBS volume being used.
 
 v1.0

--- a/docs/using/administering/index.rst
+++ b/docs/using/administering/index.rst
@@ -5,5 +5,6 @@ Administering Flocker
 .. toctree::
    :maxdepth: 2
 
+   upgrading
    debugging
    cleanup

--- a/docs/using/administering/upgrading.rst
+++ b/docs/using/administering/upgrading.rst
@@ -1,0 +1,38 @@
+=========
+Upgrading
+=========
+
+A Flocker cluster can be upgraded to a newer version of Flocker while preserving all data and configuration of the Flocker cluster provided certain steps are followed.
+The correct steps to follow may vary depending on the versions of Flocker being upgraded from and to.
+A common requirement for all currently supported upgrade paths is that all nodes and the control service must be running the same version of Flocker.
+
+Flocker 1.0.1
+-------------
+
+Recommended Steps
+^^^^^^^^^^^^^^^^^
+
+  #. Stop the control service and the agent services on all nodes.
+  #. Install Flocker 1.0.1 on all hosts in the Flocker cluster.
+  #. Reboot each of the agent nodes.
+  #. If you have not configured the Flocker agents to start automatically on boot,
+     restart the agent services on all nodes.
+  #. Restart the control service.
+
+Details
+^^^^^^^
+
+The upgrade to Flocker 1.0.1 involves changing the metadata on the filesystems created on the volumes managed by the AWS EBS and OpenStack Cinder storage drivers.
+These metadata changes will be made automatically by ``flocker-dataset-agent`` as part of its normal operation.
+However, these metadata changes can only be performed when the filesystems themselves are unmounted (therefore not in use).
+The easiest way to ensure ``flocker-dataset-agent`` will be able to perform these upgrades is to reboot the node where the agent is running.
+When the node starts up again, all Flocker-managed filesystems will start unmounted.
+``flocker-dataset-agent`` will upgrade each filesystem before re-mounting the filesystem for use by applications.
+You can observe the upgrade process by finding ``agent:blockdevice:1.0.0:upgrade:fs`` and ``agent:blockdevice:1.0.0:mounted:fs`` events in the ``flocker-dataset-agent`` log.
+The former indicates a filesystem upgrade is being attempted.
+The latter indicates a filesystem was found mounted and no upgrade was attempted.
+
+Flocker 1.0.0
+-------------
+
+There are no supported upgrade paths from versions of Flocker older than 1.0.0.

--- a/docs/using/administering/upgrading.rst
+++ b/docs/using/administering/upgrading.rst
@@ -1,3 +1,5 @@
+.. _upgrading-flocker:
+
 =========
 Upgrading
 =========

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1560,7 +1560,7 @@ class BlockDeviceDeployer(PRecord):
             if device_path in mounted:
                 FLOCKER_1_0_0_FS_MOUNTED(
                     block_device_id=volume.blockdevice_id,
-                    device_path=device_path.path,
+                    block_device_path=device_path,
                 ).write()
                 continue
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1432,7 +1432,7 @@ def _ext4_fs_uuid(device_path):
     for line in blkid.splitlines():
         key, value = line.split(b"=")
         if key == b"ID_FS_UUID":
-            return value.decode("ascii")
+            return UUID(value)
     raise ValueError(
         "Failed to find UUID on {} in output: {}".format(
             device_path.path, blkid
@@ -1582,7 +1582,7 @@ class BlockDeviceDeployer(PRecord):
                 block_device_id=volume.blockdevice_id,
                 dataset_id=volume.dataset_id
             ) as upgrade:
-                upgrade.addSuccessFields(old_fs_uuid=old_fs_uuid)
+                upgrade.addSuccessFields(old_fs_uuid=unicode(old_fs_uuid))
                 output = tune2fs(
                     # Change the UUID to this value
                     b"-U", bytes(volume.dataset_id),

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1419,6 +1419,16 @@ def _manifestation_from_volume(volume):
 
 
 def _ext4_fs_uuid(device_path):
+    """
+    Get the EXT4 filesystem UUID from the filesystem on the device at the given
+    path.
+
+    :param FilePath device_path: The path to the device on which the filesystem
+        resides.
+
+    :return: A ``UUID`` instance giving the UUID from the filesystem.
+    :rtype: ``UUID``
+    """
     blkid = _blkid(
         # Display a slightly more parseable format.
         b"-o", b"udev",
@@ -1441,6 +1451,15 @@ def _ext4_fs_uuid(device_path):
 
 
 def tune2fs(*argv):
+    """
+    Run the ``tune2fs`` utility with the given arguments and return its stdout
+    and stderr.
+
+    :param argv: ``bytes`` giving the argument vector to pass to the process.
+
+    :return: ``bytes`` giving the stdout and stderr of tune2fs (mixed
+        together).
+    """
     return check_output([b"tune2fs"] + list(argv), stderr=STDOUT)
 
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1555,6 +1555,10 @@ class BlockDeviceDeployer(PRecord):
             # mounted filesystems.  They're not supposed to be mounted because
             # we told the user to restart the node.
             if device_path in mounted:
+                FLOCKER_1_0_0_FS_MOUNTED(
+                    block_device_id=volume.blockdevice_id,
+                    device_path=device_path.path,
+                ).write()
                 continue
 
             # Put the dataset id into the ext4 filesystem UUID field for future

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1541,6 +1541,24 @@ class BlockDeviceDeployer(PRecord):
         }
 
     def _upgrade_1_0_0_filesystem(self, api, volumes):
+        """
+        Upgrade any old, Flocker 1.0.0-created filesystems.
+
+        Examine each volume attached to this host.  Determine if the filesystem
+        on the volume has the corresponding dataset_id recorded in its UUID.
+        This is how filesystems are created post-1.0.0 (see FLOC-2369).  If the
+        filesystem does not have this information recorded and the filesystem
+        is not mounted, put it there.  If the filesystem is mounted we cannot
+        modify it.  We will fix it when we notice it is unmounted.
+
+        The intent is for this to cause Flocker 1.0.0-created volumes to look
+        just like they would have if they had been created by Flocker >1.0.0.
+
+        :param IBlockDeviceAPI api: The storage driver responsible for the
+            volumes.
+        :param list volumes: The ``BlockDeviceVolumes`` that exist and will be
+            considered for upgrade.
+        """
         mounted = {
             FilePath(partition.device)
             for partition

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1527,7 +1527,11 @@ class BlockDeviceDeployer(PRecord):
         compute_instance_id = api.compute_instance_id()
         for volume in _attached_volumes(compute_instance_id, volumes):
             try:
-                device_path = get_device_for_dataset_id(volume.dataset_id)
+                get_device_for_dataset_id(volume.dataset_id)
+                # If we found the dataset_id like this the filesystem is
+                # sufficiently new to not need any changes.  Proceed to the
+                # next volume.
+                continue
             except KeyError:
                 # There is no filesystem on the volume because volume setup
                 # failed partway through the process or there is no filesystem

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -198,8 +198,15 @@ CREATE_BLOCK_DEVICE_DATASET = ActionType(
     u"A block-device-backed dataset is being created.",
 )
 
+FLOCKER_1_0_0_FS_MOUNTED = MessageType(
+    u"agent:blockdevice:1.0.0:mounted:fs",
+    [BLOCK_DEVICE_ID, BLOCK_DEVICE_PATH],
+    u"A filesystem created by Flocker 1.0.0 was encountered and was mounted "
+    u"so it could not be upgraded.",
+)
+
 FLOCKER_1_0_0_FS_UPGRADE = ActionType(
-    u"agent:blockdevice:upgrade:1.0.0:fs",
+    u"agent:blockdevice:1.0.0:upgrade:fs",
     [BLOCK_DEVICE_ID, DATASET_ID],
     fields(old_fs_uuid=unicode, tune2fs_output=unicode),
     u"A filesystem created by Flocker 1.0.0 was encountered and its "

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1572,6 +1572,8 @@ class BlockDeviceDeployer(PRecord):
                 # filesystem it's meant to have.  This would be a good time
                 # to mark the volume for fixing (put a filesystem on it).
                 # For now, ignore it.
+                #
+                # FLOC-1576
                 continue
 
             # Put the dataset id into the ext4 filesystem UUID field for future
@@ -1610,6 +1612,15 @@ class BlockDeviceDeployer(PRecord):
             ).write(_logger)
             return False
 
+        # The state discovery method is basically the wrong place to do the
+        # filesystem upgrade.  Sadly, determining the necessity of each of
+        # these upgrades depends on more state than we can easily convey to
+        # `calculate_changes` (the technical term for this situation might be
+        # "design flaw").  Since we really do want to do these upgrades and
+        # we'd like to do them with a minimum of code churn, sticking this
+        # upgrade step into the discovery method makes the most sense.  This
+        # will be another datapoint to consider when revamping the way this
+        # IDeployer works.
         self._upgrade_1_0_0_filesystem(api, volumes)
 
         # Find the devices for any manifestations on this node.  Build up a

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -14,7 +14,7 @@ from errno import EEXIST
 
 from bitmath import GiB
 
-from eliot import MessageType, ActionType, Field, Logger
+from eliot import MessageType, ActionType, Field, Logger, fields
 from eliot.serializers import identity
 
 from zope.interface import implementer, Interface
@@ -196,6 +196,14 @@ CREATE_BLOCK_DEVICE_DATASET = ActionType(
     [DATASET, MOUNTPOINT],
     [],
     u"A block-device-backed dataset is being created.",
+)
+
+FLOCKER_1_0_0_FS_UPGRADED = MessageType(
+    u"agent:blockdevice:upgrade:1.0.0:fs",
+    fields(block_device_id=unicode, dataset_id=unicode, old_fs_uuid=unicode),
+    u"A filesystem created by Flocker 1.0.0 was encountered and its "
+    u"filesystem UUID was changed to match the dataset id it is meant to "
+    u"represent.",
 )
 
 # Really this is the successful completion of CREATE_BLOCK_DEVICE_DATASET.  It

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1193,8 +1193,17 @@ class BlockDeviceDeployerUpgradeFilesystemTests(SynchronousTestCase):
         self._upgrade_ext4_uuid_test(mounted=False, upgraded=True)
 
     @capture_logging(
-        assertHasMessage,
-        FLOCKER_1_0_0_FS_MOUNTED, dict(dataset_id=dataset_id)
+        lambda self, logger:
+        self.assertEqual(
+            ([], 1), (
+                LoggedAction.of_type(
+                    logger.messages, FLOCKER_1_0_0_FS_UPGRADE
+                ),
+                len(LoggedMessage.of_type(
+                    logger.messages, FLOCKER_1_0_0_FS_MOUNTED
+                ))
+            )
+        )
     )
     def test_mounted_ext4_uuid(self, logger):
         """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1127,7 +1127,14 @@ class BlockDeviceDeployerUpgradeFilesystemTests(SynchronousTestCase):
     # An id that tests and logging decorators can use.
     dataset_id = uuid4()
 
-    def _upgrade_ext4_uuid_test(self, mounted, upgraded):
+    def _upgrade_ext4_uuid_test(self, mounted):
+        """
+        Test the handling of a Flocker 1.0.0-style filesystem by
+        ``BlockDeviceDeployer.discover_state``.
+
+        :param bool mounted: ``True`` to test the behavior when the filesystem
+            is mounted, ``False`` to tested it unmounted.
+        """
         deployer = create_blockdevicedeployer(self)
         api = deployer.block_device_api
         volume = api.create_volume(
@@ -1190,7 +1197,7 @@ class BlockDeviceDeployerUpgradeFilesystemTests(SynchronousTestCase):
         dataset identifier in their UUID field,
         ``BlockDeviceDeployer.discover_state`` adds the UUID.
         """
-        self._upgrade_ext4_uuid_test(mounted=False, upgraded=True)
+        self._upgrade_ext4_uuid_test(mounted=False)
 
     @capture_logging(
         lambda self, logger:
@@ -1211,7 +1218,7 @@ class BlockDeviceDeployerUpgradeFilesystemTests(SynchronousTestCase):
         represent a manifestation of some dataset even if the filesystem is
         missing the dataset identifier in its UUID field.
         """
-        self._upgrade_ext4_uuid_test(mounted=True, upgraded=False)
+        self._upgrade_ext4_uuid_test(mounted=True)
 
 
 class BlockDeviceDeployerCreationCalculateChangesTests(

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1162,7 +1162,6 @@ class BlockDeviceDeployerUpgradeFilesystemTests(SynchronousTestCase):
             mountpoint.makedirs()
             mount(device_path, mountpoint)
 
-        if mounted:
             manifestation = Manifestation(
                 dataset=Dataset(
                     dataset_id=self.dataset_id,
@@ -1181,7 +1180,8 @@ class BlockDeviceDeployerUpgradeFilesystemTests(SynchronousTestCase):
             expected_devices={self.dataset_id: device_path},
             expected_nonmanifest_datasets=expected_nonmanifest_datasets,
         )
-        if upgraded:
+        if not mounted:
+            # Only unmounted filesystems are upgraded.
             self.assertEqual(
                 device_path, get_device_for_dataset_id(self.dataset_id),
             )

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1188,9 +1188,9 @@ class BlockDeviceDeployerUpgradeFilesystemTests(SynchronousTestCase):
     )
     def test_mounted_ext4_uuid(self, logger):
         """
-        When it discovers a mounted ext4 filesystem that is missing the dataset
-        identifier in their UUID field, ``BlockDeviceDeployer.discover_state``
-        adds the UUID.
+        ``BlockDeviceDeployer.discover_state`` considers mounted filesystems to
+        represent a manifestation of some dataset even if the filesystem is
+        missing the dataset identifier in its UUID field.
         """
         self._upgrade_ext4_uuid_test(mounted=True, upgraded=False)
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -42,7 +42,7 @@ from ..blockdevice import (
     DestroyBlockDeviceDataset, UnmountBlockDevice, DetachVolume,
     AttachVolume, CreateFilesystem,
     DestroyVolume, MountBlockDevice,
-    FLOCKER_1_0_0_FS_UPGRADE,
+    FLOCKER_1_0_0_FS_UPGRADE, FLOCKER_1_0_0_FS_MOUNTED,
     get_device_for_dataset_id, DuplicateFilesystemId,
     _losetup_list_parse, _losetup_list, _blockdevicevolume_from_dataset_id,
 


### PR DESCRIPTION
(With Itamar)
Fixes https://clusterhq.atlassian.net/browse/FLOC-2376 in the 1.0.0 release branch (for 1.0.1).
See also https://clusterhq.atlassian.net/browse/FLOC-314

This adds an upgrade step to the "discovery" phase of each iteration of the `BlockDeviceDeployer`-based convergence loop.
