### PR TITLE
[FLOC-2970] Improved wait error

### DIFF
--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -516,6 +516,7 @@ class CinderBlockDeviceAPI(object):
             volume_manager=self.cinder_volume_manager,
             expected_volume=cinder_volume,
             desired_state=u'available',
+            transient_states=(u'detaching',)
         )
 
     def destroy_volume(self, blockdevice_id):

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -240,7 +240,7 @@ class TimeoutException(Exception):
         return (
             'Timed out while waiting for volume. '
             'Expected Volume: {!r}, '
-            'Expected Status: {!r}, '
+            'Expected State: {!r}, '
             'Elapsed Time: {!r}, '.format(
                 self.expected_volume, self.desired_state, self.elapsed_time)
             )
@@ -259,8 +259,8 @@ class UnexpectedStateException(Exception):
         return (
             'Unexpected state while waiting for volume. '
             'Expected Volume: {!r}, '
-            'Expected Status: {!r}, '
-            'Elapsed Time: {!r}, '.format(
+            'Expected State: {!r}, '
+            'Reached State: {!r}, '.format(
                 self.expected_volume, self.desired_state,
                 self.unexpected_state)
             )
@@ -321,7 +321,7 @@ def wait_for_volume_state(volume_manager, expected_volume, desired_state,
     :returns: The listed ``Volume`` that matches ``expected_volume``.
     """
     waiter = VolumeStateMonitor(
-        volume_manager, expected_volume, transient_states, desired_state,
+        volume_manager, expected_volume, desired_state, transient_states,
         time_limit)
     return poll_until(waiter.reached_desired_state, 1)
 

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -227,13 +227,87 @@ class INovaServerManager(Interface):
         """
 
 
-def wait_for_volume(volume_manager, expected_volume,
-                    expected_status=u'available',
-                    time_limit=60):
+class TimeoutException(Exception):
+    """
+    A timeout on waiting for volume to reach destination end state.
+    """
+    def __init__(self, expected_volume, desired_state, elapsed_time):
+        self.expected_volume = expected_volume
+        self.desired_state = desired_state
+        self.elapsed_time = elapsed_time
+
+    def __str__(self):
+        return (
+            'Timed out while waiting for volume. '
+            'Expected Volume: {!r}, '
+            'Expected Status: {!r}, '
+            'Elapsed Time: {!r}, '.format(
+                self.expected_volume, self.expected_status, self.elapsed_time)
+            )
+
+
+class UnexpectedStateException(Exception):
+    """
+    An unexpected state was encountered by a volume as a result of operation.
+    """
+    def __init__(self, expected_volume, desired_state, unexpected_state):
+        self.expected_volume = expected_volume
+        self.desired_state = desired_state
+        self.unexpected_state = unexpected_state
+
+    def __str__(self):
+        return (
+            'Unexpected state while waiting for volume. '
+            'Expected Volume: {!r}, '
+            'Expected Status: {!r}, '
+            'Elapsed Time: {!r}, '.format(
+                self.expected_volume, self.expected_status,
+                self.unexpected_state)
+            )
+
+
+class VolumeStateMonitor:
+
+    def __init__(self, volume_manager, expected_volume,
+                 desired_state, transient_states=(), time_limit=60):
+        self.volume_manager = volume_manager
+        self.expected_volume = expected_volume
+        self.desired_state = desired_state
+        self.transient_states = transient_states
+        self.time_limit = time_limit
+        self.start_time = time.time()
+
+    def reached_desired_state(self):
+        for listed_volume in self.volume_manager.list():
+            if listed_volume.id == self.expected_volume.id:
+                # Could miss the expected status because race conditions.
+                # FLOC-1832
+                current_state = listed_volume.status
+                if current_state == self.desired_state:
+                    return listed_volume
+                elif current_state not in self.transient_states:
+                    raise UnexpectedStateException(
+                        self.expected_volume, self.desired_state,
+                        current_state)
+        elapsed_time = time.time() - self.start_time
+        if elapsed_time > self.time_limit:
+            raise TimeoutException(
+                self.expected_volume, self.desired_state, elapsed_time)
+
+
+def poll_until(predicate, interval):
+    result = predicate()
+    while not result:
+        time.sleep(interval)
+        result = predicate()
+    return result
+
+
+def wait_for_volume_state(volume_manager, expected_volume, desired_state,
+                          transient_states=(), time_limit=60):
     """
     Wait for a ``Volume`` with the same ``id`` as ``expected_volume`` to be
     listed and to have a ``status`` value of ``expected_status``.
-
     :param ICinderVolumeManager volume_manager: An API for listing volumes.
     :param Volume expected_volume: The ``Volume`` to wait for.
     :param unicode expected_status: The ``Volume.status`` to wait for.
@@ -243,30 +317,10 @@ def wait_for_volume(volume_manager, expected_volume,
         listed within ``time_limit``.
     :returns: The listed ``Volume`` that matches ``expected_volume``.
     """
-    start_time = time.time()
-    # Log stuff happening in this loop.  FLOC-1833.
-    while True:
-        # Could be more efficient.  FLOC-1831
-        for listed_volume in volume_manager.list():
-            if listed_volume.id == expected_volume.id:
-                # Could miss the expected status because race conditions.
-                # FLOC-1832
-                if listed_volume.status == expected_status:
-                    return listed_volume
-
-        elapsed_time = time.time() - start_time
-        if elapsed_time < time_limit:
-            time.sleep(1.0)
-        else:
-            raise Exception(
-                'Timed out while waiting for volume. '
-                'Expected Volume: {!r}, '
-                'Expected Status: {!r}, '
-                'Elapsed Time: {!r}, '
-                'Time Limit: {!r}.'.format(
-                    expected_volume, expected_status, elapsed_time, time_limit
-                )
-            )
+    waiter = VolumeStateMonitor(
+        volume_manager, expected_volume, transient_states, desired_state,
+        time_limit)
+    return poll_until(waiter.reached_desired_state, 1)
 
 
 def _extract_nova_server_addresses(addresses):
@@ -377,9 +431,10 @@ class CinderBlockDeviceAPI(object):
         )
         Message.new(message_type=CINDER_CREATE,
                     blockdevice_id=requested_volume.id).write()
-        created_volume = wait_for_volume(
+        created_volume = wait_for_volume_state(
             volume_manager=self.cinder_volume_manager,
             expected_volume=requested_volume,
+            desired_state=u'available',
         )
         return _blockdevicevolume_from_cinder_volume(
             cinder_volume=created_volume,
@@ -426,10 +481,11 @@ class CinderBlockDeviceAPI(object):
             # Have Nova assign a device file for us.
             device=None,
         )
-        attached_volume = wait_for_volume(
+        attached_volume = wait_for_volume_state(
             volume_manager=self.cinder_volume_manager,
             expected_volume=nova_volume,
-            expected_status=u'in-use',
+            desired_state=u'in-use',
+            transient_states=(u'attaching',),
         )
 
         attached_volume = unattached_volume.set('attached_to', attach_to)

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -547,7 +547,7 @@ class CinderBlockDeviceAPI(object):
             volume_manager=self.cinder_volume_manager,
             expected_volume=cinder_volume,
             desired_state=u'available',
-            transient_states=(u'detaching',)
+            transient_states=(u'in-use', u'detaching')
         )
 
     def destroy_volume(self, blockdevice_id):

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -278,21 +278,17 @@ class VolumeStateMonitor:
         self.start_time = time.time()
 
     def reached_desired_state(self):
-        import traceback
-        try:
-            listed_volume = self.volume_manager.show(self.expected_volume.id)
-        except:
-            traceback.print_exc()
-            raise
-        # Could miss the expected status because race conditions.
-        # FLOC-1832
-        current_state = listed_volume.status
-        if current_state == self.desired_state:
-            return listed_volume
-        elif current_state not in self.transient_states:
-            raise UnexpectedStateException(
-                self.expected_volume, self.desired_state,
-                current_state)
+        for listed_volume in self.volume_manager.list():
+            if listed_volume.id == self.expected_volume.id:
+                # Could miss the expected status because race conditions.
+                # FLOC-1832
+                current_state = listed_volume.status
+                if current_state == self.desired_state:
+                    return listed_volume
+                elif current_state not in self.transient_states:
+                    raise UnexpectedStateException(
+                        self.expected_volume, self.desired_state,
+                        current_state)
         elapsed_time = time.time() - self.start_time
         if elapsed_time > self.time_limit:
             raise TimeoutException(

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -438,6 +438,7 @@ class CinderBlockDeviceAPI(object):
             volume_manager=self.cinder_volume_manager,
             expected_volume=requested_volume,
             desired_state=u'available',
+            transient_states=(u'creating',),
         )
         return _blockdevicevolume_from_cinder_volume(
             cinder_volume=created_volume,

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -281,6 +281,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_manager=self.nova.volumes,
             expected_volume=volume,
             desired_state=u'available',
+            transient_states=(u'detaching',),
         )
 
     def _cleanup(self, instance_id, volume):
@@ -402,4 +403,4 @@ class CinderAttachmentTests(SynchronousTestCase):
                 desired_state=u'in-use',
                 transient_states=(u'attaching',),
             )
-        self.assertEqual(e.unexpected_state, u'available')
+        self.assertEqual(e.exception.unexpected_state, u'available')

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -398,7 +398,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             wait_for_volume_state(
                 volume_manager=self.cinder.volumes,
                 expected_volume=attached_volume,
-                expected_status=u'in-use',
+                desired_state=u'in-use',
                 transient_states=(u'attaching',),
             )
         self.assertEqual(e.unexpected_state, u'available')

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -281,7 +281,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_manager=self.nova.volumes,
             expected_volume=volume,
             desired_state=u'available',
-            transient_states=(u'detaching',),
+            transient_states=(u'in-use', u'detaching'),
         )
 
     def _cleanup(self, instance_id, volume):

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -111,6 +111,7 @@ class CinderBlockDeviceAPIInterfaceTests(
             volume_manager=cinder_client.volumes,
             expected_volume=requested_volume,
             desired_state=u'available',
+            transient_states=(u'creating',),
         )
         self.assertEqual([], self.api.list_volumes())
 
@@ -300,7 +301,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
-            desired_state=u'available')
+            desired_state=u'available', transient_states=(u'creating',))
 
         devices_before = set(FilePath('/dev').children())
 
@@ -343,7 +344,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
-            desired_state=u'available')
+            desired_state=u'available', transient_states=(u'creating',))
 
         devices_before = set(FilePath('/dev').children())
 
@@ -386,7 +387,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
-            desired_state=u'available')
+            desired_state=u'available', transient_states=(u'creating',))
 
         attached_volume = self.nova.volumes.create_server_volume(
             server_id=instance_id,

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -42,7 +42,7 @@ from ..test.blockdevicefactory import (
 )
 from ....testtools import run_process
 
-from ..cinder import wait_for_volume
+from ..cinder import wait_for_volume_state, UnexpectedStateException
 
 # Tests requiring virsh can currently only be run on a devstack installation
 # that is not within our CI system. This will be addressed with FLOC-2972.
@@ -107,9 +107,10 @@ class CinderBlockDeviceAPIInterfaceTests(
             cinder_client.volumes.delete,
             requested_volume.id,
         )
-        wait_for_volume(
+        wait_for_volume_state(
             volume_manager=cinder_client.volumes,
-            expected_volume=requested_volume
+            expected_volume=requested_volume,
+            desired_state=u'available',
         )
         self.assertEqual([], self.api.list_volumes())
 
@@ -275,10 +276,10 @@ class CinderAttachmentTests(SynchronousTestCase):
 
     def _detach(self, instance_id, volume):
         self.nova.volumes.delete_server_volume(instance_id, volume.id)
-        return wait_for_volume(
+        return wait_for_volume_state(
             volume_manager=self.nova.volumes,
             expected_volume=volume,
-            expected_status=u'available',
+            desired_state=u'available',
         )
 
     def _cleanup(self, instance_id, volume):
@@ -297,8 +298,9 @@ class CinderAttachmentTests(SynchronousTestCase):
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
-        volume = wait_for_volume(
-            volume_manager=self.cinder.volumes, expected_volume=cinder_volume)
+        volume = wait_for_volume_state(
+            volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
+            desired_state=u'available')
 
         devices_before = set(FilePath('/dev').children())
 
@@ -307,10 +309,11 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_id=volume.id,
             device=None,
         )
-        volume = wait_for_volume(
+        volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
-            expected_status=u'in-use',
+            desired_state=u'in-use',
+            transient_states=(u'attaching',),
         )
 
         devices_after = set(FilePath('/dev').children())
@@ -338,8 +341,9 @@ class CinderAttachmentTests(SynchronousTestCase):
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
-        volume = wait_for_volume(
-            volume_manager=self.cinder.volumes, expected_volume=cinder_volume)
+        volume = wait_for_volume_state(
+            volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
+            desired_state=u'available')
 
         devices_before = set(FilePath('/dev').children())
 
@@ -348,10 +352,11 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_id=volume.id,
             device=None,
         )
-        volume = wait_for_volume(
+        volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
-            expected_status=u'in-use',
+            desired_state=u'in-use',
+            transient_states=(u'attaching',),
         )
 
         devices_after = set(FilePath('/dev').children())
@@ -379,8 +384,9 @@ class CinderAttachmentTests(SynchronousTestCase):
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
-        volume = wait_for_volume(
-            volume_manager=self.cinder.volumes, expected_volume=cinder_volume)
+        volume = wait_for_volume_state(
+            volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
+            desired_state=u'available')
 
         attached_volume = self.nova.volumes.create_server_volume(
             server_id=instance_id,
@@ -388,9 +394,11 @@ class CinderAttachmentTests(SynchronousTestCase):
             device=None,
         )
 
-        with self.assertRaises(Exception):
-            wait_for_volume(
+        with self.assertRaises(UnexpectedStateException) as e:
+            wait_for_volume_state(
                 volume_manager=self.cinder.volumes,
                 expected_volume=attached_volume,
                 expected_status=u'in-use',
+                transient_states=(u'attaching',),
             )
+        self.assertEqual(e.unexpected_state, u'available')

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -7,7 +7,7 @@ basic assumptions/understandings of how Cinder works in the real world.
 
 from twisted.trial.unittest import SkipTest, SynchronousTestCase
 
-from ..cinder import wait_for_volume
+from ..cinder import wait_for_volume_state
 from ..test.blockdevicefactory import (
     InvalidConfig,
     ProviderType, get_blockdeviceapi_args,
@@ -51,9 +51,10 @@ class VolumesCreateTests(SynchronousTestCase):
             metadata=expected_metadata
         )
         self.addCleanup(self.cinder_volumes.delete, new_volume)
-        listed_volume = wait_for_volume(
+        listed_volume = wait_for_volume_state(
             volume_manager=self.cinder_volumes,
             expected_volume=new_volume,
+            desired_state=u'available',
         )
 
         expected_items = set(expected_metadata.items())
@@ -84,16 +85,18 @@ class VolumesSetMetadataTests(SynchronousTestCase):
         new_volume = self.cinder_volumes.create(size=100)
         self.addCleanup(self.cinder_volumes.delete, new_volume)
 
-        listed_volume = wait_for_volume(
+        listed_volume = wait_for_volume_state(
             volume_manager=self.cinder_volumes,
             expected_volume=new_volume,
+            desired_state=u'available',
         )
 
         self.cinder_volumes.set_metadata(new_volume, expected_metadata)
 
-        listed_volume = wait_for_volume(
+        listed_volume = wait_for_volume_state(
             volume_manager=self.cinder_volumes,
-            expected_volume=new_volume
+            expected_volume=new_volume,
+            desired_state=u'available',
         )
 
         expected_items = set(expected_metadata.items())

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -55,6 +55,7 @@ class VolumesCreateTests(SynchronousTestCase):
             volume_manager=self.cinder_volumes,
             expected_volume=new_volume,
             desired_state=u'available',
+            transient_states=(u'creating',),
         )
 
         expected_items = set(expected_metadata.items())
@@ -89,6 +90,7 @@ class VolumesSetMetadataTests(SynchronousTestCase):
             volume_manager=self.cinder_volumes,
             expected_volume=new_volume,
             desired_state=u'available',
+            transient_states=(u'creating',),
         )
 
         self.cinder_volumes.set_metadata(new_volume, expected_metadata)


### PR DESCRIPTION
This PR adds a more explicit check of the states that Cinder volumes traverse when performing create/delete and attach/detach operations.  This allows unexpected states to raise a more useful exception. See, in particular, the test `test_disk_attachment_fails_with_conflicting_disk` in `test_cinder.py`, which now sees an UnexpectedStateError rather than a TimeoutError.  The error is both more informative and occurs sooner.

To quote https://github.com/ClusterHQ/flocker/pull/1910:
"Unfortunately these tests can not be run using our existing CI system and are currently being run manually on a devstack instance running on an on-metal Rackspace server. To run these tests, ssh into the Rackspace server then ssh into the guest node on this server. The code has already been checked out on this guest and the tests can be run there. Please ask [@zubron] for connection details."

There are still some potential problems, such as another instance attaching a volume before the polling sees a final 'available' state, but these can be worked out for FLOC-1832.


