### PR TITLE
[FLOC-3017] Allow run-acceptance-tests to boot devstack guests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ Flocker 1.4.0.dev1 (2015-09-08)
 ===============================
 
 - Improved the error handling when Cinder volumes enter an unexpected state. (FLOC-2970)
+- ``run-acceptance-tests`` now supports all OpenStack variants, not just RackSpace. (FLOC-3017)
 
 Flocker 1.3.0 (2015-09-04)
 =====================================

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -791,6 +791,34 @@ class RunOptions(Options):
             package_source, dataset_backend, "rackspace", provider_config
         )
 
+    def _runner_OPENSTACK(self, package_source, dataset_backend,
+                          provider_config):
+        """
+        :param PackageSource package_source: The source of omnibus packages.
+        :param DatasetBackend dataset_backend: A ``DatasetBackend`` constant.
+        :param provider_config: The ``openstack`` section of the acceptance
+            testing configuration file.  The section of the configuration
+            file should look something like:
+
+               openstack:
+                 auth_plugin: <auth_plugin, one of "password" or "apikey">
+                 auth_url: <keystone_url, e.g. "https://192.168.1.101:5000/v2.0/tokens/">
+                 region: <region, e.g. "RegionOne">
+                 tenant: <tenant_name e.g. "demo">
+                 username: <username>
+                 secret: <password or apikey>
+                 keyname: <ssh-key-name>
+                 images:
+                   ubuntu-14.04: <image_name, e.g. "ubuntu-14_04">
+                   centos-7: image_id, e.g. "327637d0-b744-4567-837e-100f01017d56">  # noqa
+                 flavour: <flavour, e.g. "m1.large">
+
+        :see: :ref:`acceptance-testing-openstack-config`
+        """
+        return self._libcloud_runner(
+            package_source, dataset_backend, "openstack", provider_config
+        )
+
     def _runner_AWS(self, package_source, dataset_backend,
                     provider_config):
         """

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -171,21 +171,26 @@ To run the acceptance tests on Rackspace, you need:
 
 - An OpenStack account and the associated password or API key.
 - The URL of the OpenStack keystone service.
-- an ssh-key registered with the OpenStack account.
+- An ssh-key registered with the OpenStack account.
+- The OpenStack image_id for supported Flocker node operating systems.
+- The OpenStack flavour (size) to use for acceptance test nodes.
 
 To use the OpenStack provider, the configuration file should include an item like:
 
 .. code-block:: yaml
 
    openstack:
-     auth_plugin: "`password` or `apikey`"
-     auth_url: "https://192.168.1.101:5000/v2.0/tokens/"
-     region: <openstack region, e.g. "RegionOne">
+     auth_plugin: <auth_plugin, one of "password" or "apikey">
+     auth_url: <keystone_url, e.g. "https://192.168.1.101:5000/v2.0/tokens/">
+     region: <region, e.g. "RegionOne">
+     tenant: <tenant, e.g. "demo">
      username: <username>
-     password: <password>
+     secret: <password or apikey>
      keyname: <ssh-key-name>
-
-.. note:: If you use ``auth_plugin: apikey`` you will need to include a ``key: <api_key>`` entry instead of a password.
+     images:
+       ubuntu-14.04: <image_name, e.g. "ubuntu-14_04">
+       centos-7: image_id, e.g. "327637d0-b744-4567-837e-100f01017d56">  # noqa
+     flavour: <flavour, e.g. "m1.large">
 
 You will need a ssh agent running with access to the corresponding private key.
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -162,6 +162,42 @@ Rackspace can use these dataset backends:
 
   admin/run-acceptance-tests --distribution centos-7 --provider rackspace --config-file config.yml
 
+.. _acceptance-testing-openstack-config:
+
+OpenStack
+~~~~~~~~~
+
+To run the acceptance tests on Rackspace, you need:
+
+- An OpenStack account and the associated password or API key.
+- The URL of the OpenStack keystone service.
+- an ssh-key registered with the OpenStack account.
+
+To use the OpenStack provider, the configuration file should include an item like:
+
+.. code-block:: yaml
+
+   openstack:
+     auth_plugin: "`password` or `apikey`"
+     auth_url: "https://192.168.1.101:5000/v2.0/tokens/"
+     region: <openstack region, e.g. "RegionOne">
+     username: <username>
+     password: <password>
+     keyname: <ssh-key-name>
+
+.. note:: If you use ``auth_plugin: apikey`` you will need to include a ``key: <api_key>`` entry instead of a password.
+
+You will need a ssh agent running with access to the corresponding private key.
+
+Openstack can use these dataset backends:
+
+  * :ref:`OpenStack<openstack-dataset-backend>`.
+  * :ref:`ZFS<zfs-dataset-backend>`.
+  * :ref:`Loopback<loopback-dataset-backend>`.
+
+.. prompt:: bash $
+
+  admin/run-acceptance-tests --distribution centos-7 --provider openstack --config-file config.yml
 
 .. _acceptance-testing-aws-config:
 

--- a/docs/gettinginvolved/example-acceptance.yml
+++ b/docs/gettinginvolved/example-acceptance.yml
@@ -14,6 +14,17 @@ rackspace:
   key: "33333333333333333333333333333333"
   keyname: "your.rackspace.ssh.key.identifier"
 
+openstack:
+  # See ex_force_auth_version in https://libcloud.readthedocs.org/en/latest/compute/drivers/openstack.html
+  auth_plugin: "`password` or `apikey`"
+  # See ex_force_auth_url in https://libcloud.readthedocs.org/en/latest/compute/drivers/openstack.html
+  auth_url: "https://192.168.1.101:5000/v2.0/tokens/"
+  username: "your.openstack.username"
+  password: "33333333333333333333333333333333"
+  # OR key: "<api_key> if using `auth_plugin: apikey`"
+  region: "RegionOne"
+  keyname: "your.ssh.key.identifier"
+
 managed:
   addresses:
     - "192.0.2.15"

--- a/docs/gettinginvolved/example-acceptance.yml
+++ b/docs/gettinginvolved/example-acceptance.yml
@@ -23,7 +23,12 @@ openstack:
   password: "33333333333333333333333333333333"
   # OR key: "<api_key> if using `auth_plugin: apikey`"
   region: "RegionOne"
+  tenant: <tenant_name e.g. "demo">
   keyname: "your.ssh.key.identifier"
+  images:
+    ubuntu-14.04: <image_name, e.g. "ubuntu-14_04">
+    centos-7: image_id, e.g. "327637d0-b744-4567-837e-100f01017d56">  # noqa
+  flavour: <flavour, e.g. "m1.large">
 
 managed:
   addresses:

--- a/flocker/provision/__init__.py
+++ b/flocker/provision/__init__.py
@@ -7,11 +7,13 @@ Provisioning for acceptance tests.
 from ._common import PackageSource, Variants
 from ._install import provision, configure_cluster
 from ._rackspace import rackspace_provisioner
+from ._openstack import openstack_provisioner
 from ._aws import aws_provisioner
 from ._ca import Certificates
 
 CLOUD_PROVIDERS = {
     'rackspace': rackspace_provisioner,
+    'openstack': openstack_provisioner,
     'aws': aws_provisioner,
 }
 

--- a/flocker/provision/_openstack.py
+++ b/flocker/provision/_openstack.py
@@ -13,16 +13,22 @@ from ._ssh import run_remotely
 
 from ._effect import sequence
 
+# XXX: Copied from _aws. Needs refactoring
+_usernames = {
+    'centos-7': 'centos',
+    'ubuntu-14.04': 'ubuntu',
+    'ubuntu-15.04': 'ubuntu',
+}
+
 
 def get_default_username(distribution):
     """
     Return the username available by default on a system.
 
     :param str distribution: Name of the operating system distribution
-    :return str: The username made available by Rackspace for this
-        distribution.
+    :return str: The username made available by AWS for this distribution.
     """
-    return 'root'
+    return _usernames[distribution]
 
 
 def provision_openstack(node, package_source, distribution, variants):
@@ -52,13 +58,6 @@ def provision_openstack(node, package_source, distribution, variants):
     ))
 
     return sequence(commands)
-
-
-IMAGE_NAMES = {
-    'centos-7': u'CentOS 7 (PVHVM)',
-    'ubuntu-14.04': u'Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)',
-    'ubuntu-15.04': u'Ubuntu 15.04 (Vivid Vervet) (PVHVM)',
-}
 
 
 def openstack_provisioner(auth_url, auth_plugin, username, secret, region,

--- a/flocker/provision/_openstack.py
+++ b/flocker/provision/_openstack.py
@@ -1,0 +1,117 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+OpenStack provisioner.
+"""
+
+from ._libcloud import LibcloudProvisioner
+from ._install import (
+    provision,
+    task_open_control_firewall,
+)
+from ._ssh import run_remotely
+
+from ._effect import sequence
+
+
+def get_default_username(distribution):
+    """
+    Return the username available by default on a system.
+
+    :param str distribution: Name of the operating system distribution
+    :return str: The username made available by Rackspace for this
+        distribution.
+    """
+    return 'root'
+
+
+def provision_openstack(node, package_source, distribution, variants):
+    """
+    Provision flocker on this node.
+
+    :param LibcloudNode node: Node to provision.
+    :param PackageSource package_source: See func:`task_install_flocker`
+    :param bytes distribution: See func:`task_install_flocker`
+    :param set variants: The set of variant configurations to use when
+        provisioning
+    """
+    commands = []
+    commands.append(run_remotely(
+        username=get_default_username(distribution),
+        address=node.address,
+        commands=sequence([
+            provision(
+                package_source=package_source,
+                distribution=node.distribution,
+                variants=variants,
+            ),
+            # https://clusterhq.atlassian.net/browse/FLOC-1550
+            # This should be part of ._install.configure_cluster
+            task_open_control_firewall(node.distribution),
+        ]),
+    ))
+
+    return sequence(commands)
+
+
+IMAGE_NAMES = {
+    'centos-7': u'CentOS 7 (PVHVM)',
+    'ubuntu-14.04': u'Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)',
+    'ubuntu-15.04': u'Ubuntu 15.04 (Vivid Vervet) (PVHVM)',
+}
+
+
+def openstack_provisioner(auth_url, auth_plugin, username, secret, region,
+                          keyname, images, flavour, tenant):
+    """
+    Create a LibCloudProvisioner for provisioning nodes on openstack.
+
+    :param bytes auth_url: The keystone URL.
+    :param bytes auth_plugin: The OpenStack authentication mechanism. One of
+        password or apikey.
+    :param bytes username: The user to connect to with.
+    :param bytes secret: The password or API key associated with the user.
+    :param bytes region: The region in which to launch the instance.
+    :param bytes keyname: The name of an existing ssh public key configured in
+       openstack. The provision step assumes the corresponding private key is
+       available from an agent.
+    :param dict images: A mapping of supported operating systems to a
+        corresponding OpenStack image name or image ID.
+    :param bytes flavour: A flavour name or flavour ID available in the target
+        OpenStack installation.
+    :param bytes tenant: The name of an OpenStack tenant or project.
+    """
+    # Import these here, so that this can be imported without
+    # installng libcloud.
+    from libcloud.compute.providers import get_driver, Provider
+
+    # LibCloud chooses OpenStack auth plugins using a weird naming scheme.
+    # See https://libcloud.readthedocs.org/en/latest/compute/drivers/openstack.html#connecting-to-the-openstack-installation  # noqa
+    auth_versions = {
+        "apikey": "2.0_apikey",
+        "password": "2.0_password",
+    }
+    # See https://libcloud.readthedocs.org/en/latest/compute/drivers/openstack.html  # noqa
+    driver = get_driver(Provider.OPENSTACK)(
+        key=username,
+        secret=secret,
+        region=region,
+        ex_force_auth_url=auth_url,
+        ex_force_auth_version=auth_versions[auth_plugin],
+        ex_force_service_region=region,
+        ex_tenant_name=tenant,
+    )
+
+    provisioner = LibcloudProvisioner(
+        driver=driver,
+        keyname=keyname,
+        image_names=images,
+        create_node_arguments=lambda **kwargs: {
+            "ex_config_drive": "true",
+        },
+        provision=provision_openstack,
+        default_size=flavour,
+        get_default_user=get_default_username,
+    )
+
+    return provisioner


### PR DESCRIPTION
Design / Partial implementation for: https://clusterhq.atlassian.net/browse/FLOC-3017

TODO
 * Figure out how to get libcloud to wait for public IP of instance on Rackspace and private IP on devstack, OR
 * Figure out how to assign public IPs on devstack (needn't be actual public IPs, maybe just so called floating IPs)
 * devstack guests need to be able to access the internet but can't without some nat IPtables rules on the devstack host. We'd been adding the rules individually for each guest but perhaps somethign like `iptables -t nat  -I POSTROUTING --source 10.0.0.0/8 -j MASQUERADE` will do the trick.