### PR TITLE
[FLOC-2974] Release Flocker 1.3.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 Flocker 1.3.0 (2015-09-04)
 =====================================
 
-- Stricter check to determine attached blockdevice path on Cinder backend. (FLOC-2859)
+- Fixed a bug where OpenStack Cinder volumes could be mapped to the wrong device and therefore mounted in the wrong location. (FLOC-2859)
 - Reduce logs generated from EBS storage driver on success path. (FLOC-2929)
 
 Flocker 1.2.0 (2015-08-25)

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Flocker 1.3.0 (2015-09-04)
+=====================================
+
+- New Flocker API endpoints to create, list, renew, and delete lease on a dataset.
+- Flocker now works on servers where SELinux is enabled. (FLOC-2417)
+- Stricter check to determine attached blockdevice path on Cinder backend. (FLOC-2859)
+- Reduce logs generated from EBS storage driver on success path. (FLOC-2929)
+
 Flocker 1.2.0 (2015-08-25)
 =====================================
 

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,6 @@
 Flocker 1.3.0 (2015-09-04)
 =====================================
 
-- New Flocker API endpoints to create, list, renew, and delete lease on a dataset.
-- Flocker now works on servers where SELinux is enabled. (FLOC-2417)
 - Stricter check to determine attached blockdevice path on Cinder backend. (FLOC-2859)
 - Reduce logs generated from EBS storage driver on success path. (FLOC-2929)
 
@@ -13,6 +11,8 @@ Flocker 1.2.0 (2015-08-25)
 - Flocker ``.deb`` and ``.rpm`` packages no longer declare any dependency on a Docker package.
   This allows users to install any version of Docker.
   Users must now install Docker on agent nodes before installing Flocker. (FLOC-2447)
+- Flocker's container management functionality now integrates with SELinux.
+  Flocker can now be used in ``SELinux=enforcing`` environments. (FLOC-2417)
 
 Flocker 1.1.0 (2015-08-13)
 ==========================

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,8 +13,6 @@ You can learn more about where we might be going with future releases by:
 v1.3
 ====
 
-* Flocker API has new endpoints to create, list, renew, and delete lease on a dataset.
-* Flocker now works on servers where ``SELinux`` is enabled.
 * Flocker is more accurate in figuring out attached block device path on ``Cinder`` backend.
 * Flocker now has smaller log footprint from ``EBS`` storage driver on success path.
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,7 +14,6 @@ v1.3
 ====
 
 * Fixed a bug where OpenStack Cinder volumes could be mapped to the wrong device and therefore mounted in the wrong location.
-* Flocker now has smaller log footprint from ``EBS`` storage driver on success path.
 
 v1.2
 ====

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,7 +13,7 @@ You can learn more about where we might be going with future releases by:
 v1.3
 ====
 
-* Flocker is more accurate in figuring out attached block device path on ``Cinder`` backend.
+* Fixed a bug where OpenStack Cinder volumes could be mapped to the wrong device and therefore mounted in the wrong location.
 * Flocker now has smaller log footprint from ``EBS`` storage driver on success path.
 
 v1.2

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,14 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.3
+====
+
+* Flocker API has new endpoints to create, list, renew, and delete lease on a dataset.
+* Flocker now works on servers where ``SELinux`` is enabled.
+* Flocker is more accurate in figuring out attached blockdevice path on ``Cinder`` backend.
+* Flocker now has smaller log footprint from ``EBS`` storage driver on success path.
+
 v1.2
 ====
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -15,7 +15,7 @@ v1.3
 
 * Flocker API has new endpoints to create, list, renew, and delete lease on a dataset.
 * Flocker now works on servers where ``SELinux`` is enabled.
-* Flocker is more accurate in figuring out attached blockdevice path on ``Cinder`` backend.
+* Flocker is more accurate in figuring out attached block device path on ``Cinder`` backend.
 * Flocker now has smaller log footprint from ``EBS`` storage driver on success path.
 
 v1.2


### PR DESCRIPTION
Reasoning for Buildbot failures:

1. http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fcentos-7%2Faws/builds/2006/steps/trial/logs/stdio
Failed due to flocker.acceptance.endtoend.test_dockerplugin failure. This test seems to have failed in the recent runs as well: http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fcentos-7%2Faws/builds/1992/steps/trial/logs/stdio

-> Waiting on confirmation that this is currently being worked on.

2. http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fubuntu-14.04%2Faws/builds/2054/steps/trial/logs/stdio
-> Known issue: FLOC-1384

3. http://build.clusterhq.com/builders/flocker-centos-7/builds/6516/steps/trial/logs/stdio
``test_pull_image_if_necessary`` is an intermittent known failure (https://zulip.com/#narrow/stream/engineering/topic/test_pull_timeout).