### PR TITLE
Remove setenforce from aws centos jenkins jobs floc 2891

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -450,7 +450,7 @@ job_type:
             cli: [ *hashbang,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
                    'export DISTRIBUTION_NAME=centos-7',
-                   *setup_aws_env_vars, *check_version, *disable_selinux,
+                   *setup_aws_env_vars, *check_version,
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,

--- a/build.yaml
+++ b/build.yaml
@@ -498,7 +498,7 @@ job_type:
             cli: [ *hashbang,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
                    'export DISTRIBUTION_NAME=centos-7',
-                   *setup_aws_env_vars, *check_version, *disable_selinux,
+                   *setup_aws_env_vars, *check_version,
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,


### PR DESCRIPTION
need to disable selinux setenforce 0 calls, as selinux is disabled on the baked image.
This causes the job to fail