### PR TITLE
Skip test_application_volume_quotas, because it's flaky

### DIFF
--- a/flocker/acceptance/test_deployment.py
+++ b/flocker/acceptance/test_deployment.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from pyrsistent import pmap
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SkipTest, TestCase
 
 from ..control.httpapi import container_configuration_response
 

--- a/flocker/acceptance/test_deployment.py
+++ b/flocker/acceptance/test_deployment.py
@@ -67,6 +67,9 @@ class DeploymentTests(TestCase):
         In other words, the defined volume quota size is preserved from one
         node to the next.
         """
+        raise SkipTest(
+            'Sometimes times out on acceptance/aws/centos-7/aws. '
+            'See FLOC-2555.')
         (node_1, node_1_uuid), (node_2, node_2_uuid) = [
             (node.reported_hostname, node.uuid) for node in cluster.nodes]
         mongo_dataset_id = unicode(uuid4())


### PR DESCRIPTION
Raise `SkipTest` in test_application_volume_quotas, linking to the bug that tracks us fixing it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1733)
<!-- Reviewable:end -->
