### PR TITLE
[FLOC-2035] [FLOC-2627]  Upgrade to docker-py-1.3.1 and requests-2.7.1

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -312,7 +312,6 @@ class FakeDockerClient(object):
 
 # Basic namespace for Flocker containers:
 BASE_NAMESPACE = u"flocker--"
-BASE_DOCKER_API_URL = u'unix://var/run/docker.sock'
 
 
 class TimeoutClient(Client):
@@ -358,7 +357,7 @@ class DockerClient(object):
         long-running operations, particularly pulling an image.
     """
     def __init__(
-            self, namespace=BASE_NAMESPACE, base_url=BASE_DOCKER_API_URL,
+            self, namespace=BASE_NAMESPACE, base_url=None,
             long_timeout=600):
         self.namespace = namespace
         self._client = TimeoutClient(
@@ -826,7 +825,7 @@ class NamespacedDockerClient(proxyForInterface(IDockerClient, "_client")):
     containers in ``/flocker/`` and this class would look at containers in
     in ``/flocker/<namespace>/``.
     """
-    def __init__(self, namespace, base_url=BASE_DOCKER_API_URL):
+    def __init__(self, namespace, base_url=None):
         """
         :param unicode namespace: Namespace to restrict containers to.
         """

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -140,15 +140,6 @@ class GenericDockerClientTests(TestCase):
 
         return d
 
-    def test_default_base_url(self):
-        """
-        ``DockerClient`` instantiated with a default base URL for a socket
-        connection has a client HTTP url after the connection is made.
-        """
-        client = DockerClient()
-        self.assertEqual(client._client.base_url,
-                         u'http+unix://var/run/docker.sock')
-
     def test_custom_base_url_tcp_http(self):
         """
         ``DockerClient`` instantiated with a custom base URL for a TCP

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -22,39 +22,34 @@ from zope.interface.verify import verifyObject
 
 from eliot import Logger, ActionType
 
-from ._docker import BASE_DOCKER_API_URL
 from . import IDeployer, IStateChange, sequentially
 from ..testtools import loop_until
 from ..control import (
     IClusterStateChange, Node, NodeState, Deployment, DeploymentState)
 from ..control._model import ip_to_uuid
-
-DOCKER_SOCKET_PATH = BASE_DOCKER_API_URL.split(':/')[-1]
+from ._docker import DockerClient
 
 
 def docker_accessible():
     """
     Attempt to connect to the Docker control socket.
 
-    This may address https://clusterhq.atlassian.net/browse/FLOC-85.
-
     :return: A ``bytes`` string describing the reason Docker is not
         accessible or ``None`` if it appears to be accessible.
     """
     try:
-        with closing(socket.socket(family=socket.AF_UNIX)) as docker_socket:
-            docker_socket.connect(DOCKER_SOCKET_PATH)
-    except socket.error as e:
-        return os.strerror(e.errno)
+        client = DockerClient()
+        client._client.ping()
+    except Exception as e:
+        return str(e)
     return None
 
 _docker_reason = docker_accessible()
 
 if_docker_configured = skipIf(
     _docker_reason,
-    "User {!r} cannot access Docker via {!r}: {}".format(
+    "User {!r} cannot access Docker: {}".format(
         pwd.getpwuid(os.geteuid()).pw_name,
-        DOCKER_SOCKET_PATH,
         _docker_reason,
     ))
 

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -6,9 +6,7 @@ Testing utilities for ``flocker.node``.
 
 import os
 import pwd
-import socket
 from unittest import skipIf
-from contextlib import closing
 from uuid import uuid4
 
 from zope.interface import implementer

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.1.2
 characteristic==14.3.0
 cryptography==0.9.1
 debtcollector==0.5.0
-docker-py==0.7.1
+docker-py==1.3.1
 effect==0.1a13
 eliot==0.7.1
 enum34==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ python-keystoneclient-rackspace==0.1.3
 python-novaclient==2.24.1
 pytz==2015.4
 PyYAML==3.10
-requests==2.4.3
+requests==2.7.0
 service-identity==14.0.0
 setuptools==18.0.1
 simplejson==3.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+argparse==1.3.0
 Babel==1.3
-backports.ssl-match-hostname==3.4.0.2
-bitmath==1.2.3.post4
+backports.ssl_match_hostname==3.4.0.2
+bitmath==1.2.3-4
 boto==2.38.0
 cffi==1.1.2
 characteristic==14.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-argparse==1.3.0
 Babel==1.3
-backports.ssl_match_hostname==3.4.0.2
-bitmath==1.2.3-4
+backports.ssl-match-hostname==3.4.0.2
+bitmath==1.2.3.post4
 boto==2.38.0
 cffi==1.1.2
 characteristic==14.3.0


### PR DESCRIPTION
Fixes:
 * https://clusterhq.atlassian.net/browse/FLOC-2035
 * https://clusterhq.atlassian.net/browse/FLOC-2627

Docker-py-1.3.1 fixes https://github.com/docker/docker-py/pull/681 which is what prevented `flocker-container-agent` pulling images from private registries.

Docker-py depends on Requests >= 2.5.1
 * https://github.com/docker/docker-py/commit/9bed480c2745b06219c629dbbfd46b298c005447

So I updated that too.

I haven't updated `python-keystoneclient` - there doesn't seem any reason to. 

We can update all our dependencies properly when we start using `requires.io` or similar in 
 * https://clusterhq.atlassian.net/browse/FLOC-1172

FLOC-2035 says "restore test that depends on modern requests" but the commit ID in the issue description refers to something different. So I'll leave that unless @adamtheturtle can remember which test it was.