### PR TITLE
[FLOC-2746] Add network logging to release processes.

### DIFF
--- a/admin/release.py
+++ b/admin/release.py
@@ -9,6 +9,7 @@ https://clusterhq.atlassian.net/browse/FLOC-397
 """
 
 import json
+import logging
 import os
 import sys
 import tempfile
@@ -67,6 +68,12 @@ from .yum import (
 from .vagrant import vagrant_version
 from .homebrew import make_recipe
 from .packaging import available_distributions, DISTRIBUTION_NAME_MAP
+
+# Log information about network connections
+logging.basicConfig()
+requests_log = logging.getLogger("requests.packages.urllib3")
+requests_log.setLevel(logging.DEBUG)
+requests_log.propagate = True
 
 
 DEV_ARCHIVE_BUCKET = 'clusterhq-dev-archive'


### PR DESCRIPTION
This PR enables the requests library logging to display the URLs and status of HTTP connections.  This makes it easier to see which URLs have failed if an error occurs.

This is particularly useful now, as we start running dev releases with the PEP440 changes.

To test, run a command like:
```
./admin/publish-artifacts --target=clusterhq-archive-testing --flocker-version=0.9.0pre1
```

In other branches, the only information is a stack trace and:
```
flocker.provision._effect.SequenceFailed: <SequenceFailed(results=[], exc_info=(<class 'requests.exceptions.HTTPError'>, HTTPError('404 Client Error: Not Found',), <traceback object at 0x3a65488>))>
```

With this branch, before the stack trace, we also see:
```
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): build.clusterhq.com
DEBUG:requests.packages.urllib3.connectionpool:"GET /results/omnibus/0.9.0pre1/centos-7/clusterhq-python-flocker-0.9.0-0.rc.1.x86_64.rpm HTTP/1.1" 404 145
```
which makes it quicker to see where an expected file is missing.