### PR TITLE
[FLOC-2771] Run client installation tests using Docker

### DIFF
--- a/admin/client.py
+++ b/admin/client.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
 """
 Run the client installation tests.
 """

--- a/admin/client.py
+++ b/admin/client.py
@@ -84,7 +84,7 @@ def make_script_file(dir, effects):
     Create a shell script file from a sequence of effects.
 
     :param bytes dir: The directory in which to create the script.
-    :param Effect effects: An effect which contain the commands,
+    :param Effect effects: An effect which contains the commands,
         typically a Sequence containing multiple commands.
     :return: The base filename of the script.
     """
@@ -98,7 +98,7 @@ def make_script_file(dir, effects):
 
 class DockerRunner:
     """
-    Run commands on Docker.
+    Run commands in a Docker container.
     """
 
     def __init__(self, image):

--- a/admin/client.py
+++ b/admin/client.py
@@ -1,6 +1,6 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 """
-Run the acceptance tests.
+Run the client installation tests.
 """
 
 import os
@@ -10,21 +10,20 @@ import tempfile
 import yaml
 
 import docker
+from effect import TypeDispatcher, sync_performer, perform
 from twisted.python.usage import Options, UsageError
 from twisted.python.filepath import FilePath
+
+import flocker
 from flocker.common.version import make_rpm_version
 from flocker.provision import PackageSource
-import flocker
-from flocker.provision._install import (
-    task_client_installation_test,
-    task_install_cli,
-)
-from effect.twisted import perform
-
-from effect import TypeDispatcher, sync_performer
 from flocker.provision._effect import Sequence, perform_sequence
-from flocker.provision._ssh._model import Run, Sudo, Put, Comment
+from flocker.provision._install import (
+    task_install_cli,
+    task_client_installation_test,
+)
 from flocker.provision._ssh._conch import perform_sudo, perform_put
+from flocker.provision._ssh._model import Run, Sudo, Put, Comment
 
 DOCKER_IMAGES = {
     'centos-7': 'centos:7',
@@ -44,7 +43,10 @@ class ScriptBuilder(TypeDispatcher):
     """
 
     def __init__(self, effects):
-        self.lines = ['#!/bin/bash', 'set -ex']
+        self.lines = [
+            '#!/bin/bash',
+            'set -ex'
+        ]
         TypeDispatcher.__init__(self, {
             Run: self.perform_run,
             Sudo: perform_sudo,

--- a/admin/client.py
+++ b/admin/client.py
@@ -174,7 +174,7 @@ class RunOptions(Options):
          'Version of flocker to install'],
         ['build-server', None, 'http://build.clusterhq.com/',
          'Base URL of build server for package downloads'],
-        # XXX - remove the remaining flags once Buildbot is updated
+        # XXX - remove the remaining flags once Buildbot is updated (FLOC-2813)
         ['provider', None, None, 'No longer used.'],
         ['config-file', None, None, 'No longer used.'],
     ]

--- a/admin/client.py
+++ b/admin/client.py
@@ -96,9 +96,6 @@ class DockerRunner:
     def install_client(self, distribution, package_source):
         tmpdir = tempfile.mkdtemp()
         try:
-            install = make_script_file(
-                tmpdir, task_install_cli(distribution, package_source))
-            dotest = make_script_file(tmpdir, task_client_installation_test())
             image = DOCKER_IMAGES[distribution]
             self.docker.pull(image)
             container = self.docker.create_container(
@@ -113,8 +110,12 @@ class DockerRunner:
                 }
             )
             try:
+                install = make_script_file(
+                    tmpdir, task_install_cli(distribution, package_source))
                 self.run_script_file(
                     container_id, '/mnt/script/{}'.format(install))
+                dotest = make_script_file(
+                    tmpdir, task_client_installation_test())
                 self.run_script_file(
                     container_id, '/mnt/script/{}'.format(dotest))
             finally:

--- a/admin/client.py
+++ b/admin/client.py
@@ -26,7 +26,6 @@ from flocker.provision._ssh._conch import perform_sudo, perform_put
 from flocker.provision._ssh._model import Run, Sudo, Put, Comment
 
 DOCKER_IMAGES = {
-    'centos-7': 'centos:7',
     'ubuntu-14.04': 'ubuntu:14.04',
     'ubuntu-15.04': 'ubuntu:15.04',
 }

--- a/admin/client.py
+++ b/admin/client.py
@@ -44,7 +44,7 @@ class ScriptBuilder(TypeDispatcher):
     """
 
     def __init__(self, effects):
-        self.lines = ['#!/bin/bash', 'set -e']
+        self.lines = ['#!/bin/bash', 'set -ex']
         TypeDispatcher.__init__(self, {
             Run: self.perform_run,
             Sudo: perform_sudo,

--- a/admin/client.py
+++ b/admin/client.py
@@ -201,7 +201,7 @@ def main(args, base_path, top_level):
                 session_id = session[u'Id']
                 output = docker.exec_start(session)
                 status = docker.exec_inspect(session_id)[u'ExitCode']
-                if status != 0:
+                if status == 0:
                     sys.stdout.write(output)
                 else:
                     sys.exit(output)
@@ -209,7 +209,7 @@ def main(args, base_path, top_level):
                 session_id = session[u'Id']
                 output = docker.exec_start(session)
                 status = docker.exec_inspect(session_id)[u'ExitCode']
-                if status != 0:
+                if status == 0:
                     sys.stdout.write(output)
                 else:
                     sys.exit(output)

--- a/admin/client.py
+++ b/admin/client.py
@@ -25,7 +25,13 @@ from flocker.provision._effect import Sequence, perform_sequence
 from flocker.provision._ssh._model import Run, Sudo, Put, Comment
 from flocker.provision._ssh._conch import perform_sudo, perform_put
 
-DISTRIBUTIONS = ('centos-7', 'ubuntu-14.04', 'ubuntu-15.04')
+DOCKER_IMAGES = {
+    'centos-7': 'centos:7',
+    'ubuntu-14.04': 'ubuntu:14.04',
+    'ubuntu-15.04': 'ubuntu:15.04',
+}
+
+DISTRIBUTIONS = DOCKER_IMAGES.keys()
 
 
 class ScriptBuilder(TypeDispatcher):
@@ -167,7 +173,7 @@ def main(args, base_path, top_level):
         dotest = make_script_file(task_client_installation_test())
         try:
             docker = dockerpy.Client(version='1.18')
-            image = 'ubuntu:14.04'
+            image = DOCKER_IMAGES[distribution]
             docker.pull(image)
             container = docker.create_container(
                 image=image, command='/bin/bash', tty=True,

--- a/admin/client.py
+++ b/admin/client.py
@@ -22,8 +22,8 @@ from flocker.provision._install import (
     task_install_cli,
     task_client_installation_test,
 )
-from flocker.provision._ssh._conch import perform_sudo, perform_put
-from flocker.provision._ssh._model import Run, Sudo, Put, Comment
+from flocker.provision._ssh import (
+    Run, Sudo, Put, Comment, perform_sudo, perform_put)
 
 DOCKER_IMAGES = {
     'ubuntu-14.04': 'ubuntu:14.04',

--- a/admin/client.py
+++ b/admin/client.py
@@ -169,23 +169,19 @@ class RunOptions(Options):
         ['distribution', None, None,
          'The target distribution. '
          'One of {}.'.format(', '.join(DISTRIBUTIONS))],
-        # XXX - remove the following flag once Buildbot is updated
-        ['provider', None, None, 'No longer used'],
-        ['config-file', None, None,
-         'Configuration for providers.'],
         ['branch', None, None, 'Branch to grab packages from'],
         ['flocker-version', None, flocker.__version__,
          'Version of flocker to install'],
         ['build-server', None, 'http://build.clusterhq.com/',
          'Base URL of build server for package downloads'],
-    ]
-
-    optFlags = [
-        ["keep", "k", "Keep VMs around, if the tests fail."],
+        # XXX - remove the remaining flags once Buildbot is updated
+        ['provider', None, None, 'No longer used.'],
+        ['config-file', None, None, 'No longer used.'],
     ]
 
     synopsis = ('Usage: run-client-tests --distribution <distribution> '
-                '[--provider <provider>]')
+                '[--branch <branch>] [--flocker-version <version>] '
+                '[--build-server <url>]')
 
     def __init__(self, top_level):
         """
@@ -229,7 +225,7 @@ def main(args, base_path, top_level):
     """
     :param list args: The arguments passed to the script.
     :param FilePath base_path: The executable being run.
-    :param FilePath top_level: The top-level of the flocker repository.
+    :param FilePath top_level: The top-level of the Flocker repository.
     """
     options = RunOptions(top_level=top_level)
 

--- a/admin/client.py
+++ b/admin/client.py
@@ -81,10 +81,11 @@ class ScriptBuilder(TypeDispatcher):
 
 def make_script_file(dir, effects):
     """
-    Create a shell script file from a set of effects.
+    Create a shell script file from a sequence of effects.
 
-    :param dir: The directory in which to create the script.
-    :param effects: The effects which contain the commands.
+    :param bytes dir: The directory in which to create the script.
+    :param Effect effects: An effect which contain the commands,
+        typically a Sequence containing multiple commands.
     :return: The base filename of the script.
     """
     builder = ScriptBuilder(effects)
@@ -144,10 +145,10 @@ class DockerRunner:
         The output of the commands is sent to the ``out`` file object,
         which must have a ``write`` method.
 
-        :param commands: An Effect containing the commands to run,
+        :param Effect commands: An Effect containing the commands to run,
             probably a Sequence of Effects, one for each command to run.
-        :param out: Where to send command output. A file-like object
-            with a ``write`` method.
+        :param out: Where to send command output. Any object with a
+            ``write`` method.
         :return int: The exit status of the commands.  If all commands
             succeed, this will be zero. If any command fails, this will
             be non-zero.

--- a/admin/client.py
+++ b/admin/client.py
@@ -78,6 +78,8 @@ class RunOptions(Options):
         ['distribution', None, None,
          'The target distribution. '
          'One of {}.'.format(', '.join(DISTRIBUTIONS))],
+        # XXX - remove the following flag once Buildbot is updated
+        ['provider', None, None, 'No longer used'],
         ['config-file', None, None,
          'Configuration for providers.'],
         ['branch', None, None, 'Branch to grab packages from'],

--- a/admin/client.py
+++ b/admin/client.py
@@ -71,6 +71,17 @@ def make_script_file(effects):
     return filename
 
 
+def run_script_file(docker, container_id, script):
+    session = docker.exec_create(container_id, script)
+    session_id = session[u'Id']
+    output = docker.exec_start(session)
+    status = docker.exec_inspect(session_id)[u'ExitCode']
+    if status == 0:
+        sys.stdout.write(output)
+    else:
+        sys.exit(output)
+
+
 class RunOptions(Options):
     description = "Run the client tests."
 
@@ -171,22 +182,8 @@ def main(args, base_path, top_level):
                 }
             )
             try:
-                session = docker.exec_create(container_id, '/install.sh')
-                session_id = session[u'Id']
-                output = docker.exec_start(session)
-                status = docker.exec_inspect(session_id)[u'ExitCode']
-                if status == 0:
-                    sys.stdout.write(output)
-                else:
-                    sys.exit(output)
-                session = docker.exec_create(container_id, '/dotest.sh')
-                session_id = session[u'Id']
-                output = docker.exec_start(session)
-                status = docker.exec_inspect(session_id)[u'ExitCode']
-                if status == 0:
-                    sys.stdout.write(output)
-                else:
-                    sys.exit(output)
+                run_script_file(docker, container_id, '/install.sh')
+                run_script_file(docker, container_id, '/dotest.sh')
             finally:
                 docker.stop(container_id)
         finally:

--- a/admin/client.py
+++ b/admin/client.py
@@ -168,11 +168,15 @@ def main(args, base_path, top_level):
 
     distribution = options['distribution']
     package_source = options['package_source']
+    docker = dockerpy.Client(version='1.18')
+    install_client(distribution, package_source, docker)
+
+
+def install_client(distribution, package_source, docker):
     install = make_script_file(task_install_cli(distribution, package_source))
     try:
         dotest = make_script_file(task_client_installation_test())
         try:
-            docker = dockerpy.Client(version='1.18')
             image = DOCKER_IMAGES[distribution]
             docker.pull(image)
             container = docker.create_container(

--- a/admin/run-client-tests
+++ b/admin/run-client-tests
@@ -9,6 +9,5 @@ from _preamble import TOPLEVEL, BASEPATH
 import sys
 
 if __name__ == '__main__':
-    from twisted.internet.task import react
     from admin.client import main
-    react(main, (sys.argv[1:], BASEPATH, TOPLEVEL))
+    main(sys.argv[1:], BASEPATH, TOPLEVEL)

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -224,57 +224,6 @@ The nodes should be configured to allow key based SSH connections as user ``root
    admin/run-acceptance-tests --distribution centos-7 --provider managed --config-file config.yml
 
 
-.. _client-acceptance-tests:
-
-Client Installation Testing
-===========================
-
-Flocker includes client installation tests and a tool for running them in Docker containers.
-It is called like this:
-
-.. prompt:: bash $
-
-   admin/run-client-tests <options>
-
-
-The :program:`admin/run-client-tests` script has several options:
-
-.. program:: admin/run-client-tests
-
-.. option:: --distribution <distribution>
-
-   Specifies the distribution on which to run the installation test.
-
-.. option:: --flocker-version <version>
-
-   Specifies the version of flocker to install.
-   If this isn't specified, the most recent version will be installed.
-   If a branch is also specified, the most recent version from that branch will be installed.
-   If a branch is not specified, the most recent release will be installed.
-
-   .. note::
-
-      The build server merges forward before building packages, except on release branches.
-      If you want to run the client tests against a branch in development,
-      you probably only want to specify the branch.
-
-.. option:: --branch <branch>
-
-   Specifies the branch from which packages are installed.
-   If this isn't specified, packages will be installed from the release repository.
-
-.. option:: --build-server <buildserver>
-
-   Specifies the base URL of the build server to install from.
-   This is probably only useful when testing changes to the build server.
-
-To see the supported values for each option, run:
-
-.. prompt:: bash $
-
-   admin/run-client-tests --help
-
-
 Functional Testing
 ==================
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -226,10 +226,10 @@ The nodes should be configured to allow key based SSH connections as user ``root
 
 .. _client-acceptance-tests:
 
-Client Testing
-==============
+Client Installation Testing
+===========================
 
-Flocker includes client installation tests and a tool for running them.
+Flocker includes client installation tests and a tool for running them in Docker containers.
 It is called like this:
 
 .. prompt:: bash $

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -234,7 +234,7 @@ It is called like this:
 
 .. prompt:: bash $
 
-   admin/run-cluster-tests <options> [<test-cases>]
+   admin/run-client-tests <options>
 
 
 The :program:`admin/run-client-tests` script has several options:
@@ -243,11 +243,7 @@ The :program:`admin/run-client-tests` script has several options:
 
 .. option:: --distribution <distribution>
 
-   Specifies what distribution to use on the created nodes.
-
-.. option:: --provider <provider>
-
-   Specifies what provider to use to create the nodes.
+   Specifies the distribution on which to run the installation test.
 
 .. option:: --flocker-version <version>
 
@@ -259,7 +255,7 @@ The :program:`admin/run-client-tests` script has several options:
    .. note::
 
       The build server merges forward before building packages, except on release branches.
-      If you want to run the acceptance tests against a branch in development,
+      If you want to run the client tests against a branch in development,
       you probably only want to specify the branch.
 
 .. option:: --branch <branch>
@@ -271,18 +267,6 @@ The :program:`admin/run-client-tests` script has several options:
 
    Specifies the base URL of the build server to install from.
    This is probably only useful when testing changes to the build server.
-
-.. option:: --config-file <config-file>
-
-   Specifies a YAML configuration file that contains provider specific configuration.
-   See the acceptance testing section above for the required configuration options.
-   If the configuration contains a ``metadata`` key,
-   the contents will be added as metadata of the created nodes,
-   if the provider supports it.
-
-.. option:: --keep
-
-   Keep VMs around, if the tests fail.
 
 To see the supported values for each option, run:
 

--- a/docs/gettinginvolved/client-testing.rst
+++ b/docs/gettinginvolved/client-testing.rst
@@ -1,21 +1,70 @@
-.. _cli-testing:
+.. _client-testing:
 
 Client Testing
 ==============
 
-There are automated acceptance tests for the Flocker CLI on some platforms.
-See :ref:`client-acceptance-tests`.
+Automated Testing
+-----------------
+
+Flocker includes client installation tests and a tool for running them in Docker containers.
+It is called like this:
+
+.. prompt:: bash $
+
+   admin/run-client-tests <options>
+
+
+The :program:`admin/run-client-tests` script has several options:
+
+.. program:: admin/run-client-tests
+
+.. option:: --distribution <distribution>
+
+   Specifies the distribution on which to run the installation test.
+
+.. option:: --flocker-version <version>
+
+   Specifies the version of flocker to install.
+   If this isn't specified, the most recent version will be installed.
+   If a branch is also specified, the most recent version from that branch will be installed.
+   If a branch is not specified, the most recent release will be installed.
+
+   .. note::
+
+      The build server merges forward before building packages, except on release branches.
+      If you want to run the client tests against a branch in development,
+      you probably only want to specify the branch.
+
+.. option:: --branch <branch>
+
+   Specifies the branch from which packages are installed.
+   If this isn't specified, packages will be installed from the release repository.
+
+.. option:: --build-server <buildserver>
+
+   Specifies the base URL of the build server to install from.
+   This is probably only useful when testing changes to the build server.
+
+To see the supported values for each option, run:
+
+.. prompt:: bash $
+
+   admin/run-client-tests --help
+
+
+Manual Testing
+--------------
 
 Sometimes it is useful to manually test CLIs and their installation instructions on various platforms.
 
 OS X
-----
+~~~~
 
 ClusterHQ has a Mac with the ability to start an OS X Virtual Machine.
 An internal document describing how to use this is available at "Infrastructure > OS X Development Machine".
 
 Linux
------
+~~~~~
 
 To test on various Linux distributions, it is possible to create either Docker containers or Vagrant virtual machines.
 

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -241,9 +241,9 @@ def install_cli_commands_ubuntu(distribution, package_source):
         # Minimal images often have cleared apt caches and are missing
         # packages that are common in a typical release.  These commands
         # ensure that we start from a good base system with the required
-        # capabilities, particularly that the add-apt-repository command
-        # and HTTPS URLs are supported.
-        # FLOC-1880 will ensure these are necessary and sufficient.
+        # capabilities, particularly that sudo and add-apt-repository
+        # commands are available, and HTTPS URLs are supported.
+        run("which sudo || su root -c 'apt-get -y install sudo'"),
         sudo_from_args(["apt-get", "update"]),
         sudo_from_args([
             "apt-get", "-y", "install", "apt-transport-https",

--- a/flocker/provision/_ssh/__init__.py
+++ b/flocker/provision/_ssh/__init__.py
@@ -6,6 +6,7 @@ from ._model import (
     Put, put,
     Comment, comment,
     RunRemotely, run_remotely,
+    perform_comment, perform_put, perform_sudo
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "Put", "put",
     "Comment", "comment",
     "RunRemotely", "run_remotely",
+    "perform_comment", "perform_put", "perform_sudo",
 ]

--- a/flocker/provision/_ssh/_conch.py
+++ b/flocker/provision/_ssh/_conch.py
@@ -1,12 +1,9 @@
-from pipes import quote as shell_quote
 
 from characteristic import attributes
 
 from eliot import Message, MessageType, Field
 
-from effect import (
-    sync_performer, TypeDispatcher, ComposedDispatcher, Effect,
-    )
+from effect import TypeDispatcher, ComposedDispatcher
 from effect.twisted import (
     make_twisted_dispatcher,
 )
@@ -32,7 +29,9 @@ import os
 
 from flocker.testtools import loop_until
 
-from ._model import Run, Sudo, Put, Comment, RunRemotely, identity
+from ._model import (
+    Run, Sudo, Put, Comment, RunRemotely, perform_comment, perform_put,
+    perform_sudo)
 
 from .._effect import dispatcher as base_dispatcher
 
@@ -87,36 +86,6 @@ class CommandProtocol(LineOnlyReceiver, object):
             message_type="flocker.provision.ssh:run:output",
             line=line,
         ).write()
-
-
-@sync_performer
-def perform_sudo(dispatcher, intent):
-    """
-    See :py:class:`Sudo`.
-    """
-    return Effect(Run(
-        command='sudo ' + intent.command, log_command_filter=identity))
-
-
-@sync_performer
-def perform_put(dispatcher, intent):
-    """
-    See :py:class:`Put`.
-    """
-    def create_put_command(content, path):
-        return 'printf -- %s > %s' % (shell_quote(content), shell_quote(path))
-    return Effect(Run(
-        command=create_put_command(intent.content, intent.path),
-        log_command_filter=lambda _: create_put_command(
-            intent.log_content_filter(intent.content), intent.path)
-        ))
-
-
-@sync_performer
-def perform_comment(dispatcher, intent):
-    """
-    See :py:class:`Comment`.
-    """
 
 
 def get_ssh_dispatcher(connection, context):


### PR DESCRIPTION
The client tests currently start cloud nodes for testing. Since the tests are very short, this is wasteful in time and money, especially since the tests do not need the same capabilities as the acceptance tests.

This PR changes the tests to use a local Docker container.

Apart from the resource usage argument above, this PR is motivated by
- FLOC-2750, regarding client test failures due to cloud request limits, and 
- the code review of FLOC-2769.  The problem with the PR #1820 is that the cloud tests do not maintain the environment between commands. Each command runs in a separate SSH channel. This prevents `virtualenv` being used sensibly. The Docker Runner in this PR supports keeping the environment between commands in a sequence, so will allow a cleaner solution to that PR.

Although the commits are a set of gradual changes to the files, for review it is probably easier to consider the file `admin/client.py` as completely re-written code rather than looking at the diff.

To test, run a command like:
```
./admin/run-client-tests --distribution ubuntu-15.04 --flocker-version=1.1.0.dev2
```
