### PR TITLE
[FLOC-2975] Cleanup PKI keys used for testing

### DIFF
--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -203,6 +203,19 @@ class VirtIOClient:
         communication to the routing gateway (in particular from VM
         guest to VM host), where a MITM attack is unlikely.
 
+        The tests require that disks are attached using libvirt, but not
+        using Cinder, as the problem they test is libvirt disks that are
+        not known by Cinder.  Note, this rules out solutions using
+        ``mknod`` directly on the guest.
+
+        Creating a TLS connection is one of the simplest ways to set-up
+        libvirtd to listen on a network socket.  Disabling the actual
+        certificate verification on both ends of the connection allows
+        connection of the TLS endpoint without sharing any files (e.g.
+        CA cert and key, or a CSR).  This means the tests are contained
+        on one guest, with only a network connection required to attach
+        and delete nodes from the host.
+
         :param instance_id: The UUID of the guest instance.
         :param FilePath tempdir: A temporary directory that will exist
             until the VirtIOClient is done.

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -189,12 +189,19 @@ class VirtIOClient:
         self.url = url
 
     @classmethod
-    def from_instance_id(cls, instance_id, tempdir):
+    def using_insecure_tls(cls, instance_id, tempdir):
         """
-        Create a connection to the host using the default gateway.
+        Create an insecure connection to the VM host.
 
         The credentials for this connection only allow unverified
-        connections to the TLS endpoint of libvirtd.
+        connections to the TLS endpoint of libvirtd.  The libvirtd
+        server must be configured to not verify the client credentials,
+        with server configuration ``tls_no_verify_certificate=1`` and
+        ``tls_no_verify_address=1``.
+
+        This would be vulnerable to MITM attacks, but is used for
+        communication to the routing gateway (in particular from VM
+        guest to VM host), where a MITM attack is unlikely.
 
         :param instance_id: The UUID of the guest instance.
         :param FilePath tempdir: A temporary directory that will exist
@@ -324,7 +331,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         host_device = "/dev/null"
         tmpdir = FilePath(self.mktemp())
         tmpdir.makedirs()
-        virtio = VirtIOClient.from_instance_id(instance_id, tmpdir)
+        virtio = VirtIOClient.using_insecure_tls(instance_id, tmpdir)
         virtio.attach_disk(host_device, "vdc")
         self.addCleanup(virtio.detach_disk, host_device)
 
@@ -369,7 +376,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         host_device = "/dev/null"
         tmpdir = FilePath(self.mktemp())
         tmpdir.makedirs()
-        virtio = VirtIOClient.from_instance_id(instance_id, tmpdir)
+        virtio = VirtIOClient.using_insecure_tls(instance_id, tmpdir)
         virtio.attach_disk(host_device, "vdb")
         self.addCleanup(virtio.detach_disk, host_device)
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-2975

This is a cleanup for the tests added in #1910 

Those tests copied PKI keys and certs into the `/etc/pki` directories, and left them there.

This PR creates the keys and certs in a temporary directory, which is removed at the end of test.

This PR also renames the factory function for the `VirtIOClient` to give a better idea of it's main characteristics; `from_instance_id` was a terrible but simple name. `using_insecure_tls` is more informative, and emphasises that this should not be used outside it's current context without detailed consideration.

To quote PR #1910:
> Unfortunately these tests can not be run using our existing CI system and are currently being run manually on a devstack instance running on an on-metal Rackspace server. To run these tests, ssh into the Rackspace server then ssh into the guest node on this server. The code has already been checked out on this guest and the tests can be run there. Please ask [@zubron] for connection details.
