### PR TITLE
[FLOC-2558] Increase timeout on acceptance deployment tests

### DIFF
--- a/flocker/acceptance/test_deployment.py
+++ b/flocker/acceptance/test_deployment.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 from pyrsistent import pmap
 
-from twisted.trial.unittest import SkipTest, TestCase
+from twisted.trial.unittest import TestCase
 
 from ..control.httpapi import container_configuration_response
 
@@ -54,6 +54,8 @@ class DeploymentTests(TestCase):
     http://doc-dev.clusterhq.com/gettingstarted/tutorial/
     moving-applications.html#starting-an-application
     """
+    timeout = 200
+
     @require_moving_backend
     @require_flocker_cli
     @require_cluster(num_nodes=2)
@@ -67,9 +69,6 @@ class DeploymentTests(TestCase):
         In other words, the defined volume quota size is preserved from one
         node to the next.
         """
-        raise SkipTest(
-            'Sometimes times out on acceptance/aws/centos-7/aws. '
-            'See FLOC-2555.')
         (node_1, node_1_uuid), (node_2, node_2_uuid) = [
             (node.reported_hostname, node.uuid) for node in cluster.nodes]
         mongo_dataset_id = unicode(uuid4())


### PR DESCRIPTION
"Fixes" FLOC-2558
Increases the timeout on `flocker.acceptance.test_deployment.DeploymentTests` to 200 seconds. See https://clusterhq.atlassian.net/browse/FLOC-2558?focusedCommentId=18735&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-18735

This may be sufficient for our immediate purposes. AWS builds are passing (for now).