### PR TITLE
[FLOC-2475] Release Flocker 1.0.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Flocker 1.0.1 (2015-06-19)
+Flocker 1.0.1 (2015-06-20)
 ==========================
 
 - Fixed a bug where EBS volumes were mapped to the wrong device and therefore mounted in the wrong location. (FLOC-2329).


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2475

This is ready for a pre-tag review process.

The only failing tests are known and in ``flocker.provision.test.test_ssh_conch``.

Please follow http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html#pre-tag-review-process