### PR TITLE
[FLOC-2909] Use openshift/busybox-http-app:latest

### DIFF
--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -31,7 +31,7 @@ from ...testtools import (
     loop_until, find_free_port, DockerImageBuilder, assertContainsAll,
     random_name)
 
-from ..test.test_docker import make_idockerclient_tests
+from ..test.test_docker import ANY_IMAGE, make_idockerclient_tests
 from .._docker import (
     DockerClient, PortMap, Environment, NamespacedDockerClient,
     BASE_NAMESPACE, Volume, AddressInUse,
@@ -228,13 +228,14 @@ class GenericDockerClientTests(TestCase):
 
         def tag_and_push_image(ignored):
             client = Client()
+            image = ANY_IMAGE
             # The image will normally have been pre-pulled on build slaves, but
             # may not already be available when running tests locally.
-            client.pull('openshift/busybox-http-app')
+            client.pull(image)
             # Tag an image with a repository name matching the locally running
             # registry container.
             client.tag(
-                image='openshift/busybox-http-app',
+                image=image,
                 repository=private_image.repository,
                 tag=private_image.tag,
             )
@@ -996,13 +997,11 @@ class DockerClientTests(TestCase):
         flocker_docker_client = DockerClient(namespace=namespace)
 
         name1 = random_name(self)
-        adding_unit1 = flocker_docker_client.add(
-            name1, u'openshift/busybox-http-app')
+        adding_unit1 = flocker_docker_client.add(name1, ANY_IMAGE)
         self.addCleanup(flocker_docker_client.remove, name1)
 
         name2 = random_name(self)
-        adding_unit2 = flocker_docker_client.add(
-            name2, u'openshift/busybox-http-app')
+        adding_unit2 = flocker_docker_client.add(name2, ANY_IMAGE)
         self.addCleanup(flocker_docker_client.remove, name2)
 
         docker_client = flocker_docker_client._client

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -101,7 +101,7 @@ class GenericDockerClientTests(TestCase):
             name=container_name, image=image)
 
     def start_container(self, unit_name,
-                        image_name=u"openshift/busybox-http-app",
+                        image_name=u"openshift/busybox-http-app:latest",
                         ports=None, expected_states=(u'active',),
                         environment=None, volumes=(),
                         mem_limit=None, cpu_shares=None,
@@ -164,14 +164,17 @@ class GenericDockerClientTests(TestCase):
         """
         ``DockerClient.add`` creates a container with the specified image.
         """
+        image_name = u"openshift/busybox-http-app:latest"
         name = random_name(self)
-        d = self.start_container(name)
+        d = self.start_container(name, image_name=image_name)
 
         def started(_):
             docker = Client()
             data = docker.inspect_container(self.namespacing_prefix + name)
-            self.assertEqual(data[u"Config"][u"Image"],
-                             u"openshift/busybox-http-app")
+            self.assertEqual(
+                image_name,
+                data[u"Config"][u"Image"],
+            )
         d.addCallback(started)
         return d
 

--- a/flocker/node/test/test_docker.py
+++ b/flocker/node/test/test_docker.py
@@ -23,6 +23,12 @@ from .._docker import (
 
 from ...control._model import RestartAlways, RestartNever, RestartOnFailure
 
+# Just some image we can use to start a container.  No particularly behavior
+# should be expected from this image except that it exists.
+#
+# Note we explicitly select the "latest" tag to avoid tripping over a Docker
+# 1.8.1 / Docker hub interaction that results in pulls failing. See
+# https://github.com/docker/docker/issues/15699
 ANY_IMAGE = u"openshift/busybox-http-app:latest"
 
 ADDRESS_IN_USE = MessageType(

--- a/flocker/node/test/test_docker.py
+++ b/flocker/node/test/test_docker.py
@@ -23,7 +23,7 @@ from .._docker import (
 
 from ...control._model import RestartAlways, RestartNever, RestartOnFailure
 
-ANY_IMAGE = u"openshift/busybox-http-app"
+ANY_IMAGE = u"openshift/busybox-http-app:latest"
 
 ADDRESS_IN_USE = MessageType(
     u"flocker:test:address_in_use",
@@ -135,7 +135,7 @@ def make_idockerclient_tests(fixture):
             """
             client = fixture(self)
             name = random_name(self)
-            d = client.add(name, u"openshift/busybox-http-app")
+            d = client.add(name, ANY_IMAGE)
             d.addCallback(lambda _: client.remove(name))
             d.addCallback(lambda _: client.exists(name))
             d.addCallback(self.assertFalse)
@@ -209,7 +209,7 @@ def make_idockerclient_tests(fixture):
             """
             client = fixture(self)
             name = random_name(self)
-            image = u"openshift/busybox-http-app"
+            image = ANY_IMAGE
 
             portmaps = []
             volumes = (
@@ -293,7 +293,7 @@ def make_idockerclient_tests(fixture):
             client = fixture(self)
             name = random_name(self)
 
-            d = client.add(name, u"openshift/busybox-http-app")
+            d = client.add(name, ANY_IMAGE)
             d.addCallback(lambda _: client.remove(name))
             d.addCallback(lambda _: client.list())
 


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2909

This is a work-around for a Docker 1.8.1 / Docker hub bug.  Hopefully Docker upstream will fix whatever the underlying problem is.  This avoids us having hanging/failing test suite meanwhile.

Note that BuildBot is still using an older version of Docker - probably around 1.3.3.  Ideally we would have coverage on the CI system for the old and new versions of Docker until we finish the transition.  Failing that, build results against Docker 1.8.1 are available at http://54.200.233.212/boxes-flocker?branch=http-app-latest-FLOC-2909 (for as long as I happen to be running that alternate master).