### PR TITLE
[FLOC-2949] Mark failing Docker tests as expected failing

### DIFF
--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -104,6 +104,10 @@ class GenericDockerClientTests(TestCase):
     """
     clientException = APIError
 
+    UPGRADING_DOCKER = (
+        "FLOC-2902: Some of these tests will fail while we are upgrading "
+        "docker.")
+
     @if_docker_configured
     def setUp(self):
         self.namespacing_prefix = namespace_for_test(self)
@@ -493,6 +497,7 @@ class GenericDockerClientTests(TestCase):
         d = client.add(name, image)
         d.addCallback(lambda _: self.assertTrue(docker.inspect_image(image)))
         return d
+    test_pull_image_if_necessary.todo = UPGRADING_DOCKER
 
     def push_to_registry(self, image_name, registry):
         """
@@ -656,6 +661,7 @@ class GenericDockerClientTests(TestCase):
         Pulling an image times-out if it takes longer than a provided timeout.
         """
         return self._pull_timeout()
+    test_pull_timeout.todo = UPGRADING_DOCKER
 
     def test_pull_timeout_pull(self):
         """
@@ -692,6 +698,7 @@ class GenericDockerClientTests(TestCase):
 
         d.addCallbacks(unexpected_success, expected_failure)
         return d
+    test_pull_timeout_pull.todo = UPGRADING_DOCKER
 
     def test_namespacing(self):
         """

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -97,16 +97,18 @@ class Registry(PClass):
         return "{host}:{port}".format(host=self.host, port=self.port)
 
 
+UPGRADING_DOCKER = (
+    "FLOC-2902: Some of these tests will fail while we are upgrading "
+    "docker. Skipping because some errors are AlreadyCalledErrors which "
+    "are treated as test errors even when marked as 'todo'.")
+
+
 class GenericDockerClientTests(TestCase):
     """
     Functional tests for ``DockerClient`` and other clients that talk to
     real Docker.
     """
     clientException = APIError
-
-    UPGRADING_DOCKER = (
-        "FLOC-2902: Some of these tests will fail while we are upgrading "
-        "docker.")
 
     @if_docker_configured
     def setUp(self):
@@ -497,7 +499,7 @@ class GenericDockerClientTests(TestCase):
         d = client.add(name, image)
         d.addCallback(lambda _: self.assertTrue(docker.inspect_image(image)))
         return d
-    test_pull_image_if_necessary.todo = UPGRADING_DOCKER
+    test_pull_image_if_necessary.skip = UPGRADING_DOCKER
 
     def push_to_registry(self, image_name, registry):
         """
@@ -661,7 +663,7 @@ class GenericDockerClientTests(TestCase):
         Pulling an image times-out if it takes longer than a provided timeout.
         """
         return self._pull_timeout()
-    test_pull_timeout.todo = UPGRADING_DOCKER
+    test_pull_timeout.skip = UPGRADING_DOCKER
 
     def test_pull_timeout_pull(self):
         """
@@ -698,7 +700,7 @@ class GenericDockerClientTests(TestCase):
 
         d.addCallbacks(unexpected_success, expected_failure)
         return d
-    test_pull_timeout_pull.todo = UPGRADING_DOCKER
+    test_pull_timeout_pull.skip = UPGRADING_DOCKER
 
     def test_namespacing(self):
         """


### PR DESCRIPTION
As discussed on [FLOC-2949](https://clusterhq.atlassian.net/browse/FLOC-2949), I prematurely upgraded the version of docker on the slaves, causing the tests to fail. 

This patch disables those tests in the sure and certain hope that we can land [FLOC-2912](https://clusterhq.atlassian.net/browse/FLOC-2912) (#1877) and [FLOC-2915](https://clusterhq.atlassian.net/browse/FLOC-2915) (#1878) quickly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1896)
<!-- Reviewable:end -->
