### PR TITLE
[FLOC-2581] Remove doc and release targets

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,22 +52,26 @@ Have questions or need help?
 Development Environment
 =======================
 
-* To run the complete test suite you will need `ZFS`_ and `Docker`_ installed.
-  The recommended way to get an environment with these installed is to use the included ``Vagrantfile`` which will create a pre-configured CentOS 7 virtual machine.
-  Vagrant 1.6.2 or later is required.
-  Once you have Vagrant installed (see the `Vagrant documentation <https://docs.vagrantup.com/v2/>`_) you can run the following to get going:
+To run the complete test suite you will need `ZFS`_ and `Docker`_ installed.
+The recommended way to get an environment with these installed is to use the included ``Vagrantfile`` which will create a pre-configured CentOS 7 virtual machine.
+Vagrant 1.6.2 or later is required.
+Once you have Vagrant installed (see the `Vagrant documentation <https://docs.vagrantup.com/v2/>`_) you can run the following to get going:
 
-  .. code-block:: console
+.. code-block:: console
 
-     $ vagrant up
-     $ vagrant ssh
+   $ vagrant up
+   $ vagrant ssh
 
-* You will need Python 2.7 and a recent version of PyPy installed on your development machine.
-* If you don't already have ``tox`` on your development machine, you can install it and other development dependencies (ideally in a ``virtualenv``) by doing:
+You will need Python 2.7 and a recent version of PyPy installed on your development machine.
 
-  .. code-block:: console
+Install Flocker and its development dependencies in a ``virtualenv`` by running the following commands:
 
-     $ pip install --editable .[dev]
+.. code-block:: console
+
+   $ mkvirtualenv flocker
+   $ git clone https://github.com/ClusterHQ/flocker.git
+   $ cd flocker
+   $ pip install --editable .[dev]
 
 .. _ZFS: http://zfsonlinux.org
 .. _Docker: https://www.docker.com/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,7 +67,7 @@ Development Environment
 
   .. code-block:: console
 
-     $ python setup.py install .[doc,dev]
+     $ pip install --editable .[dev]
 
 .. _ZFS: http://zfsonlinux.org
 .. _Docker: https://www.docker.com/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,8 +52,18 @@ Have questions or need help?
 Development Environment
 =======================
 
-To run the complete test suite you will need `ZFS`_ and `Docker`_ installed.
-The recommended way to get an environment with these installed is to use the included ``Vagrantfile`` which will create a pre-configured CentOS 7 virtual machine.
+You will need Python 2.7 (and optionally a recent version of PyPy) installed on your development machine.
+To run the complete test suite you will also need `ZFS`_ and `Docker`_ installed.
+
+The recommended way to get an environment with these installed is to use Vagrant to run a pre-configured Flocker development virtual machine.
+
+First, clone the Flocker repository on your local machine:
+
+.. code-block:: console
+
+   $ git clone https://github.com/ClusterHQ/flocker.git
+   $ cd flocker
+
 Vagrant 1.6.2 or later is required.
 Once you have Vagrant installed (see the `Vagrant documentation <https://docs.vagrantup.com/v2/>`_) you can run the following to get going:
 
@@ -62,15 +72,13 @@ Once you have Vagrant installed (see the `Vagrant documentation <https://docs.va
    $ vagrant up
    $ vagrant ssh
 
-You will need Python 2.7 and a recent version of PyPy installed on your development machine.
-
-Install Flocker and its development dependencies in a ``virtualenv`` by running the following commands:
+The ``flocker`` directory created above will be shared in the virtual machine at ``/vagrant``.
+Install Flocker's development dependencies in a ``virtualenv`` by running the following commands:
 
 .. code-block:: console
 
+   $ cd /vagrant
    $ mkvirtualenv flocker
-   $ git clone https://github.com/ClusterHQ/flocker.git
-   $ cd flocker
    $ pip install --editable .[dev]
 
 .. _ZFS: http://zfsonlinux.org
@@ -92,7 +100,7 @@ You can also run specific tests in a specific environment:
 
    $ tox -e py27 flocker.control.test.test_httpapi
 
-Functional tests require ``ZFS`` and ``Docker`` to be installed and in the case of the latter running as well.
+Functional tests require ``ZFS`` and ``Docker`` to be installed and, in the case of Docker, running.
 In addition, ``tox`` needs to be run as root:
 
 .. code-block:: console

--- a/docs/gettinginvolved/infrastructure/packaging.rst
+++ b/docs/gettinginvolved/infrastructure/packaging.rst
@@ -13,7 +13,7 @@ To build omnibus packages, create a VirtualEnv and install Flocker then its rele
    cd /path/to/flocker
    mkvirtualenv flocker-packaging
    pip install .
-   pip install Flocker[release]
+   pip install Flocker[dev]
 
 Then run the following command from a clean checkout of the Flocker repository:
 

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -120,7 +120,7 @@ Preparing For a Release
       git clone git@github.com:ClusterHQ/flocker.git
       cd flocker
       mkvirtualenv flocker-release
-      pip install --editable .[release]
+      pip install --editable .[dev]
       admin/create-release-branch --flocker-version="${VERSION}"
 
 #. Ensure the release notes in :file:`NEWS` are up-to-date:


### PR DESCRIPTION
#1724 removed the `doc` and `release` targets in `setup.py`. All the packages mentioned in these targets were moved to the `dev` target. This was done because most people who are developing Flocker will need all of these dependencies at some stage.

This PR removes some mentions of these targets which were missed in the earlier patch, replacing `doc` and `release` with `dev`.

In addition, the instructions in the `CONTRIBUTING.rst` file did not work, even when modified. So this patch also replaces these instructions with ones that work, and removes the bullet point structure to match the subsequent sections on running tests.