### PR TITLE
test_exception_aborts_write: the writer sometimes can get IOError/EPIPE

### DIFF
--- a/flocker/volume/test/filesystemtests.py
+++ b/flocker/volume/test/filesystemtests.py
@@ -614,16 +614,23 @@ def make_istoragepool_tests(fixture, snapshot_factory):
                 path.child(b"anotherfile").setContent(b"hello")
 
                 to_filesystem = volume2.get_filesystem()
-                try:
-                    with from_filesystem.reader() as reader:
-                        with to_filesystem.writer() as writer:
-                            data = reader.read()
-                            writer.write(data[1:])
-                            raise ZeroDivisionError()
-                except ZeroDivisionError:
-                    pass
-                to_path = volume2.get_filesystem().get_path()
-                self.assertFalse(to_path.child(b"anotherfile").exists())
+                getting_snapshots = to_filesystem.snapshots()
+
+                def got_snapshots(snapshots):
+                    try:
+                        with from_filesystem.reader(snapshots) as reader:
+                            with to_filesystem.writer() as writer:
+                                data = reader.read()
+                                writer.write(data[:-1])
+                                raise ZeroDivisionError()
+                    except ZeroDivisionError:
+                        pass
+                    to_path = volume2.get_filesystem().get_path()
+                    self.assertFalse(to_path.child(b"anotherfile").exists())
+
+                getting_snapshots.addCallback(got_snapshots)
+                return getting_snapshots
+
             d.addCallback(got_volumes)
             return d
 


### PR DESCRIPTION
The previous code had 2 problems and each of them ensured that the test
would pass (except for possible EPIPE) even if the tested code didn't behave as expected.

- previously the test would discard the first byte of the stream, so the
  receiving side could know that the stream is corrupt just from reading
  its header and thus it wouldn't need to read the rest of the stream
  and so the exception would change little
- even if a completely valid stream were sent then the receiving side would
  still reject it because 'snapshots' parameter was not passed to the
  sending side and, thus, the sending side would generate a full stream
  for a filesystem that already exists and that would be rejected

So now we make sure that an incremental stream is sent.
Also we send all of the stream except the last byte, so that the receiving
side sees a completely valid stream until the exception is raised and the
stream is aborted.  Note that if we sent a full stream then it would be
possible that the receiving side would apply it before the exception is
raised.

See https://clusterhq.atlassian.net/browse/FLOC-2507