### PR TITLE
[FLOC-3008] Idempotent repo installation on CentOS

### DIFF
--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -232,12 +232,14 @@ def install_commands_yum(package_name, distribution, package_source,
     :return: a sequence of commands to run on the distribution
     """
     commands = [
-        # May have been previously installed by previous install run, so do
-        # update instead of install:
-        run(command="yum update -y " + get_repository_url(
-            distribution=distribution,
-            flocker_version=get_installable_version(version))),
-    ]
+        # If package has previously been installed, 'yum install' fails,
+        # so check if it is installed first.
+        run(
+            command="yum list installed clusterhq-release || yum install -y {0}".format(  # noqa
+                get_repository_url(
+                    distribution=distribution,
+                    flocker_version=get_installable_version(version)))),
+        ]
 
     if base_url is not None:
         repo = dedent(b"""\


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-3008

The command to install the repo YUM package on CentOS needs to work on both systems where Flocker has been installed previously, and on systems where it hasn't.

Although `yum install` handles a repeated install fairly cleanly, it does exit with non-zero, causing problems for our automated testing.

A previous attempt to solve this changed the command to `yum update` which works on systems where Flocker has been installed before, but fails on fresh systems.

The whole exercise was obscured by the fact that for Buildbot tests, another repo is added to make the branch repos available, thus masking the absence of the production repo, until the actual instructions in the docs are followed.

This PR checks whether the yum package is installed before attempting to install it, thus working in all environments.

To test, start a Docker instance using `docker run -it --rm centos:7 /bin/bash`, and then run the first command in the Installing on CentOS instructions.

For 1.3.0, these instructions are at https://docs.clusterhq.com/en/1.3.0/install/install-node.html#installing-on-centos-7 and running the first command will fail with non-zero exit.

Replacing `yum update` with `yum install` in this command will succeed on the first attempt, but fail for subsequent attempts.

Running the new command from this branch http://build.clusterhq.com/results/docs/yum-install-update-FLOC-3008/build-9900/install/install-node.html#installing-on-centos-7 should work, no matter how many times you run it. However, a real error (e.g. changing the URL to point to a non-existent file) will fail with non-zero status, as expected and desired.