### PR TITLE
[FLOC-2640] Display debug information to help diagnose yum network problems

### DIFF
--- a/admin/build_targets/centos-7/Dockerfile
+++ b/admin/build_targets/centos-7/Dockerfile
@@ -5,6 +5,7 @@
 
 FROM centos:centos7
 MAINTAINER ClusterHQ <contact@clusterhq.com>
+# URLGRABBER_DEBUG=1 to log low-level network info - see FLOC-2640
 RUN ["env", "URLGRABBER_DEBUG=1", "yum", "groupinstall", "--assumeyes", "Development Tools"]
 RUN ["env", "URLGRABBER_DEBUG=1", "yum", "install", "--assumeyes", "epel-release"]
 RUN ["env", "URLGRABBER_DEBUG=1", "yum", "install", "--assumeyes", "git", "ruby-devel", "python-devel", "libffi-devel", "openssl-devel", "python-pip", "rpmlint"]

--- a/admin/build_targets/centos-7/Dockerfile
+++ b/admin/build_targets/centos-7/Dockerfile
@@ -5,9 +5,9 @@
 
 FROM centos:centos7
 MAINTAINER ClusterHQ <contact@clusterhq.com>
-RUN ["yum", "groupinstall", "--assumeyes", "Development Tools"]
-RUN ["yum", "install", "--assumeyes", "epel-release"]
-RUN ["yum", "install", "--assumeyes", "git", "ruby-devel", "python-devel", "libffi-devel", "openssl-devel", "python-pip", "rpmlint"]
+RUN ["env", "URLGRABBER_DEBUG=1", "yum", "groupinstall", "--assumeyes", "Development Tools"]
+RUN ["env", "URLGRABBER_DEBUG=1", "yum", "install", "--assumeyes", "epel-release"]
+RUN ["env", "URLGRABBER_DEBUG=1", "yum", "install", "--assumeyes", "git", "ruby-devel", "python-devel", "libffi-devel", "openssl-devel", "python-pip", "rpmlint"]
 # Despite being a packaging tool, fpm isn't yet packaged for CentOS.
 # See https://github.com/jordansissel/fpm/issues/611
 RUN ["gem", "install", "fpm"]


### PR DESCRIPTION
This PR makes `yum` display details about low-level network operations while building the CentOS Dockerfile. This additional information might be useful next time FLOC-2452 shows up, or for other network problems.  The additional information is sent to stderr, and gets logged near the top of the `flocker-omnibus-centos-7` `build-package` step.
