### PR TITLE
[FLOC-2775] Move logging setup from release code to publish-artifacts

### DIFF
--- a/admin/publish-artifacts
+++ b/admin/publish-artifacts
@@ -6,7 +6,14 @@ Publish release artifacts.
 
 from _preamble import TOPLEVEL, BASEPATH
 
+import logging
 import sys
+
+# Log information about network connections
+logging.basicConfig()
+requests_log = logging.getLogger("requests.packages.urllib3")
+requests_log.setLevel(logging.DEBUG)
+requests_log.propagate = True
 
 if __name__ == '__main__':
     from admin.release import publish_artifacts_main as main

--- a/admin/release.py
+++ b/admin/release.py
@@ -9,7 +9,6 @@ https://clusterhq.atlassian.net/browse/FLOC-397
 """
 
 import json
-import logging
 import os
 import sys
 import tempfile
@@ -68,12 +67,6 @@ from .yum import (
 from .vagrant import vagrant_version
 from .homebrew import make_recipe
 from .packaging import available_distributions, DISTRIBUTION_NAME_MAP
-
-# Log information about network connections
-logging.basicConfig()
-requests_log = logging.getLogger("requests.packages.urllib3")
-requests_log.setLevel(logging.DEBUG)
-requests_log.propagate = True
 
 
 DEV_ARCHIVE_BUCKET = 'clusterhq-dev-archive'


### PR DESCRIPTION
The change in #1803 made `publish-artifacts` display useful logging information. However, it also added logging to commands such as `test-redirects` which uses the same module for its core functions.

While the debugging info helps in `publish-artifacts`, it obscures in `test-redirects`. Hence, this PR moves the logging setup code into the top-level `publish-artifacts` script, so it only affects that code.

The command `./admin/publish-artifacts --flocker-version=0.9.0pre1 --target=clusterhq-archive-testing` still provides network logging.

The command `./admin/test-redirects` does not. (It will probably complain about the redirects, but will not display INFO and DEBUG messages).