### PR TITLE
[FLOC-1968] Automate copyright changes in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014, 2015 ClusterHQ
+   Copyright 2014-1000 ClusterHQ
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014-1000 ClusterHQ
+   Copyright 2014-2015 ClusterHQ
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -175,17 +175,6 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
    Copyright 2014-2015 ClusterHQ
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/admin/LICENSE.template
+++ b/admin/LICENSE.template
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2014-{current_year} ClusterHQ
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/admin/LICENSE.template
+++ b/admin/LICENSE.template
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "{{}}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a

--- a/admin/LICENSE.template
+++ b/admin/LICENSE.template
@@ -175,17 +175,6 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{{}}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
    Copyright 2014-{current_year} ClusterHQ
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/admin/release.py
+++ b/admin/release.py
@@ -22,6 +22,7 @@ from effect.do import do
 
 from characteristic import attributes
 from git import GitCommandError, Repo
+from pytz import UTC
 
 import requests
 
@@ -1079,7 +1080,7 @@ def publish_dev_box_main(args, base_path, top_level):
     )
 
 
-def update_license_file(args, top_level, year=datetime.now().year):
+def update_license_file(args, top_level, year=datetime.now(UTC).year):
     """
     Update the LICENSE file to include the current year.
 

--- a/admin/release.py
+++ b/admin/release.py
@@ -13,6 +13,7 @@ import os
 import sys
 import tempfile
 
+from datetime import datetime
 from subprocess import check_call
 
 from effect import (
@@ -1078,7 +1079,7 @@ def publish_dev_box_main(args, base_path, top_level):
     )
 
 
-def update_license_file(args, base_path, top_level):
+def update_license_file(args, base_path, top_level, year=datetime.now().year):
     """
     Update the LICENSE file to include the current year.
 
@@ -1089,4 +1090,4 @@ def update_license_file(args, base_path, top_level):
     license_template = top_level.child('admin').child('LICENSE.template')
     with license_template.open() as input_file:
         with top_level.child('LICENSE').open('w') as output_file:
-            output_file.write(input_file.read().format(current_year=1000))
+            output_file.write(input_file.read().format(current_year=year))

--- a/admin/release.py
+++ b/admin/release.py
@@ -1078,57 +1078,17 @@ def publish_dev_box_main(args, base_path, top_level):
     )
 
 
-def publish_dev_box_main(args, base_path, top_level):
+def update_license_file(args, base_path, top_level):
     """
-    Publish a development Vagrant box.
+    Update the LICENSE file to include the current year.
 
     :param list args: The arguments passed to the script.
     :param FilePath base_path: The executable being run.
     :param FilePath top_level: The top-level of the flocker repository.
     """
-    options = PublishDevBoxOptions()
+    license_template = top_level.child('admin').child('LICENSE.template')
+    with open(license_template) as input_file:
+        license_content = input_file.read().format(current_year=1000)
 
-    try:
-        options.parseOptions(args)
-    except UsageError as e:
-        sys.stderr.write("%s: %s\n" % (base_path.basename(), e))
-        raise SystemExit(1)
-
-    scratch_directory = FilePath(tempfile.mkdtemp(
-        prefix=b'flocker-upload-'))
-    scratch_directory.child('vagrant').createDirectory()
-
-    box_type = "flocker-dev"
-    prefix = 'vagrant/dev/'
-
-    box_name = "{box_type}-{version}.box".format(
-        box_type=box_type,
-        version=options['flocker-version'],
-    )
-
-    box_url = "https://{bucket}.s3.amazonaws.com/{key}".format(
-        bucket=options['target'],
-        key=prefix + box_name,
-    )
-
-    sync_perform(
-        dispatcher=ComposedDispatcher([boto_dispatcher, base_dispatcher]),
-        effect=sequence([
-            Effect(
-                CopyS3Keys(
-                    source_bucket=DEV_ARCHIVE_BUCKET,
-                    source_prefix=prefix,
-                    destination_bucket=options['target'],
-                    destination_prefix=prefix,
-                    keys=[box_name],
-                )
-            ),
-            publish_vagrant_metadata(
-                version=options['flocker-version'],
-                box_url=box_url,
-                scratch_directory=scratch_directory.child('vagrant'),
-                box_name=box_type,
-                target_bucket=options['target'],
-            ),
-        ]),
-    )
+    with open(top_level.child('LICENSE')) as output_file:
+        output_file.write(license_content)

--- a/admin/release.py
+++ b/admin/release.py
@@ -1079,12 +1079,10 @@ def publish_dev_box_main(args, base_path, top_level):
     )
 
 
-def update_license_file(args, base_path, top_level, year=datetime.now().year):
+def update_license_file(top_level, year=datetime.now().year):
     """
     Update the LICENSE file to include the current year.
 
-    :param list args: The arguments passed to the script.
-    :param FilePath base_path: The executable being run.
     :param FilePath top_level: The top-level of the flocker repository.
     """
     license_template = top_level.child('admin').child('LICENSE.template')

--- a/admin/release.py
+++ b/admin/release.py
@@ -1087,8 +1087,6 @@ def update_license_file(args, base_path, top_level):
     :param FilePath top_level: The top-level of the flocker repository.
     """
     license_template = top_level.child('admin').child('LICENSE.template')
-    with open(license_template) as input_file:
-        license_content = input_file.read().format(current_year=1000)
-
-    with open(top_level.child('LICENSE')) as output_file:
-        output_file.write(license_content)
+    with license_template.open() as input_file:
+        with top_level.child('LICENSE').open('w') as output_file:
+            output_file.write(input_file.read().format(current_year=1000))

--- a/admin/release.py
+++ b/admin/release.py
@@ -1079,10 +1079,11 @@ def publish_dev_box_main(args, base_path, top_level):
     )
 
 
-def update_license_file(top_level, year=datetime.now().year):
+def update_license_file(args, top_level, year=datetime.now().year):
     """
     Update the LICENSE file to include the current year.
 
+    :param list args: The arguments passed to the script.
     :param FilePath top_level: The top-level of the flocker repository.
     """
     license_template = top_level.child('admin').child('LICENSE.template')

--- a/admin/test/test_release.py
+++ b/admin/test/test_release.py
@@ -2126,3 +2126,11 @@ class TestRedirectsOptionsTests(SynchronousTestCase):
         options = TestRedirectsOptions()
         options.parseOptions(['--production'])
         self.assertEqual(options.environment, Environments.PRODUCTION)
+
+class UpdateLicenseFileTests(SynchronousTestCase):
+    """
+    Tests for :func:`update_license_file`.
+    """
+
+    def test_update_license_file(self):
+        pass

--- a/admin/test/test_release.py
+++ b/admin/test/test_release.py
@@ -35,6 +35,7 @@ from ..release import (
     UploadOptions, create_pip_index, upload_pip_index,
     publish_homebrew_recipe, PushFailed,
     publish_vagrant_metadata, TestRedirectsOptions, get_expected_redirects,
+    update_license_file,
 )
 
 from ..packaging import Distribution
@@ -2133,4 +2134,25 @@ class UpdateLicenseFileTests(SynchronousTestCase):
     """
 
     def test_update_license_file(self):
-        pass
+        """
+        A LICENSE file is written to the top level directory from a template in
+        the admin directory, and is formatted to include the given year.
+        """
+        content = dedent("""
+            Some license text.
+
+            More, {current_year} even more.
+            """)
+
+        top_level = FilePath(self.mktemp())
+        top_level.child('admin').makedirs()
+        top_level.child('admin').child('LICENSE.template').setContent(content)
+        update_license_file(top_level=top_level, year=123)
+        self.assertEqual(
+            top_level.child('LICENSE').getContent(),
+            dedent("""
+                Some license text.
+
+                More, 123 even more.
+                """)
+        )

--- a/admin/test/test_release.py
+++ b/admin/test/test_release.py
@@ -2138,21 +2138,13 @@ class UpdateLicenseFileTests(SynchronousTestCase):
         A LICENSE file is written to the top level directory from a template in
         the admin directory, and is formatted to include the given year.
         """
-        content = dedent("""
-            Some license text.
-
-            More, {current_year} even more.
-            """)
-
         top_level = FilePath(self.mktemp())
         top_level.child('admin').makedirs()
-        top_level.child('admin').child('LICENSE.template').setContent(content)
-        update_license_file(top_level=top_level, year=123)
+        top_level.child('admin').child('LICENSE.template').setContent(
+            "Text including the current year: {current_year}.")
+        update_license_file(args=[], top_level=top_level, year=123)
+
         self.assertEqual(
             top_level.child('LICENSE').getContent(),
-            dedent("""
-                Some license text.
-
-                More, 123 even more.
-                """)
+            "Text including the current year: 123."
         )

--- a/admin/update-license
+++ b/admin/update-license
@@ -4,10 +4,10 @@
 Update the Copyright years in the LICENSE file.
 """
 
-from _preamble import TOPLEVEL, BASEPATH
+from _preamble import TOPLEVEL
 
 import sys
 
 if __name__ == '__main__':
     from admin.release import update_license_file as main
-    main(sys.argv[1:], top_level=TOPLEVEL, base_path=BASEPATH)
+    main(sys.argv[1:], top_level=TOPLEVEL)

--- a/admin/update-license
+++ b/admin/update-license
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 """
 Update the Copyright years in the LICENSE file.
 """

--- a/admin/update-license
+++ b/admin/update-license
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+"""
+Update the Copyright years in the LICENSE file.
+"""
+
+from _preamble import TOPLEVEL, BASEPATH
+
+import sys
+
+if __name__ == '__main__':
+    from admin.release import update_license_file as main
+    main(sys.argv[1:], top_level=TOPLEVEL, base_path=BASEPATH)

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -122,6 +122,8 @@ Preparing For a Release
       mkvirtualenv flocker-release
       pip install --editable .[dev]
       admin/create-release-branch --flocker-version="${VERSION}"
+      admin/update-license
+      git commit -am "Updated copyright in LICENSE file"
 
 #. Ensure the release notes in :file:`NEWS` are up-to-date:
 
@@ -158,16 +160,6 @@ Preparing For a Release
    .. prompt:: bash [vagrant@localhost]$
 
       git commit -am "Updated Release Notes"
-
-#. Ensure copyright dates in :file:`LICENSE` are up-to-date:
-
-   - The list of years near the end of :file:`LICENSE` should include each year in which commits were made to the project.
-   - This is already the case up to and including 2015.
-   - If any such years are not present in the list, add them and commit the changes:
-
-   .. prompt:: bash [vagrant@localhost]$
-
-      git commit -am "Updated copyright"
 
 #. Push the changes:
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-1968

This duplicates the LICENSE file into a template and makes two changes to it:
* A set of braces "`{}`" are replaced with "`{{}}`", but this does not change the rendered file
* Instead of `2014, 2015` the LICENSE file now has `2014-{current_year}`. 