### PR TITLE
Change instance types floc 2891

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -283,7 +283,7 @@ job_type:
   run_trial:
   # http://build.clusterhq.com/builders/flocker-centos-7
     run_trial_on_AWS_CentOS_7:
-      on_nodes_with_labels: 'aws-centos-7-T2Micro'
+      on_nodes_with_labels: 'aws-centos-7-T2Small'
       with_modules:
         - flocker.acceptance
         - flocker.apiclient
@@ -321,7 +321,7 @@ job_type:
 # http://build.clusterhq.com/builders/flocker-admin
 # http://build.clusterhq.com/builders/flocker-ubuntu-14.04
     run_trial_on_AWS_Ubuntu_Trusty:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T1Micro'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
       with_modules:
         - admin
         - flocker.acceptance
@@ -359,7 +359,7 @@ job_type:
 
   run_trial_for_storage_driver:
     run_trial_for_ebs_storage_driver_on_CentOS_7:
-      on_nodes_with_labels: 'aws-centos-7-T2Micro'
+      on_nodes_with_labels: 'aws-centos-7-T2Small'
       with_modules:
         - flocker/node/agents/ebs.py
       with_steps:
@@ -375,7 +375,7 @@ job_type:
       clean_repo: true
 
     run_trial_for_ebs_storage_driver_on_Ubuntu_trusty:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T1Micro'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
       with_modules:
         - flocker/node/agents/ebs.py
       with_steps:
@@ -427,7 +427,7 @@ job_type:
   # http://build.clusterhq.com/builders/flocker-docs
   run_sphinx:
     run_sphinx:
-      on_nodes_with_labels: 'aws-centos-7-T2Micro'
+      on_nodes_with_labels: 'aws-centos-7-T2Small'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,  *setup_pip_cache,
@@ -438,7 +438,7 @@ job_type:
   # http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fcentos-7%2Faws
   run_acceptance:
     run_acceptance_on_AWS_CentOS_7_for:
-      on_nodes_with_labels: 'aws-centos-7-M3Medium'
+      on_nodes_with_labels: 'aws-centos-7-T2Medium'
       with_modules:
         - flocker.acceptance.endtoend.test_dataset
         - flocker.acceptance.integration.test_mongodb
@@ -461,7 +461,7 @@ job_type:
           }
       clean_repo: true
     run_acceptance_on_AWS_Ubuntu_Trusty_for:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-M3Medium'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_modules:
         - flocker.acceptance.endtoend.test_dataset
         - flocker.acceptance.integration.test_mongodb
@@ -486,7 +486,7 @@ job_type:
     run_acceptance_on_Rackspace_CentOS_7_for:
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS
-      on_nodes_with_labels: 'aws-centos-7-M3Medium'
+      on_nodes_with_labels: 'aws-centos-7-T2Medium'
       with_modules:
         - flocker.acceptance.endtoend.test_dataset
         - flocker.acceptance.integration.test_mongodb
@@ -511,7 +511,7 @@ job_type:
     run_acceptance_on_Rackspace_Ubuntu_Trusty_for:
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS
-      on_nodes_with_labels: 'aws-ubuntu-trusty-M3Medium'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_modules:
         - flocker.acceptance.endtoend.test_dataset
         - flocker.acceptance.integration.test_mongodb
@@ -536,7 +536,7 @@ job_type:
 
   run_client:
     run_client_installation_on_Ubuntu_Trusty:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-M3Medium'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,  *setup_pip_cache,
@@ -551,7 +551,7 @@ job_type:
           }
       clean_repo: true
     run_client_installation_on_Ubuntu_Vivid:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-M3Medium'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,  *setup_pip_cache,
@@ -569,7 +569,7 @@ job_type:
   cronly_jobs:
     run_docker_build_centos7_fpm:
       at: '0 0 * * *'
-      on_nodes_with_labels: 'aws-centos-7-M3Medium'
+      on_nodes_with_labels: 'aws-centos-7-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,
@@ -580,7 +580,7 @@ job_type:
           }
     run_docker_build_ubuntu_trusty_fpm:
       at: '0 1 * * *'
-      on_nodes_with_labels: 'aws-centos-7-M3Medium'
+      on_nodes_with_labels: 'aws-centos-7-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,
@@ -591,7 +591,7 @@ job_type:
           }
     run_docker_build_ubuntu_vivid_fpm:
       at: '0 2 * * *'
-      on_nodes_with_labels: 'aws-centos-7-M3Medium'
+      on_nodes_with_labels: 'aws-centos-7-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,

--- a/build.yaml
+++ b/build.yaml
@@ -450,7 +450,7 @@ job_type:
             cli: [ *hashbang,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
                    'export DISTRIBUTION_NAME=centos-7',
-                   *setup_aws_env_vars, *check_version, *disable_selinux,
+                   *setup_aws_env_vars, *check_version,
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,

--- a/build.yaml
+++ b/build.yaml
@@ -498,7 +498,7 @@ job_type:
             cli: [ *hashbang,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
                    'export DISTRIBUTION_NAME=centos-7',
-                   *setup_aws_env_vars, *check_version, *disable_selinux,
+                   *setup_aws_env_vars, *check_version,
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,


### PR DESCRIPTION
Disabling SElinux setenforce 0 calls, as selinux is disabled on the new baked images.
Had to update the instance types as I had a few out-mem conditions with the T2micros.
With the new images we aren't requited to use the M3 old generation instances and can use T2 all around