### PR TITLE
[FLOC-2677] add Optimizely to docs template

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -204,7 +204,11 @@
         </script>
     {% endif %}
 
-    <!-- Optimizely -->
+    <!-- 
+        Optimizely: AB Testing tool
+        Snippet generated from:
+        https://app.optimizely.com/projects/2309470232/implementation
+    -->
     <script src="https://cdn.optimizely.com/js/2309470232.js"></script>
 
     <!-- Heatmap.me snippet -->

--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -204,6 +204,9 @@
         </script>
     {% endif %}
 
+    <!-- Optimizely -->
+    <script src="https://cdn.optimizely.com/js/2309470232.js"></script>
+
     <!-- Heatmap.me snippet -->
     <script type="text/javascript">
     (function() {


### PR DESCRIPTION
Optimizely snippet.

Fixes FLOC-2677

http://build.clusterhq.com/results/docs/docs-optimizely-FLOC-2677/build-9236/ is running a test at the moment, I changed the text to 

> You are reading an in-development version of the documentation. Some of the functionality may not work as expected. Things may break.

In the warning I added "Things may break"