### PR TITLE
[FLOC-2911] [FLOC-2882] Don't use Docker hub in test_pull_timeout

### DIFF
--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -11,6 +11,7 @@ import socket
 from functools import partial
 
 from requests import Response
+from requests.exceptions import ReadTimeout
 from docker.errors import APIError
 from docker import Client
 # Docker-py uses 1.16 API by default, which isn't supported by docker, so force
@@ -637,14 +638,14 @@ class GenericDockerClientTests(TestCase):
             app_name = random_name(self)
             d = docker_client.add(app_name, registry_image.full_name)
 
-            # Assert that the timeout triggers requests has a TimeoutError, but
-            # timeout raises a ConnectionError.  Both are subclasses of
-            # IOError, so use that for now
+            # Assert that the timeout triggers.
+            #
+            # requests has a TimeoutError but timeout raises a ConnectionError.
             # https://github.com/kennethreitz/requests/issues/2620
             #
             # XXX DockerClient.add is our API.  We could make it fail with a
             # more coherent exception type if we wanted.
-            self.assertFailure(d, IOError)
+            self.assertFailure(d, ReadTimeout)
             d.addCallback(lambda ignored: (registry_image, registry))
             return d
         running.addCallback(setup_image)


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2911
Fixes https://clusterhq.atlassian.net/browse/FLOC-2882

This removes the possibility of intermittent failures of this test caused by problems with Docker hub itself or with the test client's network connection to Docker hub.

FLOC-2882 is fixed as a side-effect due to the deterministic control afforded (and exercised) over the local registry the test now talks to.

See FLOC-2902 and FLOC-2910 for further context.

Depends on #1874 (note diff is currently wrong, including those changes)