### PR TITLE
Revert "[FLOC-2369] Store dataset UUIDs on filesystems we create"

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -8,7 +8,7 @@ devices.
 """
 
 from uuid import UUID, uuid4
-from subprocess import check_output, CalledProcessError, STDOUT
+from subprocess import CalledProcessError, check_output, STDOUT
 from stat import S_IRWXU, S_IRWXG, S_IRWXO
 from errno import EEXIST
 
@@ -420,7 +420,6 @@ class CreateFilesystem(PRecord):
             _ensure_no_filesystem(device)
             check_output([
                 b"mkfs", b"-t", self.filesystem.encode("ascii"),
-                b"-U", bytes(self.volume.dataset_id),
                 # This is ext4 specific, and ensures mke2fs doesn't ask
                 # user interactively about whether they really meant to
                 # format whole device rather than partition. It will be
@@ -1856,39 +1855,3 @@ class ProcessLifetimeCache(proxyForInterface(IBlockDeviceAPI, "_api")):
         except KeyError:
             pass
         return self._api.detach_volume(blockdevice_id)
-
-
-class DuplicateFilesystemId(Exception):
-    """
-    Two devices were found with filesystems that have the same UUID. It is
-    not clear which one is the actual dataset we are looking for.
-    """
-
-
-def get_device_for_dataset_id(dataset_id):
-    """
-    Lookup the path of the device for an attached dataset on this machine.
-
-    :param UUID dataset_id: The dataset we're looking up.
-
-    :raise KeyError: If device is not found.
-    :raise DuplicateFilesystemId: If more than one device is found.
-
-    :return: ``FilePath`` of device where the dataset is attached.
-    """
-    try:
-        result = check_output([b"blkid",
-                               # Only list the device:
-                               b"-o", b"device",
-                               # Search by UUID:
-                               b"-t", b'UUID="{}"'.format(dataset_id)])
-    except CalledProcessError as e:
-        if e.returncode == 2:
-            raise KeyError(dataset_id)
-        else:
-            # This code path is untested, unfortunately.
-            raise
-    paths = result.splitlines()
-    if len(paths) > 1:
-        raise DuplicateFilesystemId(paths)
-    return FilePath(paths[0])

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -42,7 +42,6 @@ from ..blockdevice import (
     DestroyBlockDeviceDataset, UnmountBlockDevice, DetachVolume,
     AttachVolume, CreateFilesystem,
     DestroyVolume, MountBlockDevice,
-    get_device_for_dataset_id, DuplicateFilesystemId,
     _losetup_list_parse, _losetup_list, _blockdevicevolume_from_dataset_id,
 
     DESTROY_BLOCK_DEVICE_DATASET, UNMOUNT_BLOCK_DEVICE, DETACH_VOLUME,
@@ -3585,97 +3584,3 @@ class ProcessLifetimeCacheTests(SynchronousTestCase):
 
         self.assertRaises(UnattachedVolume,
                           self.cache.get_device_path, attached_id1)
-
-
-class GetDeviceForDatasetIdTests(SynchronousTestCase):
-    """
-    Tests for ``get_device_for_dataset_id``.
-    """
-
-    def test_found(self):
-        """
-        Filesystems created with ``CreateFilesystem`` can be looked up by
-        dataset ID using ``get_device_for_dataset_id``.
-        """
-        one_dataset_id = uuid4()
-        another_dataset_id = uuid4()
-        uninitialized_dataset_id = uuid4()
-
-        deployer = create_blockdevicedeployer(self)
-        api = deployer.block_device_api
-
-        # Here are a couple volumes that will have filesystems that the
-        # implementation will have to correctly identify.
-        one_volume = api.create_volume(
-            one_dataset_id, LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
-        )
-        another_volume = api.create_volume(
-            another_dataset_id, LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
-        )
-
-        # This is a trap.  Hopefully the implementation ignores it.
-        uninitialized_volume = api.create_volume(
-            uninitialized_dataset_id, LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
-        )
-
-        for volume in [one_volume, another_volume, uninitialized_volume]:
-            api.attach_volume(volume.blockdevice_id, api.compute_instance_id())
-
-        for volume in [one_volume, another_volume]:
-            self.successResultOf(
-                run_state_change(
-                    CreateFilesystem(volume=volume, filesystem=u"ext4"),
-                    deployer,
-                )
-            )
-
-        expected = (
-            api.get_device_path(one_volume.blockdevice_id),
-            api.get_device_path(another_volume.blockdevice_id)
-        )
-        actual = (
-            get_device_for_dataset_id(one_dataset_id),
-            get_device_for_dataset_id(another_dataset_id)
-        )
-        self.assertEqual(expected, actual)
-
-    def test_not_found(self):
-        """
-        If a matching device cannot be found by ``get_device_for_dataset_id``
-        it raises a ``KeyError``.
-        """
-        self.assertRaises(KeyError, get_device_for_dataset_id, uuid4())
-
-    def test_duplicate(self):
-        """
-        Filesystems created with ``CreateFilesystem`` with duplicate dataset
-        IDs cause ``get_device_for_dataset_id`` to raise a
-        ``DuplicateFilesystemId`` exception.
-        """
-        dataset_id = uuid4()
-
-        deployer = create_blockdevicedeployer(self)
-        api = deployer.block_device_api
-
-        one_volume = api.create_volume(
-            dataset_id, LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
-        )
-        # This volume has different UUID, but we'll trick CreateFilesystem
-        # into setting duplicate UUID when doing mkfs.
-        another_volume = api.create_volume(
-            uuid4(), LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
-        ).set(dataset_id=dataset_id)
-
-        for volume in [one_volume, another_volume]:
-            api.attach_volume(volume.blockdevice_id, api.compute_instance_id())
-
-        for volume in [one_volume, another_volume]:
-            self.successResultOf(
-                run_state_change(
-                    CreateFilesystem(volume=volume, filesystem=u"ext4"),
-                    deployer,
-                )
-            )
-
-        self.assertRaises(DuplicateFilesystemId, get_device_for_dataset_id,
-                          dataset_id)


### PR DESCRIPTION
Reverts ClusterHQ/flocker#1653

For 1.0.1 we're going with a different implementation strategy to resolve this bug.  To minimize the size of the change, this change should be backed out because it will not be required for the alternate strategy.