### PR TITLE
[FLOC-2532] Fix dataset logging

### DIFF
--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -589,7 +589,7 @@ def _remove_dataset_fields(content):
     for key in dataset:
         if key not in _ok_to_log:
             dataset[key] = 'REMOVED'
-    return yaml.safe_dump(dataset)
+    return yaml.safe_dump(content)
 
 
 def task_configure_flocker_agent(control_node, dataset_backend,

--- a/flocker/provision/test/test_install.py
+++ b/flocker/provision/test/test_install.py
@@ -447,6 +447,9 @@ enabled=0
 
 
 class PrivateKeyLoggingTest(SynchronousTestCase):
+    """
+    Test removal of private keys from logs.
+    """
 
     def test_private_key_removed(self):
         """
@@ -501,8 +504,14 @@ class PrivateKeyLoggingTest(SynchronousTestCase):
 
 
 class DatasetLoggingTest(SynchronousTestCase):
+    """
+    Test removal of sensitive information from logged configuration files.
+    """
 
     def test_dataset_logged_safely(self):
+        """
+        Values are either the same or replaced by 'REMOVED'.
+        """
         config = {
             'dataset': {
                 'secret': 'SENSITIVE',

--- a/flocker/provision/test/test_install.py
+++ b/flocker/provision/test/test_install.py
@@ -512,4 +512,5 @@ class DatasetLoggingTest(SynchronousTestCase):
         content = yaml.safe_dump(config)
         logged = _remove_dataset_fields(content)
         self.assertEqual(
-            yaml.safe_load(logged), {'secret': 'REMOVED', 'zone': 'keep'})
+            yaml.safe_load(logged),
+            {'dataset': {'secret': 'REMOVED', 'zone': 'keep'}})


### PR DESCRIPTION
For review, check acceptance tests step `trial` stdio file includes the entire `agent.yml` file, not just the dataset backend. Search for `/etc/flocker/agent.yml`

This PR is against `master`. See previous review at #1725 which was against 1.0.1 (but not going to be merged).