### PR TITLE
[FLOC-2529] Add notice for out of date docs

### DIFF
--- a/docs/_themes/clusterhq/layout.html
+++ b/docs/_themes/clusterhq/layout.html
@@ -1,5 +1,7 @@
 {%- if meta is defined and meta.get('layout') == 'homepage' -%}
 {%- extends 'layout_homepage.html' -%}
+{%- elif pagename =='version' -%}
+{%- extends 'layout_version.html' -%}
 {%- else -%}
 {%- extends 'layout_docs.html' -%}
 {%- endif -%}

--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -1,4 +1,4 @@
-„<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+„<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -218,6 +218,26 @@
     hm.src = ('++u-heatmap-it+log-js').replace(/[+]/g,'/').replace(/-/g,'.');
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(hm, s);
     })();
+    </script>
+
+    <!-- Display out-of-date documentation notice -->
+    <script>
+        // Do an AJAX request to check latest version
+        var request = $.ajax({url: "https://docs.clusterhq.com/en/latest/version.html"});
+
+        request.done(function( msg ) {
+            // Trim HTML from returned contents
+            currentversion = $(msg).text();
+
+            // Is version equal to this documentation release?
+            if (currentversion !== DOCUMENTATION_OPTIONS.VERSION) {
+                $('.section:first').prepend('<div class="admonition note warning"> \
+                    <p class="last"> \
+                        You are currently viewing a different version of the documentation to the latest release of Flocker. \
+                        The latest version is ' + currentversion + ', you are viewing ' + DOCUMENTATION_OPTIONS.VERSION + '.</p> \
+                    </div>');
+            }
+        });
     </script>
   </body>
 </html>

--- a/docs/_themes/clusterhq/layout_version.html
+++ b/docs/_themes/clusterhq/layout_version.html
@@ -1,0 +1,1 @@
+{% block body %}{% endblock %}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,4 +23,9 @@ Flocker is an open-source project, and in our :ref:`Getting Involved section<get
    faq/index
    gettinginvolved/index
 
+.. toctree::
+   :hidden:
+
+   version
+
 .. _Getting Started with Flocker: https://clusterhq.com/flocker/getting-started/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,8 @@ Flocker is an open-source project, and in our :ref:`Getting Involved section<get
    faq/index
    gettinginvolved/index
 
+.. The version page is used only for a version of the documentation to know what the latest version is.
+
 .. toctree::
    :hidden:
 

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -1,0 +1,1 @@
+|version|


### PR DESCRIPTION
Added javascript to AJAX GET https://docs.clusterhq.com/en/lates/version.html and compare to DOCUMENTATION_OPTIONS

Added new theme with no markup for version output. Added logic to use plain layout for version.rst.

Fixes FLOC-2529