### PR TITLE
[FLOC-2607] Fix invalid Eliot log message from EBS driver.

### DIFF
--- a/flocker/node/agents/_logging.py
+++ b/flocker/node/agents/_logging.py
@@ -52,7 +52,7 @@ BOTO_EC2RESPONSE_ERROR = MessageType(
 
 DEVICES = Field.for_types(
     u"devices", [list],
-    u"List of devices currently in use by the compute instance.")
+    u"Set of devices currently in use by the compute instance.")
 NO_AVAILABLE_DEVICE = MessageType(
     u"flocker:node:agents:blockdevice:aws:no_available_device",
     [DEVICES],

--- a/flocker/node/agents/_logging.py
+++ b/flocker/node/agents/_logging.py
@@ -52,7 +52,7 @@ BOTO_EC2RESPONSE_ERROR = MessageType(
 
 DEVICES = Field.for_types(
     u"devices", [list],
-    u"Set of devices currently in use by the compute instance.")
+    u"List of devices currently in use by the compute instance.")
 NO_AVAILABLE_DEVICE = MessageType(
     u"flocker:node:agents:blockdevice:aws:no_available_device",
     [DEVICES],

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -662,7 +662,7 @@ class EBSBlockDeviceAPI(object):
         devices = pset({v.attach_data.device for v in volumes
                        if v.attach_data.instance_id == instance_id})
         devices = devices | devices_in_use
-        IN_USE_DEVICES(devices=devices).write()
+        IN_USE_DEVICES(devices=list(devices)).write()
 
         for suffix in b"fghijklmonp":
             file_name = u'/dev/sd' + suffix

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -64,7 +64,7 @@ class EBSBlockDeviceAPIInterfaceTests(
     """
     def test_foreign_volume(self):
         """
-        Test that ``list_volumes`` lists only those volumes
+        ``list_volumes`` lists only those volumes
         belonging to the current Flocker cluster.
         """
         try:
@@ -85,7 +85,7 @@ class EBSBlockDeviceAPIInterfaceTests(
 
     def test_foreign_cluster_volume(self):
         """
-        Test that list_volumes() excludes volumes belonging to
+        ``list_volumes`` excludes volumes belonging to
         other Flocker clusters.
         """
         blockdevice_api2 = ebsblockdeviceapi_for_test(
@@ -100,7 +100,7 @@ class EBSBlockDeviceAPIInterfaceTests(
     @capture_logging(lambda self, logger: None)
     def test_boto_ec2response_error(self, logger):
         """
-        1. Test that invalid parameters to Boto's EBS API calls
+        1. Invalid parameters to Boto's EBS API calls
         raise the right exception after logging to Eliot.
         2. Verify Eliot log output for expected message fields
         from logging decorator for boto.exception.EC2Exception
@@ -166,12 +166,12 @@ class EBSBlockDeviceAPIInterfaceTests(
 
     @capture_logging(
         assertHasMessage, IN_USE_DEVICES, {
-            'devices': [u'/dev/sda1', u'/dev/sdf']
+            'devices': [u'/dev/sda1']
         },
     )
     def test_in_use_devices_log(self, logger):
         """
-        Test that attached device shows up as being in use during subsequent
+        Attached device shows up as being in use during subsequent
         ``attach_volume``.
         """
         volume1 = self.api.create_volume(
@@ -180,13 +180,6 @@ class EBSBlockDeviceAPIInterfaceTests(
         )
         self.api.attach_volume(
             volume1.blockdevice_id, attach_to=self.this_node,
-        )
-        volume2 = self.api.create_volume(
-            dataset_id=uuid4(),
-            size=self.minimum_allocatable_size,
-        )
-        self.api.attach_volume(
-            volume2.blockdevice_id, attach_to=self.this_node,
         )
 
 


### PR DESCRIPTION
Fix bug in EBS driver that causes failure in logging devices in use while attempting to find an available device name during attach_volume.