### PR TITLE
[FLOC-3036] Send node agent state only if it changed or new client.

### DIFF
--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -307,9 +307,7 @@ class ConvergenceLoop(object):
         self.deployer = deployer
         self.cluster_state = None
 
-        # Save last known local state, and AMP client we sent it to.
-        # Since only one control service can exist at the moment, there can
-        # no more than one AMP client at any given point in time.
+        # Save last known local state
         self.last_sent_local_state = None
 
     def output_STORE_INFO(self, context):

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -317,34 +317,37 @@ class ConvergenceLoop(object):
             # one update using the new client.
             self.last_acknowledged_state = None
 
+    def _send_state_to_control_service(self, state_changes):
+        context = LOG_SEND_TO_CONTROL_SERVICE(
+            self.fsm.logger, connection=self.client,
+            local_changes=list(state_changes),
+        )
+        with context.context():
+            d = DeferredContext(self.client.callRemote(
+                NodeStateCommand,
+                state_changes=state_changes,
+                eliot_context=context)
+            )
+
+            def record_acknowledged_state(ignored):
+                self.last_acknowledged_state = state_changes
+
+            d.addCallback(record_acknowledged_state)
+            d.addErrback(
+                writeFailure, self.fsm.logger,
+                u"Failed to send local state to control node.")
+            d.addActionFinish()
+
     def _maybe_send_state_to_control_service(self, state_changes):
         """
-        If current state_changes differ from last sent local state,
-        transmit the new state to control agent.
+        If the given ``state_changes`` differ from those last acknowledged by
+        the control service, send them to the control service.
 
         :param state_changes: State to send to the control service.
         :type state_changes: tuple of IClusterStateChange
         """
         if self.last_acknowledged_state != state_changes:
-            context = LOG_SEND_TO_CONTROL_SERVICE(
-                self.fsm.logger, connection=self.client,
-                local_changes=list(state_changes),
-            )
-            with context.context():
-                d = DeferredContext(self.client.callRemote(
-                    NodeStateCommand,
-                    state_changes=state_changes,
-                    eliot_context=context)
-                )
-
-                def record_acknowledged_state(ignored):
-                    self.last_acknowledged_state = state_changes
-
-                d.addCallback(record_acknowledged_state)
-                d.addErrback(
-                    writeFailure, self.fsm.logger,
-                    u"Failed to send local state to control node.")
-                d.addActionFinish()
+            self._send_state_to_control_service(state_changes)
 
     def output_CONVERGE(self, context):
         known_local_state = self.cluster_state.get_node(

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -290,10 +290,10 @@ class ConvergenceLoop(object):
 
     :ivar fsm: The finite state machine this is part of.
 
-    :ivar last_acknowledged_state: The last state that was sent to and
+    :ivar _last_acknowledged_state: The last state that was sent to and
         acknowledged by the control service over the most recent connection
         to the control service.
-    :type last_acknowledged_state: tuple of IClusterStateChange
+    :type _last_acknowledged_state: tuple of IClusterStateChange
     """
     def __init__(self, reactor, deployer):
         """
@@ -306,7 +306,7 @@ class ConvergenceLoop(object):
         self.deployer = deployer
         self.cluster_state = None
         self.client = None
-        self.last_acknowledged_state = None
+        self._last_acknowledged_state = None
 
     def output_STORE_INFO(self, context):
         old_client = self.client
@@ -315,7 +315,7 @@ class ConvergenceLoop(object):
         if old_client is not self.client:
             # State updates are now being sent somewhere else.  At least send
             # one update using the new client.
-            self.last_acknowledged_state = None
+            self._last_acknowledged_state = None
 
     def _send_state_to_control_service(self, state_changes):
         context = LOG_SEND_TO_CONTROL_SERVICE(
@@ -330,7 +330,7 @@ class ConvergenceLoop(object):
             )
 
             def record_acknowledged_state(ignored):
-                self.last_acknowledged_state = state_changes
+                self._last_acknowledged_state = state_changes
 
             d.addCallback(record_acknowledged_state)
             d.addErrback(
@@ -346,7 +346,7 @@ class ConvergenceLoop(object):
         :param state_changes: State to send to the control service.
         :type state_changes: tuple of IClusterStateChange
         """
-        if self.last_acknowledged_state != state_changes:
+        if self._last_acknowledged_state != state_changes:
             self._send_state_to_control_service(state_changes)
 
     def output_CONVERGE(self, context):

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -1,5 +1,5 @@
-# -*- test-case-name: flocker.node.test.test_loop -*-
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# -*- test-case-name: flocker.node.test.test_loop -*-
 
 """
 Convergence loop for a node-specific dataset agent.

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -368,11 +368,17 @@ class ConvergenceLoop(object):
         def got_local_state(state_changes):
             # Current cluster state is likely out of date as regards the local
             # state, so update it accordingly.
+            #
+            # XXX This somewhat side-steps the whole explicit-state-machine
+            # thing we're aiming for here.  It would be better for these state
+            # changes to arrive as an input to the state machine.
             for state in state_changes:
                 self.cluster_state = state.update_cluster_state(
                     self.cluster_state
                 )
 
+            # XXX And for this update to be the side-effect of an output
+            # resulting.
             self._maybe_send_state_to_control_service(state_changes)
 
             action = self.deployer.calculate_changes(

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -14,8 +14,6 @@ The ClusterStatus state machine receives inputs from the connection to the
 control service, and sends inputs to the ConvergenceLoop state machine.
 """
 
-import threading
-
 from zope.interface import implementer
 
 from eliot import ActionType, Field, writeFailure, MessageType
@@ -310,7 +308,6 @@ class ConvergenceLoop(object):
         # Save last known local state, and AMP client we sent it to.
         # Since only one control service can exist at the moment, there can
         # no more than one AMP client at any given point in time.
-        self.lock = threading.Lock()
         self.last_sent_local_state = None
         self.last_sent_client = None
 
@@ -340,14 +337,12 @@ class ConvergenceLoop(object):
                 )
 
                 def set_sent_state(_):
-                    with self.lock:
-                        self.last_sent_local_state = state_changes
-                        self.last_sent_client = self.client
+                    self.last_sent_local_state = state_changes
+                    self.last_sent_client = self.client
 
                 def clear_sent_state(f):
-                    with self.lock:
-                        self.last_sent_local_state = None
-                        self.last_sent_client = None
+                    self.last_sent_local_state = None
+                    self.last_sent_client = None
                     return f
                 d.addCallbacks(set_sent_state, clear_sent_state)
                 d.addErrback(

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -347,6 +347,13 @@ class ConvergenceLoop(object):
         :type state_changes: tuple of IClusterStateChange
         """
         if self._last_acknowledged_state != state_changes:
+            # XXX If a prior attempt to send the state is still in progress,
+            # it's not a great idea to initiate a new attempt.  The control
+            # service should respond to requests in order, though, so it may
+            # not be catastrophic.  At the very least, the comparison above
+            # doesn't account for this case.  The last acknowledged state may
+            # be stale while state in the process of being sent could be fully
+            # up-to-date.
             self._send_state_to_control_service(state_changes)
 
     def output_CONVERGE(self, context):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -431,6 +431,49 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         send our state, even if we already sent that state on a different
         connection.
         """
+        local_state = NodeState(hostname=u'192.0.2.123')
+        local_state2 = NodeState(hostname=u'192.0.2.123')
+        configuration = Deployment(nodes=frozenset([to_node(local_state)]))
+        state = DeploymentState(nodes=[local_state])
+        action = ControllableAction(result=succeed(None))
+        # Because the second action result is unfired Deferred, the second
+        # iteration will never finish; applying its changes waits for this
+        # Deferred to fire.
+        action2 = ControllableAction(result=Deferred())
+        deployer = ControllableDeployer(
+            local_state.hostname,
+            [succeed(local_state), succeed(local_state2)],
+            [action, action2])
+        client = self.make_amp_client([local_state])
+        reactor = Clock()
+        loop = build_convergence_loop_fsm(reactor, deployer)
+        loop.receive(_ClientStatusUpdate(
+            client=client, configuration=configuration, state=state))
+
+        # Disconnect client
+        loop.receive(ClusterStatusInputs.DISCONNECTED_FROM_CONTROL_SERVICE)
+
+        # Reconnect new client
+        client2 = self.make_amp_client([local_state2])
+        loop.receive(_ConnectedToControlService(client=client2))
+        state2 = DeploymentState(nodes=[local_state2])
+        loop.receive(_ClientStatusUpdate(
+            client=client2, configuration=configuration, state=state2))
+        reactor.advance(1.0)
+
+        # Calculating actions happened, result was run... and then we did
+        # whole thing again:
+        self.assertEqual(
+            (deployer.calculate_inputs, client.calls, client2.calls),
+            (
+                # Check that the loop has run twice
+                [(local_state, configuration, state),
+                 (local_state, configuration, state)],
+                [(NodeStateCommand, dict(state_changes=(local_state,)))],
+                # And that state was resent even though it remained unchanged
+                [(NodeStateCommand, dict(state_changes=(local_state2,)))],
+            )
+        )
 
     @validate_logging(assertHasMessage, LOG_CALCULATED_ACTIONS)
     def test_convergence_done_update_local_state(self, logger):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -403,16 +403,13 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         local_state = NodeState(hostname=u'192.0.2.123')
         configuration = Deployment(nodes=[to_node(local_state)])
         state = DeploymentState(nodes=[local_state])
-        action = ControllableAction(result=succeed(None))
-        # Because the second action result is unfired Deferred, the second
-        # iteration will never finish; applying its changes waits for this
-        # Deferred to fire.
-        action2 = ControllableAction(result=Deferred())
         deployer = ControllableDeployer(
             local_state.hostname,
             [succeed(local_state), succeed(local_state.copy())],
-            [action, action2])
-        client = self.make_amp_client([local_state, local_state.copy()], succeed=False)
+            [no_action(), no_action()])
+        client = self.make_amp_client(
+            [local_state, local_state.copy()], succeed=False
+        )
         reactor = Clock()
         loop = build_convergence_loop_fsm(reactor, deployer)
         loop.receive(_ClientStatusUpdate(

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -395,10 +395,10 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
             )
         )
 
-    def test_converence_sent_state_fail_resends(self):
+    def test_convergence_sent_state_fail_resends(self):
         """
-        If sending state toe the control node fails, the next iteration will
-        send state even if the state hasn't changed.
+        If sending state to the control node fails the next iteration will send
+        state even if the state hasn't changed.
         """
         local_state = NodeState(hostname=u'192.0.2.123')
         configuration = Deployment(nodes=[to_node(local_state)])

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -314,7 +314,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         the control service.
         """
         local_state = NodeState(hostname=u'192.0.2.123')
-        configuration = Deployment(nodes=frozenset([to_node(local_state)]))
+        configuration = Deployment(nodes=[to_node(local_state)])
         state = DeploymentState(nodes=[local_state])
         action = ControllableAction(result=succeed(None))
         # Because the second action result is unfired Deferred, the second
@@ -355,7 +355,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         local_state2 = NodeState(
             hostname=u'192.0.2.123', used_ports=pset([80]),
             applications=pset())
-        configuration = Deployment(nodes=frozenset([to_node(local_state)]))
+        configuration = Deployment(nodes=[to_node(local_state)])
         state = DeploymentState(nodes=[local_state])
         state2 = DeploymentState(nodes=[local_state2])
         action = ControllableAction(result=succeed(None))
@@ -395,7 +395,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         """
         local_state = NodeState(hostname=u'192.0.2.123')
         local_state2 = NodeState(hostname=u'192.0.2.123')
-        configuration = Deployment(nodes=frozenset([to_node(local_state)]))
+        configuration = Deployment(nodes=[to_node(local_state)])
         state = DeploymentState(nodes=[local_state])
         action = ControllableAction(result=succeed(None))
         # Because the second action result is unfired Deferred, the second

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -424,7 +424,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
                 # Check that the loop has run twice
                 [(local_state, configuration, state),
                  (local_state, configuration, state)],
-                # And that state was resent even though it remained unchanged
+                # And that state was re-sent even though it remained unchanged
                 [(NodeStateCommand, dict(state_changes=(local_state,))),
                  (NodeStateCommand, dict(state_changes=(local_state,)))],
             )

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -394,7 +394,6 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         send state even if the state hasn't changed.
         """
         local_state = NodeState(hostname=u'192.0.2.123')
-        local_state2 = NodeState(hostname=u'192.0.2.123')
         configuration = Deployment(nodes=[to_node(local_state)])
         state = DeploymentState(nodes=[local_state])
         action = ControllableAction(result=succeed(None))
@@ -404,9 +403,9 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         action2 = ControllableAction(result=Deferred())
         deployer = ControllableDeployer(
             local_state.hostname,
-            [succeed(local_state), succeed(local_state2)],
+            [succeed(local_state), succeed(local_state.copy())],
             [action, action2])
-        client = self.make_amp_client([local_state, local_state2], True)
+        client = self.make_amp_client([local_state, local_state.copy()], True)
         reactor = Clock()
         loop = build_convergence_loop_fsm(reactor, deployer)
         loop.receive(_ClientStatusUpdate(
@@ -423,7 +422,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
                  (local_state, configuration, state)],
                 # And that state was resent even though it remained unchanged
                 [(NodeStateCommand, dict(state_changes=(local_state,))),
-                 (NodeStateCommand, dict(state_changes=(local_state2,)))],
+                 (NodeStateCommand, dict(state_changes=(local_state,)))],
             )
         )
 

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -39,7 +39,7 @@ from twisted.internet.interfaces import (
 from twisted.python.filepath import FilePath, Permissions
 from twisted.python.reflect import prefixedMethodNames, safe_repr
 from twisted.internet.task import Clock, deferLater
-from twisted.internet.defer import maybeDeferred, Deferred, succeed
+from twisted.internet.defer import maybeDeferred, Deferred, succeed, fail
 from twisted.internet.error import ConnectionDone
 from twisted.internet import reactor
 from twisted.trial.unittest import SynchronousTestCase, SkipTest
@@ -860,9 +860,16 @@ class FakeAMPClient(object):
         been sent using ``callRemote``.
     """
 
-    def __init__(self):
+    def __init__(self, health_status):
+        """
+        Initial a Fake AMP client with input health status.
+
+        :param Bool health_status: True, if client simulates successful
+            execution of remote commands.
+        """
         self._responses = {}
         self.calls = []
+        self.health_status = True
 
     def _makeKey(self, command, kwargs):
         """
@@ -910,7 +917,10 @@ class FakeAMPClient(object):
         # response register
         if 'eliot_context' in kwargs:
             kwargs.pop('eliot_context')
-        return succeed(self._responses[self._makeKey(command, kwargs)])
+        if self.health_status:
+            return succeed(self._responses[self._makeKey(command, kwargs)])
+        else:
+            return fail(self._responses[self._makeKey(command, kwargs)])
 
 
 class CustomException(Exception):

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -860,7 +860,7 @@ class FakeAMPClient(object):
         been sent using ``callRemote``.
     """
 
-    def __init__(self, health_status):
+    def __init__(self, flaky=False):
         """
         Initial a Fake AMP client with input health status.
 
@@ -869,7 +869,7 @@ class FakeAMPClient(object):
         """
         self._responses = {}
         self.calls = []
-        self.health_status = True
+        self.flaky = flaky
 
     def _makeKey(self, command, kwargs):
         """
@@ -917,10 +917,11 @@ class FakeAMPClient(object):
         # response register
         if 'eliot_context' in kwargs:
             kwargs.pop('eliot_context')
-        if self.health_status:
-            return succeed(self._responses[self._makeKey(command, kwargs)])
-        else:
+        import pdb; pdb.set_trace()
+        if self.flaky:
             return fail(self._responses[self._makeKey(command, kwargs)])
+        else:
+            return succeed(self._responses[self._makeKey(command, kwargs)])
 
 
 class CustomException(Exception):

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -862,9 +862,9 @@ class FakeAMPClient(object):
 
     def __init__(self, flaky=False):
         """
-        Initial a Fake AMP client with input health status.
+        Initial a Fake AMP client with desired flaky setting.
 
-        :param Bool health_status: True, if client simulates successful
+        :param Bool flaky: True, if client simulates unsuccessful
             execution of remote commands.
         """
         self._responses = {}

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -917,7 +917,6 @@ class FakeAMPClient(object):
         # response register
         if 'eliot_context' in kwargs:
             kwargs.pop('eliot_context')
-        import pdb; pdb.set_trace()
         if self.flaky:
             return fail(self._responses[self._makeKey(command, kwargs)])
         else:


### PR DESCRIPTION
Send node agent state to control agent only if:

- it differs from previously reported state, or,
- previous state send failed, or,
- last known state was sent to a different client.

@tomprince and i paired on this issue.