### PR TITLE
[FLOC-2576] Skip conch tests in Flocker 1.0.1

### DIFF
--- a/flocker/provision/test/test_ssh_conch.py
+++ b/flocker/provision/test/test_ssh_conch.py
@@ -17,6 +17,7 @@ from .._ssh._conch import make_dispatcher, RUN_OUTPUT_MESSAGE
 
 from flocker.testtools.ssh import create_ssh_server, create_ssh_agent
 
+skip = "See FLOC-1883. These tests don't properly clean up the reactor."
 
 class Tests(TestCase):
     """

--- a/flocker/provision/test/test_ssh_conch.py
+++ b/flocker/provision/test/test_ssh_conch.py
@@ -19,6 +19,7 @@ from flocker.testtools.ssh import create_ssh_server, create_ssh_agent
 
 skip = "See FLOC-1883. These tests don't properly clean up the reactor."
 
+
 class Tests(TestCase):
     """
     Tests for conch implementation of ``flocker.provision._ssh.RunRemotely``.

--- a/flocker/provision/test/test_ssh_monkeypatch.py
+++ b/flocker/provision/test/test_ssh_monkeypatch.py
@@ -20,7 +20,7 @@ class Twisted7672Tests(TestCase):
         This will be the case if the patch is still needed, or if it has been
         applied.
         """
-        self.assertFalse(
+        self.assertTrue(
             # The patch is still needed
             _patch_7672_needed()
             # Or the patch has already been applied

--- a/flocker/provision/test/test_ssh_monkeypatch.py
+++ b/flocker/provision/test/test_ssh_monkeypatch.py
@@ -16,6 +16,13 @@ class Twisted7672Tests(TestCase):
     def test_needsPatch(self):
         """
         Check to see if patch is still required.
+
+        This will be the case if the patch is still needed, or if it has been
+        applied.
         """
-        self.assertTrue((not _patch_7672_needed()) or patch_7672_applied,
-                        "Monkeypatch for twisted bug #7672 can be removed.")
+        self.assertFalse(
+            # The patch is still needed
+            _patch_7672_needed()
+            # Or the patch has already been applied
+            or patch_7672_applied,
+            "Monkeypatch for twisted bug #7672 can be removed.")


### PR DESCRIPTION
Back-porting fix to 1.0.1 to allow tests for other patches to pass.