### PR TITLE
[FLOC-2539] Update navigation in docs

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -81,7 +81,7 @@
                         <li><a href="https://clusterhq.com/flocker/introduction">About Flocker</a></li>
                         <li><a href="https://clusterhq.com/flocker/getting-started">Getting Started</a></li>
                         <li><a href="https://clusterhq.com/flocker/use-cases">Use Cases</a></li>
-                        <li><a class="active" href="https://docs.clusterhq.com/en/latest/">Docs</a></li>
+                        <li><a class="active" href="https://docs.clusterhq.com/en/latest/">Install &amp; Docs</a></li>
                         <li><a href="https://clusterhq.com/flocker/support/">Support</a></li>
                         <li><a href="https://clusterhq.com/blog/">Blog</a></li>
                         <li><a href="https://clusterhq.com/flocker/try-flocker/">Try Flocker</a></li>

--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -410,7 +410,7 @@ a.download:before {
     }
 
     .menu ul.menu {
-        padding-left: 15%;
+        padding-left: 5%;
     }
 
     ul.menu li:last-of-type a {
@@ -432,7 +432,7 @@ a.download:before {
     }
 
     .menu ul.menu {
-        padding-left: 20%;
+        padding-left: 15%;
     }
 }
 


### PR DESCRIPTION
Change navigation link to "Install & Docs" and alter the padding left to be inline with the altered version on the homepage

> You do two branches, one off current release branch (release/flocker-1.0.1 currently) and then once that's in one off master

I believe this is all I have to do for now.

Fixes FLOC-2539