### PR TITLE
[FLOC-2751] Check if node exists every 15 seconds instead of every 3 seconds

### DIFF
--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -100,7 +100,8 @@ class LibcloudNode(object):
         def do_reboot(_):
             self._node.reboot()
             self._node, self.addresses = (
-                self._node.driver.wait_until_running([self._node])[0])
+                self._node.driver.wait_until_running(
+                    [self._node], wait_period=15)[0])
             return
 
         return run_remotely(
@@ -203,7 +204,8 @@ class LibcloudProvisioner(object):
             **create_node_arguments
         )
 
-        node, addresses = self._driver.wait_until_running([node])[0]
+        node, addresses = self._driver.wait_until_running(
+            [node], wait_period=15)[0]
 
         public_address = addresses[0]
 


### PR DESCRIPTION
… to reduce chances of hitting rate limits on cloud provider.

Node startup takes a while anyway, so it's unlikely to slow us down much. Longer term we will pre-provision nodes so we won't have this speed hit at all.