### PR TITLE
[FLOC-2851] Configuration model change detection

### DIFF
--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -621,9 +621,6 @@ class Deployment(PRecord):
     :ivar Leases leases: A map of ``Lease`` instances by dataset id.
     """
     nodes = pset_field(Node)
-    # XXX delete in final version, this demonstrates how changing the
-    # model results in failed test:
-    uhoh_new_field = field()
 
     get_node = _get_node(Node)
 

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -4,14 +4,10 @@
 """
 Record types for representing deployment models.
 
-There are different categories of classes:
-
-1. Those that involve information that can be both in configuration and state.
-   This includes ``Deployment`` and all classes on it.
-   (Metadata should really be configuration only, but that hasn't been
-   fixed yet on the model level.)
-2. State-specific classes, currently ``NodeState``.
-3. Configuration-specific classes, none implemented yet.
+**IMPORTANT:**
+If you change classes in this module that get serialized as part of the
+cluster configuration file you need to write upgrade code to support
+upgrading from older versions of Flocker.
 """
 
 from uuid import UUID

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -625,6 +625,9 @@ class Deployment(PRecord):
     :ivar Leases leases: A map of ``Lease`` instances by dataset id.
     """
     nodes = pset_field(Node)
+    # XXX delete in final version, this demonstrates how changing the
+    # model results in failed test:
+    uhoh_new_field = field()
 
     get_node = _get_node(Node)
 

--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -23,6 +23,9 @@ from twisted.internet.task import LoopingCall
 
 from ._model import SERIALIZABLE_CLASSES, Deployment
 
+# The class at the root of the configuration tree.
+ROOT_CLASS = Deployment
+
 
 # Serialization marker storing the class name:
 _CLASS_MARKER = u"$__class__$"

--- a/flocker/control/test/persisted_model.json
+++ b/flocker/control/test/persisted_model.json
@@ -1,5 +1,4 @@
 {
-    "git_hash": "0cb9fbd1170a935f454593e1386828475a573861",
     "model": {
         "classes": {
             "__builtin__.NoneType": null,
@@ -158,5 +157,6 @@
             "uuid.UUID": null
         },
         "root": "flocker.control._model.Deployment"
-    }
+    },
+    "version": "1.1.0.dev2+274.gc8672ea.dirty"
 }

--- a/flocker/control/test/persisted_model.json
+++ b/flocker/control/test/persisted_model.json
@@ -1,1 +1,162 @@
-{"model": {"classes": {"flocker.control._model.NodePSet": null, "flocker.control._model.Deployment": {"category": "record", "fields": {"nodes": ["flocker.control._model.NodePSet"]}}}, "root": "flocker.control._model.Deployment"}, "git_hash": "dea57a9396e9b86b3afaf69f50f03d73b284f3f4"}
+{
+    "git_hash": "0cb9fbd1170a935f454593e1386828475a573861",
+    "model": {
+        "classes": {
+            "__builtin__.NoneType": null,
+            "__builtin__.bool": null,
+            "__builtin__.int": null,
+            "__builtin__.unicode": null,
+            "flocker.control._model.Application": {
+                "category": "record",
+                "fields": {
+                    "command_line": [
+                        "__builtin__.NoneType",
+                        "flocker.control._model.UnicodePVector"
+                    ],
+                    "cpu_shares": [],
+                    "environment": [
+                        "pyrsistent._pmap.PMap"
+                    ],
+                    "image": [
+                        "flocker.control._model.DockerImage"
+                    ],
+                    "links": [
+                        "flocker.control._model.LinkPSet"
+                    ],
+                    "memory_limit": [],
+                    "name": [],
+                    "ports": [
+                        "flocker.control._model.PortPSet"
+                    ],
+                    "restart_policy": [],
+                    "running": [
+                        "__builtin__.bool"
+                    ],
+                    "volume": []
+                }
+            },
+            "flocker.control._model.ApplicationPSet": {
+                "category": "set",
+                "type": [
+                    "flocker.control._model.Application"
+                ]
+            },
+            "flocker.control._model.Dataset": {
+                "category": "record",
+                "fields": {
+                    "dataset_id": [
+                        "__builtin__.unicode"
+                    ],
+                    "deleted": [
+                        "__builtin__.bool"
+                    ],
+                    "maximum_size": [],
+                    "metadata": [
+                        "pyrsistent._pmap.PMap"
+                    ]
+                }
+            },
+            "flocker.control._model.Deployment": {
+                "category": "record",
+                "fields": {
+                    "nodes": [
+                        "flocker.control._model.NodePSet"
+                    ]
+                }
+            },
+            "flocker.control._model.DockerImage": {
+                "category": "record",
+                "fields": {
+                    "repository": [],
+                    "tag": []
+                }
+            },
+            "flocker.control._model.Link": {
+                "category": "record",
+                "fields": {
+                    "alias": [],
+                    "local_port": [
+                        "__builtin__.int"
+                    ],
+                    "remote_port": [
+                        "__builtin__.int"
+                    ]
+                }
+            },
+            "flocker.control._model.LinkPSet": {
+                "category": "set",
+                "type": [
+                    "flocker.control._model.Link"
+                ]
+            },
+            "flocker.control._model.Manifestation": {
+                "category": "record",
+                "fields": {
+                    "dataset": [
+                        "flocker.control._model.Dataset"
+                    ],
+                    "primary": [
+                        "__builtin__.bool"
+                    ]
+                }
+            },
+            "flocker.control._model.Node": {
+                "category": "record",
+                "fields": {
+                    "applications": [
+                        "flocker.control._model.ApplicationPSet"
+                    ],
+                    "manifestations": [
+                        "flocker.control._model.UnicodeManifestationPMap"
+                    ],
+                    "uuid": [
+                        "uuid.UUID"
+                    ]
+                }
+            },
+            "flocker.control._model.NodePSet": {
+                "category": "set",
+                "type": [
+                    "flocker.control._model.Node"
+                ]
+            },
+            "flocker.control._model.Port": {
+                "category": "record",
+                "fields": {
+                    "external_port": [
+                        "__builtin__.int"
+                    ],
+                    "internal_port": [
+                        "__builtin__.int"
+                    ]
+                }
+            },
+            "flocker.control._model.PortPSet": {
+                "category": "set",
+                "type": [
+                    "flocker.control._model.Port"
+                ]
+            },
+            "flocker.control._model.UnicodeManifestationPMap": {
+                "category": "map",
+                "fields": {
+                    "key": [
+                        "__builtin__.unicode"
+                    ],
+                    "value": [
+                        "flocker.control._model.Manifestation"
+                    ]
+                }
+            },
+            "flocker.control._model.UnicodePVector": {
+                "category": "list",
+                "type": [
+                    "__builtin__.unicode"
+                ]
+            },
+            "pyrsistent._pmap.PMap": null,
+            "uuid.UUID": null
+        },
+        "root": "flocker.control._model.Deployment"
+    }
+}

--- a/flocker/control/test/persisted_model.json
+++ b/flocker/control/test/persisted_model.json
@@ -1,0 +1,1 @@
+{"model": {"classes": {"flocker.control._model.NodePSet": null, "flocker.control._model.Deployment": {"category": "record", "fields": {"nodes": ["flocker.control._model.NodePSet"]}}}, "root": "flocker.control._model.Deployment"}, "git_hash": "dea57a9396e9b86b3afaf69f50f03d73b284f3f4"}

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -43,7 +43,7 @@ def _precord_model(klass):
     record = {u"category": u"record",
               u"fields": {}}
     for name, field_info in getattr(klass, attr_name).items():
-        record[u"fields"][name] = list(
+        record[u"fields"][name] = sorted(
             fqpn(cls) for cls in field_info.type)
         for cls in field_info.type:
             further_classes.add(cls)
@@ -60,9 +60,9 @@ def _pmap_model(klass):
     record = {
         u"category": u"map",
         u"fields": {
-            u"key": list(
+            u"key": sorted(
                 fqpn(cls) for cls in klass._checked_key_types),
-            u"value": list(
+            u"value": sorted(
                 fqpn(cls) for cls in klass._checked_value_types)}}
     further_classes = set()
     for cls in klass._checked_key_types + klass._checked_value_types:
@@ -81,7 +81,7 @@ def _psequence_model(klass):
     category = u"set" if issubclass(klass, CheckedPSet) else u"list"
     record = {
         u"category": category,
-        u"type": list(fqpn(cls) for cls in klass._checked_types),
+        u"type": sorted(fqpn(cls) for cls in klass._checked_types),
     }
     further_classes = set(klass._checked_types)
     return record, further_classes

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -379,9 +379,9 @@ def persist_model():
     git_hash = check_output(
         [b"git", b"show", b'--format=%H', b"-s"]).strip()
     model = generate_model()
-    PERSISTED_MODEL.setContent(dumps({
-        u"git_hash": git_hash, u"model": model,
-    }))
+    PERSISTED_MODEL.setContent(dumps(
+        {u"git_hash": git_hash, u"model": model}, sort_keys=True, indent=4,
+        separators=(',', ': ')))
     print("Persisted model for git hash {}.".format(git_hash))
 
 

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -17,14 +17,10 @@ from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 from twisted.python.reflect import qual as fqpn
 
-from .._model import Deployment
+from .._persistence import ROOT_CLASS
 from ... import __version__
 
 PERSISTED_MODEL = FilePath(__file__).sibling(b"persisted_model.json")
-
-# The class at the root of the configuration tree. This may need to be
-# changed if the configuration's root class changes.
-ROOT_CLASS = Deployment
 
 
 def _precord_model(klass):

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -8,7 +8,6 @@ code is always implemented when necessary.
 """
 
 from json import loads, dumps
-from subprocess import check_output
 
 from pyrsistent import (
     PRecord, PClass, CheckedPSet, CheckedPVector, CheckedPMap, field,
@@ -19,6 +18,7 @@ from twisted.python.filepath import FilePath
 from twisted.python.reflect import qual as fqpn
 
 from .._model import Deployment
+from ... import __version__
 
 PERSISTED_MODEL = FilePath(__file__).sibling(b"persisted_model.json")
 
@@ -414,13 +414,10 @@ def persist_model():
     We also store the git hash of current checkout, so it's clear what
     version of code was used to generate the model.
     """
-    git_hash = check_output(
-        [b"git", b"show", b'--format=%H', b"-s"]).strip()
     model = generate_model()
     PERSISTED_MODEL.setContent(dumps(
-        {u"git_hash": git_hash, u"model": model}, sort_keys=True, indent=4,
-        separators=(',', ': ')))
-    print("Persisted model for git hash {}.".format(git_hash))
+        {u"version": __version__, u"model": model},
+        sort_keys=True, indent=4, separators=(',', ': ')))
 
 
 class ConfigurationModelChanged(SynchronousTestCase):
@@ -456,3 +453,4 @@ class ConfigurationModelChanged(SynchronousTestCase):
 
 if __name__ == '__main__':
     persist_model()
+    print("Persisted model for version {}.".format(__version__))

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -431,7 +431,7 @@ class ConfigurationModelChanged(SynchronousTestCase):
     def test_model_changed(self):
         """
         Most of the time if the configuration model changes this test will
-        fail.
+        fail. If you changed configuration and it didn't fail, see below.
 
         This does not indicate a bug. Rather, it indicates that you should
         implement upgrade code for the on-disk configuration. Once you are
@@ -445,12 +445,14 @@ class ConfigurationModelChanged(SynchronousTestCase):
 
         Note that this test may *not* fail in some cases where you still
         need to write upgrade code, so don't rely on it to always tell you
-        when you need to write upgrade code.
+        when you need to write upgrade code. In that case you should also
+        try to extend this module so it catches that category of change
+        next time someone makes it.
         """
         current_model = generate_model()
         previous_model = loads(PERSISTED_MODEL.getContent())[u"model"]
-        self.assertEqual(current_model, previous_model,
-                         self.test_model_changed.__doc__)
+        self.assertDictEqual(current_model, previous_model,
+                             self.test_model_changed.__doc__)
 
 
 if __name__ == '__main__':

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -422,14 +422,15 @@ class ConfigurationModelChanged(SynchronousTestCase):
     """
     def test_model_changed(self):
         """
-        Most of the time if the configuration model changes this test will
-        fail. If you changed configuration and it didn't fail, see below.
+        If the configuration model changes this test will (usually) fail.
+        If you changed configuration and it didn't fail, see below.
 
-        This does not indicate a bug. Rather, it indicates that you should
-        implement upgrade code for the on-disk configuration. Once you are
-        confident it is possible to upgrade from older versions of Flocker
-        to the new version of the code you have introduced, you can update
-        this test by running:
+        This failing test does not indicate a bug. Rather, it is a
+        reminder that since you have changed the model, you MUST IMPLEMENT
+        UPGRADE CODE for the on-disk configuration. Once you are confident
+        it is possible to upgrade from older versions of Flocker to the
+        new version of the code you have introduced, you can update this
+        test by running:
 
             $ python -m flocker.control.test.test_model_change
 

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -70,6 +70,14 @@ def generate_model(root_class=ROOT_CLASS):
                         fqpn(cls) for cls in klass._checked_value_types)}}
             for cls in klass._checked_key_types + klass._checked_value_types:
                 classes.add(cls)
+        elif issubclass(klass, (CheckedPSet, CheckedPVector)):
+            category = u"set" if issubclass(klass, CheckedPSet) else u"list"
+            record = {
+                u"category": category,
+                u"type": list(fqpn(cls) for cls in klass._checked_types),
+            }
+            for cls in klass._checked_types:
+                classes.add(cls)
         classes_result[klass_name] = record
     return result
 
@@ -310,23 +318,55 @@ class GenerateModelTests(SynchronousTestCase):
         """
         If the type of the value of a ``PSet`` changes the output changes.
         """
+        class Original(CheckedPSet):
+            __type__ = int
+
+        class Different(CheckedPSet):
+            __type__ = str
+        Different.__name__ = "Original"
+
+        self.assert_catches_changes(Original, Different)
 
     def test_pset_value_type_changed(self):
         """
         If the type of the value of a ``PSet`` is the same, but it has
         internally changed then the output changes.
         """
+        class Original(CheckedPSet):
+            __type__ = Subtype
+
+        class Different(CheckedPSet):
+            __type__ = ChangedSubtype
+        Different.__name__ = "Original"
+
+        self.assert_catches_changes(Original, Different)
 
     def test_pvector_value_new_type(self):
         """
         If the type of the value of a ``PVector`` changes the output changes.
         """
+        class Original(CheckedPVector):
+            __type__ = int
+
+        class Different(CheckedPVector):
+            __type__ = str
+        Different.__name__ = "Original"
+
+        self.assert_catches_changes(Original, Different)
 
     def test_pvector_value_type_changed(self):
         """
         If the type of the value of a ``PVector`` is the same, but it has
         internally changed then the output changes.
         """
+        class Original(CheckedPVector):
+            __type__ = Subtype
+
+        class Different(CheckedPVector):
+            __type__ = ChangedSubtype
+        Different.__name__ = "Original"
+
+        self.assert_catches_changes(Original, Different)
 
 
 def persist_model():

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -125,14 +125,16 @@ class Subtype(PRecord):
     """
     A sub-type used in ``GenerateModelTests``.
     """
+OriginalSubtype = Subtype
 
 
-class ChangedSubtype(PRecord):
+class Subtype(PRecord):
     """
     A changed variant of ``Subtype``.
     """
     x = field()
-ChangedSubtype.__name__ = "Subtype"
+ChangedSubtype = Subtype
+Subtype = OriginalSubtype
 
 
 class GenerateModelTests(SynchronousTestCase):
@@ -153,12 +155,15 @@ class GenerateModelTests(SynchronousTestCase):
         dumps(original_model)
         dumps(changed_model)
         self.assertEqual(
-            # Changes result in a difference:
-            (original_model != changed_model,
+            # If not the calling test is buggy, since it's catching wrong
+            # thing, a mere name change:
+            (fqpn(original_class) == fqpn(changed_class),
+             # Changes result in a difference:
+             original_model != changed_model,
              # No changes result in same output:
              original_model == generate_model(original_class),
              changed_model == generate_model(changed_class)),
-            (True, True, True))
+            (True, True, True, True))
 
     def test_different_class(self):
         """
@@ -170,18 +175,19 @@ class GenerateModelTests(SynchronousTestCase):
         class Different(PClass):
             pass
 
-        self.assert_catches_changes(Original, Different)
+        self.assertNotEqual(generate_model(Original),
+                            generate_model(Different))
 
     def test_precord_new_field(self):
         """
         If a new field is added to a ``PRecord`` the output changes.
         """
-        class Original(PRecord):
+        class Different(PRecord):
             pass
+        Original = Different
 
         class Different(PRecord):
             x = field()
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -190,13 +196,13 @@ class GenerateModelTests(SynchronousTestCase):
         If an existing field is removed from a ``PRecord`` the output
         changes.
         """
-        class Original(PRecord):
+        class Different(PRecord):
             x = field()
             y = field()
+        Original = Different
 
         class Different(PRecord):
             x = field()
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -205,12 +211,12 @@ class GenerateModelTests(SynchronousTestCase):
         If an existing field has its type changed in a ``PRecord`` the output
         changes.
         """
-        class Original(PRecord):
+        class Different(PRecord):
             x = field()
+        Original = Different
 
         class Different(PRecord):
             x = field(type=int)
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -219,12 +225,12 @@ class GenerateModelTests(SynchronousTestCase):
         If the an existing field in a ``PRecord`` has the same type, but the
         type changed somehow, the output changes.
         """
-        class Original(PRecord):
+        class Different(PRecord):
             x = field(type=Subtype)
+        Original = Different
 
         class Different(PRecord):
             x = field(type=ChangedSubtype)
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -232,12 +238,12 @@ class GenerateModelTests(SynchronousTestCase):
         """
         If a new field is added to a ``PClass`` the output changes.
         """
-        class Original(PClass):
+        class Different(PClass):
             pass
+        Original = Different
 
         class Different(PClass):
             x = field()
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -246,13 +252,13 @@ class GenerateModelTests(SynchronousTestCase):
         If an existing field is removed from a ``PClass`` the output
         changes.
         """
-        class Original(PClass):
+        class Different(PClass):
             x = field()
             y = field()
+        Original = Different
 
         class Different(PClass):
             x = field()
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -261,12 +267,12 @@ class GenerateModelTests(SynchronousTestCase):
         If an existing field has its type changed in a ``PClass`` the output
         changes.
         """
-        class Original(PClass):
+        class Different(PClass):
             x = field()
+        Original = Different
 
         class Different(PClass):
             x = field(type=int)
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -275,19 +281,12 @@ class GenerateModelTests(SynchronousTestCase):
         If the an existing field in a ``PClass`` has the same type, but the
         type changed somehow, the output changes.
         """
-        class Subtype(PClass):
-            pass
-
-        class ChangedSubtype(PClass):
-            x = field()
-        ChangedSubtype.__name__ = "Subtype"
-
-        class Original(PClass):
+        class Different(PClass):
             x = field(type=Subtype)
+        Original = Different
 
         class Different(PClass):
             x = field(type=ChangedSubtype)
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -295,14 +294,14 @@ class GenerateModelTests(SynchronousTestCase):
         """
         If the type of the key of a ``PMap`` changes the output changes.
         """
-        class Original(CheckedPMap):
+        class Different(CheckedPMap):
             __key_type__ = int
             __value_type__ = int
+        Original = Different
 
         class Different(CheckedPMap):
             __key_type__ = str
             __value_type__ = int
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -310,14 +309,14 @@ class GenerateModelTests(SynchronousTestCase):
         """
         If the type of the value of a ``PMap`` changes the output changes.
         """
-        class Original(CheckedPMap):
+        class Different(CheckedPMap):
             __key_type__ = int
             __value_type__ = int
+        Original = Different
 
         class Different(CheckedPMap):
             __key_type__ = int
             __value_type__ = str
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -326,14 +325,14 @@ class GenerateModelTests(SynchronousTestCase):
         If the type of the key of a ``PMap`` is the same, but it has
         internally changed then the output changes.
         """
-        class Original(CheckedPMap):
+        class Different(CheckedPMap):
             __key_type__ = Subtype
             __value_type__ = int
+        Original = Different
 
         class Different(CheckedPMap):
             __key_type__ = ChangedSubtype
             __value_type__ = int
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -342,14 +341,14 @@ class GenerateModelTests(SynchronousTestCase):
         If the type of the value of a ``PMap`` is the same, but it has
         internally changed then the output changes.
         """
-        class Original(CheckedPMap):
+        class Different(CheckedPMap):
             __key_type__ = int
             __value_type__ = Subtype
+        Original = Different
 
         class Different(CheckedPMap):
             __key_type__ = int
             __value_type__ = ChangedSubtype
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -357,12 +356,12 @@ class GenerateModelTests(SynchronousTestCase):
         """
         If the type of the value of a ``PSet`` changes the output changes.
         """
-        class Original(CheckedPSet):
+        class Different(CheckedPSet):
             __type__ = int
+        Original = Different
 
         class Different(CheckedPSet):
             __type__ = str
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -371,12 +370,12 @@ class GenerateModelTests(SynchronousTestCase):
         If the type of the value of a ``PSet`` is the same, but it has
         internally changed then the output changes.
         """
-        class Original(CheckedPSet):
+        class Different(CheckedPSet):
             __type__ = Subtype
+        Original = Different
 
         class Different(CheckedPSet):
             __type__ = ChangedSubtype
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -384,12 +383,12 @@ class GenerateModelTests(SynchronousTestCase):
         """
         If the type of the value of a ``PVector`` changes the output changes.
         """
-        class Original(CheckedPVector):
+        class Different(CheckedPVector):
             __type__ = int
+        Original = Different
 
         class Different(CheckedPVector):
             __type__ = str
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 
@@ -398,12 +397,12 @@ class GenerateModelTests(SynchronousTestCase):
         If the type of the value of a ``PVector`` is the same, but it has
         internally changed then the output changes.
         """
-        class Original(CheckedPVector):
+        class Different(CheckedPVector):
             __type__ = Subtype
+        Original = Different
 
         class Different(CheckedPVector):
             __type__ = ChangedSubtype
-        Different.__name__ = "Original"
 
         self.assert_catches_changes(Original, Different)
 

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -1,0 +1,104 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Whenever the configuration model changes we need to write code to
+upgrade the on-disk format from previous releases. This module will
+automatically detect such changes by failing a test, ensuring that upgrade
+code is always implemented when necessary.
+"""
+
+from json import loads, dumps
+from subprocess import check_output
+
+from pyrsistent import PRecord
+
+from twisted.trial.unittest import SynchronousTestCase
+from twisted.python.filepath import FilePath
+from twisted.python.reflect import qual as fqpn
+
+from .._model import Deployment
+
+PERSISTED_MODEL = FilePath(__file__).sibling(b"persisted_model.json")
+
+# The class at the root of the configuration tree. This may need to be
+# changed if the configuration's root class changes.
+ROOT_CLASS = Deployment
+
+
+def generate_model():
+    """
+    Generate a data-structure that represents the current configuration
+    model.
+
+    Changes to output may require regenerating the persisted version
+    on-disk.
+    """
+    classes_result = {}
+    result = {u"root": fqpn(ROOT_CLASS),
+              u"classes": classes_result}
+    classes = {ROOT_CLASS}
+    while classes:
+        klass = classes.pop()
+        klass_name = fqpn(klass)
+        if klass_name in classes_result:
+            continue
+        record = None
+        if issubclass(klass, PRecord):
+            record = {u"category": u"record",
+                      u"fields": {}}
+            # XXX file issue with pyrsistent to add introspection API if I
+            # can't find anything in docs:
+            for name, field in klass._precord_fields.items():
+                record[u"fields"][name] = list(fqpn(cls) for cls in field.type)
+                for cls in field.type:
+                    classes.add(cls)
+        # XXX CheckedPMap and friends
+        classes_result[klass_name] = record
+    return result
+
+
+# XXX generate_model() is probably sufficiently important to get right that is should also have tests.
+
+
+def persist_model():
+    """
+    Store the current model to disk.
+
+    We also store the git hash of current checkout, so it's clear what
+    version of code was used to generate the model.
+    """
+    git_hash = check_output(
+        [b"git", b"show", b"--format=%H"]).strip()
+    model = generate_model()
+    PERSISTED_MODEL.setContent(dumps({
+        u"git_hash": git_hash, u"model": model,
+    }))
+    print("Persisted model for git hash {}.".format(git_hash))
+
+
+class ConfigurationModelChanged(SynchronousTestCase):
+    """
+    Detect when the configuration model has changed.
+    """
+    def test_model_changed(self):
+        """
+        If the configuration model changes this test will fail.
+
+        This does not indicate a bug. Rather, it indicates that you should
+        implement upgrade code for the on-disk configuration. Once you are
+        confident it is possible to upgrade from older versions of Flocker
+        to the new version of the code you have introduced, you can update
+        this test by running:
+
+            $ python -m flocker.control.test.test_model_change
+
+        And then committing the resulting changes to git.
+        """
+        current_model = generate_model()
+        previous_model = loads(PERSISTED_MODEL.getContent())[u"model"]
+        self.assertEqual(current_model, previous_model,
+                         self.test_model_changed.__doc__)
+
+
+if __name__ == '__main__':
+    persist_model()

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -377,7 +377,7 @@ def persist_model():
     version of code was used to generate the model.
     """
     git_hash = check_output(
-        [b"git", b"show", b"--format=%H"]).strip()
+        [b"git", b"show", b'--format=%H', b"-s"]).strip()
     model = generate_model()
     PERSISTED_MODEL.setContent(dumps({
         u"git_hash": git_hash, u"model": model,

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -230,6 +230,20 @@ class GenerateModelTests(SynchronousTestCase):
 
         self.assert_catches_changes(Original, Different)
 
+    def test_precord_field_types_reordered(self):
+        """
+        The order of types in a ``PRecord`` doesn't change the output.
+        """
+        class Different(PRecord):
+            x = field(type=(int, str))
+        Original = Different
+
+        class Different(PRecord):
+            x = field(type=(str, int))
+
+        self.assertEqual(generate_model(Original),
+                         generate_model(Different))
+
     def test_pclass_new_field(self):
         """
         If a new field is added to a ``PClass`` the output changes.
@@ -285,6 +299,20 @@ class GenerateModelTests(SynchronousTestCase):
             x = field(type=ChangedSubtype)
 
         self.assert_catches_changes(Original, Different)
+
+    def test_pclass_field_types_reordered(self):
+        """
+        The order of types in a ``PClass`` doesn't change the output.
+        """
+        class Different(PClass):
+            x = field(type=(int, str))
+        Original = Different
+
+        class Different(PClass):
+            x = field(type=(str, int))
+
+        self.assertEqual(generate_model(Original),
+                         generate_model(Different))
 
     def test_pmap_key_new_type(self):
         """
@@ -348,6 +376,38 @@ class GenerateModelTests(SynchronousTestCase):
 
         self.assert_catches_changes(Original, Different)
 
+    def test_pmap_key_types_reordered(self):
+        """
+        The order of types in a ``PMap`` key doesn't change the output.
+        """
+        class Different(CheckedPMap):
+            __key_type__ = (int, str)
+            __value_type__ = int
+        Original = Different
+
+        class Different(CheckedPMap):
+            __key_type__ = (str, int)
+            __value_type__ = int
+
+        self.assertEqual(generate_model(Original),
+                         generate_model(Different))
+
+    def test_pmap_value_types_reordered(self):
+        """
+        The order of types in a ``PMap`` value doesn't change the output.
+        """
+        class Different(CheckedPMap):
+            __value_type__ = (int, str)
+            __key_type__ = int
+        Original = Different
+
+        class Different(CheckedPMap):
+            __value_type__ = (str, int)
+            __key_type__ = int
+
+        self.assertEqual(generate_model(Original),
+                         generate_model(Different))
+
     def test_pset_value_new_type(self):
         """
         If the type of the value of a ``PSet`` changes the output changes.
@@ -375,6 +435,21 @@ class GenerateModelTests(SynchronousTestCase):
 
         self.assert_catches_changes(Original, Different)
 
+    def test_pset_value_types_reordered(self):
+        """
+        The order of types in a ``PSet`` type definition doesn't change the
+        output.
+        """
+        class Different(CheckedPSet):
+            __type__ = (int, str)
+        Original = Different
+
+        class Different(CheckedPSet):
+            __type__ = (str, int)
+
+        self.assertEqual(generate_model(Original),
+                         generate_model(Different))
+
     def test_pvector_value_new_type(self):
         """
         If the type of the value of a ``PVector`` changes the output changes.
@@ -401,6 +476,21 @@ class GenerateModelTests(SynchronousTestCase):
             __type__ = ChangedSubtype
 
         self.assert_catches_changes(Original, Different)
+
+    def test_pvector_value_types_reordered(self):
+        """
+        The order of types in a ``PVector`` type definition doesn't change the
+        output.
+        """
+        class Different(CheckedPVector):
+            __type__ = (int, str)
+        Original = Different
+
+        class Different(CheckedPVector):
+            __type__ = (str, int)
+
+        self.assertEqual(generate_model(Original),
+                         generate_model(Different))
 
 
 def persist_model():

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ setup(
         'flocker.control': ['schema/*.yml'],
         # These files are used by the Docker plugin API:
         'flocker.dockerplugin': ['schema/*.yml'],
+        # Configuration schema, used to detect need for upgrade code:
+        'flocker.control.test': ['persisted_model.json'],
     },
 
     entry_points={


### PR DESCRIPTION
If someone changes `flocker.control._model` this should detect that and cause a failing test, warning the developer that they need to write upgrade code for our on-disk format.

Support for upgrade code is being implemented in a different branch.