### PR TITLE
[FLOC-2783] Simple API calls for Docker plugin API

### DIFF
--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -3,7 +3,6 @@
 Tests for ``flocker.control.httpapi``.
 """
 
-from io import BytesIO
 from uuid import uuid4
 from copy import deepcopy
 

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -20,15 +20,14 @@ from twisted.web.http import (
     CREATED, OK, CONFLICT, BAD_REQUEST, NOT_FOUND, INTERNAL_SERVER_ERROR,
     NOT_ALLOWED as METHOD_NOT_ALLOWED
 )
-from twisted.web.http_headers import Headers
-from twisted.web.client import FileBodyProducer, readBody
+from twisted.web.client import readBody
 from twisted.application.service import IService
 from twisted.python.filepath import FilePath
 from twisted.internet.ssl import ClientContextFactory
 from twisted.internet.task import Clock
 
 from ...restapi.testtools import (
-    buildIntegrationTests, dumps, loads)
+    buildIntegrationTests, loads, APIAssertionsMixin)
 
 from .. import (
     Application, Dataset, Manifestation, Node, NodeState,
@@ -48,7 +47,7 @@ from .test_config import COMPLEX_APPLICATION_YAML, COMPLEX_DEPLOYMENT_YAML
 from ... import __version__
 
 
-class APITestsMixin(object):
+class APITestsMixin(APIAssertionsMixin):
     """
     Helpers for writing integration tests for the Dataset Manager API.
     """
@@ -71,96 +70,6 @@ class APITestsMixin(object):
         self.cluster_state_service.startService()
         self.addCleanup(self.cluster_state_service.stopService)
         self.addCleanup(self.persistence_service.stopService)
-
-    def assertResponseCode(self, method, path, request_body, expected_code):
-        """
-        Issue an HTTP request and make an assertion about the response code.
-
-        :param bytes method: The HTTP method to use in the request.
-        :param bytes path: The resource path to use in the request.
-        :param dict request_body: A JSON-encodable object to encode (as JSON)
-            into the request body.  Or ``None`` for no request body.
-        :param int expected_code: The status code expected in the response.
-
-        :return: A ``Deferred`` that will fire when the response has been
-            received.  It will fire with a failure if the status code is
-            not what was expected.  Otherwise it will fire with an
-            ``IResponse`` provider representing the response.
-        """
-        if request_body is None:
-            headers = None
-            body_producer = None
-        else:
-            headers = Headers({b"content-type": [b"application/json"]})
-            body_producer = FileBodyProducer(BytesIO(dumps(request_body)))
-
-        requesting = self.agent.request(
-            method, path, headers, body_producer
-        )
-
-        def check_code(response):
-            self.assertEqual(expected_code, response.code)
-            return response
-        requesting.addCallback(check_code)
-        return requesting
-
-    def assertResult(self, method, path, request_body,
-                     expected_code, expected_result):
-        """
-        Assert a particular JSON response for the given API request.
-
-        :param bytes method: HTTP method to request.
-        :param bytes path: HTTP path.
-        :param unicode request_body: Body of HTTP request.
-        :param int expected_code: The code expected in the response.
-            response.
-        :param list|dict expected_result: The body expected in the response.
-
-        :return: A ``Deferred`` that fires when test is done.
-        """
-        requesting = self.assertResponseCode(
-            method, path, request_body, expected_code)
-        requesting.addCallback(readBody)
-        requesting.addCallback(loads)
-
-        def assertEqualAndReturn(expected, actual):
-            """
-            Assert that ``expected`` is equal to ``actual`` and return
-            ``actual`` for further processing.
-            """
-            self.assertEqual(expected, actual)
-            return actual
-
-        requesting.addCallback(
-            lambda actual_result: assertEqualAndReturn(
-                expected_result, actual_result)
-        )
-        return requesting
-
-    def assertResultItems(self, method, path, request_body,
-                          expected_code, expected_result):
-        """
-        Assert a JSON array response for the given API request.
-
-        The API returns a JSON array, which matches a Python list, by
-        comparing that matching items exist in each sequence, but may
-        appear in a different order.
-
-        :param bytes method: HTTP method to request.
-        :param bytes path: HTTP path.
-        :param unicode request_body: Body of HTTP request.
-        :param int expected_code: The code expected in the response.
-        :param list expected_result: A list of items expects in a
-            JSON array response.
-
-        :return: A ``Deferred`` that fires when test is done.
-        """
-        requesting = self.assertResponseCode(
-            method, path, request_body, expected_code)
-        requesting.addCallback(readBody)
-        requesting.addCallback(lambda body: self.assertItemsEqual(
-            expected_result, loads(body)))
-        return requesting
 
 
 class VersionTestsMixin(APITestsMixin):

--- a/flocker/dockerplugin/__init__.py
+++ b/flocker/dockerplugin/__init__.py
@@ -1,0 +1,7 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Docker plugin allowing use of Flocker to manage Docker volumes.
+
+This may eventually be a standalone package.
+"""

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -1,0 +1,52 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+An HTTP API implementing the Docker Volumes Plugin API.
+
+See https://github.com/docker/docker/tree/master/docs/extend for details.
+
+We don't validate inputs with a schema since this is pre-existing code
+maintained by someone else, and lacking a schema provided by Docker we
+can't be sure they won't change things in minor ways. We do validate
+outputs to ensure we output the documented requirements.
+"""
+
+import yaml
+
+from twisted.python.filepath import FilePath
+
+from klein import Klein
+
+from ..restapi import structured
+
+SCHEMA_BASE = FilePath(__file__).sibling(b'schema')
+SCHEMAS = {
+    b'/types.json': yaml.safe_load(
+        SCHEMA_BASE.child(b'types.yml').getContent()),
+    b'/endpoints.json': yaml.safe_load(
+        SCHEMA_BASE.child(b'endpoints.yml').getContent()),
+    }
+
+
+class VolumePlugin(object):
+    """
+    An implementation of the Docker Volumes Plugin API.
+    """
+    app = Klein()
+
+    def __init__(self, flocker_client, node_id):
+        """
+        :param IFlockerAPIV1Client flocker_client: Client that allows
+            communication with Flocker.
+
+        :param UUID node_id: The identity of the local node this plugin is
+            running on.
+        """
+        # These parameters will get used in latter issues: FLOC-2784,
+        # FLOC-2785 and FLOC-2786.
+        pass
+
+    def plugin_activate(self):
+        """
+        Return which Docker plugin APIs this plugin supports.
+        """

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -4,12 +4,9 @@
 An HTTP API implementing the Docker Volumes Plugin API.
 
 See https://github.com/docker/docker/tree/master/docs/extend for details.
-
-We don't validate inputs with a schema since this is pre-existing code
-maintained by someone else, and lacking a schema provided by Docker we
-can't be sure they won't change things in minor ways. We do validate
-outputs to ensure we output the documented requirements.
 """
+
+from functools import wraps
 
 import yaml
 
@@ -28,9 +25,35 @@ SCHEMAS = {
     }
 
 
+def _endpoint(name):
+    """
+    Decorator factory for API endpoints, adding appropriate JSON in/out
+    encoding.
+
+    :param unicode name: The name of the endpoint in the schema.
+
+    :return: Decorator for a method.
+    """
+    def decorator(f):
+        @wraps(f)
+        @structured(
+            inputSchema={},
+            outputSchema={u"$ref": u"/endpoints.json#/definitions/" + name},
+            schema_store=SCHEMAS)
+        def wrapped(*args, **kwargs):
+            return f(*args, **kwargs)
+        return wrapped
+    return decorator
+
+
 class VolumePlugin(object):
     """
     An implementation of the Docker Volumes Plugin API.
+
+    We don't validate inputs with a schema since this is pre-existing code
+    maintained by someone else, and lacking a schema provided by Docker we
+    can't be sure they won't change things in minor ways. We do validate
+    outputs to ensure we output the documented requirements.
     """
     app = Klein()
 
@@ -46,7 +69,43 @@ class VolumePlugin(object):
         # FLOC-2785 and FLOC-2786.
         pass
 
+    @app.route("/Plugin.Activate", methods=["POST"])
+    @_endpoint(u"PluginActivate")
     def plugin_activate(self):
         """
-        Return which Docker plugin APIs this plugin supports.
+        Return which Docker plugin APIs this object supports.
         """
+        return {u"Implements": [u"VolumeDriver"]}
+
+    @app.route("/VolumeDriver.Remove", methods=["POST"])
+    @_endpoint(u"Remove")
+    def volumedriver_remove(self, Name):
+        """
+        Remove a Docker volume.
+
+        :param unicode Name: The name of the volume.
+
+        In practice we don't actually delete anything. As a multi-node
+        volume driver the fact that a particular container is done with a
+        volume doesn't mean another won't elsewhere, so we don't delete
+        datasets based on information from Docker.
+
+        :return: Result indicating success.
+        """
+        return {u"Err": None}
+
+    @app.route("/VolumeDriver.Unmount", methods=["POST"])
+    @_endpoint(u"Unmount")
+    def volumedriver_unmount(self, Name):
+        """
+        The Docker container is no longer using the given volume.
+
+        :param unicode Name: The name of the volume.
+
+        For now this does nothing. In FLOC-2755 this will release the
+        lease acquired for the dataset by the ``VolumeDriver.Mount``
+        handler.
+
+        :return: Result indicating success.
+        """
+        return {u"Err": None}

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -86,8 +86,8 @@ class VolumePlugin(object):
         :param unicode Name: The name of the volume.
 
         In practice we don't actually delete anything. As a multi-node
-        volume driver the fact that a particular container is done with a
-        volume doesn't mean another won't elsewhere, so we don't delete
+        volume driver we want to keep volumes around beyond lifetime of a
+        specific container, or even a single node, so we don't delete
         datasets based on information from Docker.
 
         :return: Result indicating success.

--- a/flocker/dockerplugin/schema/endpoints.yml
+++ b/flocker/dockerplugin/schema/endpoints.yml
@@ -1,7 +1,7 @@
 $schema: http://json-schema.org/draft-04/schema#
 id: http://api.clusterhq.com/dockerplugin/dockerplugin.json
 definitions:
-  PluginAttach:
+  PluginActivate:
     description: "Initial handshake."
     type: object
     properties:

--- a/flocker/dockerplugin/schema/endpoints.yml
+++ b/flocker/dockerplugin/schema/endpoints.yml
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-04/schema#
+id: http://api.clusterhq.com/dockerplugin/dockerplugin.json
+definitions:
+  PluginAttach:
+    description: "Initial handshake."
+    type: object
+    properties:
+      Implements:
+        type: "array"
+        title: "List of APIs we support."
+        decription: "See Docker plugin API docs."
+        items:
+          - type: "string"
+            enum: "VolumeDriver"
+    required:
+      - "Implements"
+    additionalProperties: false
+
+  Remove:
+    description: "Remove response."
+    type: object
+    properties:
+      Err:
+        '$ref': 'types.json#/definitions/Err'
+    required:
+      - "Err"
+    additionalProperties: false
+
+  Unmount:
+    description: "Unmount response."
+    type: object
+    properties:
+      Err:
+        '$ref': 'types.json#/definitions/Err'
+    required:
+      - "Err"
+    additionalProperties: false

--- a/flocker/dockerplugin/schema/types.yml
+++ b/flocker/dockerplugin/schema/types.yml
@@ -1,0 +1,9 @@
+$schema: http://json-schema.org/draft-04/schema#
+id: http://api.clusterhq.com/dockerplugin/types.json
+definitions:
+  Err:
+    title: "Error response"
+    description: "Null indicates success, string indicates error."
+    type:
+      - "string"
+      - "null"

--- a/flocker/dockerplugin/test/__init__.py
+++ b/flocker/dockerplugin/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Unit tests for the Docker plugin.
+"""

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -3,3 +3,59 @@
 """
 Tests for the Volumes Plugin API provided by the plugin.
 """
+
+from uuid import uuid4
+
+from twisted.web.http import OK
+
+from .._api import VolumePlugin
+from ...apiclient import FakeFlockerClient
+
+from ...restapi.testtools import buildIntegrationTests, APIAssertionsMixin
+
+
+class APITestsMixin(APIAssertionsMixin):
+    """
+    Helpers for writing tests for the Docker Volume Plugin API.
+    """
+    NODE_A = uuid4()
+    NODE_B = uuid4()
+
+    def initialize(self):
+        """
+        Create initial objects for the ``VolumePlugin``.
+        """
+        self.flocker_client = FakeFlockerClient()
+
+    def test_pluginactivate(self):
+        """
+        ``/Plugins.Activate`` indicates the plugin is a volume driver.
+        """
+        # Really we should be sending a blank body, but that has some
+        # issues since @structured then expects a POST to have a
+        # application/json content type. Fixing up the content type issues
+        # (a necessary chunk of work) is covered by FLOC-2811, which
+        # should also fix this.
+        return self.assertResult(b"POST", b"/Plugin.Activate", {}, OK,
+                                 {u"Implements": [u"VolumeDriver"]})
+
+    def test_remove(self):
+        """
+        ``/VolumeDriver.Remove`` returns a successful result.
+        """
+        return self.assertResult(b"POST", b"/VolumeDriver.Remove",
+                                 {u"Name": u"vol"}, OK, {u"Err": None})
+
+    def test_unmount(self):
+        """
+        ``/VolumeDriver.Unmount`` returns a successful result.
+        """
+        return self.assertResult(b"POST", b"/VolumeDriver.Unmount",
+                                 {u"Name": u"vol"}, OK, {u"Err": None})
+
+
+def _build_app(test):
+    test.initialize()
+    return VolumePlugin(test.flocker_client, test.NODE_A).app
+RealTestsAPI, MemoryTestsAPI = buildIntegrationTests(
+    APITestsMixin, "API", _build_app)

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -1,0 +1,5 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for the Volumes Plugin API provided by the plugin.
+"""

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -1,0 +1,62 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for Docker plugin API schemas.
+"""
+
+from __future__ import unicode_literals
+
+from ...restapi.testtools import build_schema_test
+from .._api import SCHEMAS
+
+
+def build_simple_test(command_name):
+    """
+    Build a test for simple API commands that respond only with ``Err`` field.
+
+    :param unicode command_name: The command in the schema to validate.
+
+    :return: ``TestCase``.
+    """
+    return build_schema_test(
+        name=str(command_name + "Tests"),
+        schema={"$ref": "/endpoints.json#/definitions/" + command_name},
+        schema_store=SCHEMAS,
+        failing_instances=[
+            # Wrong types:
+            [], "", None,
+            # Missing field:
+            {},
+            # Wrong fields:
+            {"Result": "hello"},
+            # Wrong Err types:
+            {"Err": 1}, {"Err": {}},
+            # Extra field:
+            {"Err": None, "Extra": ""},
+        ],
+        passing_instances=[
+            {"Err": None},
+            {"Err": "Something went wrong!"},
+        ])
+
+RemoveTests = build_simple_test("Remove")
+UnmountTests = build_simple_test("Unmount")
+
+
+PluginAttachTests = build_schema_test(
+    name=str("PluginAttachTests"),
+    schema={"$ref": "/endpoints.json#/definitions/PluginAttach"},
+    schema_store=SCHEMAS,
+    failing_instances=[
+        # Wrong types:
+        [], "", None,
+        # Missing field:
+        {},
+        # Wrong fields:
+        {"Result": "hello"},
+        # Extra field:
+        {"Implements": ["VolumeDriver"], "X": "Y"},
+    ],
+    passing_instances=[
+        {"Implements": ["VolumeDriver"]},
+    ])

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -43,9 +43,9 @@ RemoveTests = build_simple_test("Remove")
 UnmountTests = build_simple_test("Unmount")
 
 
-PluginAttachTests = build_schema_test(
-    name=str("PluginAttachTests"),
-    schema={"$ref": "/endpoints.json#/definitions/PluginAttach"},
+PluginActivateTests = build_schema_test(
+    name=str("PluginActivateTests"),
+    schema={"$ref": "/endpoints.json#/definitions/PluginActivate"},
     schema_store=SCHEMAS,
     failing_instances=[
         # Wrong types:

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ setup(
         # These data files are used by the volumes API to define input and
         # output schemas.
         'flocker.control': ['schema/*.yml'],
+        # These files are used by the Docker plugin API:
+        'flocker.dockerplugin': ['schema/*.yml'],
     },
 
     entry_points={


### PR DESCRIPTION
1. Move a bunch of utility code out of `flocker.control.test.test_httpapi` and into `flocker.restapi.testtools`. It is not modified in any way.
2. Add basic (output) schema and API call implementations for three trivial Docker plugin API endpoints.

The relevant documentation:
https://github.com/docker/docker/blob/master/docs/extend/plugin_api.md#pluginactivate
https://github.com/docker/docker/blob/master/docs/extend/plugins_volume.md#volumedriverremove
https://github.com/docker/docker/blob/master/docs/extend/plugins_volume.md#volumedriverunmount