### PR TITLE
[FLOC-2913] Disable pyrsistent C extensions

### DIFF
--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -39,3 +39,19 @@ def _redirect_eliot_logs_for_trial():
         redirectLogsForTrial()
 _redirect_eliot_logs_for_trial()
 del _redirect_eliot_logs_for_trial
+
+
+def _disable_pyrsistent_c_extensions():
+    """
+    Pyrsistent sometimes segfaults. Disabling C extensions reduces the
+    likelihood of this happening.
+
+    See https://github.com/tobgu/pyrsistent/issues/52 and FLOC-2913.
+
+    The mechanism for disabling extensions is documented at
+    https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt#L17-L19.
+    """
+    import os
+    os.environ[b"PYRSISTENT_NO_C_EXTENSION"] = b"1"
+_disable_pyrsistent_c_extensions()
+del _disable_pyrsistent_c_extensions


### PR DESCRIPTION
We're seeing [segfaults in our tests](https://clusterhq.atlassian.net/browse/FLOC-2913), and the evidence points to them being [due to pyrsistent's C extensions](https://github.com/tobgu/pyrsistent/issues/52). 

To do this patch, I followed the [advice from Jean-Paul and Itamar in the comments](https://clusterhq.atlassian.net/browse/FLOC-2913?focusedCommentId=19430&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-19430) and the pattern already established in `flocker/__init__.py`. 

Writing a good automated test for this is tricky, and since neither `_suppress_warnings` nor `_redirect_eliot_logs_for_trial` have automated tests, I haven't done so.

I *have* run the `flocker.control.test.test_persistence` tests (i.e. the tests that segfault) locally, and used `ps` and `lsof` to verify that `python` didn't have any of pyrsistent's dynamic libraries open.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1891)
<!-- Reviewable:end -->
