### PR TITLE
[FLOC-2866] REST API no longer requires application/json content-type

### DIFF
--- a/flocker/restapi/_error.py
+++ b/flocker/restapi/_error.py
@@ -7,10 +7,9 @@ encountered by the implementation of the API.
 __all__ = [
     "BadRequest", "InvalidRequestJSON", "makeBadRequest",
 
-    "DECODING_ERROR_DESCRIPTION", "ILLEGAL_CONTENT_TYPE_DESCRIPTION",
+    "DECODING_ERROR_DESCRIPTION",
 
-    "DECODING_ERROR", "ILLEGAL_CONTENT_TYPE", "UNAUTHORIZED",
-    "ENTITY_NOT_FOUND",
+    "DECODING_ERROR", "UNAUTHORIZED", "ENTITY_NOT_FOUND",
 
     "NameCollision",
 
@@ -62,9 +61,6 @@ DECODING_ERROR_DESCRIPTION = cleandoc(u"""
     The request body could not be decoded according to the value of the
     Content-Type header.
     """)
-ILLEGAL_CONTENT_TYPE_DESCRIPTION = cleandoc(u"""
-    The request Content-Type was not a supported type (application/json).
-    """)
 NOT_FOUND_DESCRIPTION = cleandoc(u"""
     The specified entity either does not exist or you are not allowed to access
     it.
@@ -74,8 +70,6 @@ UNAUTHORIZED_DESCRIPTION = cleandoc("""
     """)
 
 DECODING_ERROR = makeBadRequest(description=DECODING_ERROR_DESCRIPTION)
-ILLEGAL_CONTENT_TYPE = makeBadRequest(
-    description=ILLEGAL_CONTENT_TYPE_DESCRIPTION)
 ENTITY_NOT_FOUND = makeBadRequest(
     code=NOT_FOUND, description=NOT_FOUND_DESCRIPTION)
 UNAUTHORIZED = makeBadRequest(

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -21,8 +21,7 @@ from twisted.web.http import OK, INTERNAL_SERVER_ERROR
 from eliot import Logger, writeFailure
 from eliot.twisted import DeferredContext
 
-from ._error import (
-    DECODING_ERROR, BadRequest, InvalidRequestJSON)
+from ._error import DECODING_ERROR, BadRequest, InvalidRequestJSON
 from ._logging import LOG_SYSTEM, REQUEST, JSON_REQUEST
 from ._schema import getValidator
 

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -183,11 +183,6 @@ def structured(inputSchema, outputSchema, schema_store=None,
             if request.method in (b"GET", b"DELETE") or ignore_body:
                 objects = {}
             else:
-                contentType = request.requestHeaders.getRawHeaders(
-                    b"content-type", [None])[0]
-                if contentType != b"application/json":
-                    raise ILLEGAL_CONTENT_TYPE
-
                 body = request.content.read()
                 try:
                     objects = loads(body)

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -22,7 +22,7 @@ from eliot import Logger, writeFailure
 from eliot.twisted import DeferredContext
 
 from ._error import (
-    ILLEGAL_CONTENT_TYPE, DECODING_ERROR, BadRequest, InvalidRequestJSON)
+    DECODING_ERROR, BadRequest, InvalidRequestJSON)
 from ._logging import LOG_SYSTEM, REQUEST, JSON_REQUEST
 from ._schema import getValidator
 

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -24,8 +24,7 @@ from .._infrastructure import (
     EndpointResponse, user_documentation, structured, UserDocumentation)
 from .._logging import REQUEST, JSON_REQUEST
 from .._error import (
-    ILLEGAL_CONTENT_TYPE_DESCRIPTION, DECODING_ERROR_DESCRIPTION,
-    BadRequest)
+    DECODING_ERROR_DESCRIPTION, BadRequest)
 
 
 from eliot.testing import validateLogging, LoggedAction

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -473,7 +473,7 @@ class StructuredJSONTests(SynchronousTestCase):
     @validateLogging(_assertRequestLogged(b"/foo/ignore_body", b"POST"))
     def test_noBodyPOST(self, logger):
         """
-        The I{JSON}-encoded request is body is ignored for methods with
+        The I{JSON}-encoded request body is ignored for methods with
         C{{ignore_body}} set to C{{True}}.
         """
         self.assertNoDecodeLogged(logger, b"POST", b"/foo/ignore_body")
@@ -481,7 +481,7 @@ class StructuredJSONTests(SynchronousTestCase):
     @validateLogging(_assertRequestLogged(b"/foo/ignore_body", b"POST"))
     def test_noBodyPOSTnotJSON(self, logger):
         """
-        A non-I{JSON} request is body is ignored for methods with
+        A non-I{JSON} request body is ignored for methods with
         C{{ignore_body}} set to C{{True}}.
         """
         request = dummyRequest(

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -23,8 +23,7 @@ from twisted.trial.unittest import SynchronousTestCase
 from .._infrastructure import (
     EndpointResponse, user_documentation, structured, UserDocumentation)
 from .._logging import REQUEST, JSON_REQUEST
-from .._error import (
-    DECODING_ERROR_DESCRIPTION, BadRequest)
+from .._error import DECODING_ERROR_DESCRIPTION, BadRequest
 
 
 from eliot.testing import validateLogging, LoggedAction


### PR DESCRIPTION
1. Docker doesn't send it, and Docker API plugin needs to deal with this somehow.
2. More generally, it's better to be lenient in what one accepts.