### PR TITLE
[FLOC-2633] Retry HTTP requests in case it takes a while for the HTTP server to start up

### DIFF
--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -314,14 +314,20 @@ class ContainerAPITests(TestCase):
         the HTTP server via Flocker in order to check if that particular
         setup succeeded.
 
+        We try three times since it may take a little time for the HTTP
+        server to start up.
+
         :param bytes host: Host to connect to.
         :param int port: Port to connect to.
         """
-        def query(host, port):
+        def query(host, port, count=0):
             req = get(
                 "http://{host}:{port}".format(host=host, port=port),
                 persistent=False
-            ).addCallback(content)
+            )
+            req.addCallback(content)
+            if count < 3:
+                req.addErrback(lambda _: query(host, port, count + 1))
             return req
 
         d = verify_socket(host, port)

--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -325,7 +325,12 @@ class ContainerAPITests(TestCase):
                 "http://{host}:{port}".format(host=host, port=port),
                 persistent=False
             )
-            req.addCallbacks(content, lambda _: False)
+
+            def failed(failure):
+                Message.new(message_type=u"acceptance:http_query_failed",
+                            reason=unicode(failure)).write()
+                return False
+            req.addCallbacks(content, failed)
             return req
 
         d = verify_socket(host, port)

--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -320,18 +320,16 @@ class ContainerAPITests(TestCase):
         :param bytes host: Host to connect to.
         :param int port: Port to connect to.
         """
-        def query(host, port, count=0):
+        def query(host, port):
             req = get(
                 "http://{host}:{port}".format(host=host, port=port),
                 persistent=False
             )
-            req.addCallback(content)
-            if count < 3:
-                req.addErrback(lambda _: query(host, port, count + 1))
+            req.addCallbacks(content, lambda _: False)
             return req
 
         d = verify_socket(host, port)
-        d.addCallback(lambda _: query(host, port))
+        d.addCallback(lambda _: loop_until(lambda: query(host, port)))
         d.addCallback(self.assertEqual, b"hi")
         return d
 

--- a/flocker/acceptance/test_api.py
+++ b/flocker/acceptance/test_api.py
@@ -314,9 +314,6 @@ class ContainerAPITests(TestCase):
         the HTTP server via Flocker in order to check if that particular
         setup succeeded.
 
-        We try three times since it may take a little time for the HTTP
-        server to start up.
-
         :param bytes host: Host to connect to.
         :param int port: Port to connect to.
         """


### PR DESCRIPTION
Does seem to fix the issue - notice that if I add a print statement for count it sometimes needs to retry:

```
flocker.acceptance.test_api
  ContainerAPITests
    test_linking ... 
1
2
                                                      [OK]

```