### PR TITLE
[FLOC-2890] CoreOS & ZFS labs docs for installer

### DIFF
--- a/docs/labs/docker-plugin.rst
+++ b/docs/labs/docker-plugin.rst
@@ -24,7 +24,7 @@ As a user of Docker, it means you can use Flocker directly via:
 
 See the `Docker documentation on volume plugins`_.
 
-This depends on Docker 1.8.
+This depends on Docker 1.8 or later.
 
 See also the `GitHub repo for this project <https://github.com/ClusterHQ/flocker-docker-plugin>`_.
 
@@ -91,7 +91,8 @@ Then perform the following instructions on each of the hosts where you want to i
 Install Docker
 --------------
 
-Install Docker 1.8 or later:
+Install Docker 1.8 or later.
+The following command will install the latest version available:
 
 .. prompt:: bash $
 

--- a/docs/labs/docker-plugin.rst
+++ b/docs/labs/docker-plugin.rst
@@ -24,7 +24,7 @@ As a user of Docker, it means you can use Flocker directly via:
 
 See the `Docker documentation on volume plugins`_.
 
-This currently depends on the `experimental build of Docker <https://github.com/docker/docker/tree/master/experimental>`_.
+This depends on the Docker 1.8.
 
 See also the `GitHub repo for this project <https://github.com/ClusterHQ/flocker-docker-plugin>`_.
 
@@ -88,17 +88,17 @@ Upload these files to ``/etc/flocker/plugin.key`` and ``/etc/flocker/plugin.crt`
 
 Then perform the following instructions on each of the hosts where you want to install the Flocker Docker plugin.
 
-Install Experimental Docker
----------------------------
+Install Docker
+--------------
 
-Install the experimental build of Docker:
+Install Docker 1.8 or later:
 
 .. prompt:: bash $
 
-    wget -qO- https://experimental.docker.com/ | sudo sh
+    wget -qO- https://get.docker.com/ | sudo sh
 
-You must ensure that Docker is using the ``AUFS`` storage driver.
-The easiest way to do this is to add a ``-s aufs`` option to the ``/etc/defaults/docker`` file.
+On Ubuntu, it's best to ensure that Docker is using the ``AUFS`` storage driver.
+The easiest way to do this is to add a ``-s aufs`` option to the ``/etc/default/docker`` file.
 
 Here is an example::
 

--- a/docs/labs/docker-plugin.rst
+++ b/docs/labs/docker-plugin.rst
@@ -24,7 +24,7 @@ As a user of Docker, it means you can use Flocker directly via:
 
 See the `Docker documentation on volume plugins`_.
 
-This depends on the Docker 1.8.
+This depends on Docker 1.8.
 
 See also the `GitHub repo for this project <https://github.com/ClusterHQ/flocker-docker-plugin>`_.
 

--- a/docs/labs/installer.rst
+++ b/docs/labs/installer.rst
@@ -168,7 +168,7 @@ This will configure API certificates for the Flocker Docker plugin and push them
 
 It will install the Flocker Docker plugin, and write a service file (``upstart``/``systemd``) for the plugin (as described in the :ref:`manual installation instructions for the Flocker Docker plugin <labs-docker-plugin>`.
 
-It will also download and install an experimental Docker binary that supports the ``--volume-driver`` flag and restart the Docker service.
+It will also download and install a Docker binary that supports the ``--volume-driver`` flag and restart the Docker service.
 
 It supports several optional environment variables:
 

--- a/docs/labs/installer.rst
+++ b/docs/labs/installer.rst
@@ -71,8 +71,11 @@ Get some nodes
 
 So now let's use the tools we've just installed to deploy and configure a Flocker cluster quickly!
 
-Provision some machines on AWS or an OpenStack deployment (e.g. Rackspace).
+Provision some machines on AWS or an OpenStack deployment (e.g. Rackspace), or even bare metal if you want to try out the experimental ZFS backend.
 Use Ubuntu 14.04, CentOS 7, or CoreOS.
+
+.. warning::
+    Note that CoreOS support is experimental, and should not be used for production workloads. ZFS support is similarly experimental.
 
 We recommend Ubuntu 14.04 if you want to try the Flocker Docker plugin.
 
@@ -82,7 +85,7 @@ Make sure you create the servers a reasonable amount of disk space, since Docker
 * Use an OpenStack deployment (e.g. Rackspace, private cloud) if you want to try our OpenStack backend. VMs must be deployed in the same region.
 
 .. warning::
-    Make sure you can log into the nodes as **root** with a private key. (e.g. on Ubuntu on AWS, ``sudo cp .ssh/authorized_keys /root/.ssh/authorized_keys``)
+    Make sure you can log into the nodes as **root** with a private key. (e.g. on Ubuntu or CoreOS on AWS, log in as the default user, then run ``sudo mkdir /root/.ssh; sudo cp .ssh/authorized_keys /root/.ssh/authorized_keys``)
 
 You may want to pick a node to be the control node and give it a DNS name (if you do this, set up an A record for it with your DNS provider). Using a DNS name is optional, you can also just use its IP address.
 
@@ -100,6 +103,9 @@ This will create some sample configuration files that correspond to the backend 
 * AWS EBS: ``cluster.yml.ebs.sample``
 * OpenStack (including Rackspace): ``cluster.yml.openstack.sample``
 * ZFS (local storage): ``cluster.yml.zfs.sample``
+
+.. warning::
+    Note that ZFS support is experimental, and should not be used for production workloads.
 
 Choose the one that's appropriate for you, and then customize it with your choice of text editor.
 For example:

--- a/docs/labs/installer.rst
+++ b/docs/labs/installer.rst
@@ -75,7 +75,8 @@ Provision some machines on AWS or an OpenStack deployment (e.g. Rackspace), or e
 Use Ubuntu 14.04, CentOS 7, or CoreOS.
 
 .. warning::
-    Note that CoreOS support is experimental, and should not be used for production workloads. ZFS support is similarly experimental.
+    CoreOS support is experimental, and should not be used for production workloads.
+	ZFS support is similarly experimental.
 
 We recommend Ubuntu 14.04 if you want to try the Flocker Docker plugin.
 

--- a/docs/labs/installer.rst
+++ b/docs/labs/installer.rst
@@ -82,13 +82,16 @@ We recommend Ubuntu 14.04 if you want to try the Flocker Docker plugin.
 
 Make sure you create the servers a reasonable amount of disk space, since Docker images will be stored on the VM root disk itself.
 
-* Use Amazon EC2 if you want to use our EBS backend. **Note that VMs must be deployed in the same AZ.**
-* Use an OpenStack deployment (e.g. Rackspace, private cloud) if you want to try our OpenStack backend. VMs must be deployed in the same region.
+* Use Amazon EC2 if you want to use our EBS backend.
+  **Note that VMs must be deployed in the same AZ.**
+* Use an OpenStack deployment (e.g. Rackspace, private cloud) if you want to try our OpenStack backend.
+  VMs must be deployed in the same region.
 
 .. warning::
-    Make sure you can log into the nodes as **root** with a private key. (e.g. on Ubuntu or CoreOS on AWS, log in as the default user, then run ``sudo mkdir /root/.ssh; sudo cp .ssh/authorized_keys /root/.ssh/authorized_keys``)
+    Make sure you can log into the nodes as **root** with a private key (e.g. on Ubuntu or CoreOS on AWS, log in as the default user, then run ``sudo mkdir /root/.ssh; sudo cp .ssh/authorized_keys /root/.ssh/authorized_keys``).
 
-You may want to pick a node to be the control node and give it a DNS name (if you do this, set up an A record for it with your DNS provider). Using a DNS name is optional, you can also just use its IP address.
+You may want to pick a node to be the control node and give it a DNS name (if you do this, set up an A record for it with your DNS provider).
+Using a DNS name is optional, you can also just use its IP address.
 
 cluster.yml
 ===========

--- a/docs/labs/installer.rst
+++ b/docs/labs/installer.rst
@@ -72,13 +72,14 @@ Get some nodes
 So now let's use the tools we've just installed to deploy and configure a Flocker cluster quickly!
 
 Provision some machines on AWS or an OpenStack deployment (e.g. Rackspace).
-Use Ubuntu 14.04 or CentOS 7.
+Use Ubuntu 14.04, CentOS 7, or CoreOS.
+
 We recommend Ubuntu 14.04 if you want to try the Flocker Docker plugin.
 
 Make sure you create the servers a reasonable amount of disk space, since Docker images will be stored on the VM root disk itself.
 
-* Use Amazon EC2 if you want to use our EBS backend (note VMs must be deployed in the same AZ).
-* Use an OpenStack deployment (e.g. Rackspace, private cloud) if you want to try our OpenStack backend (VMs must be deployed in the same region).
+* Use Amazon EC2 if you want to use our EBS backend. **Note that VMs must be deployed in the same AZ.**
+* Use an OpenStack deployment (e.g. Rackspace, private cloud) if you want to try our OpenStack backend. VMs must be deployed in the same region.
 
 .. warning::
     Make sure you can log into the nodes as **root** with a private key. (e.g. on Ubuntu on AWS, ``sudo cp .ssh/authorized_keys /root/.ssh/authorized_keys``)
@@ -98,8 +99,7 @@ This will create some sample configuration files that correspond to the backend 
 
 * AWS EBS: ``cluster.yml.ebs.sample``
 * OpenStack (including Rackspace): ``cluster.yml.openstack.sample``
-
-.. * ZFS: ``cluster.yml.zfs.sample`` XXX put this back when https://github.com/ClusterHQ/unofficial-flocker-tools/issues/2 lands
+* ZFS (local storage): ``cluster.yml.zfs.sample``
 
 Choose the one that's appropriate for you, and then customize it with your choice of text editor.
 For example:
@@ -138,7 +138,7 @@ From the directory where your ``cluster.yml`` file is now, run the following com
 This will configure certificates, push them to your nodes, and set up firewall rules for the control service.
 
 .. warning::
-    On AWS, you also need to add a firewall rule allowing traffic for TCP port 4523 and 4524 if you want to access the control service or API remotely.
+    On AWS, you also need to add a firewall rule allowing traffic for TCP port 4523 and 4524.
 
 Install Flocker Docker plugin (optional)
 ========================================
@@ -177,9 +177,3 @@ Print a simple tutorial
     flocker-tutorial cluster.yml
 
 This will print out a short tutorial on exercising the Flocker volumes and containers APIs, customized to your deployment.
-
-Known limitations
-=================
-
-* This installer doesn't yet do the key management required for the ZFS backend to operate.
-  See `#2 <https://github.com/ClusterHQ/unofficial-flocker-tools/issues/2>`_.


### PR DESCRIPTION
Fixes FLOC 2890

* Mention that CoreOS is supported as experimental option.
* Uncomment ZFS support because unofficial-flocker-tools#2 landed.
* Fix typo in FDP install page
* Mention that FDP doesn't depend on Docker experimental any more.