### PR TITLE
[FLOC-1040] test_added_is_listed intermittent failure

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -173,35 +173,28 @@ class IDockerClient(Interface):
         Install and start a new unit.
 
         Note that callers should not assume success indicates the unit has
-        finished starting up. In addition to asynchronous nature of Docker,
-        even if container is up and running the application within it
-        might still be starting up, e.g. it may not have bound the
-        external ports yet. As a result the final success of application
-        startup is out of scope for this method.
+        finished starting up.  In addition to asynchronous nature of Docker,
+        even if container is up and running the application within it might
+        still be starting up, e.g. it may not have bound the external ports
+        yet.  As a result the final success of application startup is out of
+        scope for this method.
 
         :param unicode unit_name: The name of the unit to create.
-
         :param unicode image_name: The Docker image to use for the unit.
-
         :param list ports: A list of ``PortMap``\ s mapping ports exposed in
-            the container to ports exposed on the host. Default ``None`` means
+            the container to ports exposed on the host.  Default ``None`` means
             that no port mappings will be configured for this unit.
-
         :param Environment environment: Environment variables for the
-            container. Default ``None`` means that no environment
-            variables will be supplied to the unit.
-
+            container.  Default ``None`` means that no environment variables
+            will be supplied to the unit.
         :param volumes: A sequence of ``Volume`` instances to mount.
-
         :param int mem_limit: The number of bytes to which to limit the in-core
             memory allocations of the new unit.  Or ``None`` to apply no
             limits.
-
         :param int cpu_shares: The number of CPU shares to allocate to the new
             unit.  Or ``None`` to let it have the default number of shares.
             Docker maps this value onto the cgroups ``cpu.shares`` value (the
             default of which is probably 1024).
-
         :param IRestartPolicy restart_policy: The restart policy of the
             container.
 
@@ -210,7 +203,6 @@ class IDockerClient(Interface):
 
         :return: ``Deferred`` that fires on success, or errbacks with
             :class:`AlreadyExists` if a unit by that name already exists.
-
         """
 
     def exists(unit_name):

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -197,8 +197,7 @@ class IDockerClient(Interface):
             default of which is probably 1024).
         :param IRestartPolicy restart_policy: The restart policy of the
             container.
-
-        :ivar command_line: Custom command to run using the image, a sequence
+        :param command_line: Custom command to run using the image, a sequence
             of ``unicode``, or ``None`` to use default image command line.
 
         :return: ``Deferred`` that fires on success, or errbacks with

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -17,7 +17,8 @@ from docker.utils import create_host_config
 
 from eliot import Message
 
-from pyrsistent import field, PRecord
+from pyrsistent import field, PRecord, pset
+from characteristic import with_cmp
 
 from twisted.python.components import proxyForInterface
 from twisted.python.filepath import FilePath
@@ -31,6 +32,21 @@ from ..control._model import (
 
 class AlreadyExists(Exception):
     """A unit with the given name already exists."""
+
+
+@with_cmp(["address"])
+class AddressInUse(Exception):
+    """
+    The listen address for an exposed port was in use and could not be bound.
+    """
+    def __init__(self, address):
+        """
+        :param tuple address: The conventional Python representation of the
+            address which could not be bound (eg, an (ipv4 address, port
+            number) pair for IPv4 addresses).
+        """
+        Exception.__init__(self, address)
+        self.address = address
 
 
 class Environment(PRecord):
@@ -236,6 +252,9 @@ class FakeDockerClient(object):
     The state the the simulated units is stored in memory.
 
     :ivar dict _units: See ``units`` of ``__init__``\ .
+    :ivar pset _used_ports: A set of integers giving the port numbers which
+        will be considered in use.  Attempts to add containers which use these
+        ports will fail.
     """
 
     def __init__(self, units=None):
@@ -248,17 +267,32 @@ class FakeDockerClient(object):
         if units is None:
             units = {}
         self._units = units
+        self._used_ports = pset()
 
     def add(self, unit_name, image_name, ports=frozenset(), environment=None,
             volumes=frozenset(), mem_limit=None, cpu_shares=None,
             restart_policy=RestartNever(), command_line=None):
         if unit_name in self._units:
             return fail(AlreadyExists(unit_name))
+        for port in ports:
+            if port.external_port in self._used_ports:
+                raise AddressInUse(address=(b"0.0.0.0", port.external_port))
+
+        all_ports = set(range(2 ** 15, 2 ** 16))
+        assigned_ports = []
+        for port in ports:
+            if port.external_port == 0:
+                available_ports = pset(all_ports) - self._used_ports
+                assigned = next(iter(available_ports))
+                port = port.set(external_port=assigned)
+            assigned_ports.append(port)
+            self._used_ports = self._used_ports.add(port.external_port)
+
         self._units[unit_name] = Unit(
             name=unit_name,
             container_name=unit_name,
             container_image=image_name,
-            ports=frozenset(ports),
+            ports=frozenset(assigned_ports),
             environment=environment,
             volumes=frozenset(volumes),
             activation_state=u'active',
@@ -447,6 +481,35 @@ class DockerClient(object):
         """
         return apierror.response.status_code == NOT_FOUND
 
+    def _address_in_use(self, apierror):
+        """
+        Inspect a ``docker.errors.APIError`` to determine if it represents a
+        failure to start a container because the container is configured to use
+        ports that are already in use on the system.
+
+        :return: If this is the reason, an exception to raise describing the
+            problem.  Otherwise, ``None``.
+        """
+        # Recognize an error (without newline) like:
+        #
+        # Cannot start container <name>: Error starting userland proxy:
+        # listen tcp <ip>:<port>: bind: address already in use
+        #
+        # Or (without newline) like:
+        #
+        # Cannot start container <name>: Bind for <ip>:<port> failed:
+        # port is already allocated
+        #
+        # because Docker can't make up its mind about which format to use.
+        parts = apierror.explanation.split(b": ")
+        if parts[-1] == b"address already in use":
+            ip, port = parts[-3].split()[-1].split(b":")
+        elif parts[-1] == b"port is already allocated":
+            ip, port = parts[-2].split()[2].split(b":")
+        else:
+            return None
+        return AddressInUse(address=(ip, int(port)))
+
     def add(self, unit_name, image_name, ports=None, environment=None,
             volumes=(), mem_limit=None, cpu_shares=None,
             restart_policy=RestartNever(), command_line=None):
@@ -522,6 +585,15 @@ class DockerClient(object):
             code = failure.value.response.status_code
             if code == 409:
                 raise AlreadyExists(unit_name)
+
+            in_use = self._address_in_use(failure.value)
+            if in_use is not None:
+                # We likely can't start the container because its
+                # configuration conflicts with something else happening on
+                # the system.  Reflect this failure condition in a more
+                # easily recognized way.
+                raise in_use
+
             return failure
         d.addErrback(_extract_error)
         return d
@@ -684,7 +756,7 @@ class DockerClient(object):
                         raise
                 if image_data[u"Config"][u"Cmd"] == command:
                     command = None
-                port_bindings = data[u"HostConfig"][u"PortBindings"]
+                port_bindings = data[u"NetworkSettings"][u"Ports"]
                 if port_bindings is not None:
                     ports = self._parse_container_ports(port_bindings)
                 else:

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -183,7 +183,10 @@ class IDockerClient(Interface):
         :param unicode image_name: The Docker image to use for the unit.
         :param list ports: A list of ``PortMap``\ s mapping ports exposed in
             the container to ports exposed on the host.  Default ``None`` means
-            that no port mappings will be configured for this unit.
+            that no port mappings will be configured for this unit.  If a
+            ``PortMap`` instance's ``external_port`` is set to ``0`` a free
+            port will automatically be assigned.  The assigned port will be
+            reported for the container in the result of ``IDockerClient.list``.
         :param Environment environment: Environment variables for the
             container.  Default ``None`` means that no environment variables
             will be supplied to the unit.

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -44,7 +44,7 @@ def namespace_for_test(test_case):
 class IDockerClientTests(make_idockerclient_tests(
         lambda test_case: DockerClient(
             namespace=namespace_for_test(test_case)
-        )
+        ),
 )):
     """
     ``IDockerClient`` tests for ``DockerClient``.

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -7,6 +7,7 @@ Functional tests for :module:`flocker.node._docker`.
 from __future__ import absolute_import
 
 import time
+import socket
 from functools import partial
 
 from docker.errors import APIError
@@ -32,7 +33,8 @@ from ...testtools import (
 from ..test.test_docker import make_idockerclient_tests
 from .._docker import (
     DockerClient, PortMap, Environment, NamespacedDockerClient,
-    BASE_NAMESPACE, Volume)
+    BASE_NAMESPACE, Volume, AddressInUse,
+)
 from ...control._model import RestartNever, RestartAlways, RestartOnFailure
 from ..testtools import if_docker_configured, wait_for_unit_state
 
@@ -297,6 +299,27 @@ class GenericDockerClientTests(TestCase):
             return response
 
         return loop_until(send_request)
+
+    def test_non_docker_port_collision(self):
+        """
+        ``DockerClient.add`` returns a ``Deferred`` that fails with
+        ``AddressInUse`` if the external port of one of the ``PortMap``
+        instances passed for ``ports`` is already in use on the system by
+        something other than a Docker container.
+        """
+        address_user = socket.socket()
+        self.addCleanup(address_user.close)
+
+        address_user.bind(('', 0))
+        used_address = address_user.getsockname()
+
+        name = random_name(self)
+        d = self.start_container(
+            name, ports=[
+                PortMap(internal_port=10000, external_port=used_address[1]),
+            ],
+        )
+        return self.assertFailure(d, AddressInUse)
 
     def test_add_with_port(self):
         """

--- a/flocker/node/test/test_docker.py
+++ b/flocker/node/test/test_docker.py
@@ -4,19 +4,41 @@
 Tests for :module:`flocker.node._docker`.
 """
 
+import psutil
+
 from zope.interface.verify import verifyObject
 
 from pyrsistent import pset, pvector
 
+from eliot import MessageType, fields
+
 from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
 
-from ...testtools import random_name, make_with_init_tests
+from ...testtools import random_name, make_with_init_tests, find_free_port
 from .._docker import (
-    IDockerClient, FakeDockerClient, AlreadyExists, PortMap, Unit,
-    Environment, Volume)
+    IDockerClient, FakeDockerClient, AddressInUse, AlreadyExists, PortMap,
+    Unit, Environment, Volume,
+)
 
 from ...control._model import RestartAlways, RestartNever, RestartOnFailure
+
+ANY_IMAGE = u"openshift/busybox-http-app"
+
+ADDRESS_IN_USE = MessageType(
+    u"flocker:test:address_in_use",
+    fields(ip=unicode, port=int, name=bytes),
+)
+
+
+def find_process_name(port_number):
+    """
+    Get the name of the process using the given port number.
+    """
+    for connection in psutil.net_connections():
+        if connection.laddr[1] == port_number:
+            return psutil.Process(connection.pid).name()
+    return None
 
 
 def make_idockerclient_tests(fixture):
@@ -119,6 +141,68 @@ def make_idockerclient_tests(fixture):
             d.addCallback(self.assertFalse)
             return d
 
+        def test_zero_port_randomly_assigned(self):
+            """
+            If an external port number is given as 0, a random available port
+            number is used.
+            """
+            client = fixture(self)
+            name = random_name(self)
+            portmap = PortMap(
+                internal_port=1234, external_port=0,
+            )
+            self.addCleanup(client.remove, name)
+            d = client.add(name, ANY_IMAGE, ports=(portmap,))
+            d.addCallback(lambda ignored: client.list())
+
+            def check_port(units):
+                portmap = list(list(units)[0].ports)[0]
+                self.assertTrue(
+                    0 < portmap.external_port < 2 ** 16,
+                    "Unexpected automatic port assignment: {}".format(
+                        portmap.external_port
+                    ),
+                )
+            d.addCallback(check_port)
+            return d
+
+        def test_port_collision_raises_addressinuse(self):
+            """
+            If the container is configured with an external port number which
+            is already in use, ``AddressInUse`` is raised.
+            """
+            client = fixture(self)
+            name = random_name(self)
+            portmap = PortMap(
+                internal_port=12345, external_port=0,
+            )
+            self.addCleanup(client.remove, name)
+            d = client.add(name, ANY_IMAGE, ports=(portmap,))
+            d.addCallback(lambda ignored: client.list())
+
+            def extract_port(units):
+                return list(list(units)[0].ports)[0].external_port
+            d.addCallback(extract_port)
+
+            def collide(external_port):
+                self.external_port = external_port
+                portmap = PortMap(
+                    internal_port=54321, external_port=external_port,
+                )
+                name = random_name(self)
+                self.addCleanup(client.remove, name)
+                return client.add(name, ANY_IMAGE, ports=(portmap,))
+            d.addCallback(collide)
+            d = self.assertFailure(d, AddressInUse)
+
+            def failed(exception):
+                self.assertEqual(
+                    AddressInUse(address=(b"0.0.0.0", self.external_port)),
+                    exception,
+                )
+            d.addCallback(failed)
+            return d
+
         def test_added_is_listed(self):
             """
             An added container is included in the output of ``list()``.
@@ -126,10 +210,8 @@ def make_idockerclient_tests(fixture):
             client = fixture(self)
             name = random_name(self)
             image = u"openshift/busybox-http-app"
-            portmaps = (
-                PortMap(internal_port=80, external_port=8080),
-                PortMap(internal_port=5432, external_port=5432)
-            )
+
+            portmaps = []
             volumes = (
                 Volume(node_path=FilePath(b'/tmp'),
                        container_path=FilePath(b'/var/lib/data')),
@@ -140,16 +222,46 @@ def make_idockerclient_tests(fixture):
             )
             environment = Environment(variables=frozenset(environment))
             self.addCleanup(client.remove, name)
-            d = client.add(
-                name,
-                image,
-                ports=portmaps,
-                volumes=volumes,
-                environment=environment,
-                mem_limit=100000000,
-                cpu_shares=512,
-                restart_policy=RestartAlways(),
-            )
+
+            def add_with_retry():
+                # In case the "free" ports aren't really free, re-generate them
+                # on each attempt.
+                ports = [find_free_port()[1] for i in range(2)]
+                # Store them on portmaps defined in the outer scope so that the
+                # assertion below can use the values that eventually actually
+                # succeed.
+                portmaps[:] = [
+                    PortMap(internal_port=80, external_port=ports[0]),
+                    PortMap(internal_port=5432, external_port=ports[1]),
+                ]
+                d = client.add(
+                    name,
+                    image,
+                    ports=portmaps,
+                    volumes=volumes,
+                    environment=environment,
+                    mem_limit=100000000,
+                    cpu_shares=512,
+                    restart_policy=RestartAlways(),
+                )
+                d.addErrback(retry_on_port_collision)
+                return d
+
+            def retry_on_port_collision(reason):
+                # We select a random, available port number on each attempt.
+                # If it was in use it's because the "available" part of that
+                # port number selection logic is fairly shaky.  It should be
+                # good enough that trying again works fairly well, though.  So
+                # do that.
+                reason.trap(AddressInUse)
+                ip, port = reason.value.address
+                used_by = find_process_name(port)
+                ADDRESS_IN_USE(ip=ip, port=port, name=used_by).write()
+                d = client.remove(name)
+                d.addCallback(lambda ignored: add_with_retry())
+                return d
+
+            d = add_with_retry()
             d.addCallback(lambda _: client.list())
 
             expected = Unit(

--- a/flocker/node/test/test_docker.py
+++ b/flocker/node/test/test_docker.py
@@ -1,6 +1,8 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
-"""Tests for :module:`flocker.node._docker`."""
+"""
+Tests for :module:`flocker.node._docker`.
+"""
 
 from zope.interface.verify import verifyObject
 
@@ -277,7 +279,10 @@ def make_idockerclient_tests(fixture):
 
 
 class FakeIDockerClientTests(
-        make_idockerclient_tests(lambda t: FakeDockerClient())):
+        make_idockerclient_tests(
+            fixture=lambda test_case: FakeDockerClient(),
+        )
+):
     """
     ``IDockerClient`` tests for ``FakeDockerClient``.
     """


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1040

This changes the test to retry when it encounters this error.  In support of this, a new exception, `AddressInUse` is also introduced and the implementations updated to raise it when this particular failure is encountered.  In support for *this*, automatic port assignment (specify port 0, get a free port) is also added to the Docker client implementations.

Note the first revision in the branch is assorted refactoring I did while working on the rest.  Behavior changes are all in the second revision.