### PR TITLE
[FLOC-2740] Respect leases when calculating changes

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1591,7 +1591,7 @@ class BlockDeviceDeployer(PRecord):
         if local_state.applications is None:
             return in_parallel(changes=[])
 
-        not_in_use = NotInUseDatasets(local_state)
+        not_in_use = NotInUseDatasets(local_state, configuration.leases)
 
         configured_manifestations = this_node_config.manifestations
 

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -27,7 +27,7 @@ from . import IDeployer, IStateChange, sequentially
 from ..testtools import loop_until
 from ..control import (
     IClusterStateChange, Node, NodeState, Deployment, DeploymentState)
-from ..control._model import ip_to_uuid
+from ..control._model import ip_to_uuid, Leases
 from ._docker import DockerClient
 
 
@@ -264,7 +264,8 @@ def to_node(node_state):
 
 def assert_calculated_changes_for_deployer(
         case, deployer, node_state, node_config, nonmanifest_datasets,
-        additional_node_states, additional_node_config, expected_changes
+        additional_node_states, additional_node_config, expected_changes,
+        leases=Leases(),
 ):
     """
     Assert that ``calculate_changes`` returns certain changes when it is
@@ -283,6 +284,7 @@ def assert_calculated_changes_for_deployer(
     :param set additional_node_states: A set of ``NodeState`` for other nodes.
     :param set additional_node_config: A set of ``Node`` for other nodes.
     :param expected_changes: The ``IStateChange`` expected to be returned.
+    :param Leases leases: Currently configured leases. By default none exist.
     """
     cluster_state = DeploymentState(
         nodes={node_state} | additional_node_states,
@@ -293,6 +295,7 @@ def assert_calculated_changes_for_deployer(
     )
     cluster_configuration = Deployment(
         nodes={node_config} | additional_node_config,
+        leases=leases,
     )
     changes = deployer.calculate_changes(
         cluster_configuration, cluster_state,


### PR DESCRIPTION
If a lease is held on a dataset on the current node we shouldn't delete it or resize it or unmount it, since that means it's in use. (Eventually leases will be the only way to make things in-use, but for now we also consider application state.)