### PR TITLE
[FLOC-2946] Docker plugin acceptance tests for volume movement

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -875,6 +875,7 @@ def capture_journal(reactor, host, output_file):
             b'-u', b'flocker-control',
             b'-u', b'flocker-dataset-agent',
             b'-u', b'flocker-container-agent',
+            b'-u', b'flocker-docker-plugin',
         ],
         handle_stdout=lambda line: output_file.write(line + b'\n')
     )

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -59,7 +59,7 @@ class DockerPluginTests(TestCase):
         :param Cluster cluster: Description of the cluster we're talking to.
         :param bytes address: The public IP of the node where it will run.
         :param dict docker_arguments: Additional arguments to pass to
-            Docker run call.
+            Docker ``create_container()`` call.
         :param FilePath script: The script to run.
         :param list script_arguments: Additional arguments to pass to the
             script.
@@ -89,7 +89,7 @@ class DockerPluginTests(TestCase):
         """
         Docker can run a container with a volume provisioned by Flocker.
         """
-        data = "hello world"
+        data = random_name(self).encode("utf-8")
         node = cluster.nodes[0]
         http_port = 8080
 
@@ -101,6 +101,8 @@ class DockerPluginTests(TestCase):
                 port_bindings={http_port: http_port}),
              "ports": [http_port]},
             SCRIPTS.child(b"datahttp.py"),
+            # This tells the script where it should store its data,
+            # and we want it to specifically use the volume:
             [u"/data"])
 
         d = post_http_server(self, node.public_address, http_port,
@@ -133,6 +135,8 @@ class DockerPluginTests(TestCase):
         cid = self.run_python_container(
             cluster, origin_node.public_address, container_args,
             SCRIPTS.child(b"datahttp.py"),
+            # This tells the script where it should store its data,
+            # and we want it to specifically use the volume:
             [u"/data"], cleanup=False)
 
         # Post to container on origin node:

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -24,23 +24,14 @@ class DockerPluginTests(TestCase):
     """
     Tests for the Docker plugin.
     """
-    def run_python_container(self, cluster, address, docker_arguments, script,
-                             script_arguments):
+    def client(self, cluster, address):
         """
-        Run a Python script as a Docker container with the Flocker volume
-        driver.
-
-        This is a blocking call.
+        Open a Docker client to the given address.
 
         :param Cluster cluster: Description of the cluster we're talking to.
-        :param bytes address: The public IP of the node where it will run.
-        :param dict docker_arguments: Additional arguments to pass to
-            Docker run call.
-        :param FilePath script: The script to run.
-        :param list script_arguments: Additional arguments to pass to the
-            script.
+        :param bytes address: The public IP of the node to connect to.
 
-        :return: When Docker container has started.
+        :return: Docker ``Client`` instance.
         """
         def get_path(name):
             return cluster.certificates_path.child(name).path
@@ -54,8 +45,29 @@ class DockerPluginTests(TestCase):
             # do verify certificate authority signed the server certificate:
             assert_hostname=False,
             verify=get_path(b"cluster.crt"))
-        client = Client(base_url="https://{}:{}".format(address, DOCKER_PORT),
-                        tls=tls, timeout=100)
+        return Client(base_url="https://{}:{}".format(address, DOCKER_PORT),
+                      tls=tls, timeout=100)
+
+    def run_python_container(self, cluster, address, docker_arguments, script,
+                             script_arguments, cleanup=True):
+        """
+        Run a Python script as a Docker container with the Flocker volume
+        driver.
+
+        This is a blocking call.
+
+        :param Cluster cluster: Description of the cluster we're talking to.
+        :param bytes address: The public IP of the node where it will run.
+        :param dict docker_arguments: Additional arguments to pass to
+            Docker run call.
+        :param FilePath script: The script to run.
+        :param list script_arguments: Additional arguments to pass to the
+            script.
+        :param cleanup: If true, cleanup the container at test end.
+
+        :return: Container id, once the Docker container has started.
+        """
+        client = self.client(cluster, address)
 
         # Remove all existing containers on the node, in case they're left
         # over from previous test:
@@ -66,8 +78,11 @@ class DockerPluginTests(TestCase):
             "python:2.7-slim",
             ["python", "-c", script.getContent()] + list(script_arguments),
             volume_driver="flocker", **docker_arguments)
-        client.start(container=container["Id"])
-        self.addCleanup(client.remove_container, container["Id"], force=True)
+        cid = container["Id"]
+        client.start(container=cid)
+        if cleanup:
+            self.addCleanup(client.remove_container, cid, force=True)
+        return cid
 
     @require_cluster(1)
     def test_run_container_with_volume(self, cluster):
@@ -93,3 +108,65 @@ class DockerPluginTests(TestCase):
         d.addCallback(lambda _: assert_http_server(
             self, node.public_address, http_port, expected_response=data))
         return d
+
+    def _test_move(self, cluster, origin_node, destination_node):
+        """
+        Assert that Docker can run a container with a volume provisioned by
+        Flocker, shut down the container and then start a new container
+        with the same volume on the specified node.
+
+        :param cluster: The ``Cluster`` to talk to.
+        :param Node origin_node: Original node to start container on.
+        :param Node destination_node: Original node to start container on.
+
+        :return: ``Deferred`` that fires on assertion success, or failure.
+        """
+        data = "hello world"
+        http_port = 8080
+        volume_name = random_name(self)
+        container_args = {
+            "host_config": create_host_config(
+                binds=["{}:/data".format(volume_name)],
+                port_bindings={http_port: http_port}),
+            "ports": [http_port]}
+
+        cid = self.run_python_container(
+            cluster, origin_node.public_address, container_args,
+            SCRIPTS.child(b"datahttp.py"),
+            [u"/data"], cleanup=False)
+
+        # Post to container on origin node:
+        d = post_http_server(self, origin_node.public_address, http_port,
+                             {"data": data})
+
+        def posted(_):
+            # Shutdown original container:
+            self.client(cluster, origin_node.public_address).remove_container(
+                cid, force=True)
+            # Start container on destination node with same volume:
+            self.run_python_container(
+                cluster, destination_node.public_address, container_args,
+                SCRIPTS.child(b"datahttp.py"), [u"/data"])
+        d.addCallback(posted)
+        d.addCallback(lambda _: assert_http_server(
+            self, destination_node.public_address, http_port,
+            expected_response=data))
+        return d
+
+    @require_cluster(1)
+    def test_move_volume_single_node(self, cluster):
+        """
+        Docker can run a container with a volume provisioned by Flocker, shut
+        down the container and then start a new container with the same
+        volume on the same machine.
+        """
+        return self._test_move(cluster, cluster.nodes[0], cluster.nodes[0])
+
+    @require_cluster(2)
+    def test_move_volume_different_node(self, cluster):
+        """
+        Docker can run a container with a volume provisioned by Flocker, shut
+        down the container and then start a new container with the same
+        volume on a different machine.
+        """
+        return self._test_move(cluster, cluster.nodes[0], cluster.nodes[1])

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -169,34 +169,29 @@ class VolumePlugin(object):
         creating.addCallback(lambda _: {u"Err": None})
         return creating
 
-    def _path_response(self, name):
+    def _get_path(self, name):
         """
-        Wait until a dataset has been mounted and then return its path.
+        Return a volume's path if available.
 
         :param unicode name: The name of the volume.
 
-        :return: Result that includes the mountpoint.
+        :return: ``Deferred`` that fires with the mountpoint ``FilePath``,
+            or ``None`` if it is currently unknown.
         """
         # If we ever get rid of dataset_id hashing hack we'll need to
         # lookup the dataset by its metadata, not its id.
-        def get_state():
-            dataset_id = UUID(dataset_id_from_name(name))
-            d = self._flocker_client.list_datasets_state()
+        dataset_id = UUID(dataset_id_from_name(name))
+        d = self._flocker_client.list_datasets_state()
 
-            def got_state(datasets):
-                datasets = [dataset for dataset in datasets
-                            if dataset.dataset_id == dataset_id]
-                if datasets and datasets[0].primary == self._node_id:
-                    return datasets[0].path
-                return deferLater(
-                    self._reactor, self._POLL_INTERVAL, get_state)
-            d.addCallback(got_state)
-            return d
-
-        result = get_state()
-        result.addCallback(lambda path: {u"Err": None,
-                                         u"Mountpoint": path.path})
-        return result
+        def got_state(datasets):
+            datasets = [dataset for dataset in datasets
+                        if dataset.dataset_id == dataset_id]
+            if datasets and datasets[0].primary == self._node_id:
+                return datasets[0].path
+            else:
+                return None
+        d.addCallback(got_state)
+        return d
 
     @app.route("/VolumeDriver.Mount", methods=["POST"])
     @_endpoint(u"Mount")
@@ -213,17 +208,44 @@ class VolumePlugin(object):
         """
         dataset_id = UUID(dataset_id_from_name(Name))
         d = self._flocker_client.move_dataset(self._node_id, dataset_id)
-        d.addCallback(lambda _: self._path_response(Name))
+
+        def get_state(_=None):
+            getting_path = self._get_path(Name)
+
+            def got_path(path):
+                if path is None:
+                    return deferLater(
+                        self._reactor, self._POLL_INTERVAL, get_state)
+                else:
+                    return {u"Err": None,
+                            u"Mountpoint": path.path}
+            getting_path.addCallback(got_path)
+            return getting_path
+        d.addCallback(get_state)
         return d
 
     @app.route("/VolumeDriver.Path", methods=["POST"])
     @_endpoint(u"Path")
     def volumedriver_path(self, Name):
         """
-        Wait until the dataset is mounted locally, then return its path.
+        Return the path of a locally mounted volume if possible.
+
+        Docker will call this in situations where it's not clear to us
+        whether the dataset should be local or not, so we can't wait for a
+        result.
 
         :param unicode Name: The name of the volume.
 
         :return: Result indicating success.
         """
-        return self._path_response(Name)
+        d = self._get_path(Name)
+
+        def got_path(path):
+            if path is None:
+                return {u"Err": u"Volume not available.",
+                        u"Mountpoint": u""}
+            else:
+                return {u"Err": None,
+                        u"Mountpoint": path.path}
+        d.addCallback(got_path)
+        return d

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -189,6 +189,12 @@ class APITestsMixin(APIAssertionsMixin):
         """
         ``/VolumeDriver.Path`` returns an error when asked for the mount path
         of a volume that is not mounted locally.
+
+        This can happen as a result of ``docker inspect`` on a container
+        that has been created but is still waiting for its volume to
+        arrive from another node. It seems like Docker may also call this
+        after ``/VolumeDriver.Create``, so again while waiting for a
+        volume to arrive.
         """
         name = u"myvol"
         dataset_id = UUID(dataset_id_from_name(name))

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -153,15 +153,15 @@ class APITestsMixin(APIAssertionsMixin):
 
     def test_path(self):
         """
-        ``/VolumeDriver.Path`` returns the mount path of the given volume.
+        ``/VolumeDriver.Path`` returns the mount path of the given volume if
+        it is currently known.
         """
         name = u"myvol"
         dataset_id = UUID(dataset_id_from_name(name))
 
         d = self.create(name)
-        # After a polling interval the dataset arrives as state:
-        reactor.callLater(VolumePlugin._POLL_INTERVAL,
-                          self.flocker_client.synchronize_state)
+        # The dataset arrives as state:
+        d.addCallback(lambda _: self.flocker_client.synchronize_state())
 
         d.addCallback(lambda _: self.assertResponseCode(
             b"POST", b"/VolumeDriver.Mount", {u"Name": name}, OK))
@@ -172,6 +172,40 @@ class APITestsMixin(APIAssertionsMixin):
                           {u"Name": name}, OK,
                           {u"Err": None,
                            u"Mountpoint": u"/flocker/{}".format(dataset_id)}))
+        return d
+
+    def test_unknown_path(self):
+        """
+        ``/VolumeDriver.Path`` returns an error when asked for the mount path
+        of a non-existent volume.
+        """
+        name = u"myvol"
+        return self.assertResult(
+            b"POST", b"/VolumeDriver.Path",
+            {u"Name": name}, OK,
+            {u"Err": u"Volume not available.", u"Mountpoint": u""})
+
+    def test_non_local_path(self):
+        """
+        ``/VolumeDriver.Path`` returns an error when asked for the mount path
+        of a volume that is not mounted locally.
+        """
+        name = u"myvol"
+        dataset_id = UUID(dataset_id_from_name(name))
+
+        # Create dataset on node B:
+        d = self.flocker_client.create_dataset(
+            self.NODE_B, DEFAULT_SIZE, metadata={u"name": name},
+            dataset_id=dataset_id)
+        d.addCallback(lambda _: self.flocker_client.synchronize_state())
+
+        # Ask for path on node A:
+        d.addCallback(lambda _:
+                      self.assertResult(
+                          b"POST", b"/VolumeDriver.Path",
+                          {u"Name": name}, OK,
+                          {u"Err": "Volume not available.",
+                           u"Mountpoint": u""}))
         return d
 
 

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -722,7 +722,11 @@ class DockerClient(object):
                     if e.response.status_code == NOT_FOUND:
                         continue
                     else:
-                        raise
+                        # XXX I suspect we're hitting re-entry issue with
+                        # the Docker plugin, try to verify by not blowing up here:
+                        Message.log(message_type="XXXX", exception=unicode(e))
+                        continue
+                        #raise
 
                 state = (u"active" if data[u"State"][u"Running"]
                          else u"inactive")

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -722,11 +722,7 @@ class DockerClient(object):
                     if e.response.status_code == NOT_FOUND:
                         continue
                     else:
-                        # XXX I suspect we're hitting re-entry issue with
-                        # the Docker plugin, try to verify by not blowing up here:
-                        Message.log(message_type="XXXX", exception=unicode(e))
-                        continue
-                        #raise
+                        raise
 
                 state = (u"active" if data[u"State"][u"Running"]
                          else u"inactive")


### PR DESCRIPTION
Demonstrate that volumes can be moved to different containers on the same node and on different nodes.

This also includes a fix to the way the plugin API work which is necessary for the tests to pass: the `/VolumeDriver.Path` call needs to return a result immediately even if it doesn't know the path yet.

Finally, the acceptance test remote log capture also captures the flocker-docker-plugin logs since that was helpful when debugging.