### PR TITLE
[FLOC 2389] Update info in the Flocker Doc landing page

### DIFF
--- a/docs/gettinginvolved/index.rst
+++ b/docs/gettinginvolved/index.rst
@@ -1,3 +1,5 @@
+.. _getting-involved:
+
 ================
 Getting Involved
 ================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,13 @@
 Flocker Documentation
 =====================
 
-Flocker is a data volume manager and multi-host Docker cluster management tool.
-With it, you can control your data using the same tools you use for your stateless applications.
-This means that you can run your databases, queues and key-value stores in Docker and move them around, as easily as the rest of your app.
+Welcome to the Flocker docs! If you're just getting started with Flocker, it might be worth reading our :ref:`introduction`, or trying our simple tutorial on the `Getting Started with Flocker`_ page.
 
-With Flocker's command line tools and simple configuration language, you can deploy your Docker-based applications onto one or more Linux hosts.
-Once deployed, your applications will have access to the volumes configured for them.
-When you use Flocker to move containers between different hosts in your Flocker cluster, those volumes will follow.
+In the documentation listed below, you'll be able to find instructions on how to install, configure, and use Flocker, including an in-depth :ref:`MongoDB tutorial<tutmongo>`.
 
-Contents:
+You'll be able to find concept and reference material, and our :ref:`Labs section<labs-projects>` contains all the information you need about our experimental projects.
+
+Flocker is an open-source project, and in our :ref:`Getting Involved section<getting-involved>`, there is information about how you can collaborate with ClusterHQ.
 
 .. toctree::
    :maxdepth: 2
@@ -23,3 +21,5 @@ Contents:
    labs/index
    faq/index
    gettinginvolved/index
+
+.. _Getting Started with Flocker: https://clusterhq.com/flocker/getting-started/

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -1,3 +1,5 @@
+.. _introduction:
+
 =======================
 Introduction to Flocker
 =======================


### PR DESCRIPTION
Fixes 2389

Note - the issue requests that the content be copied from the Introduction to Flocker page - I thought this was unnecessary repetition, and have written a short intro to the documentation, and what the user can expect to find.