### PR TITLE
Make tox runs faster

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
 envlist = pypy, py27, lint, sphinx
+distribute = False
+minversion = 1.6
+skipsdist = True
 
 [testenv]
 # We want modern pip so we can install packages that only have wheels:


### PR DESCRIPTION
- Skip creating a source distribution. This takes time and is not
  necessary.
- Do not install distribute
- Require version 1.6 which added support for these flags