### PR TITLE
[FLOC-2929] Reduce EBS driver log spew by avoiding logging "msg": "Path: /" and "Method: POST"

### DIFF
--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -173,7 +173,7 @@ class UnexpectedStateException(Exception):
 
 
 class EliotLogHandler(logging.Handler):
-    _to_log = {"Method", "Path", "Params"}
+    _to_log = {"Params"}
 
     def emit(self, record):
         fields = vars(record)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -173,6 +173,7 @@ class UnexpectedStateException(Exception):
 
 
 class EliotLogHandler(logging.Handler):
+    # Whitelist ``"msg": "Params:`` field for logging.
     _to_log = {"Params"}
 
     def emit(self, record):


### PR DESCRIPTION
From builder flocker/functional/aws/ubuntu-14.04/storage-driver logs (http://build.clusterhq.com/builders/flocker%2Ffunctional%2Faws%2Fubuntu-14.04%2Fstorage-driver/builds/2209), all ``Method`` key values are ``POST``, and all ``Path`` key values are ``/``:
_______
Madhuris-MacBook-Pro-2:~ madhuriyechuri$ grep "Method:" /tmp/m2 | wc -l
376
Madhuris-MacBook-Pro-2:~ madhuriyechuri$ grep "Method:" /tmp/m2 | grep -v POST | wc -l
0
Madhuris-MacBook-Pro-2:~ madhuriyechuri$ grep "Path:" /tmp/m2 | wc -l
376
Madhuris-MacBook-Pro-2:~ madhuriyechuri$ grep "Path:" /tmp/m2 | grep -v "Path: /" | wc -l
0
Madhuris-MacBook-Pro-2:~ madhuriyechuri$ cat /tmp/m2 | wc -l
    1765
_______

Reduce log spew by 42% by removing these logs that aren't useful for debugging. 