### PR TITLE
[FLOC-2531] Fix to log entire agent.yaml file, not just dataset

### DIFF
--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -575,7 +575,7 @@ def _remove_dataset_fields(content):
     for key in dataset:
         if key not in _ok_to_log:
             dataset[key] = 'REMOVED'
-    return yaml.safe_dump(dataset)
+    return yaml.safe_dump(content)
 
 
 def task_configure_flocker_agent(control_node, dataset_backend,

--- a/flocker/provision/test/test_install.py
+++ b/flocker/provision/test/test_install.py
@@ -483,4 +483,5 @@ class DatasetLoggingTest(SynchronousTestCase):
         content = yaml.safe_dump(config)
         logged = _remove_dataset_fields(content)
         self.assertEqual(
-            yaml.safe_load(logged), {'secret': 'REMOVED', 'zone': 'keep'})
+            yaml.safe_load(logged),
+            {'dataset': {'secret': 'REMOVED', 'zone': 'keep'}})


### PR DESCRIPTION
This fixes a bug introduced in FLOC-2428. The log needs to record the entire value of the agent.yml file, not just the dataset.
