### PR TITLE
Revert "[FLOC-2372] Remember discovered device path in EBSBlockDevice…

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -63,12 +63,10 @@ class DatasetWithoutVolume(Exception):
 class VolumeException(Exception):
     """
     A base class for exceptions raised by  ``IBlockDeviceAPI`` operations.
+
+    :param unicode blockdevice_id: The unique identifier of the block device.
     """
     def __init__(self, blockdevice_id):
-        """
-        :param unicode blockdevice_id: The unique identifier of the block
-            device.
-        """
         if not isinstance(blockdevice_id, unicode):
             raise TypeError(
                 'Unexpected blockdevice_id type. '
@@ -105,17 +103,6 @@ class DatasetExists(Exception):
     def __init__(self, blockdevice):
         Exception.__init__(self, blockdevice)
         self.blockdevice = blockdevice
-
-
-class InformationUnavailable(VolumeException):
-    """
-    An ``IBlockDeviceAPI.get_device_path`` was asked for the OS device path for
-    a block device but the implementation can't reliably provide that
-    information.
-
-    For example, this might happen when using AWS/EBS which can only accurately
-    report the OS device path on Amazon-provided AMIs.
-    """
 
 
 class FilesystemExists(Exception):
@@ -960,14 +947,10 @@ class IBlockDeviceAPI(Interface):
 
         :param unicode blockdevice_id: The unique identifier for the block
             device.
-
         :raises UnknownVolume: If the supplied ``blockdevice_id`` does not
             exist.
-        :raises InformationUnavailable: If the OS device path for the supplied
-            ``blockdevice_id`` isn't known by this implementation.  This is
-            allowed any time the Python object which attached the volume is not
-            the same Python object as ``get_device_path`` is called on.
-
+        :raises UnattachedVolume: If the supplied ``blockdevice_id`` is
+            not attached to a host.
         :returns: A ``FilePath`` for the device.
         """
 

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -14,8 +14,8 @@ from boto.exception import EC2ResponseError
 from twisted.trial.unittest import SkipTest
 from eliot.testing import LoggedMessage, capture_logging
 
-from ..ebs import _wait_for_volume, BOTO_EC2RESPONSE_ERROR
-from ..blockdevice import InformationUnavailable
+from ..ebs import (_wait_for_volume, ATTACHED_DEVICE_LABEL,
+                   BOTO_EC2RESPONSE_ERROR, UnattachedVolume)
 
 from .._logging import (
     AWS_CODE, AWS_MESSAGE, AWS_REQUEST_ID, BOTO_LOG_HEADER,
@@ -89,6 +89,27 @@ class EBSBlockDeviceAPIInterfaceTests(
         )
         self.assert_foreign_volume(flocker_volume)
 
+    def test_attached_volume_missing_device_tag(self):
+        """
+        Test that missing ATTACHED_DEVICE_LABEL on an EBS
+        volume causes `UnattacheVolume` while attempting
+        `get_device_path()`.
+        """
+        volume = self.api.create_volume(
+            dataset_id=uuid4(),
+            size=self.minimum_allocatable_size,
+        )
+        self.api.attach_volume(
+            volume.blockdevice_id,
+            attach_to=self.this_node,
+        )
+
+        self.api.connection.delete_tags([volume.blockdevice_id],
+                                        [ATTACHED_DEVICE_LABEL])
+
+        self.assertRaises(UnattachedVolume, self.api.get_device_path,
+                          volume.blockdevice_id)
+
     @capture_logging(lambda self, logger: None)
     def test_boto_ec2response_error(self, logger):
         """
@@ -155,23 +176,3 @@ class EBSBlockDeviceAPIInterfaceTests(
         result = self.api._next_device(self.api.compute_instance_id(), [],
                                        {u"/dev/sdf"})
         self.assertEqual(result, u"/dev/sdg")
-
-    def test_device_path_information_unavailable(self):
-        """
-        If ``get_device_path`` doesn't have the OS device path for an attached
-        volume cached then it raises ``InformationUnavailable``.
-        """
-        # Create and attach the volume using a second instance so that the
-        # first one can't have anything in its cache.
-        another_api = self.blockdevice_api_factory(test_case=self)
-        volume = another_api.create_volume(
-            dataset_id=uuid4(), size=self.minimum_allocatable_size
-        )
-        another_api.attach_volume(
-            volume.blockdevice_id, another_api.compute_instance_id()
-        )
-        exception = self.assertRaises(
-            InformationUnavailable,
-            self.api.get_device_path, volume.blockdevice_id,
-        )
-        self.assertEqual(volume.blockdevice_id, exception.blockdevice_id)

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -59,7 +59,6 @@ from ..blockdevice import (
     _backing_file_name,
     ProcessLifetimeCache,
     FilesystemExists,
-    InformationUnavailable,
 )
 
 from ... import run_state_change, in_parallel
@@ -1753,43 +1752,19 @@ class IBlockDeviceAPITestsMixin(object):
 
     def test_get_device_path_unattached_volume(self):
         """
-        ``get_device_path`` raises ``UnattachedVolume`` or
-        ``InformationUnavailable`` if the supplied ``blockdevice_id``
-        corresponds to an unattached volume.
+        ``get_device_path`` raises ``UnattachedVolume`` if the supplied
+        ``blockdevice_id`` corresponds to an unattached volume.
         """
         new_volume = self.api.create_volume(
             dataset_id=uuid4(),
             size=self.minimum_allocatable_size
         )
         exception = self.assertRaises(
-            (UnattachedVolume, InformationUnavailable),
+            UnattachedVolume,
             self.api.get_device_path,
             new_volume.blockdevice_id
         )
         self.assertEqual(new_volume.blockdevice_id, exception.blockdevice_id)
-
-    def test_get_device_path_detached_volume(self):
-        """
-        ``get_device_path`` raises ``UnattachedVolume`` or
-        ``InformationUnavailable`` if the supplied ``blockdevice_id``
-        corresponds to a volume that was attached to the node but has been
-        detached from it.
-        """
-        volume = self.api.create_volume(
-            dataset_id=uuid4(),
-            size=self.minimum_allocatable_size
-        )
-        self.api.attach_volume(
-            volume.blockdevice_id,
-            attach_to=self.this_node,
-        )
-        self.api.detach_volume(volume.blockdevice_id)
-        exception = self.assertRaises(
-            (UnattachedVolume, InformationUnavailable),
-            self.api.get_device_path,
-            volume.blockdevice_id,
-        )
-        self.assertEqual(volume.blockdevice_id, exception.blockdevice_id)
 
     def test_get_device_path_device(self):
         """
@@ -2043,7 +2018,6 @@ def make_iblockdeviceapi_tests(
     """
     class Tests(IBlockDeviceAPITestsMixin, SynchronousTestCase):
         def setUp(self):
-            self.blockdevice_api_factory = blockdevice_api_factory
             self.api = blockdevice_api_factory(test_case=self)
             self.unknown_blockdevice_id = unknown_blockdevice_id_factory(self)
             check_allocatable_size(


### PR DESCRIPTION
Reverts ClusterHQ/flocker#1659

For 1.0.1 we're going with a different implementation strategy to resolve this bug.  To minimize the size of the change, this change should be backed out because it will not be required for the alternate strategy.