### PR TITLE
[FLOC-2671] Release/flocker 1.1.0dev1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Flocker 1.1.0dev1 (2015-07-17)
+==============================
+
+- The flocker-deploy command supports specification of the pathnames of certificate and key files. (FLOC-2398)
+- Allow specification of a CA certificate for OpenStack HTTPS verification. (FLOC-2504)
+
 Flocker 1.0.3 (2015-07-09)
 ==========================
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,14 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+Next Release
+============
+
+* The flocker-deploy command supports specification of the pathnames of certificate and key files.
+  See :ref:`flocker-deploy-authentication`.
+* The agent configuration file allows specification of a CA certificate for OpenStack HTTPS verification.
+  See :ref:`openstack-dataset-backend`.
+
 v1.0.3
 ======
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,7 +13,7 @@ You can learn more about where we might be going with future releases by:
 Next Release
 ============
 
-* The flocker-deploy command supports specification of the pathnames of certificate and key files.
+* ``flocker-deploy`` supports specification of the pathnames of certificate and key files.
   See :ref:`flocker-deploy-authentication`.
 * The agent configuration file allows specification of a CA certificate for OpenStack HTTPS verification.
   See :ref:`openstack-dataset-backend`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -65,6 +65,7 @@ namespace
 NAT'd
 online
 OpenStack
+pathnames
 pem
 petabyte
 petabytes

--- a/docs/using/config/usage.rst
+++ b/docs/using/config/usage.rst
@@ -28,6 +28,8 @@ See :ref:`configuration` for details about the two files.
 You can run ``flocker-deploy`` anywhere you have it installed.
 The containers you are managing do not need to be running on the same host as ``flocker-deploy``\ .
 
+.. _flocker-deploy-authentication:
+
 Authentication
 ==============
 


### PR DESCRIPTION
Waiting for tests to pass due to "no space" problem.
There is one error with the link check:
```
reference/api.rst:1: [redirected with Found] https://clusterhq.atlassian.net/browse/FLOC-2044 to https://clusterhq.atlassian.net/login?dest-url=%2Fbrowse%2FFLOC-2044&permission-violation=true
```
This is a JIRA link redirecting to the login page so will happen with all JIRA links. Does the filter need to be updated?