### PR TITLE
Build vagrant basebox floc 2494

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy, py27, lint, sphinx
+envlist = py27, lint, sphinx
 
 [testenv]
 # We want modern pip so we can install packages that only have wheels:
@@ -13,9 +13,6 @@ commands =
     trial --rterrors {posargs:flocker}
 setenv =
     PYTHONHASHSEED=random
-
-[testenv:pypy]
-basepython = pypy
 
 [testenv:py27]
 basepython = python2.7

--- a/vagrant/basebox/README.rst
+++ b/vagrant/basebox/README.rst
@@ -1,0 +1,3 @@
+Code for generating the box for the development vagrant image.
+
+See the `documentation <../../docs/gettinginvolved/infrastructure/vagrant.rst#boxes>`_ for details.

--- a/vagrant/basebox/Vagrantfile
+++ b/vagrant/basebox/Vagrantfile
@@ -1,0 +1,58 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# This allows the VM to be restarted during provisioning, necessary after
+# updating the kernel
+unless Vagrant.has_plugin?("vagrant-reload")
+  raise "vagrant-reload plugin is not installed"
+end
+
+=begin
+  The following error may occur when running `vagrant up`, potentially because
+  of a problem with some VirtualBox versions.
+
+    # Failed to mount folders in Linux guest. This is usually because
+    # the "vboxsf" file system is not available. Please verify that
+    # the guest additions are properly installed in the guest and
+    # can work properly. The command attempted was:
+    #
+    # mount -t vboxsf -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3` vagrant /vagrant
+    # mount -t vboxsf -o uid=`id -u vagrant`,gid=`id -g vagrant` vagrant /vagrant
+    #
+    # The error output from the last command was:
+    #
+    # /sbin/mount.vboxsf: mounting failed with the error: No such device
+
+  To avoid this potential issue, the vagrant-vbguest plugin is required.
+  If it remains, try updating VirtualBox.
+=end
+unless Vagrant.has_plugin?("vagrant-vbguest")
+  raise "vagrant-vbguest plugin is not installed"
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "box-cutter/centos70"
+  # Update kernel and start to configure base system
+  config.vm.provision :shell, :path => "bootstrap.sh", :privileged => true
+  config.vm.provision :reload
+  # Finish configuring base system
+  config.vm.provision :shell, :path => "post-reboot-bootstrap.sh", :privileged => true
+  # Prepare caches
+  config.vm.provision :shell, :path => "cache.sh", :privileged => true
+  # Cleanup
+  config.vm.provision :shell, :path => "../cleanup.sh", :privileged => true
+
+  # Don't use a shared folder.
+  # - It isn't used during the build.
+  # - The vguest plugin tries to compile a new vboxsf module, but
+  #   fails on the first boot, since it can't install the corresponding
+  #   kernel-devel headers.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+end

--- a/vagrant/basebox/bootstrap.sh
+++ b/vagrant/basebox/bootstrap.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# This script performs the steps to build the base flocker-dev box until the
+# box must be rebooted.
+
+set -e
+
+yum update -y
+# Install useful yum repos
+yum install -y https://s3.amazonaws.com/archive.zfsonlinux.org/epel/zfs-release$(rpm -E %dist).noarch.rpm
+yum install -y epel-release
+yum install -y https://s3.amazonaws.com/clusterhq-archive/centos/clusterhq-release$(rpm -E %dist).noarch.rpm
+
+# Install packages
+yum install -y \
+	@buildsys-build git \
+	dkms kernel-headers kernel-devel rpmdevtools \
+	zlib-devel libuuid-devel libselinux-devel \
+	automake autoconf libtool \
+	rpm-devel rpmlint mock createrepo \
+	docker \
+	python-devel python-tox \
+	python-virtualenv python-virtualenvwrapper python-pip \
+	enchant \
+	libffi-devel openssl-devel \
+	yum-utils \
+	pypy pypy-devel
+
+
+# dpkg isn't currently available upstream
+# https://bugzilla.redhat.com/show_bug.cgi?id=1149590
+yum install -y --enablerepo=epel-testing dpkg-dev

--- a/vagrant/basebox/build
+++ b/vagrant/basebox/build
@@ -1,0 +1,1 @@
+../../admin/build-vagrant-box

--- a/vagrant/basebox/cache.sh
+++ b/vagrant/basebox/cache.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Pre-cache downloads.
+
+set -e
+
+# Download docker images used.
+systemctl start docker
+docker pull busybox
+docker pull openshift/busybox-http-app
+

--- a/vagrant/basebox/post-reboot-bootstrap.sh
+++ b/vagrant/basebox/post-reboot-bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This script performs the steps to build the base flocker-dev box after the
+# box has been rebooted. Installing ZFS requires a recent kernel.
+
+set -e
+
+# Enable zfs-testing repo
+yum-config-manager --enable zfs-testing
+yum install -y zfs
+
+systemctl enable docker

--- a/vagrant/dev/Vagrantfile
+++ b/vagrant/dev/Vagrantfile
@@ -34,16 +34,7 @@ unless Vagrant.has_plugin?("vagrant-vbguest")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "box-cutter/centos70"
-  # Update kernel and start to configure base system
-  config.vm.provision :shell, :path => "bootstrap.sh", :privileged => true
-  config.vm.provision :reload
-  # Finish configuring base system
-  config.vm.provision :shell, :path => "post-reboot-bootstrap.sh", :privileged => true
-  # Prepare caches
-  config.vm.provision :shell, :path => "cache.sh", :privileged => true
-  # Cleanup
-  config.vm.provision :shell, :path => "../cleanup.sh", :privileged => true
+  config.vm.box = "clusterhq/flocker-basebox"
 
   # Don't use a shared folder.
   # - It isn't used during the build.


### PR DESCRIPTION
Add a new Vagrantfile for 'basebox' virtualbox VM
Update the Vagrantfile used by the buildbot job flocker-vagrant-dev to use the new basebox
disable tox tests using pypy

The first run of the modified flocker-vagrant-dev will fail until the PR https://github.com/ClusterHQ/build.clusterhq.com/pull/108 is merged and built once.


JIRA https://clusterhq.atlassian.net/browse/FLOC-2494