### PR TITLE
[FLOC-2177] Add EMC links to Install doc

### DIFF
--- a/docs/gettinginvolved/plugins.rst
+++ b/docs/gettinginvolved/plugins.rst
@@ -11,7 +11,7 @@ Block device backends
 =====================
 
 Flocker implements generic logic for network-based block device storage.
-Examples of such storage include :ref:`Amazon EBS<aws-dataset-backend>` and :ref:`EMC ScaleIO/XtremIO<emc-dataset-backend>`.
+Examples of such storage include :ref:`Amazon EBS<aws-dataset-backend>` and :ref:`EMC ScaleIO and XtremIO<emc-dataset-backend>`.
 If you wish to support a block device that is not supported by Flocker or an existing plugin you can implement this support yourself.
 
 In order to do so you must write a Python 2.7 library providing a class implementing the `flocker.node.agents.blockdevice.IBlockDeviceAPI <https://github.com/ClusterHQ/flocker/blob/master/flocker/node/agents/blockdevice.py>`_ interface.

--- a/docs/gettinginvolved/plugins.rst
+++ b/docs/gettinginvolved/plugins.rst
@@ -11,7 +11,7 @@ Block device backends
 =====================
 
 Flocker implements generic logic for network-based block device storage.
-Examples of such storage include Amazon EBS and EMC ScaleIO.
+Examples of such storage include :ref:`Amazon EBS<aws-dataset-backend>` and :ref:`EMC ScaleIO/XtremIO<emc-dataset-backend>`.
 If you wish to support a block device that is not supported by Flocker or an existing plugin you can implement this support yourself.
 
 In order to do so you must write a Python 2.7 library providing a class implementing the `flocker.node.agents.blockdevice.IBlockDeviceAPI <https://github.com/ClusterHQ/flocker/blob/master/flocker/node/agents/blockdevice.py>`_ interface.

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -12,7 +12,7 @@ You can learn more about where we might be going with future releases by:
 v1.0
 ====
 
-* Dataset backend support for AWS Elastic Block Storage (EBS), and OpenStack Cinder.
+* Dataset backend support for :ref:`AWS Elastic Block Storage (EBS)<aws-dataset-backend>`, :ref:`OpenStack Cinder<openstack-dataset-backend>`, and :ref:`EMC ScaleIO and XtremIO<emc-dataset-backend>`.
 * Third parties can write Flocker storage drivers so that their storage systems work with Flocker.
   See :ref:`dataset-backend-plugins`.
 * It is now necessary to specify a dataset backend for each agent node.

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -559,6 +559,14 @@ The configuration item to use AWS should look like:
 Make sure that the ``region`` and ``zone`` match each other and that both match the region and zone where the Flocker agent nodes run.
 AWS must be able to attach volumes created in that availability zone to your Flocker nodes.
 
+.. _emc-dataset-backend:
+
+EMC Block Device Backend Configuration
+......................................
+
+
+
+
 .. _zfs-dataset-backend:
 
 ZFS Peer-to-Peer Backend Configuration (Experimental)

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -565,7 +565,7 @@ EMC Block Device Backend Configuration
 ......................................
 
 EMC provide plugins for Flocker integration with `ScaleIO`_ and `XtremIO`_.
-For more information, including installation, testing and usage instructions, see the following links to their GitHub repositories:
+For more information, including installation, testing and usage instructions, visit the following links to their GitHub repositories:
 
 * `EMC ScaleIO Flocker driver on GitHub`_
 * `EMC XtremIO Flocker driver on GitHub`_

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -570,7 +570,7 @@ For more information, including installation, testing and usage instructions, se
 * `EMC ScaleIO Flocker driver on GitHub`_
 * `EMC XtremIO Flocker driver on GitHub`_
 
-.. XXX FLOC xxx to improve this EMC/Backend storage section
+.. XXX FLOC 2442 and 2443 to expand this EMC/Backend storage section
 
 .. _zfs-dataset-backend:
 

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -686,3 +686,6 @@ Next Step
 ---------
 
 The next section describes your next step - setting up an :ref:`authenticated user<authenticate>`.
+
+.. _ScaleIO: https://github.com/emccorp/scaleio-flocker-driver
+.. _XtremIO: https://github.com/emccorp/xtremio-flocker-driver

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -692,7 +692,7 @@ Next Step
 
 The next section describes your next step - setting up an :ref:`authenticated user<authenticate>`.
 
-.. _ScaleIO: http://www.emc.com/storage/scaleio/index.htm
-.. _XtremIO: http://www.emc.com/storage/xtremio/overview.htm
+.. _ScaleIO: https://www.emc.com/storage/scaleio/index.htm
+.. _XtremIO: https://www.emc.com/storage/xtremio/overview.htm
 .. _EMC ScaleIO Flocker driver on GitHub: https://github.com/emccorp/scaleio-flocker-driver
 .. _EMC XtremIO Flocker driver on GitHub: https://github.com/emccorp/xtremio-flocker-driver

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -559,8 +559,6 @@ The configuration item to use AWS should look like:
 Make sure that the ``region`` and ``zone`` match each other and that both match the region and zone where the Flocker agent nodes run.
 AWS must be able to attach volumes created in that availability zone to your Flocker nodes.
 
-.. _emc-dataset-backend:
-
 EMC Block Device Backend Configuration
 ......................................
 

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -564,8 +564,13 @@ AWS must be able to attach volumes created in that availability zone to your Flo
 EMC Block Device Backend Configuration
 ......................................
 
-* `EMC ScaleIO`_
-* `EMC XtremeIO`_
+EMC provide plugins for Flocker integration with `ScaleIO`_ and `XtremIO`_.
+For more information, including installation, testing and usage instructions, see the following links to their GitHub repositories:
+
+* `EMC ScaleIO Flocker driver on GitHub`_
+* `EMC XtremIO Flocker driver on GitHub`_
+
+.. XXX FLOC xxx to improve this EMC/Backend storage section
 
 .. _zfs-dataset-backend:
 
@@ -687,5 +692,7 @@ Next Step
 
 The next section describes your next step - setting up an :ref:`authenticated user<authenticate>`.
 
-.. _EMC ScaleIO: https://github.com/emccorp/scaleio-flocker-driver
-.. _EMC XtremIO: https://github.com/emccorp/xtremio-flocker-driver
+.. _ScaleIO: http://www.emc.com/storage/scaleio/index.htm
+.. _XtremIO: http://www.emc.com/storage/xtremio/overview.htm
+.. _EMC ScaleIO Flocker driver on GitHub: https://github.com/emccorp/scaleio-flocker-driver
+.. _EMC XtremIO Flocker driver on GitHub: https://github.com/emccorp/xtremio-flocker-driver

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -559,6 +559,8 @@ The configuration item to use AWS should look like:
 Make sure that the ``region`` and ``zone`` match each other and that both match the region and zone where the Flocker agent nodes run.
 AWS must be able to attach volumes created in that availability zone to your Flocker nodes.
 
+.. _emc-dataset-backend:
+
 EMC Block Device Backend Configuration
 ......................................
 

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -564,8 +564,8 @@ AWS must be able to attach volumes created in that availability zone to your Flo
 EMC Block Device Backend Configuration
 ......................................
 
-
-
+* `EMC ScaleIO`_
+* `EMC XtremeIO`_
 
 .. _zfs-dataset-backend:
 
@@ -687,5 +687,5 @@ Next Step
 
 The next section describes your next step - setting up an :ref:`authenticated user<authenticate>`.
 
-.. _ScaleIO: https://github.com/emccorp/scaleio-flocker-driver
-.. _XtremIO: https://github.com/emccorp/xtremio-flocker-driver
+.. _EMC ScaleIO: https://github.com/emccorp/scaleio-flocker-driver
+.. _EMC XtremIO: https://github.com/emccorp/xtremio-flocker-driver


### PR DESCRIPTION
This is a somewhat light effort, but covers the EMC GitHub repos. I discussed this @ferrantim and this covers the EMC backend, but we will need to expand this in the future.

I've created FLOC 2442 and 2443 to make this whole section easier to find, and use.