### PR TITLE
[FLOC-2752] Sketch of fake client and minimal interface

### DIFF
--- a/flocker/apiclient/__init__.py
+++ b/flocker/apiclient/__init__.py
@@ -1,0 +1,12 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Client for the Flocker REST API.
+
+This may eventually be a standalone package.
+"""
+
+from ._client import IFlockerAPIV1, FakeFlockerAPIV1
+
+
+__all__ = ["IFlockerAPIV1", "FakeFlockerAPIV1"]

--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -1,0 +1,90 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Client for the Flocker REST API.
+"""
+
+from uuid import UUID
+
+from zope.interface import Interface
+
+from pyrsistent import PClass, field, pmap_field
+
+
+class Dataset(PClass):
+    """
+    A dataset in the configuration.
+    """
+    dataset_id = field(type=UUID)
+    primary = field(type=UUID)
+    maximum_size = field(type=int)
+    deleted = field(type=bool)
+    metadata = pmap_field(unicode, unicode)
+
+
+class DatasetState(PClass):
+    """
+    The state of a dataset in the cluster.
+    """
+    dataset_id = field(type=UUID)
+    primary = field(type=UUID)
+    maximum_size = field(type=int)
+
+
+class DatasetAlreadyExists(Exception):
+    """
+    The suggested dataset ID already exists.
+    """
+
+
+class IFlockerAPIV1(Interface):
+    """
+    The Flocker REST API, v1.
+    """
+    def create_dataset(primary, maximum_size, dataset_id=None, metadata=None):
+        """
+        Create a new dataset in the configuration.
+
+        :return: ``Deferred`` firing with resulting ``Dataset``, or
+            errbacking with ``DatasetAlreadyExists``.
+        """
+
+    def move_dataset(primary, dataset_id):
+        """
+        Move the dataset to a new location.
+
+        :return: ``Deferred`` firing with resulting ``Dataset``.
+        """
+
+    def list_datasets_configuration():
+        """
+        Return the configured datasets.
+
+        :return: ``Deferred`` firing with iterable of ``Dataset``.
+        """
+
+    def list_datasets_state():
+        """
+        Return the actual datasets in the cluster.
+
+        :return: ``Deferred`` firing with iterable of ``DatasetState``.
+        """
+
+
+@implementer(IFlockerAPIV1)
+class FakeFlockerAPIV1(object):
+    """
+    Fake in-memory implementation of ``IFlockerAPIV1``.
+    """
+    def __init__(self):
+        # self._configured_datasets
+        # self._state_datasets
+
+    # Interface methods manipulate the above
+
+    def synchronize_state(self):
+        """
+        Copy configuration into state.
+        """
+        self._state_datasets = [DatasetState(...) for dataset in self._configured_datasets]
+

--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -1,0 +1,47 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for the Flocker REST API client.
+"""
+
+
+def make_clientv1_tests(client_factory, synchronize_state):
+    """
+    Create a ``TestCase`` for testing ``IFlockerAPIV1``.
+
+    The presumption is that the state of datasets is completely under
+    control of this process. So when testing a real client it will be
+    talking to a in-process server.
+
+    :param client_factory: Callable that returns a ``IFlockerAPIV1`` provider.
+    :param synchronize_state: Callable that makes state match configuration.
+    """
+    class InterfaceTests(TestCase):
+        # The created client provides ``IFlockerAPIV1``.
+
+        # Create returns a ``Dataset`` with matching attributes.
+
+        # Create returns an error on conflicting dataset_id.
+
+        # A created dataset is listed in the configuration.
+
+        # A created dataset with custom dataset id is listed in the
+        # configuration.
+
+        # A created dataset with metadata is listed in the
+        # configuration.
+
+        # Move changes the primary of the dataset.
+
+        # State returns information about state (uses
+        # synchronize_state to populate expected information)
+
+    return InterfaceTests
+
+
+class FakeFlockerAPIV1Tests(
+        InterfaceTests(FakeFlockerAPIV1,
+                       lambda client: client.synchronize_state())):
+    """
+    Interface tests for ``FakeFlockerAPIV1``.
+    """


### PR DESCRIPTION
The goal is just enough of a client interface to allow proceeding with implementing the Docker plugin business logic. Thus some of the client's API is not implemented, e.g. delete isn't really necessary at this point.