### PR TITLE
[FLOC-3023] + signs aren't allowed in ruby class names

### DIFF
--- a/admin/homebrew.py
+++ b/admin/homebrew.py
@@ -59,7 +59,7 @@ def get_class_name(version):
         created is called "flocker-$VERSION.rb".
     """
     class_name = list('Flocker' + version)
-    disallowed_characters = ['-', '.']
+    disallowed_characters = ['-', '.', '+']
     characters = []
 
     for index, character in enumerate(class_name):

--- a/admin/test/test_homebrew.py
+++ b/admin/test/test_homebrew.py
@@ -131,10 +131,10 @@ class GetClassNameTests(SynchronousTestCase):
     """
     def test_disallowed_characters_removed(self):
         """
-        Hyphens and periods are removed.
+        Hyphens, periods and + signs are removed.
         """
         self.assertEqual(
-            get_class_name(version='0.3.0-444-05215b'),
+            get_class_name(version='0.3.0-+444-05215b'),
             'Flocker03044405215b')
 
     def test_caps_after_disallowed(self):

--- a/admin/test/test_homebrew.py
+++ b/admin/test/test_homebrew.py
@@ -134,8 +134,8 @@ class GetClassNameTests(SynchronousTestCase):
         Hyphens, periods and + signs are removed.
         """
         self.assertEqual(
-            get_class_name(version='0.3.0-+444-05215b'),
-            'Flocker03044405215b')
+            get_class_name(version='0.3.0.dev1+444-05215b'),
+            'Flocker030Dev144405215b')
 
     def test_caps_after_disallowed(self):
         """


### PR DESCRIPTION
Fixes an error on Jenkins where building the package fails due to a '+' signal

```
11:52:48 + /tmp/v/bin/python admin/build-package --destination-path repo --distribution OSX /flocker/dist/Flocker-1.4.0.dev1+71.g8a99cdb.tar.gz
11:52:50 Traceback (most recent call last):
11:52:50   File "admin/build-package", line 13, in <module>
11:52:50     main(top_level=TOPLEVEL, base_path=BASEPATH)
11:52:50   File "/scratch/jenkins/workspace/ClusterHQ-flocker/flocker-create-jenkins-osx-job-FLOC-2854/run_client_installation_on_OSX/admin/packaging.py", line 1315, in main
11:52:50     distribution=options['distribution'],
11:52:50   File "/scratch/jenkins/workspace/ClusterHQ-flocker/flocker-create-jenkins-osx-job-FLOC-2854/run_client_installation_on_OSX/admin/packaging.py", line 1125, in build_in_docker
11:52:50     requirements_file.copyTo(tmp_requirements)
11:52:50   File "/tmp/v/lib/python2.7/site-packages/twisted/python/filepath.py", line 1488, in copyTo
11:52:50     writefile = destination.open('w')
11:52:50   File "/tmp/v/lib/python2.7/site-packages/twisted/python/filepath.py", line 845, in open
11:52:50     return open(self.path, mode + 'b')
11:52:50 IOError: [Errno 2] No such file or directory: '/scratch/jenkins/workspace/ClusterHQ-flocker/flocker-create-jenkins-osx-job-FLOC-2854/run_client_installation_on_OSX/admin/build_targets/OSX/requirements.txt'
11:52:50 Build step 'Execute shell' marked build as failure
11:52:50 Finished: FAILURE

```