### PR TITLE
[FLOC-2492] Linkcheck

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -130,8 +130,6 @@ Once your pull request is merged, as a small thank you for contributing to Flock
 Just send an email to thankyou@clusterhq.com with your t-shirt size, mailing address and a phone number to be used only for filling out the shipping form.
 We'll get something in the mail to you.
 
-.. _JIRA: https://clusterhq.atlassian.net
-
 
 Merge Requirements
 ^^^^^^^^^^^^^^^^^^
@@ -165,7 +163,7 @@ While we're happy to look at contributions in any state as GitHub PRs, the requi
 Project Development Process
 ===========================
 
-The core development team uses a `JIRA workflow`_ to track planned work.
+The core development team uses a `JIRA`_ workflow to track planned work.
 Issues are organized by sprints, and can reside in various states:
 
 Backlog
@@ -198,8 +196,6 @@ Done
     The issue has been closed.
     Some final work may remain to address review comments; once this is done and the branch is merged the GitHub PR will be closed.
 
-.. _JIRA workflow: https://clusterhq.atlassian.net/secure/Dashboard.jspa
-
 
 .. _reporting-security-issues:
 
@@ -213,3 +209,5 @@ Flocker bugs should normally be :ref:`reported publicly<talk-to-us>`, but due to
 Instead, if you believe you have found something in Flocker (or any other ClusterHQ software) which has security implications, please send a description of the issue via email to security@clusterhq.com.
 Your message will be forwarded to the ClusterHQ security team (a small group of trusted developers) for triage and it will not be publicly readable.
 Once you have submitted an issue via email, you should receive an acknowledgment from a member of the security team within 48 hours, and depending on the action to be taken, you may receive further follow up emails.
+
+.. _JIRA: https://clusterhq.atlassian.net/secure/Dashboard.jspa

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -55,7 +55,7 @@ Development Environment
 * To run the complete test suite you will need `ZFS`_ and `Docker`_ installed.
   The recommended way to get an environment with these installed is to use the included ``Vagrantfile`` which will create a pre-configured CentOS 7 virtual machine.
   Vagrant 1.6.2 or later is required.
-  Once you have Vagrant installed (see the `Vagrant documentation <http://docs.vagrantup.com/>`_) you can run the following to get going:
+  Once you have Vagrant installed (see the `Vagrant documentation <https://docs.vagrantup.com/v2/>`_) you can run the following to get going:
 
   .. code-block:: console
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,7 @@ Talk to Us
 
 Have questions or need help?
 
-* If you want to follow our development plans, our main issue tracker is https://clusterhq.atlassian.net.
+* If you want to follow our development plans, our main issue tracker is https://clusterhq.atlassian.net/secure/Dashboard.jspa.
 * You can open an account there to file issues, but we're also happy to accept `GitHub issues`_ with feature requests or bug reports and :ref:`security issues should be reported directly to our security team<reporting-security-issues>`.
 * You can also join us on the ``#clusterhq`` channel on the ``irc.freenode.net`` IRC network or on the `flocker-users Google Group`_.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,7 +198,7 @@ Done
     The issue has been closed.
     Some final work may remain to address review comments; once this is done and the branch is merged the GitHub PR will be closed.
 
-.. _JIRA workflow: https://clusterhq.atlassian.net/
+.. _JIRA workflow: https://clusterhq.atlassian.net/secure/Dashboard.jspa
 
 
 .. _reporting-security-issues:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,7 @@ Talk to Us
 
 Have questions or need help?
 
-* If you want to follow our development plans, our main issue tracker is https://clusterhq.atlassian.net/secure/Dashboard.jspa.
+* If you want to follow our development plans, our main issue tracker is `JIRA`_.
 * You can open an account there to file issues, but we're also happy to accept `GitHub issues`_ with feature requests or bug reports and :ref:`security issues should be reported directly to our security team<reporting-security-issues>`.
 * You can also join us on the ``#clusterhq`` channel on the ``irc.freenode.net`` IRC network or on the `flocker-users Google Group`_.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -157,7 +157,7 @@ While we're happy to look at contributions in any state as GitHub PRs, the requi
    Documentation should be as accessible and inclusive as possible.
    Avoid language and markup which assumes the ability to precisely use a mouse and keyboard, or that the reader has perfect vision.
    Create alternative but equal documentation for the visually impaired, for example, by using alternative text on all images.
-   If in doubt, particularly about markup changes, use http://achecker.ca/ and fix any "Known Problems" and "Likely Problems".
+   If in doubt, particularly about markup changes, use http://achecker.ca/checker/index.php and fix any "Known Problems" and "Likely Problems".
 
 
 Project Development Process

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ You can run all of the tox environments using the command ``tox``.
 Flocker is also tested using `continuous integration`_.
 
 .. _ClusterHQ: https://clusterhq.com/
-.. _Twisted: https://twistedmatrix.com
+.. _Twisted: https://twistedmatrix.com/trac/
 .. _installing Flocker: https://docs.clusterhq.com/en/latest/using/installing/index.html
 .. _tutorial: https://docs.clusterhq.com/en/latest/using/tutorial/index.html
 .. _features of Flocker and its architecture: https://docs.clusterhq.com/en/latest/introduction/index.html

--- a/docs/concepts/security.rst
+++ b/docs/concepts/security.rst
@@ -6,7 +6,7 @@ Cluster Security & Authentication
 
 A Flocker cluster comprises a control service and convergence agents, along with some command line tools that are provided to interact with, and manage the cluster. For more information, see :ref:`architecture`.
 
-Flocker uses `Transport Layer Security <http://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (TLS) to authenticate components of a cluster, in a `mutual authentication  <http://en.wikipedia.org/wiki/Mutual_authentication>`_ model.
+Flocker uses `Transport Layer Security <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (TLS) to authenticate components of a cluster, in a `mutual authentication  <http://en.wikipedia.org/wiki/Mutual_authentication>`_ model.
 
 This ensures that the control service, convergence agents, and API end users are communicating with a verified component of a cluster, helping to prevent unauthorised access, and mitigating some potential attack vectors.
 

--- a/docs/concepts/security.rst
+++ b/docs/concepts/security.rst
@@ -6,7 +6,7 @@ Cluster Security & Authentication
 
 A Flocker cluster comprises a control service and convergence agents, along with some command line tools that are provided to interact with, and manage the cluster. For more information, see :ref:`architecture`.
 
-Flocker uses `Transport Layer Security <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (TLS) to authenticate components of a cluster, in a `mutual authentication  <http://en.wikipedia.org/wiki/Mutual_authentication>`_ model.
+Flocker uses `Transport Layer Security <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ (TLS) to authenticate components of a cluster, in a `mutual authentication <https://en.wikipedia.org/wiki/Mutual_authentication>`_ model.
 
 This ensures that the control service, convergence agents, and API end users are communicating with a verified component of a cluster, helping to prevent unauthorised access, and mitigating some potential attack vectors.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,4 +325,6 @@ linkcheck_ignore = [
     r'https://console.aws.amazon.com/ec2/v2/home\S+',
     # Internal ClusterHQ documents need a login to see
     r'https://docs.google.com/a/clusterhq.com/\S+',
+    # Example Flocker GUI local URL
+    r'http://localhost/client/#/nodes/list',
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -327,4 +327,11 @@ linkcheck_ignore = [
     r'https://docs.google.com/a/clusterhq.com/\S+',
     # Example Flocker GUI local URL
     r'http://localhost/client/#/nodes/list',
+
+    # The following link checks fail because of a TLS handshake error.
+    # The link checking should be fixed and these ignores should be removed.
+    # See https://clusterhq.atlassian.net/browse/FLOC-1156.
+    r'https://docs.clusterhq.com/',
+    r'https://docs.staging.clusterhq.com/',
+    r'https://docs.docker.com/\S+',
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,10 +317,11 @@ linkcheck_anchors = False
 linkcheck_ignore = [
     # Don't check links to tutorial IPs
     r'http://172\.16\.255\.',
-    # This is an example GitHub URL
-    r'https://github.com/ClusterHQ/flocker/compare/release/flocker-1.2.3...release-maintenance/flocker-1.2.3/fix-a-bug-FLOC-1234\?expand=1'
+    # Example comparisons between branches
+    r'https://github.com/ClusterHQ/flocker/compare/\S+',
     # Some Amazon EC2 links require a login and so
     # "HTTP Error 401: Unauthorized" is given.
+    r'https://console.aws.amazon.com/cloudfront/home',
     r'https://console.aws.amazon.com/ec2/v2/home\S+',
     # Internal ClusterHQ documents need a login to see
     r'https://docs.google.com/a/clusterhq.com/\S+',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,5 +321,7 @@ linkcheck_ignore = [
     r'https://github.com/ClusterHQ/flocker/compare/release/flocker-1.2.3...release-maintenance/flocker-1.2.3/fix-a-bug-FLOC-1234\?expand=1'
     # Some Amazon EC2 links require a login and so
     # "HTTP Error 401: Unauthorized" is given.
-    r'https://console.aws.amazon.com/ec2/v2/home\S+'
+    r'https://console.aws.amazon.com/ec2/v2/home\S+',
+    # Internal ClusterHQ documents need a login to see
+    r'https://docs.google.com/a/clusterhq.com/\S+',
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -319,4 +319,7 @@ linkcheck_ignore = [
     r'http://172\.16\.255\.',
     # This is an example GitHub URL
     r'https://github.com/ClusterHQ/flocker/compare/release/flocker-1.2.3...release-maintenance/flocker-1.2.3/fix-a-bug-FLOC-1234\?expand=1'
+    # Some Amazon EC2 links require a login and so
+    # "HTTP Error 401: Unauthorized" is given.
+    r'https://console.aws.amazon.com/ec2/v2/home\S+'
 ]

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -21,13 +21,13 @@ By the end of the release process we will have:
 - Ubuntu 14.04 DEBs for software on the node and client,
 - Ubuntu 15.04 DEBs for software on the node and client,
 - a Vagrant base tutorial image,
-- documentation on `docs.clusterhq.com <https://docs.clusterhq.com>`_, and
+- documentation on `docs.clusterhq.com <https://docs.clusterhq.com/>`_, and
 - an updated Homebrew recipe.
 
 For a maintenance or documentation release, we will have:
 
 - a tag in version control,
-- documentation on `docs.clusterhq.com <https://docs.clusterhq.com>`_.
+- documentation on `docs.clusterhq.com <https://docs.clusterhq.com/>`_.
 
 
 Prerequisites

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -45,7 +45,7 @@ Software
 
      vagrant plugin install vagrant-scp
 
-.. _`Vagrant`: https://docs.vagrantup.com/
+.. _`Vagrant`: https://docs.vagrantup.com/v2/
 .. _`VirtualBox`: https://www.virtualbox.org/
 
 Access

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -56,7 +56,7 @@ Access
 
 - SSH access to ClusterHQ's GitHub repositories.
 
-- The ability to create issues in `the ClusterHQ JIRA <https://clusterhq.atlassian.net>`_.
+- The ability to create issues in `the ClusterHQ JIRA <https://clusterhq.atlassian.net/secure/Dashboard.jspa>`_.
 
 .. _preparing-for-a-release:
 

--- a/docs/gettinginvolved/infrastructure/vagrant.rst
+++ b/docs/gettinginvolved/infrastructure/vagrant.rst
@@ -69,10 +69,8 @@ If you pass a ``--branch`` argument to :file:`build`, then it will use the RPMs 
 Legacy
 ^^^^^^
 
-Metadata for Vagrant boxes was hosted on `Atlas`_.
+Metadata for Vagrant boxes was hosted on `Atlas <https://atlas.hashicorp.com>`_.
 
 The Vagrant boxes were hosted on Google Cloud Storage.
 
 The development box used to be based on Fedora 20.
-
-.. _`Atlas`: https://atlas.hashicorp.com/vagrant

--- a/docs/gettinginvolved/plugins.rst
+++ b/docs/gettinginvolved/plugins.rst
@@ -42,7 +42,7 @@ To test that your implementation is correct you can instantiate a generic test s
         Tests for your storage.
         """
 
-You can run these tests with ``trial`` test runner provided by `Twisted <https://twistedmatrix.com>`_, one of Flocker's dependencies:
+You can run these tests with ``trial`` test runner provided by `Twisted <https://twistedmatrix.com/trac/>`_, one of Flocker's dependencies:
 
 .. prompt:: bash $
 

--- a/docs/labs/docker-plugin.rst
+++ b/docs/labs/docker-plugin.rst
@@ -24,7 +24,7 @@ As a user of Docker, it means you can use Flocker directly via:
 
 See the `Docker documentation on volume plugins <https://github.com/docker/docker/blob/master/experimental/plugins_volume.md>`_.
 
-This currently depends on the `experimental build of Docker <https://github.com/docker/docker/blob/master/experimental/>`_.
+This currently depends on the `experimental build of Docker <https://github.com/docker/docker/tree/master/experimental>`_.
 
 See also the `GitHub repo for this project <https://github.com/ClusterHQ/flocker-docker-plugin>`_.
 

--- a/docs/labs/docker-plugin.rst
+++ b/docs/labs/docker-plugin.rst
@@ -4,7 +4,7 @@
 Flocker Docker plugin
 =====================
 
-The Flocker Docker plugin is a `Docker volumes plugin <https://github.com/docker/docker/blob/master/experimental/plugins_volume.md>`_, connecting Docker on a host directly to Flocker, where Flocker agents will be running on the same host and hooked up to the Flocker control service.
+The Flocker Docker plugin is a `Docker volumes plugin <https://github.com/docker/docker/tree/master/experimental/plugins_volume.md>`_, connecting Docker on a host directly to Flocker, where Flocker agents will be running on the same host and hooked up to the Flocker control service.
 
 This diagram explains how the architecture of a Flocker cluster with the Docker plugin would look if the user is also using :ref:`Docker Swarm <labs-swarm>` and :ref:`Docker Compose <labs-compose>`:
 

--- a/docs/labs/docker-plugin.rst
+++ b/docs/labs/docker-plugin.rst
@@ -4,7 +4,7 @@
 Flocker Docker plugin
 =====================
 
-The Flocker Docker plugin is a `Docker volumes plugin <https://github.com/docker/docker/tree/master/experimental/plugins_volume.md>`_, connecting Docker on a host directly to Flocker, where Flocker agents will be running on the same host and hooked up to the Flocker control service.
+The Flocker Docker plugin is a `Docker volumes plugin <https://github.com/docker/docker/blob/master/experimental/plugins_volume.md>`_, connecting Docker on a host directly to Flocker, where Flocker agents will be running on the same host and hooked up to the Flocker control service.
 
 This diagram explains how the architecture of a Flocker cluster with the Docker plugin would look if the user is also using :ref:`Docker Swarm <labs-swarm>` and :ref:`Docker Compose <labs-compose>`:
 

--- a/docs/labs/weave.rst
+++ b/docs/labs/weave.rst
@@ -13,7 +13,7 @@ Installation
 ============
 
 Flocker and Weave both have Docker plugins.
-So you can simply install the :ref:`Flocker Docker plugin <labs-docker-plugin>` and install the `Weave Docker plugin <http://weave.works/docker-plugins>`_ and it should Just Work.
+So you can simply install the :ref:`Flocker Docker plugin <labs-docker-plugin>` and install the `Weave Docker plugin <http://weave.works/docker-plugins/index.html>`_ and it should Just Work.
 
 Demo
 ====

--- a/docs/using/installing/index.rst
+++ b/docs/using/installing/index.rst
@@ -174,7 +174,7 @@ Using Amazon Web Services
 -------------------------
 
 .. note:: If you are not familiar with EC2 you may want to `read more about the terminology and concepts <https://fedoraproject.org/wiki/User:Gholms/EC2_Primer>`_ used in this document.
-          You can also refer to `the full documentation for interacting with EC2 from Amazon Web Services <http://docs.amazonwebservices.com/AWSEC2/latest/GettingStartedGuide/>`_.
+          You can also refer to `the full documentation for interacting with EC2 from Amazon Web Services <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html>`_.
 
 
 .. The AMI links were created using the ami_links tool in ClusterHQ's internal-tools repository.

--- a/docs/using/tutorial/vagrant-setup.rst
+++ b/docs/using/tutorial/vagrant-setup.rst
@@ -277,7 +277,7 @@ Alternatively, if you do not have the original ``Vagrantfile`` or if the ``vagra
 The two virtual machines will have names like ``flocker-tutorial_node1_1410450919851_28614`` and ``flocker-tutorial_node2_1410451102837_79031``.
 
 .. _`Homebrew`: http://brew.sh/
-.. _`Vagrant`: https://docs.vagrantup.com/
+.. _`Vagrant`: https://docs.vagrantup.com/v2/
 .. _`VirtualBox`: https://www.virtualbox.org/
 .. _`MongoDB installation guide`: http://docs.mongodb.org/manual/installation/
 .. _`directly from VirtualBox`: https://www.virtualbox.org/manual/ch01.html#idp55629568


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2492

This changes redirected links, and then ignores links which are:
* Examples, to show a structure (e.g. a GitHub comparison)
* Password protected
* Failing because of https://clusterhq.atlassian.net/browse/FLOC-1156

FLOC-1156 is a follow up to this.