### PR TITLE
[FLOC-2757] Release Flocker 1.1.0.dev2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+Flocker 1.1.0.dev2 (2015-07-29)
+===============================
+
+- The flocker-deploy command supports specification of the pathnames of certificate and key files. (FLOC-2398)
+- Allow specification of a CA certificate for OpenStack HTTPS verification. (FLOC-2504)
+- Flocker can now start containers using images from private Docker registries. (FLOC-2627)
+- Upgraded to docker-py-1.3.1 and requests-2.7.1 to fix a bug when pulling images from private Docker registries. (FLOC-2035)
+- rsyslogd is now restarted after installing the ``clusterhq-flocker-node`` package to prevent duplicate logging of Flocker log messages. (FLOC-2648)
+- Various fixes for slow and flaky-tests.
+- Various documentation improvements and fixes.
+
 Flocker 1.0.3 (2015-07-09)
 ==========================
 

--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@ Flocker 1.1.0.dev2 (2015-07-29)
 - Flocker can now start containers using images from private Docker registries. (FLOC-2627)
 - Upgraded to docker-py-1.3.1 and requests-2.7.1 to fix a bug when pulling images from private Docker registries. (FLOC-2035)
 - rsyslogd is now restarted after installing the ``clusterhq-flocker-node`` package to prevent duplicate logging of Flocker log messages. (FLOC-2648)
-- Various fixes for slow and flaky-tests.
+- Various fixes for slow and fragile tests.
 - Various documentation improvements and fixes.
 
 Flocker 1.0.3 (2015-07-09)

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -18,7 +18,7 @@ Next Release
 * The agent configuration file allows specification of a CA certificate for OpenStack HTTPS verification.
   See :ref:`openstack-dataset-backend`.
 * Flocker can now start containers using images from private Docker registries.
-* On Centos 7, installing or upgrading the ``clusterhq-flocker-node`` package now reloads the ``rsyslog`` service to ensure that Flocker logging policy takes immediate effect.
+* On CentOS 7, installing or upgrading the ``clusterhq-flocker-node`` package now reloads the ``rsyslog`` service to ensure that Flocker logging policy takes immediate effect.
 
 v1.0.3
 ======

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,14 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+Next Release
+============
+
+* ``flocker-deploy`` supports specification of the pathnames of certificate and key files.
+  See :ref:`flocker-deploy-authentication`.
+* The agent configuration file allows specification of a CA certificate for OpenStack HTTPS verification.
+  See :ref:`openstack-dataset-backend`.
+
 v1.0.3
 ======
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -17,6 +17,8 @@ Next Release
   See :ref:`flocker-deploy-authentication`.
 * The agent configuration file allows specification of a CA certificate for OpenStack HTTPS verification.
   See :ref:`openstack-dataset-backend`.
+* Flocker can now start containers using images from private Docker registries.
+* On Centos 7, installing or upgrading the ``clusterhq-flocker-node`` package now reloads the ``rsyslog`` service to ensure that Flocker logging policy takes immediate effect.
 
 v1.0.3
 ======

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -65,6 +65,7 @@ namespace
 NAT'd
 online
 OpenStack
+pathnames
 pem
 petabyte
 petabytes

--- a/docs/using/config/usage.rst
+++ b/docs/using/config/usage.rst
@@ -28,6 +28,8 @@ See :ref:`configuration` for details about the two files.
 You can run ``flocker-deploy`` anywhere you have it installed.
 The containers you are managing do not need to be running on the same host as ``flocker-deploy``\ .
 
+.. _flocker-deploy-authentication: 
+
 Authentication
 ==============
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-2757

News and What's New changes are based on the aborted dev1 release in https://github.com/ClusterHQ/flocker/pull/1779 with a few additions.


