### PR TITLE
[FLOC-2617] Release Flocker 1.0.3pre1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Flocker 1.0.3pre1 (2015-07-07)
+==============================
+
+- On Ubuntu-14.04, log files are now written to /var/log/flocker and rotated in five 100MiB files, so as not fill up the system disk. (FLOC-2538) 
+
 Flocker 1.0.2 (2015-07-03)
 ==========================
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.0.3pre1
+==========
+
+* On Ubuntu-14.04, log files are now written to /var/log/flocker and rotated in five 100MiB files, so as not fill up the system disk. 
+
 v1.0.2
 ======
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-2617

Expected test failures:
 * http://build.clusterhq.com/builders/flocker-centos-7/builds/5482 (these conch test failures are known and fixed or skipped in master)
 * http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fubuntu-14.04%2Faws/builds/1064 (this mongo object mismatch is already fixed in master)

Please follow the pre-tag release review process:
 * http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html#pre-tag-review-process