### PR TITLE
Remove coveralls badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,7 @@
 Want to get your hands dirty? Skip ahead to the `tutorial`_.
 
-Flocker |coveralls|
-===================
-
-.. |coveralls| image:: https://coveralls.io/repos/ClusterHQ/flocker/badge.png
-  :target: https://coveralls.io/r/ClusterHQ/flocker
+Flocker
+=======
 
 Flocker is an open-source Container Data Volume Manager for your Dockerized applications.
 


### PR DESCRIPTION
Once the fix to [FLOC-2567](https://clusterhq.atlassian.net/browse/FLOC-2567) lands, the badge will be out of date.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1736)
<!-- Reviewable:end -->
