### PR TITLE
Ubuntu packages floc 2904

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,13 +3,19 @@ apache-libcloud==0.17.0
 awscli==1.7.35
 backports.ssl-match-hostname==3.4.0.2
 botocore==1.0.0rc1
+cached-property==1.2.0
+chardet==2.3.0
 colorama==0.3.3
+coloredlogs==1.0.1
+deb-pkg-tools==1.34
 docutils==0.12
 ecdsa==0.13
+executor==4.4
 Fabric==1.10.2
 flake8==2.4.1
 gitdb==0.6.4
 GitPython==1.0.1
+humanfriendly==1.33
 hypothesis==1.10.3
 Jinja2==2.7.3
 jmespath==0.7.1
@@ -28,6 +34,7 @@ Pygments==2.0.2
 pymongo==3.0.2
 PyMySQL==0.6.6
 python-dateutil==2.4.2
+python-debian==0.1.23
 requests-file==1.3.1
 rsa==3.1.4
 smmap==0.9.0


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2904

I ran `admin/publish-artifacts --flocker-version=1.2.0.dev1` from the tag of the last dev release with these changes. This has been tested by running the Ubuntu CLI instructions from http://doc-dev.clusterhq.com/install/install-client.html#ubuntu-14-04.

The initial problem was that various versions of `dpkg-scanpackages` had different outputs - we didn't notice until we started doing releases outside of Vagrant. The approach that this uses is to introduce a Python dependency which has consistent output across the `dpkg-scanpackages` versions I've tested and has the side-effect of making the code nicer, in my opinion.