### PR TITLE
[FLOC-2736] REST API endpoint: list leases

### DIFF
--- a/docs/reference/api_examples.yml
+++ b/docs/reference/api_examples.yml
@@ -632,8 +632,35 @@
       {
         "uuid": "%(NODE_0)s",
         "host": "10.0.0.3",
+      },
       {
         "uuid": "%(NODE_1)s",
         "host": "10.0.0.4",
+      },
+    ]
+
+-
+  id: "list leases"
+
+  doc: |
+    List the leases on datasets in the cluster.
+    Notice how one lease expires in 30 seconds, and one will never expire.
+
+  request: |
+    GET /v1/configuration/leases
+
+  response: |
+    HTTP/1.1 200 OK
+
+    [
+      {
+        "dataset_id": "886ed03a-5606-453a-94a9-a1cbaf35164c",
+        "node_uuid": "%(NODE_0)s",
+        "expires": null,
+      },
+      {
+        "dataset_id": "47440eff-e933-4de0-b56c-d3469b61421f",
+        "node_uuid": "%(NODE_1)s",
+        "expires": 30,
       },
     ]

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -866,6 +866,17 @@ class ConfigurationAPIUserV1(object):
     @app.route("/configuration/leases", methods=['GET'])
     # This can stop being private as part of FLOC-2741:
     @private_api
+    @user_documentation(
+        u"""
+        List the currently existing leases on datasets, including which
+        node the lease is for and when if ever the lease will expire.
+        """,
+        header=u"List all leases on datasets",
+        examples=[
+            u"list leases",
+        ],
+        section=u"dataset",
+    )
     @structured(
         inputSchema={},
         outputSchema={

--- a/flocker/control/schema/endpoints.yml
+++ b/flocker/control/schema/endpoints.yml
@@ -200,3 +200,9 @@ definitions:
       - applications
       - deployment
     additionalProperties: false
+
+  list_leases:
+    decription: "An array of dataset leases in the cluster."
+    type: array
+    items:
+      '$ref': 'types.json#/definitions/lease'

--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -280,3 +280,36 @@ definitions:
       primary:
         '$ref': '#/definitions/primary'
     additionalProperties: false
+
+  lease_expiration:
+    title: "Lease Expiration"
+    description: |
+      The number of seconds until a lease expires, or null to indicate no expiration.
+    type:
+      - "number"
+      - "null"
+
+  lease_dataset_id:
+    title: "Dataset"
+    description: |
+      An opaque identifier, unique across the cluster, identifying a
+      particular dataset.
+    type: string
+    # The length of a stringified uuid
+    minLength: 36
+    maxLength: 36
+
+  lease:
+    type: object
+    properties:
+      dataset_id:
+        '$ref': '#/definitions/lease_dataset_id'
+      node_uuid:
+        '$ref': '#/definitions/node_uuid'
+      expires:
+        '$ref': '#/definitions/lease_expiration'
+    required:
+      - 'dataset_id'
+      - 'node_uuid'
+      - 'expires'
+    additionalProperties: false

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -35,7 +35,7 @@ from .. import (
     Application, Dataset, Manifestation, Node, NodeState,
     Deployment, AttachedVolume, DockerImage, Port, RestartOnFailure,
     RestartAlways, RestartNever, Link, same_node, DeploymentState,
-    NonManifestDatasets,
+    NonManifestDatasets, Leases,
 )
 from ..httpapi import (
     ConfigurationAPIUserV1, create_api_service, datasets_from_deployment,
@@ -45,7 +45,6 @@ from .._persistence import ConfigurationPersistenceService
 from .._clusterstate import ClusterStateService
 from .._config import (
     FlockerConfiguration, FigConfiguration, model_from_configuration)
-from .._model import Leases
 from .test_config import COMPLEX_APPLICATION_YAML, COMPLEX_DEPLOYMENT_YAML
 from ... import __version__
 

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -785,3 +785,51 @@ NodesTests = build_schema_test(
          {'host': '192.168.1.11', 'uuid': unicode(uuid4())}],
     ],
 )
+
+
+LEASE_WITH_EXPIRATION = {'dataset_id': unicode(uuid4()),
+                         'node_uuid': unicode(uuid4()),
+                         'expires': 15}
+# Can happen sometimes, means time went backwards or a bug but at least we
+# should report things accurately.
+LEASE_WITH_NEGATIVE_EXPIRATION = {'dataset_id': unicode(uuid4()),
+                                  'node_uuid': unicode(uuid4()),
+                                  'expires': -0.1}
+LEASE_NO_EXPIRES = {'dataset_id': unicode(uuid4()),
+                    'node_uuid': unicode(uuid4()),
+                    'expires': None}
+BAD_LEASES = [
+    # Wrong types:
+    None, [], 1,
+    # Missing dataset_id:
+    {'node_uuid': unicode(uuid4()), 'expires': None},
+    # Missing node_uuid:
+    {'dataset_id': unicode(uuid4()), 'expires': None},
+    # Missing expires:
+    {'node_uuid': unicode(uuid4()), 'dataset_id': unicode(uuid4())},
+    # Wrong type for dataset_id:
+    {'node_uuid': unicode(uuid4()), 'dataset_id': 123,
+     'expires': None},
+    # Wrong type for node_uuid:
+    {'dataset_id': unicode(uuid4()), 'node_uuid': 123,
+     'expires': None},
+    # Wrong type for expires:
+    {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
+     'expires': []},
+    # Extra key:
+    {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
+     'expires': None, 'extra': 'key'},
+]
+
+ListLeasesTests = build_schema_test(
+    name="ListLeasesTests",
+    schema={'$ref': '/v1/endpoints.json#/definitions/list_leases'},
+    schema_store=SCHEMAS,
+    failing_instances=[None, {}, 1] + list(
+        [bad] for bad in BAD_LEASES),
+    passing_instances=[
+        [],
+        [LEASE_NO_EXPIRES],
+        [LEASE_WITH_EXPIRATION, LEASE_WITH_NEGATIVE_EXPIRATION],
+    ],
+)


### PR DESCRIPTION
1. Expand schema to know about leases. The tests were structured so the good/bad examples can be re-used in later schema tests.
2. Add a new endpoint for listing leases.
