### PR TITLE
[FLOC-2741] End to end tests for leases

### DIFF
--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -34,64 +34,51 @@ class LeaseAPITests(TestCase):
 
         def acquire_lease(dataset):
             # Call the API to acquire a lease with the dataset ID.
+            # Give the lease an expiry of 60 seconds.
             pass
 
-        def attempt_move_dataset(dataset):
-            pass
+        def start_http_container(dataset):
+            # In the 60 seconds before the lease expires, we can launch
+            # the acceptance tests' data HTTP container and make POST requests
+            # to it in a looping call every second.
+            # return looping call deferred
 
-        XXX what do we do here? Some options:
-        * Modify the dataset configuration API:
-          to return an error if the dataset has a lease?
+        def request_move_dataset(self):
+            # We can then request to move the dataset attached to the container.
+            return deferred
 
-        * Wait and timeout?
-          The dataset-agent won't move the dataset because it has a lease so
-          the state will not be updated.
-          But how do we distinguish this from a dataset move which has not
-          yet been performed (delayed for some reason)?
+        def wait_some_amount_of_time(self):
+            # Because the dataset is leased, we should be able to continue
+            # writing data via HTTP requests to the running container.
+            # We should be able to do this for some number of seconds.
+            # The looping call running in parallel to this is continuing to
+            # write data.
 
-        * Check the dataset-agent logs?
-          except that `calculate_changes` doesn't currently log anything if a
-          dataset is leased to nodeA but configured to be on nodeB.
+            # wait some time and return a deferred
 
-        * Don't attempt an acceptance test for this situation.
-          It's already tested in the blockdevice API tests...
-        """
-        self.fail("not implemented yet")
+        def stop_container(self):
+            # We stop the container, so that there is no constraint outside
+            # of leases to prevent the volume from being unmounted.
 
-    @require_moving_backend
-    @require_cluster(2)
-    def test_move_dataset_after_lease_release(self, cluster):
-        """
-        A dataset can be moved once a lease held on it by a
-        particular node is released.
+            def confirmed_stopped(self):
+                # When the container is confirmed as stopped,
+                # restart the container again, to prove the dataset
+                # hasn't moved.
+                # If the dataset had moved, the host path on the volume would
+                # have been unmounted. # XXX is this actually true, does
+                # Flocker remove mountpoint directories?
 
-        ...instead we could write only this test which issues the same API
-        calls that the Docker Plugin is likely to make eg
+        def stop_container_again(self):
+            # Stop the container again.
 
-        Kubernetes schedules Postgres on NodeA with -v PostgresData
-            Docker(NodeA) calls ``VolumePlugin.mount`` PostgresData
-                Flongle responds by:
-                    Create dataset for FooBar
-                    Acquire lease for FooBar on NodeA
-            Docker(NodeA) starts Postgres
+            def stopped_again(self):
+                # Ask for the lease to be released, causing the dataset to move.
+                # Wait a couple of seconds.
 
-        Kubernetes schedules Postgres on NodeB with -v PostgresData
-            Docker(NodaA) stops container
-            Docker(NodeA) calls ``VolumePlugin.umount`` PostgresData
-                Flongle releases lease for FooBar on NodeB
-
-            Docker(NodeB) calls ``VolumePlugin.mount`` PostgresData
-                Flongle
-                    Checks for PostgresData -- exists
-                    Checks for PostgresData leases -- none
-                    Move PostgresData to NodeB
-                    Acquire lease for FooBar on NodeB
-            Docker(NodeB) starts Postgres
-
-        @itamarst, is this what you mean by:
-        > so perhaps try thinking about leases from point of view of users,
-          e.g. docker plugin - how and when will they use it? what would they
-          care about?
+        def try_to_start_again(self):
+            # After a couple of seconds, we can try to recreate the container
+            # and that should fail, because the host mount path for the volume
+            # should no longer exist.
         """
         self.fail("not implemented yet")
 

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -33,7 +33,6 @@ class LeaseAPITests(TestCase):
         """
         http_port = 8080
         dataset_id = uuid4()
-        dataset_path = []
         datasets = []
         client = get_docker_client(cluster, cluster.nodes[0].public_address)
         d = create_dataset(
@@ -51,7 +50,6 @@ class LeaseAPITests(TestCase):
                 getting_datasets = cluster.client.list_datasets_state()
 
                 def extract_dataset_path(datasets):
-                    dataset_path.insert(0, datasets[0].path)
                     return datasets[0].path
 
                 getting_datasets.addCallback(extract_dataset_path)
@@ -66,7 +64,6 @@ class LeaseAPITests(TestCase):
             # Launch data HTTP container and make POST requests
             # to it in a looping call every second.
             # return looping call deferred
-            # import pdb;pdb.set_trace()
             script = SCRIPTS.child("datahttp.py")
             script_arguments = [u"/data"]
             docker_arguments = {
@@ -186,10 +183,10 @@ class LeaseAPITests(TestCase):
 
     @require_moving_backend
     @require_cluster(2)
-    def test_delete_dataset_after_lease_release(self, cluster):
+    def test_move_dataset_after_lease_expiry(self, cluster):
         """
         A dataset can be deleted once a lease held on it by a
-        particular node is released.
+        particular node has expired.
         """
         self.fail("not implemented yet")
 

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -44,9 +44,15 @@ class LeaseAPITests(TestCase):
         def acquire_lease(dataset):
             # Call the API to acquire a lease with the dataset ID.
             acquiring_lease = cluster.client.acquire_lease(
-                dataset.dataset_id, UUID(cluster.nodes[0].uuid))
+                dataset.dataset_id, UUID(cluster.nodes[0].uuid), expires=1000)
 
             def get_dataset_path(lease, created_dataset):
+                # import pdb;pdb.set_trace()
+                get_leases = cluster.client.list_leases()
+                def check_leases(leases):
+                    #import pdb;pdb.set_trace()
+                    pass
+                get_leases.addCallback(check_leases)
                 getting_datasets = cluster.client.list_datasets_state()
 
                 def extract_dataset_path(datasets):
@@ -132,10 +138,11 @@ class LeaseAPITests(TestCase):
             def got_leases(leases):
                 import pdb;pdb.set_trace()
             get_leases.addCallback(got_leases)
-            import pdb;pdb.set_trace()
-            releasing = cluster.client.release_lease(dataset_id)
-            releasing.addCallback(lambda _: container_id)
-            return releasing
+            return get_leases
+            # import pdb;pdb.set_trace()
+            #releasing = cluster.client.release_lease(dataset_id)
+            #releasing.addCallback(lambda _: container_id)
+            #return releasing
 
         d.addCallback(stop_container_again, client, dataset_id)
 

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -101,6 +101,16 @@ class LeaseAPITests(TestCase):
                     http_port, expected_response=data
                 )
             )
+
+            def check_leases_again(_):
+                get_leases = cluster.client.list_leases()
+                def check_leases(leases):
+                    import pdb;pdb.set_trace()
+                    pass
+                get_leases.addCallback(check_leases)
+                return get_leases
+
+            writing.addCallback(check_leases_again)
             writing.addCallback(lambda _: container_id)
             return writing
 
@@ -112,10 +122,11 @@ class LeaseAPITests(TestCase):
             # the lease.
             primary = cluster.nodes[1].uuid
             client.stop(container_id)
-            move_dataset_request = cluster.client.move_dataset(
-                primary, dataset_id)
-            move_dataset_request.addCallback(lambda _: container_id)
-            return move_dataset_request
+            #move_dataset_request = cluster.client.move_dataset(
+            #    primary, dataset_id)
+            #move_dataset_request.addCallback(lambda _: container_id)
+            #return move_dataset_request
+            return container_id
 
         d.addCallback(stop_container, client, dataset_id)
 
@@ -148,7 +159,7 @@ class LeaseAPITests(TestCase):
 
         d.addCallback(wait_five_seconds)
 
-        d.addCallback(restart_container)
+        d.addCallback(restart_container, client)
 
         def container_no_start(_):
             import pdb;pdb.set_trace()

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -156,8 +156,12 @@ class LeaseAPITests(TestCase):
         it by a particular node.
         """
         return self._assert_lease_behavior(
-            cluster, cluster.client.move_dataset,
-            {'primary': cluster.nodes[1].uuid}, cluster.wait_for_dataset)
+            cluster,
+            cluster.client.move_dataset,
+            {'primary': cluster.nodes[1].uuid},
+            cluster.wait_for_dataset,
+            expire_lease=False,
+        )
 
     @require_moving_backend
     @require_cluster(2)
@@ -167,8 +171,12 @@ class LeaseAPITests(TestCase):
         it by a particular node.
         """
         return self._assert_lease_behavior(
-            cluster, cluster.client.delete_dataset,
-            dict(), cluster.wait_for_deleted_dataset)
+            cluster,
+            cluster.client.delete_dataset,
+            {},
+            cluster.wait_for_deleted_dataset,
+            expire_lease=False,
+        )
 
     @require_moving_backend
     @require_cluster(2)
@@ -178,9 +186,12 @@ class LeaseAPITests(TestCase):
         particular node has expired.
         """
         return self._assert_lease_behavior(
-            cluster, cluster.client.move_dataset,
-            {'primary': cluster.nodes[1].uuid}, cluster.wait_for_dataset,
-            )
+            cluster,
+            cluster.client.move_dataset,
+            {'primary': cluster.nodes[1].uuid},
+            cluster.wait_for_dataset,
+            expire_lease=True
+        )
 
     @require_moving_backend
     @require_cluster(2)
@@ -189,4 +200,10 @@ class LeaseAPITests(TestCase):
         A dataset can be deleted once a lease held on it by a
         particular node has expired.
         """
-        self.fail("not implemented yet")
+        return self._assert_lease_behavior(
+            cluster,
+            cluster.client.delete_dataset,
+            {},
+            cluster.wait_for_deleted_dataset,
+            expire_lease=True
+        )

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -1,0 +1,96 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for the datasets REST API.
+"""
+
+# from uuid import UUID
+
+from twisted.trial.unittest import TestCase
+
+from ..testtools import (
+    require_cluster, require_moving_backend,  # create_dataset,
+    # REALISTIC_BLOCKDEVICE_SIZE,
+)
+
+
+class LeaseAPITests(TestCase):
+    """
+    Tests for the leases API.
+    """
+    @require_moving_backend
+    # require_cluster should probably delete leases as part of
+    # resetting the cluster state between tests
+    @require_cluster(2)
+    def test_lease_prevents_move(self, cluster):
+        """
+        A dataset cannot be moved if a lease is held on
+        it by a particular node.
+        """
+        # waiting_for_create = create_dataset(
+        #     self, cluster, maximum_size=REALISTIC_BLOCKDEVICE_SIZE)
+
+        # def acquire_lease(dataset):
+        #     # Call the API to acquire a lease with the dataset ID.
+        #     pass
+
+        # Once created, request to move the dataset to node2
+        # def attempt_move_dataset(dataset):
+        #     # XXX this should not work
+        #     dataset_moving = cluster.client.move_dataset(
+        #         UUID(cluster.nodes[1].uuid), dataset.dataset_id)
+        #     # XXX what do we do here? we ideally want a confirmation
+        #     # from the API that this has failed because we have a lease.
+        #     # wait for timeout? no. check the logs? maybe.
+
+        #     return dataset_moving
+
+        # waiting_for_create.addCallback(acquire_lease)
+        # waiting_for_create.addCallback(attempt_move_dataset)
+        # return waiting_for_create
+        self.fail("not implemented yet")
+
+    @require_moving_backend
+    @require_cluster(2)
+    def test_lease_prevents_delete(self, cluster):
+        """
+        A dataset cannot be deleted if a lease is held on
+        it by a particular node.
+        """
+        self.fail("not implemented yet")
+
+    @require_moving_backend
+    @require_cluster(2)
+    def test_move_dataset_after_lease_release(self, cluster):
+        """
+        A dataset can be moved once a lease held on it by a
+        particular node is released.
+        """
+        self.fail("not implemented yet")
+
+    @require_moving_backend
+    @require_cluster(2)
+    def test_delete_dataset_after_lease_release(self, cluster):
+        """
+        A dataset can be deleted once a lease held on it by a
+        particular node is released.
+        """
+        self.fail("not implemented yet")
+
+    @require_moving_backend
+    @require_cluster(2)
+    def test_move_dataset_after_lease_expiry(self, cluster):
+        """
+        A dataset can be moved once a lease held on it by a
+        particular node has expired.
+        """
+        self.fail("not implemented yet")
+
+    @require_moving_backend
+    @require_cluster(2)
+    def test_delete_dataset_after_lease_expiry(self, cluster):
+        """
+        A dataset can be deleted once a lease held on it by a
+        particular node has expired.
+        """
+        self.fail("not implemented yet")

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -6,11 +6,16 @@ Tests for the datasets REST API.
 
 from uuid import UUID
 
+from twisted.internet.task import LoopingCall
 from twisted.trial.unittest import TestCase
 
+from docker.utils import create_host_config
+
+from ...testtools import random_name
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset,
-    REALISTIC_BLOCKDEVICE_SIZE,
+    REALISTIC_BLOCKDEVICE_SIZE, get_docker_client,
+    post_http_server, query_http_server, assert_http_server,
 )
 
 from ..scripts import SCRIPTS
@@ -27,27 +32,61 @@ class LeaseAPITests(TestCase):
         A dataset cannot be moved if a lease is held on
         it by a particular node.
         """
+        client = get_docker_client(cluster, cluster.nodes[0].public_address)
         d = create_dataset(
             self, cluster, maximum_size=REALISTIC_BLOCKDEVICE_SIZE)
 
         def acquire_lease(dataset):
             # Call the API to acquire a lease with the dataset ID.
-            # Give the lease an expiry of 60 seconds.
+            import pdb;pdb.set_trace()
             return cluster.client.acquire_lease(
-                dataset.dataset_id, UUID(cluster.nodes[1].uuid), 120)
+                dataset.dataset_id, UUID(cluster.nodes[0].uuid))
 
         d.addCallback(acquire_lease)
 
-        def start_http_container(lease):
-            # In the 60 seconds before the lease expires, we can launch
-            # the acceptance tests' data HTTP container and make POST requests
+        def start_http_container(lease, client):
+            # Launch data HTTP container and make POST requests
             # to it in a looping call every second.
             # return looping call deferred
             # script_path = SCRIPTS.child(b"datahttp.py")
-            # import pdb;pdb.set_trace()
-            pass
+            http_port = 8080
+            volume_name = random_name(self)
+            script = SCRIPTS.child("datahttp.py")
+            script_arguments = [u"/data"]
+            # XXX how do I attach a dataset here?
+            docker_arguments = {
+                "host_config": create_host_config(
+                    binds=["{}:/data".format(volume_name)],
+                    port_bindings={http_port: http_port}),
+                "ports": [http_port]}
+            container = client.create_container(
+                "python:2.7-slim",
+                ["python", "-c", script.getContent()] + list(script_arguments),
+                **docker_arguments)
+            cid = container["Id"]
+            client.start(container=cid)
+            self.addCleanup(client.remove_container, cid, force=True)
 
-        d.addCallback(start_http_container)
+            def loop_write_data():
+                data = random_name(self).encode("utf-8")
+                d = post_http_server(
+                    self, cluster.nodes[0].public_address, http_port,
+                    {"data": data}
+                )
+                d.addCallback(
+                    lambda _: assert_http_server(
+                        self, cluster.nodes[0].public_address,
+                        http_port, expected_response=data
+                    )
+                )
+                return d
+
+            self.loop = LoopingCall(loop_write_data)
+            self.loop.start(1)
+            import pdb;pdb.set_trace()
+            return cid
+
+        d.addCallback(start_http_container, client)
         return d
 
         """

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -204,33 +204,3 @@ class LeaseAPITests(TestCase):
             cluster.wait_for_deleted_dataset,
             expire_lease=False,
         )
-
-    @require_moving_backend
-    @require_cluster(2)
-    def test_move_dataset_after_lease_expiry(self, cluster):
-        """
-        A dataset can be deleted once a lease held on it by a
-        particular node has expired.
-        """
-        return self._assert_lease_behavior(
-            cluster,
-            cluster.client.move_dataset,
-            {'primary': cluster.nodes[1].uuid},
-            cluster.wait_for_dataset,
-            expire_lease=True
-        )
-
-    @require_moving_backend
-    @require_cluster(2)
-    def test_delete_dataset_after_lease_expiry(self, cluster):
-        """
-        A dataset can be deleted once a lease held on it by a
-        particular node has expired.
-        """
-        return self._assert_lease_behavior(
-            cluster,
-            cluster.client.delete_dataset,
-            {},
-            cluster.wait_for_deleted_dataset,
-            expire_lease=True
-        )

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -155,9 +155,9 @@ class LeaseAPITests(TestCase):
         A dataset cannot be deleted if a lease is held on
         it by a particular node.
         """
-        # self._assert_lease_behavior(
-        #     cluster, cluster.client.delete_dataset,
-        #     dict(), cluster.wait_for_deleted_dataset)
+        return self._assert_lease_behavior(
+            cluster, cluster.client.delete_dataset,
+            dict(), cluster.wait_for_deleted_dataset)
 
     @require_moving_backend
     @require_cluster(2)

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -22,6 +22,7 @@ from twisted.python.filepath import FilePath
 from twisted.python.constants import Names, NamedConstant
 from twisted.python.procutils import which
 from twisted.internet import reactor
+from twisted.internet.defer import DeferredList
 
 from eliot import Logger, start_action, Message, write_failure
 from eliot.twisted import DeferredContext
@@ -618,8 +619,11 @@ class Cluster(PRecord):
             get_items = self.client.list_leases()
 
             def release_all(leases):
+                release_list = DeferredList([])
                 for lease in leases:
-                    self.client.release_lease(lease.dataset_id)
+                    release_list.append(
+                        self.client.release_lease(lease.dataset_id))
+                return release_list
 
             get_items.addCallback(release_all)
             return get_items

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -558,6 +558,8 @@ class Cluster(PRecord):
                 lambda item: self.client.delete_dataset(item.dataset_id),
             )
 
+        # cleanup_leases
+
         return cleanup_containers().addCallback(lambda _: cleanup_datasets())
 
 

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -771,7 +771,8 @@ def create_python_container(test_case, cluster, parameters, script,
 
 
 def create_dataset(test_case, cluster,
-                   maximum_size=REALISTIC_BLOCKDEVICE_SIZE):
+                   maximum_size=REALISTIC_BLOCKDEVICE_SIZE,
+                   dataset_id=None):
     """
     Create a dataset on a cluster (on its first node, specifically).
 
@@ -779,12 +780,17 @@ def create_dataset(test_case, cluster,
     :param Cluster cluster: The test ``Cluster``.
     :param int maximum_size: The size of the dataset to create on the test
         cluster.
+    :param UUID dataset_id: The v4 UUID of the dataset.
+        Generated if not specified.
     :return: ``Deferred`` firing with a ``flocker.apiclient.Dataset``
         dataset is present in actual cluster state.
     """
+    if dataset_id is None:
+        dataset_id = uuid4()
     configuring_dataset = cluster.client.create_dataset(
-        cluster.nodes[0].uuid, maximum_size=maximum_size, dataset_id=uuid4(),
-        metadata={u"name": u"my_volume"})
+        cluster.nodes[0].uuid, maximum_size=maximum_size,
+        dataset_id=dataset_id, metadata={u"name": u"my_volume"}
+    )
 
     # Wait for the dataset to be created
     waiting_for_create = configuring_dataset.addCallback(

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -22,7 +22,6 @@ from twisted.python.filepath import FilePath
 from twisted.python.constants import Names, NamedConstant
 from twisted.python.procutils import which
 from twisted.internet import reactor
-from twisted.internet.defer import DeferredList
 
 from eliot import Logger, start_action, Message, write_failure
 from eliot.twisted import DeferredContext
@@ -619,11 +618,11 @@ class Cluster(PRecord):
             get_items = self.client.list_leases()
 
             def release_all(leases):
-                release_list = DeferredList([])
+                release_list = []
                 for lease in leases:
                     release_list.append(
                         self.client.release_lease(lease.dataset_id))
-                return release_list
+                return gather_deferreds(release_list)
 
             get_items.addCallback(release_all)
             return get_items

--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -444,7 +444,7 @@ class FlockerClient(object):
                      node_uuid=UUID(dictionary[u"node_uuid"]),
                      expires=dictionary[u"expires"])
 
-    def acquire_lease(self, dataset_id, node_uuid, expires):
+    def acquire_lease(self, dataset_id, node_uuid, expires=None):
         request = self._request(b"POST", b"/configuration/leases",
                                 {u"dataset_id": unicode(dataset_id),
                                  u"node_uuid": unicode(node_uuid),

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -951,6 +951,7 @@ class ConfigurationAPIUserV1(object):
 
     @app.route("/configuration/leases", methods=['POST'])
     # This can stop being private as part of FLOC-2741:
+    # We'll remove this once the end-to-end tests are proven.
     @private_api
     @user_documentation(
         u"""


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-2741

This isn't quite what we designed, notably:
 * We can't just move / delete a dataset from underneath a running container; the Docker bind mount prevents the Flocker dataset being unmounted.
 * The 10s delay is really ugly, but how else can we catch the potential important error that would result in flocker-dataset-agent unmounting a leased dataset?
 * We'd originally planned to write tests for expiring leases too, but that's difficult because we can't really know what expiry time to use when acquiring the lease. It depends on how quickly docker responds to API requests. We could set a really long expiry time, but that would slow down the tests.