### PR TITLE
[FLOC-2628] Don't use /tmp

### DIFF
--- a/flocker/node/test/test_docker.py
+++ b/flocker/node/test/test_docker.py
@@ -129,7 +129,7 @@ def make_idockerclient_tests(fixture):
                 PortMap(internal_port=5432, external_port=5432)
             )
             volumes = (
-                Volume(node_path=FilePath(b'/tmp'),
+                Volume(node_path=FilePath(self.mktemp()),
                        container_path=FilePath(b'/var/lib/data')),
             )
             environment = (


### PR DESCRIPTION
The error in http://build.clusterhq.com/builders/flocker-centos-7/builds/5503/steps/trial/logs/stdio seems to be caused by /tmp running out of space. Don't use it and create a temporary path within trial's temp on the regular filesystem.