### PR TITLE
Release maintenance/flocker 1.0.0/ebs device name mapping floc 2329

### DIFF
--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -342,8 +342,8 @@ def _wait_for_new_device(base, size, time_limit=60):
     :param int time_limit: Time, in seconds, to wait for
         new device to manifest. Defaults to 60s.
 
-    :returns: formatted string name of the new block device.
-    :rtype: unicode
+    :returns: The path of the new block device file.
+    :rtype: ``FilePath``
     """
     start_time = time.time()
     elapsed_time = time.time() - start_time
@@ -353,8 +353,7 @@ def _wait_for_new_device(base, size, time_limit=60):
             device_name = FilePath.basename(device)
             if (device_name.startswith((b"sd", b"xvd")) and
                     _get_device_size(device_name) == size):
-                new_device = u'/dev/' + device_name.decode("ascii")
-                return new_device
+                return FilePath(b"/dev").child(device_name)
         time.sleep(0.1)
         elapsed_time = time.time() - start_time
 

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -708,6 +708,7 @@ class EBSBlockDeviceAPI(object):
 
         compute_instance_id = self.compute_instance_id()
         if volume.attached_to != compute_instance_id:
+            # This is untested.  See FLOC-2453.
             raise Exception(
                 "Volume is attached to {}, not to {}".format(
                     volume.attached_to, compute_instance_id

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -553,6 +553,10 @@ class EBSBlockDeviceAPI(object):
             corresponding to the input blockdevice_id.
         :raises AlreadyAttachedVolume: If the input volume is already attached
             to a device.
+        :raises AttachedUnexpectedDevice: If the attach operation fails to
+            associate the volume with the expected OS device file.  This
+            indicates use on an unsupported OS, a misunderstanding of the EBS
+            device assignment rules, or some other bug in this implementation.
         """
         ebs_volume = self._get_ebs_volume(blockdevice_id)
         volume = _blockdevicevolume_from_ebs_volume(ebs_volume)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -73,14 +73,27 @@ _enable_boto_logging()
 class AttachedUnexpectedDevice(Exception):
     """
     A volume was attached to a device other than the one we expected.
+
+    :ivar str _template: A native string giving the template into which to
+        format attributes for the string representation.
     """
+    _template = "AttachedUnexpectedDevice(requested={!r}, discovered={!r})"
+
     def __init__(self, requested, discovered):
         """
-        :param bytes requested: The requested device name.
-        :param bytes discovered: The device which was discovered on the system.
+        :param FilePath requested: The requested device name.
+        :param FilePath discovered: The device which was discovered on the
+            system.
         """
         self.requested = requested
         self.discovered = discovered
+
+    def __str__(self):
+        return self._template.format(
+            self.requested.path, self.discovered.path,
+        )
+
+    __repr__ = __str__
 
 
 def _expected_device(requested_device):

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -14,8 +14,9 @@ from boto.exception import EC2ResponseError
 from twisted.trial.unittest import SkipTest
 from eliot.testing import LoggedMessage, capture_logging
 
-from ..ebs import (_wait_for_volume, ATTACHED_DEVICE_LABEL,
-                   BOTO_EC2RESPONSE_ERROR, UnattachedVolume)
+from ..ebs import (
+    _wait_for_volume, BOTO_EC2RESPONSE_ERROR,
+)
 
 from .._logging import (
     AWS_CODE, AWS_MESSAGE, AWS_REQUEST_ID, BOTO_LOG_HEADER,
@@ -88,27 +89,6 @@ class EBSBlockDeviceAPIInterfaceTests(
             size=self.minimum_allocatable_size,
         )
         self.assert_foreign_volume(flocker_volume)
-
-    def test_attached_volume_missing_device_tag(self):
-        """
-        Test that missing ATTACHED_DEVICE_LABEL on an EBS
-        volume causes `UnattacheVolume` while attempting
-        `get_device_path()`.
-        """
-        volume = self.api.create_volume(
-            dataset_id=uuid4(),
-            size=self.minimum_allocatable_size,
-        )
-        self.api.attach_volume(
-            volume.blockdevice_id,
-            attach_to=self.this_node,
-        )
-
-        self.api.connection.delete_tags([volume.blockdevice_id],
-                                        [ATTACHED_DEVICE_LABEL])
-
-        self.assertRaises(UnattachedVolume, self.api.get_device_path,
-                          volume.blockdevice_id)
 
     @capture_logging(lambda self, logger: None)
     def test_boto_ec2response_error(self, logger):

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -30,4 +30,3 @@ class AttachedUnexpectedDeviceTests(SynchronousTestCase):
             expected,
             repr(AttachedUnexpectedDevice(requested, discovered))
         )
-

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -1,0 +1,33 @@
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.node.agents.ebs``.
+"""
+
+from twisted.python.filepath import FilePath
+from twisted.trial.unittest import SynchronousTestCase
+
+from ..ebs import AttachedUnexpectedDevice
+
+
+class AttachedUnexpectedDeviceTests(SynchronousTestCase):
+    """
+    Tests for ``AttachedUnexpectedDevice``.
+    """
+    def test_repr(self):
+        """
+        The string representation of ``AttachedUnexpectedDevice`` includes the
+        requested device name and the discovered device name.
+        """
+        requested = FilePath(b"/dev/sda")
+        discovered = FilePath(b"/dev/sdb")
+        expected = (
+            "AttachedUnexpectedDevice("
+            "requested='/dev/sda', discovered='/dev/sdb'"
+            ")"
+        )
+        self.assertEqual(
+            expected,
+            repr(AttachedUnexpectedDevice(requested, discovered))
+        )
+

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -7,7 +7,7 @@ Tests for ``flocker.node.agents.ebs``.
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase
 
-from ..ebs import AttachedUnexpectedDevice
+from ..ebs import AttachedUnexpectedDevice, _expected_device
 
 
 class AttachedUnexpectedDeviceTests(SynchronousTestCase):
@@ -29,4 +29,36 @@ class AttachedUnexpectedDeviceTests(SynchronousTestCase):
         self.assertEqual(
             expected,
             repr(AttachedUnexpectedDevice(requested, discovered))
+        )
+
+
+class ExpectedDeviceTests(SynchronousTestCase):
+    """
+    Tests for ``_expected_device``.
+    """
+    def test_sdX_to_xvdX(self):
+        """
+        ``sdX``-style devices are rewritten to corresponding ``xvdX`` devices.
+        """
+        self.assertEqual(
+            (FilePath(b"/dev/xvdj"), FilePath(b"/dev/xvdo")),
+            (_expected_device(b"/dev/sdj"), _expected_device(b"/dev/sdo")),
+        )
+
+    def test_non_dev_rejected(self):
+        """
+        Devices not in ``/dev`` are rejected with ``ValueError``.
+        """
+        self.assertRaises(
+            ValueError,
+            _expected_device, b"/sys/block/sda",
+        )
+
+    def test_non_sdX_rejected(self):
+        """
+        Devices not in the ``sdX`` category are rejected with ``ValueError``.
+        """
+        self.assertRaises(
+            ValueError,
+            _expected_device, b"/dev/hda",
         )


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2329

This is an entirely different approach to fixing the issue than was taken previously.  All of the filesystem UUID changes are gone.  This instead attempts to change the EBS storage driver so that it can reliably respond to `get_device_path` requests.