### PR TITLE
[FLOC-3016] Add support for ZFS 0.6.5

### DIFF
--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -877,7 +877,9 @@ def task_create_flocker_pool_file():
     return sequence([
         run('mkdir -p /var/opt/flocker'),
         run('truncate --size 10G /var/opt/flocker/pool-vdev'),
-        run('zpool create flocker /var/opt/flocker/pool-vdev'),
+        # XXX - See FLOC-3018
+        run('ZFS_MODULE_LOADING=yes '
+            'zpool create flocker /var/opt/flocker/pool-vdev'),
     ])
 
 

--- a/vagrant/tutorial/post-reboot-bootstrap.py
+++ b/vagrant/tutorial/post-reboot-bootstrap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# This script builds the base flocker-dev box.
+# This script builds the base flocker-tutorial box.
 
 import sys
 import os
@@ -102,7 +102,14 @@ check_call(['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg'])
 # convenient for a demo in a VM.
 check_call(['mkdir', '-p', '/var/opt/flocker'])
 check_call(['truncate', '--size', '1G', '/var/opt/flocker/pool-vdev'])
-check_call(['zpool', 'create', 'flocker', '/var/opt/flocker/pool-vdev'])
+# ZFS 0.6.5 stopped loading the module stack. This additional environment
+# variable makes it follow the old behaviour.  However, support for this
+# will be removed in a future release.  See FLOC-3016
+environ = os.environ.copy()
+environ['ZFS_MODULE_LOADING'] = 'yes'
+check_call(
+    ['zpool', 'create', 'flocker', '/var/opt/flocker/pool-vdev'],
+    env=environ)
 
 # Move SSH private key into place so ZFS agent can use it until we remove
 # SSH completely in FLOC-1665. The Vagrantfile copied it over, and it's

--- a/vagrant/tutorial/post-reboot-bootstrap.py
+++ b/vagrant/tutorial/post-reboot-bootstrap.py
@@ -104,7 +104,7 @@ check_call(['mkdir', '-p', '/var/opt/flocker'])
 check_call(['truncate', '--size', '1G', '/var/opt/flocker/pool-vdev'])
 # ZFS 0.6.5 stopped loading the module stack. This additional environment
 # variable makes it follow the old behaviour.  However, support for this
-# will be removed in a future release.  See FLOC-3016
+# will be removed in a future release.  See FLOC-3018
 environ = os.environ.copy()
 environ['ZFS_MODULE_LOADING'] = 'yes'
 check_call(


### PR DESCRIPTION
ZFS 0.6.5 has stopped loading modules when the `zpool` command is run.  This prevents our Vagrant Tutorial box from building, and may cause problems for people using our instructions to build a ZFS backend.

It is possible to add the environment variable `ZFS_MODULE_LOADING=yes` to continue to load modules, as for older versions of ZFS.  This is a temporary provision in the ZFS code, which will be removed at a later date. This PR applies this to our ZFS commands, to ensure our tests continue to pass when ZFS 0.6.5 is installed.

An additional issue https://clusterhq.atlassian.net/browse/FLOC-3018 exists to provide a more permanent solution.

As this issue prevents a test from passing, I would like to merge it, even if some other tests fail: particularly those that do not deal with ZFS, and in particular the acceptance tests that are currently running up against AWS request limits.