### PR TITLE
Update link to "installing" documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Flocker is also tested using `continuous integration`_.
 
 .. _ClusterHQ: https://clusterhq.com/
 .. _Twisted: https://twistedmatrix.com/trac/
-.. _installing Flocker: https://docs.clusterhq.com/en/latest/using/installing/index.html
+.. _installing Flocker: https://docs.clusterhq.com/en/latest/install/index.html
 .. _tutorial: https://docs.clusterhq.com/en/latest/using/tutorial/index.html
 .. _features of Flocker and its architecture: https://docs.clusterhq.com/en/latest/introduction/index.html
 .. _unittest: https://docs.python.org/2/library/unittest.html


### PR DESCRIPTION
The link was broken, probably pointing to an old url.