### PR TITLE
[FLOC-2985] Remove duplication in block device test setup

### DIFF
--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -764,12 +764,12 @@ def get_nova_client(session, region):
 
 def cinder_from_configuration(region, cluster_id, **config):
     """
-    Build a ``CinderBlockDeviceAPI`` using configuration and credentials in
-    ``config``.
+    Build a ``CinderBlockDeviceAPI`` using configuration and credentials
+    in ``config``.
 
-    :param str region: The region "slug" for which to configure the object.
-    :param cluster_id: The unique cluster identifier for which to configure the
-        object.
+    :param str region: The Openstack region to access.
+    :param cluster_id: The unique identifier for the cluster to access.
+    :param config: A dictionary of configuration options for Openstack.
     """
     session = get_keystone_session(**config)
     cinder_client = get_cinder_client(session, region)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -881,15 +881,6 @@ class EBSBlockDeviceAPI(object):
         return _expected_device(ebs_volume.attach_data.device)
 
 
-def make_ec2_client(region, zone, access_key_id, secret_access_key):
-    return ec2_client(
-        region=region,
-        zone=zone,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
-    )
-
-
 def aws_from_configuration(region, zone, access_key_id, secret_access_key,
                            cluster_id):
     """
@@ -910,7 +901,7 @@ def aws_from_configuration(region, zone, access_key_id, secret_access_key,
     :return: A ``EBSBlockDeviceAPI`` instance using the given parameters.
     """
     return EBSBlockDeviceAPI(
-        ec2_client=make_ec2_client(
+        ec2_client=ec2_client(
             region=region,
             zone=zone,
             access_key_id=access_key_id,

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -881,6 +881,15 @@ class EBSBlockDeviceAPI(object):
         return _expected_device(ebs_volume.attach_data.device)
 
 
+def make_ec2_client(region, zone, access_key_id, secret_access_key):
+    return ec2_client(
+        region=region,
+        zone=zone,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+    )
+
+
 def aws_from_configuration(region, zone, access_key_id, secret_access_key,
                            cluster_id):
     """
@@ -901,7 +910,7 @@ def aws_from_configuration(region, zone, access_key_id, secret_access_key,
     :return: A ``EBSBlockDeviceAPI`` instance using the given parameters.
     """
     return EBSBlockDeviceAPI(
-        ec2_client=ec2_client(
+        ec2_client=make_ec2_client(
             region=region,
             zone=zone,
             access_key_id=access_key_id,

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -35,13 +35,16 @@ from ..test.test_blockdevice import (
     make_iblockdeviceapi_tests,
 )
 from ..test.blockdevicefactory import (
-    InvalidConfig, ProviderType, get_blockdeviceapi_args,
+    InvalidConfig, ProviderType, get_blockdevice_config,
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
-    get_minimum_allocatable_size,
+    get_minimum_allocatable_size, get_openstack_region,
 )
 from ....testtools import run_process
 
-from ..cinder import wait_for_volume_state, UnexpectedStateException
+from ..cinder import (
+    get_keystone_session, get_cinder_client, get_nova_client,
+    wait_for_volume_state, UnexpectedStateException
+)
 
 # Tests requiring virsh can currently only be run on a devstack installation
 # that is not within our CI system. This will be addressed with FLOC-2972.
@@ -60,17 +63,6 @@ def cinderblockdeviceapi_for_test(test_case):
         features).
     """
     return get_blockdeviceapi_with_cleanup(test_case, ProviderType.openstack)
-
-
-def openstack_clients():
-    """
-    Get OpenStack clients for use in tests.
-    """
-    try:
-        cls, kwargs = get_blockdeviceapi_args(ProviderType.openstack)
-    except InvalidConfig as e:
-        raise SkipTest(str(e))
-    return kwargs
 
 
 # ``CinderBlockDeviceAPI`` only implements the ``create`` and ``list`` parts of
@@ -95,10 +87,12 @@ class CinderBlockDeviceAPIInterfaceTests(
         Non-Flocker Volumes are not listed.
         """
         try:
-            cls, kwargs = get_blockdeviceapi_args(ProviderType.openstack)
+            config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
             raise SkipTest(str(e))
-        cinder_client = kwargs["cinder_client"]
+        session = get_keystone_session(**config)
+        region = get_openstack_region()
+        cinder_client = get_cinder_client(session, region)
         requested_volume = cinder_client.volumes.create(
             size=int(Byte(self.minimum_allocatable_size).to_GiB().value)
         )
@@ -153,11 +147,14 @@ class CinderHttpsTests(SynchronousTestCase):
         OpenStack servers always succeeds.
         """
         try:
-            cls, kwargs = get_blockdeviceapi_args(
-                ProviderType.openstack, peer_verify=False)
+            config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
             raise SkipTest(str(e))
-        self.assertTrue(self._authenticates_ok(kwargs['cinder_client']))
+        config['peer_verify'] = False
+        session = get_keystone_session(**config)
+        region = get_openstack_region()
+        cinder_client = get_cinder_client(session, region)
+        self.assertTrue(self._authenticates_ok(cinder_client))
 
     def test_verify_ca_path_no_match_fails(self):
         """
@@ -168,13 +165,19 @@ class CinderHttpsTests(SynchronousTestCase):
         path.makedirs()
         RootCredential.initialize(path, b"mycluster")
         try:
-            cls, kwargs = get_blockdeviceapi_args(
-                ProviderType.openstack, backend='openstack',
-                auth_plugin='password', password='password', peer_verify=True,
-                peer_ca_path=path.child(AUTHORITY_CERTIFICATE_FILENAME).path)
+            config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
             raise SkipTest(str(e))
-        self.assertFalse(self._authenticates_ok(kwargs['cinder_client']))
+        config['backend'] = 'openstack'
+        config['auth_plugin'] = 'password'
+        config['password'] = 'password'
+        config['peer_verify'] = True
+        config['peer_ca_path'] = path.child(
+            AUTHORITY_CERTIFICATE_FILENAME).path
+        session = get_keystone_session(**config)
+        region = get_openstack_region()
+        cinder_client = get_cinder_client(session, region)
+        self.assertFalse(self._authenticates_ok(cinder_client))
 
 
 class VirtIOClient:
@@ -277,9 +280,14 @@ class CinderAttachmentTests(SynchronousTestCase):
     Cinder volumes can be attached and return correct device path.
     """
     def setUp(self):
-        clients = openstack_clients()
-        self.cinder = clients['cinder_client']
-        self.nova = clients['nova_client']
+        try:
+            config = get_blockdevice_config(ProviderType.openstack)
+        except InvalidConfig as e:
+            raise SkipTest(str(e))
+        region = get_openstack_region()
+        session = get_keystone_session(**config)
+        self.cinder = get_cinder_client(session, region)
+        self.nova = get_nova_client(session, region)
         self.blockdevice_api = cinderblockdeviceapi_for_test(test_case=self)
 
     def _detach(self, instance_id, volume):

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -42,7 +42,7 @@ from ..test.blockdevicefactory import (
 from ....testtools import run_process
 
 from ..cinder import (
-    get_keystone_session, get_cinder_client, get_nova_client,
+    get_keystone_session, get_cinder_v1_client, get_nova_client,
     wait_for_volume_state, UnexpectedStateException
 )
 
@@ -92,7 +92,7 @@ class CinderBlockDeviceAPIInterfaceTests(
             raise SkipTest(str(e))
         session = get_keystone_session(**config)
         region = get_openstack_region_for_test()
-        cinder_client = get_cinder_client(session, region)
+        cinder_client = get_cinder_v1_client(session, region)
         requested_volume = cinder_client.volumes.create(
             size=int(Byte(self.minimum_allocatable_size).to_GiB().value)
         )
@@ -153,7 +153,7 @@ class CinderHttpsTests(SynchronousTestCase):
         config['peer_verify'] = False
         session = get_keystone_session(**config)
         region = get_openstack_region_for_test()
-        cinder_client = get_cinder_client(session, region)
+        cinder_client = get_cinder_v1_client(session, region)
         self.assertTrue(self._authenticates_ok(cinder_client))
 
     def test_verify_ca_path_no_match_fails(self):
@@ -176,7 +176,7 @@ class CinderHttpsTests(SynchronousTestCase):
             AUTHORITY_CERTIFICATE_FILENAME).path
         session = get_keystone_session(**config)
         region = get_openstack_region_for_test()
-        cinder_client = get_cinder_client(session, region)
+        cinder_client = get_cinder_v1_client(session, region)
         self.assertFalse(self._authenticates_ok(cinder_client))
 
 
@@ -286,7 +286,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             raise SkipTest(str(e))
         region = get_openstack_region_for_test()
         session = get_keystone_session(**config)
-        self.cinder = get_cinder_client(session, region)
+        self.cinder = get_cinder_v1_client(session, region)
         self.nova = get_nova_client(session, region)
         self.blockdevice_api = cinderblockdeviceapi_for_test(test_case=self)
 

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -37,7 +37,7 @@ from ..test.test_blockdevice import (
 from ..test.blockdevicefactory import (
     InvalidConfig, ProviderType, get_blockdevice_config,
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
-    get_minimum_allocatable_size, get_openstack_region,
+    get_minimum_allocatable_size, get_openstack_region_for_test,
 )
 from ....testtools import run_process
 
@@ -91,7 +91,7 @@ class CinderBlockDeviceAPIInterfaceTests(
         except InvalidConfig as e:
             raise SkipTest(str(e))
         session = get_keystone_session(**config)
-        region = get_openstack_region()
+        region = get_openstack_region_for_test()
         cinder_client = get_cinder_client(session, region)
         requested_volume = cinder_client.volumes.create(
             size=int(Byte(self.minimum_allocatable_size).to_GiB().value)
@@ -152,7 +152,7 @@ class CinderHttpsTests(SynchronousTestCase):
             raise SkipTest(str(e))
         config['peer_verify'] = False
         session = get_keystone_session(**config)
-        region = get_openstack_region()
+        region = get_openstack_region_for_test()
         cinder_client = get_cinder_client(session, region)
         self.assertTrue(self._authenticates_ok(cinder_client))
 
@@ -175,7 +175,7 @@ class CinderHttpsTests(SynchronousTestCase):
         config['peer_ca_path'] = path.child(
             AUTHORITY_CERTIFICATE_FILENAME).path
         session = get_keystone_session(**config)
-        region = get_openstack_region()
+        region = get_openstack_region_for_test()
         cinder_client = get_cinder_client(session, region)
         self.assertFalse(self._authenticates_ok(cinder_client))
 
@@ -284,7 +284,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
             raise SkipTest(str(e))
-        region = get_openstack_region()
+        region = get_openstack_region_for_test()
         session = get_keystone_session(**config)
         self.cinder = get_cinder_client(session, region)
         self.nova = get_nova_client(session, region)

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -42,7 +42,7 @@ from ..test.blockdevicefactory import (
 from ....testtools import run_process
 
 from ..cinder import (
-    get_keystone_session, get_cinder_v1_client, get_nova_client,
+    get_keystone_session, get_cinder_v1_client, get_nova_v2_client,
     wait_for_volume_state, UnexpectedStateException
 )
 
@@ -287,7 +287,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         region = get_openstack_region_for_test()
         session = get_keystone_session(**config)
         self.cinder = get_cinder_v1_client(session, region)
-        self.nova = get_nova_client(session, region)
+        self.nova = get_nova_v2_client(session, region)
         self.blockdevice_api = cinderblockdeviceapi_for_test(test_case=self)
 
     def _detach(self, instance_id, volume):

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -7,10 +7,14 @@ basic assumptions/understandings of how Cinder works in the real world.
 
 from twisted.trial.unittest import SkipTest, SynchronousTestCase
 
-from ..cinder import wait_for_volume_state
+from ..cinder import (
+    get_keystone_session, get_cinder_client, wait_for_volume_state
+)
 from ..test.blockdevicefactory import (
     InvalidConfig,
-    ProviderType, get_blockdeviceapi_args,
+    ProviderType,
+    get_openstack_region,
+    get_blockdevice_config,
 )
 from ....testtools import random_name
 
@@ -22,10 +26,12 @@ def cinder_volume_manager():
     XXX: It will not automatically clean up after itself. See FLOC-1824.
     """
     try:
-        cls, kwargs = get_blockdeviceapi_args(ProviderType.openstack)
+        config = get_blockdevice_config(ProviderType.openstack)
     except InvalidConfig as e:
         raise SkipTest(str(e))
-    return kwargs["cinder_client"].volumes
+    region = get_openstack_region()
+    session = get_keystone_session(**config)
+    return get_cinder_client(session, region).volumes
 
 
 # All of the following tests could be part of the suite returned by

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -13,7 +13,7 @@ from ..cinder import (
 from ..test.blockdevicefactory import (
     InvalidConfig,
     ProviderType,
-    get_openstack_region,
+    get_openstack_region_for_test,
     get_blockdevice_config,
 )
 from ....testtools import random_name
@@ -29,7 +29,7 @@ def cinder_volume_manager():
         config = get_blockdevice_config(ProviderType.openstack)
     except InvalidConfig as e:
         raise SkipTest(str(e))
-    region = get_openstack_region()
+    region = get_openstack_region_for_test()
     session = get_keystone_session(**config)
     return get_cinder_client(session, region).volumes
 

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -8,7 +8,7 @@ basic assumptions/understandings of how Cinder works in the real world.
 from twisted.trial.unittest import SkipTest, SynchronousTestCase
 
 from ..cinder import (
-    get_keystone_session, get_cinder_client, wait_for_volume_state
+    get_keystone_session, get_cinder_v1_client, wait_for_volume_state
 )
 from ..test.blockdevicefactory import (
     InvalidConfig,
@@ -31,7 +31,7 @@ def cinder_volume_manager():
         raise SkipTest(str(e))
     region = get_openstack_region_for_test()
     session = get_keystone_session(**config)
-    return get_cinder_client(session, region).volumes
+    return get_cinder_v1_client(session, region).volumes
 
 
 # All of the following tests could be part of the suite returned by

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -33,7 +33,7 @@ from ..test.test_blockdevice import make_iblockdeviceapi_tests
 from ..test.blockdevicefactory import (
     InvalidConfig, ProviderType, get_blockdevice_config,
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
-    get_minimum_allocatable_size, get_ec2_client,
+    get_minimum_allocatable_size, get_ec2_client_for_test,
 )
 
 TIMEOUT = 5
@@ -71,7 +71,7 @@ class EBSBlockDeviceAPIInterfaceTests(
             config = get_blockdevice_config(ProviderType.aws)
         except InvalidConfig as e:
             raise SkipTest(str(e))
-        ec2_client = get_ec2_client(config)
+        ec2_client = get_ec2_client_for_test(config)
         requested_volume = ec2_client.connection.create_volume(
             int(Byte(self.minimum_allocatable_size).to_GiB().value),
             ec2_client.zone)

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -31,9 +31,9 @@ from .._logging import (
 from ..test.test_blockdevice import make_iblockdeviceapi_tests
 
 from ..test.blockdevicefactory import (
-    InvalidConfig, ProviderType, get_blockdeviceapi_args,
+    InvalidConfig, ProviderType, get_blockdevice_config,
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
-    get_minimum_allocatable_size,
+    get_minimum_allocatable_size, get_ec2_client,
 )
 
 TIMEOUT = 5
@@ -68,10 +68,10 @@ class EBSBlockDeviceAPIInterfaceTests(
         belonging to the current Flocker cluster.
         """
         try:
-            cls, kwargs = get_blockdeviceapi_args(ProviderType.aws)
+            config = get_blockdevice_config(ProviderType.aws)
         except InvalidConfig as e:
             raise SkipTest(str(e))
-        ec2_client = kwargs["ec2_client"]
+        ec2_client = get_ec2_client(config)
         requested_volume = ec2_client.connection.create_volume(
             int(Byte(self.minimum_allocatable_size).to_GiB().value),
             ec2_client.zone)

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -139,7 +139,10 @@ def get_blockdevice_config(provider_type):
             "the tests (%s)." % (provider_type.name, provider_environment.name)
         )
 
-    # XXX - make this an exception, and always configure externally?
+    # XXX - If provider type is Rackspace, we add the auth_plugin config
+    # here.  The CI system should be configured to provide this
+    # parameter as part of the config, to match the documented way of
+    # configuring Rackspace.
     if provider_environment == ProviderType.rackspace:
         section['auth_plugin'] = 'rackspace'
 

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -140,9 +140,9 @@ def get_blockdevice_config(provider_type):
 
     # XXX - make this an exception, and always configure externally?
     if provider_environment == ProviderType.rackspace:
-        config['auth_plugin'] = 'rackspace'
+        section['auth_plugin'] = 'rackspace'
 
-    return config
+    return section
 
 
 def get_openstack_region_for_test():

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -75,8 +75,9 @@ def _provider_for_provider_type(provider_type):
 
 def get_blockdevice_config(provider_type):
     """
-    Get initializer arguments suitable for use in the instantiation of an
-    ``IBlockDeviceAPI`` implementation compatible with the given provider.
+    Get configuration dictionary suitable for use in the instantiation
+    of an ``IBlockDeviceAPI`` implementation compatible with the given
+    provider type.
 
     :param provider_type: A provider type the ``IBlockDeviceAPI`` is to
         be compatible with.  A value from ``ProviderType``.
@@ -146,13 +147,12 @@ def get_blockdevice_config(provider_type):
 
 
 def get_openstack_region_for_test():
-    # The execution context should have set up this environment variable,
-    # probably by inspecting some cloud-y state to discover where this code is
-    # running.  Since the execution context is probably a stupid shell script,
-    # fix the casing of the region name here (keystone is very sensitive to
-    # case) instead of forcing me to figure out how to upper case things in
-    # bash (I already learned a piece of shell syntax today, once is all I can
-    # take).
+    """
+    Return a default Openstack region for testing.
+
+    The default region comes from an environment variable.  Keystone
+    uses case-sensitive regions, so ensure region is uppercase.
+    """
     region = environ.get('FLOCKER_FUNCTIONAL_TEST_OPENSTACK_REGION')
     if region is not None:
         region = region.upper()
@@ -161,13 +161,11 @@ def get_openstack_region_for_test():
 
 def _openstack(cluster_id, config):
     """
-    Create Cinder and Nova volume managers suitable for use in the creation of
-    a ``CinderBlockDeviceAPI``.  They will be configured to use the region
-    where the server that is running this code is running.
+    Create an IBlockDeviceAPI provider configured to use the Openstack
+    region where the server that is running this code is running.
 
     :param config: Any additional configuration (possibly provider-specific)
-        necessary to authenticate a session for use with the CinderClient and
-        NovaClient.
+        necessary to authenticate a keystone session.
     :return: A CinderBlockDeviceAPI instance.
     """
     region = get_openstack_region_for_test()
@@ -175,6 +173,10 @@ def _openstack(cluster_id, config):
 
 
 def get_ec2_client_for_test(config):
+    """
+    Get a simple EC2 client, configured for the test region.
+    """
+
     # We just get the credentials from the config file.
     # We ignore the region specified in acceptance test configuration,
     # and instead get the region from the zone of the host.
@@ -191,11 +193,11 @@ def get_ec2_client_for_test(config):
 
 def _aws(cluster_id, config):
     """
-    Create an EC2 client suitable for use in the creation of an
-    ``EBSBlockDeviceAPI``.
+    Create an IBlockDeviceAPI provider configured to use the AWS EC2
+    region where the server that is running this code is running.
 
-    :param bytes access_key: "access_key" credential for EC2.
-    :param bytes secret_access_key: "secret_access_token" EC2 credential.
+    :param config: Any additional configuration (possibly provider-specific)
+        necessary to authenticate an EC2 session.
     :return: An EBSBlockDeviceAPI instance.
     """
     return EBSBlockDeviceAPI(


### PR DESCRIPTION
The block device test code duplicates code for setting up `IBlockDeviceAPI` instances. In `master`, a good example is https://github.com/ClusterHQ/flocker/blob/9ebddf05cf6fc68dbd0f1af5a1d983efa232d716/flocker/node/agents/test/blockdevicefactory.py#L181-L189 which duplicates https://github.com/ClusterHQ/flocker/blob/9ebddf05cf6fc68dbd0f1af5a1d983efa232d716/flocker/node/agents/cinder.py#L773-L782.

This PR rewrites this code to reduce this repetition. The main change is that `get_blockdeviceapi_args`, which returned a factory function and a dictionary to apply to that function, is replaced by a simpler `get_blockdevice_config`, which just returns the configuration stanza relevant to the tested platform.  This means the caller needs to do a bit more work (see the change to the `get_blockdeviceapi` function, for example), but the work that is getting done is more explicit.

For the Openstack clients in particular, the tests now use utility functions to obtain the (Cinder and Nova) clients that they need. Again, while more verbose, this is more clear than the previous code, which created a dictionary containing all clients, and then extracted the required clients from the dictionary.

Where previously, configuration values that needed to be overridden for a test were passed as parameters to `get_blockdeviceapi_args`, they can now be set explicitly in the test, making the changes more explicit. Compare https://github.com/ClusterHQ/flocker/blob/9ebddf05cf6fc68dbd0f1af5a1d983efa232d716/flocker/node/agents/functional/test_cinder.py#L170-L176 in `master` with https://github.com/ClusterHQ/flocker/blob/d8b67278ca90f48ae9cb7f412518eac03f392c89/flocker/node/agents/functional/test_cinder.py#L167-L179 in this branch.

There are some changes to the AWS code, as well, to keep the changes consistent, but the changes for AWS were kept as minimal as possible.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1917)
<!-- Reviewable:end -->
