### PR TITLE
[FLOC-2768] Pass the requirements.txt path to make_recipe

### DIFF
--- a/admin/release.py
+++ b/admin/release.py
@@ -772,7 +772,7 @@ def publish_artifacts_main(args, base_path, top_level):
             version=options['flocker-version'],
             source_bucket=options['target'],
             scratch_directory=scratch_directory.child('homebrew'),
-            top_level=top_level
+            top_level=top_level,
         )
 
     finally:

--- a/admin/release.py
+++ b/admin/release.py
@@ -382,7 +382,7 @@ FLOCKER_PACKAGES = [
 
 
 def publish_homebrew_recipe(homebrew_repo_url, version, source_bucket,
-                            scratch_directory):
+                            scratch_directory, top_level):
     """
     Publish a Homebrew recipe to a Git repository.
 
@@ -392,12 +392,16 @@ def publish_homebrew_recipe(homebrew_repo_url, version, source_bucket,
     :param bytes source_bucket: S3 bucket to get source distribution from.
     :param FilePath scratch_directory: Temporary directory to create a recipe
         in.
+    :param FilePath top_level: The top-level of the flocker repository.
     """
     url_template = 'https://{bucket}.s3.amazonaws.com/python/Flocker-{version}.tar.gz'  # noqa
     sdist_url = url_template.format(bucket=source_bucket, version=version)
+    requirements_path = top_level.child('requirements.txt')
     content = make_recipe(
         version=version,
-        sdist_url=sdist_url)
+        sdist_url=sdist_url,
+        requirements_path=requirements_path,
+    )
     homebrew_repo = Repo.clone_from(
         url=homebrew_repo_url,
         to_path=scratch_directory.path)
@@ -768,6 +772,7 @@ def publish_artifacts_main(args, base_path, top_level):
             version=options['flocker-version'],
             source_bucket=options['target'],
             scratch_directory=scratch_directory.child('homebrew'),
+            top_level=top_level
         )
 
     finally:

--- a/admin/test/test_release.py
+++ b/admin/test/test_release.py
@@ -2039,7 +2039,7 @@ class PublishHomebrewRecipeTests(SynchronousTestCase):
             version='0.3.0',
             scratch_directory=FilePath(self.mktemp()),
             source_bucket="archive",
-            top_level=FLOCKER_PATH
+            top_level=FLOCKER_PATH,
         )
 
         self.patch(release, 'make_recipe',
@@ -2050,11 +2050,12 @@ class PublishHomebrewRecipeTests(SynchronousTestCase):
             version='0.3.0',
             scratch_directory=FilePath(self.mktemp()),
             source_bucket="archive",
-            top_level=FLOCKER_PATH
+            top_level=FLOCKER_PATH,
         )
 
         recipe = self.source_repo.head.commit.tree['flocker-0.3.0.rb']
         self.assertEqual(recipe.data_stream.read(), 'New content')
+
 
 class GetExpectedRedirectsTests(SynchronousTestCase):
     """

--- a/admin/test/test_release.py
+++ b/admin/test/test_release.py
@@ -1977,9 +1977,11 @@ class PublishHomebrewRecipeTests(SynchronousTestCase):
         # Making a recipe involves interacting with PyPI, this should be
         # a parameter, not a patch. See:
         # https://clusterhq.atlassian.net/browse/FLOC-1759
-        self.patch(release, 'make_recipe',
-            lambda version, sdist_url:
-                "Recipe for " + version + " at " + sdist_url)
+        self.patch(
+            release, 'make_recipe',
+            lambda version, sdist_url, requirements_path:
+            "Recipe for " + version + " at " + sdist_url
+        )
 
     def test_commit_message(self):
         """
@@ -1990,6 +1992,7 @@ class PublishHomebrewRecipeTests(SynchronousTestCase):
             version='0.3.0',
             scratch_directory=FilePath(self.mktemp()),
             source_bucket="archive",
+            top_level=FLOCKER_PATH,
         )
 
         self.assertEqual(
@@ -2005,6 +2008,7 @@ class PublishHomebrewRecipeTests(SynchronousTestCase):
             version='0.3.0',
             scratch_directory=FilePath(self.mktemp()),
             source_bucket="bucket-name",
+            top_level=FLOCKER_PATH,
         )
 
         recipe = self.source_repo.head.commit.tree['flocker-0.3.0.rb']
@@ -2019,7 +2023,12 @@ class PublishHomebrewRecipeTests(SynchronousTestCase):
         self.assertRaises(
             PushFailed,
             publish_homebrew_recipe,
-            non_bare_repo.git_dir, '0.3.0', "archive", FilePath(self.mktemp()))
+            non_bare_repo.git_dir,
+            '0.3.0',
+            "archive",
+            FilePath(self.mktemp()),
+            top_level=FLOCKER_PATH,
+        )
 
     def test_recipe_already_exists(self):
         """
@@ -2030,16 +2039,18 @@ class PublishHomebrewRecipeTests(SynchronousTestCase):
             version='0.3.0',
             scratch_directory=FilePath(self.mktemp()),
             source_bucket="archive",
+            top_level=FLOCKER_PATH
         )
 
         self.patch(release, 'make_recipe',
-            lambda version, sdist_url: "New content")
+                   lambda version, sdist_url, requirements_path: "New content")
 
         publish_homebrew_recipe(
             homebrew_repo_url=self.source_repo.git_dir,
             version='0.3.0',
             scratch_directory=FilePath(self.mktemp()),
             source_bucket="archive",
+            top_level=FLOCKER_PATH
         )
 
         recipe = self.source_repo.head.commit.tree['flocker-0.3.0.rb']


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-2768

I'm attempting to test this by finishing off the `1.1.0.dev2` release.

```
(2768)(fix-publish-artifacts-FLOC-2768 ✕?)[~/.../HybridLogic/flocker]$ ./admin/publish-artifacts --flocker-version=1.1.0.dev2
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): build.clusterhq.com
DEBUG:requests.packages.urllib3.connectionpool:"GET /results/omnibus/1.1.0.dev2/centos-7/clusterhq-python-flocker-1.1.0-0.dev.2.x86_64.rpm HTTP/1.1" 200 24757867
DEBUG:requests.packages.urllib3.connectionpool:"GET /results/omnibus/1.1.0.dev2/centos-7/clusterhq-flocker-cli-1.1.0-0.dev.2.noarch.rpm HTTP/1.1" 200 2325
DEBUG:requests.packages.urllib3.connectionpool:"GET /results/omnibus/1.1.0.dev2/centos-7/clusterhq-flocker-node-1.1.0-0.dev.2.noarch.rpm HTTP/1.1" 200 5598
...
```