### PR TITLE
[FLOC-2625] Add MiB to wordlist.

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -55,6 +55,7 @@ lifecycle
 loopback
 Mesos
 metadata
+MiB
 microservice
 microservices
 mountpoint


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-2625

ClusterHQ/build.clusterhq.com#120 moved the spelling builder to ubuntu 14.04. New versions don't like the spelling of `MiB` (I discovered this testing updated images on a staging buildbot).