### PR TITLE
[FLOC-2913] Disable pyrsistent C extension earlier in the startup process

### DIFF
--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -6,6 +6,24 @@ functionality to a Linux-based user-space operating system.
 """
 
 
+def _disable_pyrsistent_c_extensions():
+    """
+    Pyrsistent sometimes segfaults. Disabling C extensions reduces the
+    likelihood of this happening.
+
+    We do this first so it happens before pyrsistent is imported.
+
+    See https://github.com/tobgu/pyrsistent/issues/52 and FLOC-2913.
+
+    The mechanism for disabling extensions is documented at
+    https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt#L17-L19.
+    """
+    import os
+    os.environ[b"PYRSISTENT_NO_C_EXTENSION"] = b"1"
+_disable_pyrsistent_c_extensions()
+del _disable_pyrsistent_c_extensions
+
+
 def _suppress_warnings():
     """
     Suppress warnings when not running under trial.
@@ -39,19 +57,3 @@ def _redirect_eliot_logs_for_trial():
         redirectLogsForTrial()
 _redirect_eliot_logs_for_trial()
 del _redirect_eliot_logs_for_trial
-
-
-def _disable_pyrsistent_c_extensions():
-    """
-    Pyrsistent sometimes segfaults. Disabling C extensions reduces the
-    likelihood of this happening.
-
-    See https://github.com/tobgu/pyrsistent/issues/52 and FLOC-2913.
-
-    The mechanism for disabling extensions is documented at
-    https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt#L17-L19.
-    """
-    import os
-    os.environ[b"PYRSISTENT_NO_C_EXTENSION"] = b"1"
-_disable_pyrsistent_c_extensions()
-del _disable_pyrsistent_c_extensions

--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -1,8 +1,8 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 """
-Flocker is a hypervisor that provides ZFS-based replication and fail-over
-functionality to a Linux-based user-space operating system.
+Flocker is an open-source container data volume manager for your
+Dockerized applications.
 """
 
 


### PR DESCRIPTION
Eliot imports pyrsistent, so we need to disable C extension first.

Also fix docstring and copyright, since I was touching the module anyway.