### PR TITLE
Install rsyslog configuration file keeping Flocker logs out of /var/log

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Flocker 1.0.2 (2015-06-XX)
+==========================
+
+- On CentOS 7 Flocker logs are no longer written to /var/log/messages since this fills up disk space quickly and the logs are already available via journald. (FLOC-2534)
+
 Flocker 1.0.1 (2015-06-20)
 ==========================
 

--- a/admin/package-files/rsyslog/flocker.conf
+++ b/admin/package-files/rsyslog/flocker.conf
@@ -1,0 +1,6 @@
+# Flocker logs will end up in journald and can be accessed via journalctl. There
+# is therefore no need to duplicate them in /var/log/messages; instead they
+# should be discarded by rsyslog.
+if $programname == 'flocker-control' then ~
+if $programname == 'flocker-dataset-agent' then ~
+if $programname == 'flocker-container-agent' then ~

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -658,7 +658,7 @@ IGNORED_WARNINGS = {
         'file-in-etc-not-marked-as-conffile etc/init/flocker-control.conf',
 
         # rsyslog files are not installed as conffiles.
-        'file-in-etc-not-marked-as-conffile /etc/rsyslog.d/flocker.conf',
+        'file-in-etc-not-marked-as-conffile etc/rsyslog.d/flocker.conf',
 
         # Cryptography hazmat bindings
         'package-installs-python-pycache-dir opt/flocker/lib/python2.7/site-packages/cryptography/hazmat/bindings/__pycache__/',  # noqa

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -587,6 +587,9 @@ IGNORED_WARNINGS = {
         'non-conffile-in-etc /etc/init/flocker-container-agent.conf',
         'non-conffile-in-etc /etc/init/flocker-control.conf',
 
+        # rsyslog files are not installed as conffiles.
+        'non-conffile-in-etc /etc/rsyslog.d/flocker.conf',
+
         # Cryptography hazmat bindings
         'package-installs-python-pycache-dir opt/flocker/lib/python2.7/site-packages/cryptography/hazmat/bindings/__pycache__/',  # noqa
 
@@ -653,6 +656,9 @@ IGNORED_WARNINGS = {
         'file-in-etc-not-marked-as-conffile etc/init/flocker-dataset-agent.conf',  # noqa
         'file-in-etc-not-marked-as-conffile etc/init/flocker-container-agent.conf',  # noqa
         'file-in-etc-not-marked-as-conffile etc/init/flocker-control.conf',
+
+        # rsyslog files are not installed as conffiles.
+        'file-in-etc-not-marked-as-conffile /etc/rsyslog.d/flocker.conf',
 
         # Cryptography hazmat bindings
         'package-installs-python-pycache-dir opt/flocker/lib/python2.7/site-packages/cryptography/hazmat/bindings/__pycache__/',  # noqa

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -928,6 +928,9 @@ def omnibus_package_builder(
                     # Upstart configuration
                     package_files.child('upstart'):
                         FilePath('/etc/init'),
+                    # rsyslog configuration
+                    package_files.child(b'rsyslog'):
+                        FilePath(b'/etc/rsyslog.d'),
                     # Flocker Control State dir
                     empty_path: FilePath('/var/lib/flocker/'),
                 },

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -994,6 +994,9 @@ class OmnibusPackageBuilderTests(TestCase):
                         # Upstart configuration
                         package_files.child('upstart'):
                             FilePath('/etc/init'),
+                        # rsyslog configuration
+                        package_files.child(b'rsyslog'):
+                            FilePath(b"/etc/rsyslog.d"),
                         # Flocker Control State dir
                         empty_path: FilePath('/var/lib/flocker/'),
                     },

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -2,7 +2,8 @@
 Release Notes
 =============
 
-.. note:: If you already have a tutorial environment from a previous release see :ref:`upgrading-vagrant-environment`.
+See the :ref:`upgrading instructions <upgrading>` for information on upgrading Flocker clusters from earlier releases.
+If you have a Vagrant tutorial environment from a previous release see :ref:`upgrading-vagrant-environment`.
 
 You can learn more about where we might be going with future releases by:
 
@@ -12,7 +13,8 @@ You can learn more about where we might be going with future releases by:
 v1.0.2
 ======
 
-* On CentOS 7 Flocker logs are no longer written to /var/log/messages since this fills up disk space quickly and the logs are already available via journald.
+* On CentOS 7, Flocker logs are no longer written to /var/log/messages since this filled up disk space too quickly.
+  The logs are still available via journald.
 * The "on-failure" and "always" restart policies for containers have been temporarily disabled due to poor interaction with node reboots for containers with volumes (FLOC-2467).
   See :ref:`restart policy<restart configuration>`.
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,6 +9,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.0.2
+======
+
+* On CentOS 7 Flocker logs are no longer written to /var/log/messages since this fills up disk space quickly and the logs are already available via journald.
+
 v1.0.1
 ======
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -46,6 +46,7 @@ installable
 integrations
 internet
 invalidations
+journald
 Kubernetes
 libswarm
 lifecycle

--- a/docs/using/administering/upgrading.rst
+++ b/docs/using/administering/upgrading.rst
@@ -1,3 +1,5 @@
+.. _upgrading:
+
 =========
 Upgrading
 =========

--- a/docs/using/administering/upgrading.rst
+++ b/docs/using/administering/upgrading.rst
@@ -7,6 +7,23 @@ The correct steps to follow may vary depending on the versions of Flocker being 
 
 .. note:: A common requirement for all currently supported upgrade paths is that all nodes and the control service must be running the same version of Flocker.
 
+Flocker v1.0.2
+--------------
+
+Recommended Steps
+^^^^^^^^^^^^^^^^^
+
+#. Stop the agent services on all nodes, and then stop control service.
+#. Install Flocker v1.0.2 on all nodes in the Flocker cluster.
+#. If you are running on CentOS, run ``systemctl restart rsyslog`` on all machines running Flocker services.
+#. Restart the Docker service.
+#. Restart the control service.
+#. Restart the agent services on all nodes.
+
+Note that once you have done this applications you have previously configured to always restart will not be restarted.
+You will need to remove and re-add them every time they exit or you reboot.
+This feature was broken in previous releases and so has been temporarily disabled in this release.
+
 Flocker v1.0.1
 --------------
 


### PR DESCRIPTION
To review you need to install generated RPM somewhere and run the services. Things you will need to verify:

1. Flocker logs are not in /var/log/messages. Maybe... ssh into running acceptance test node?
2. Logs are still available via journald. You can validate this by checking that the remote logs for the CentOS acceptance builders still contains Flocker logs.
