### PR TITLE
[FLOC-3010] Accurate device path for Cinder devices

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,7 +14,6 @@ v1.3
 ====
 
 * Fixed a bug where OpenStack Cinder volumes could be mapped to the wrong device and therefore mounted in the wrong location.
-* Flocker now has smaller log footprint from ``EBS`` storage driver on success path.
 
 v1.2
 ====

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -12,7 +12,6 @@ from ...testtools import loop_until
 
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset,
-    REALISTIC_BLOCKDEVICE_SIZE,
 )
 
 
@@ -35,8 +34,7 @@ class DatasetAPITests(TestCase):
 
         All attributes, including the maximum size, are preserved.
         """
-        waiting_for_create = create_dataset(
-            self, cluster, maximum_size=REALISTIC_BLOCKDEVICE_SIZE)
+        waiting_for_create = create_dataset(self, cluster)
 
         # Once created, request to move the dataset to node2
         def move_dataset(dataset):

--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -12,11 +12,12 @@ from twisted.trial.unittest import TestCase
 
 from docker.utils import create_host_config
 
-from ...testtools import random_name, find_free_port
+from ...testtools import (
+    random_name, find_free_port, REALISTIC_BLOCKDEVICE_SIZE
+)
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset,
-    REALISTIC_BLOCKDEVICE_SIZE, get_docker_client,
-    post_http_server, assert_http_server,
+    get_docker_client, post_http_server, assert_http_server,
 )
 from ..scripts import SCRIPTS
 

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -472,41 +472,89 @@ class CinderBlockDeviceAPI(object):
                 break
             time.sleep(1.0)
 
+    def _get_device_path_virtio_blk(self, volume):
+        """
+        The virtio_blk driver allows a serial number to be assigned to virtual
+        blockdevices.
+        OpenStack will set a serial number containing the first 20
+        characters of the Cinder block device ID.
+        The udev daemon will read the serial number and create a
+        symlink to the canonical virtio_blk device path.
+
+        We do this because libvirt does not return the correct device path when
+        additional disks have been attached using a client other than
+        cinder. This is expected behaviour within Cinder and libvirt See
+        https://bugs.launchpad.net/cinder/+bug/1387945 and
+        http://libvirt.org/formatdomain.html#elementsDisks (target section)
+
+        :param volume: The Cinder ``Volume`` which is attached.
+        :returns: ``FilePath`` of the device created by the virtio_blk
+            driver.
+        """
+        expected_path = FilePath(
+            "/dev/disk/by-id/virtio-{}".format(volume.id[:20])
+        )
+        if expected_path.exists():
+            return expected_path.realpath()
+        else:
+            raise UnattachedVolume(volume.id)
+
+    def _get_device_path_other(self, volume):
+        """
+        On other OpenStack hypervisors (Rackspace / Xen) the Cinder
+        API reports the correct device path.
+
+        :param volume: The Cinder ``Volume`` which is attached.
+        :returns: ``FilePath`` of the device created by the virtio_blk
+            driver.
+        """
+        if volume.attachments:
+            attachment = volume.attachments[0]
+            if len(volume.attachments) > 1:
+                # As far as we know you can not have more than one attachment,
+                # but, perhaps we're wrong and there should be a test for the
+                # multiple attachment case.  FLOC-1854.
+                # Log a message if this ever happens.
+                Message.new(
+                    message_type=(
+                        u'flocker:node:agents:blockdevice:openstack:'
+                        u'get_device_path:'
+                        u'unexpected_multiple_attachments'
+                    ),
+                    volume_id=unicode(volume.id),
+                    attachment_devices=u','.join(
+                        unicode(a['device']) for a in volume.attachments
+                    ),
+                ).write()
+        else:
+            raise UnattachedVolume(volume.id)
+
+        return FilePath(attachment['device'])
+
     def get_device_path(self, blockdevice_id):
-        # libvirt does not return the correct device path when additional
-        # disks have been attached using a client other than cinder. This is
-        # expected behaviour within Cinder and libvirt
-        # See https://bugs.launchpad.net/cinder/+bug/1387945 and
-        # http://libvirt.org/formatdomain.html#elementsDisks (target section)
-        # However, the correct device is named as a udev symlink which includes
-        # the first 20 characters of the blockedevice_id.
-        device_path = FilePath(
-            "/dev/disk/by-id/virtio-{}".format(blockdevice_id[:20]))
-        if not device_path.exists():
-            # If the device path does not exist, either virtio driver is
-            # not being used (e.g. Rackspace), or the user has modified
-            # their udev rules.  The following code relies on Cinder
-            # returning the correct device path, which appears to work
-            # for Rackspace and will work with virtio if no disks have
-            # been attached outside Cinder.
-            try:
-                cinder_volume = self.cinder_volume_manager.get(blockdevice_id)
-            except CinderNotFound:
-                raise UnknownVolume(blockdevice_id)
+        try:
+            cinder_volume = self.cinder_volume_manager.get(blockdevice_id)
+        except CinderNotFound:
+            raise UnknownVolume(blockdevice_id)
 
-            # As far as we know you can not have more than one attachment,
-            # but, perhaps we're wrong and there should be a test for the
-            # multiple attachment case.  FLOC-1854.
-            try:
-                [attachment] = cinder_volume.attachments
-            except ValueError:
-                raise UnattachedVolume(blockdevice_id)
+        if _is_virtio_blk():
+            device_path = self._get_device_path_virtioblk(cinder_volume)
+        else:
+            device_path = self._get_device_path_other(cinder_volume)
 
-            device_path = FilePath(attachment['device'])
-
-        # It could be attached somewhere else...
-        # https://clusterhq.atlassian.net/browse/FLOC-1830
         return device_path
+
+
+def _is_virtio_blk():
+    """
+    Check whether the virtio_blk driver is in use.
+
+    XXX: It may not be safe to assume that this sys path only
+    exists if the virtio_blk driver is in use.
+
+    :returns: ``True`` if virtio_blk is in use, else ``False``.
+    """
+    return FilePath('/sys/bus/virtio/drivers/virtio_blk').isdir()
 
 
 def _is_cluster_volume(cluster_id, cinder_volume):

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -480,7 +480,7 @@ class CinderBlockDeviceAPI(object):
         characters of the Cinder block device ID.
 
         This was introduced in
-        * https://github.com/openstack/nova/commit/3a47c02c58cefed0e230190b4bcef14527c82709 # noqa
+        * https://github.com/openstack/nova/commit/3a47c02c58cefed0e230190b4bcef14527c82709  # noqa
         * https://bugs.launchpad.net/nova/+bug/1004328
 
         The udev daemon will read the serial number and create a

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -478,6 +478,11 @@ class CinderBlockDeviceAPI(object):
         blockdevices.
         OpenStack will set a serial number containing the first 20
         characters of the Cinder block device ID.
+
+        This was introduced in
+        * https://github.com/openstack/nova/commit/3a47c02c58cefed0e230190b4bcef14527c82709 # noqa
+        * https://bugs.launchpad.net/nova/+bug/1004328
+
         The udev daemon will read the serial number and create a
         symlink to the canonical virtio_blk device path.
 

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -566,7 +566,7 @@ def _is_virtio_blk(device_path):
     :param FilePath device_path: The device path returned by the Cinder API.
     :returns: ``True`` if it's a ``virtio_blk`` device, else ``False``.
     """
-    return device_path.path.basename().startswith('vd')
+    return device_path.basename().startswith('vd')
 
 
 def _is_cluster_volume(cluster_id, cinder_volume):

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -538,7 +538,7 @@ class CinderBlockDeviceAPI(object):
             raise UnknownVolume(blockdevice_id)
 
         if _is_virtio_blk():
-            device_path = self._get_device_path_virtioblk(cinder_volume)
+            device_path = self._get_device_path_virtio_blk(cinder_volume)
         else:
             device_path = self._get_device_path_other(cinder_volume)
 

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -410,7 +410,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
-            desired_state=u'available')
+            expected_status=u'available')
 
         # Suspend udevd before attaching the disk
         # List unpacking here ensures that the test will blow up if
@@ -431,7 +431,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         volume = wait_for_volume(
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
-            desired_state=u'in-use',
+            expected_status=u'in-use',
         )
 
         self.assertRaises(
@@ -456,7 +456,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         volume = wait_for_volume(
             volume_manager=self.cinder.volumes,
             expected_volume=cinder_volume,
-            desired_state=u'available'
+            expected_status=u'available'
         )
 
         # Attach volume
@@ -468,7 +468,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         volume = wait_for_volume(
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
-            desired_state=u'in-use',
+            expected_status=u'in-use',
         )
         self.assertEqual(
             FilePath(

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -439,7 +439,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
-            expected_status=u'available', transient_states=(u'creating',))
+            desired_state=u'available', transient_states=(u'creating',))
 
         # Suspend udevd before attaching the disk
         # List unpacking here ensures that the test will blow up if
@@ -460,7 +460,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
-            expected_status=u'in-use',
+            desired_state=u'in-use',
             transient_states=(u'attaching',),
         )
 
@@ -486,7 +486,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes,
             expected_volume=cinder_volume,
-            expected_status=u'available',
+            desired_state=u'available',
             transient_states=(u'creating',))
 
         # Attach volume
@@ -498,7 +498,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
-            expected_status=u'in-use',
+            desired_state=u'in-use',
             transient_states=(u'attaching',),
         )
         self.assertEqual(

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from bitmath import Byte
 import netifaces
+import psutil
 
 from keystoneclient.openstack.common.apiclient.exceptions import Unauthorized
 
@@ -42,7 +43,7 @@ from ..test.blockdevicefactory import (
 )
 from ....testtools import run_process
 
-from ..cinder import wait_for_volume
+from ..cinder import wait_for_volume, UnattachedVolume
 
 # Tests requiring virsh can currently only be run on a devstack installation
 # that is not within our CI system. This will be addressed with FLOC-2972.
@@ -394,3 +395,86 @@ class CinderAttachmentTests(SynchronousTestCase):
                 expected_volume=attached_volume,
                 expected_status=u'in-use',
             )
+
+    @require_virsh
+    def test_get_device_path_virtio_blk_error_without_udev(self):
+        """
+        ``get_device_path`` on systems using the virtio_blk driver raises
+        ``UnattachedVolume`` if ``/dev/disks/by-id/xxx`` is not present.
+        """
+        instance_id = self.blockdevice_api.compute_instance_id()
+        # Create volume
+        cinder_volume = self.cinder.volumes.create(
+            size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
+        )
+        self.addCleanup(self._cleanup, instance_id, cinder_volume)
+        volume = wait_for_volume(
+            volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
+            desired_state=u'available')
+
+        # Suspend udevd before attaching the disk
+        # List unpacking here ensures that the test will blow up if
+        # multiple matching processes are ever found.
+        [udev_process] = list(
+            p for p in psutil.process_iter()
+            if p.name().endswith('-udevd')
+        )
+        udev_process.suspend()
+        self.addCleanup(udev_process.resume)
+
+        # Attach volume
+        attached_volume = self.nova.volumes.create_server_volume(
+            server_id=instance_id,
+            volume_id=volume.id,
+            device=None,
+        )
+        volume = wait_for_volume(
+            volume_manager=self.cinder.volumes,
+            expected_volume=attached_volume,
+            desired_state=u'in-use',
+        )
+
+        self.assertRaises(
+            UnattachedVolume,
+            self.blockdevice_api.get_device_path,
+            volume.id,
+        )
+
+    @require_virsh
+    def test_get_device_path_virtio_blk_symlink(self):
+        """
+        ``get_device_path`` on systems using the virtio_blk driver
+        returns the target of a symlink matching
+        ``/dev/disks/by-id/virtio-<volume.id>``.
+        """
+        instance_id = self.blockdevice_api.compute_instance_id()
+        # Create volume
+        cinder_volume = self.cinder.volumes.create(
+            size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
+        )
+        self.addCleanup(self._cleanup, instance_id, cinder_volume)
+        volume = wait_for_volume(
+            volume_manager=self.cinder.volumes,
+            expected_volume=cinder_volume,
+            desired_state=u'available'
+        )
+
+        # Attach volume
+        attached_volume = self.nova.volumes.create_server_volume(
+            server_id=instance_id,
+            volume_id=volume.id,
+            device=None,
+        )
+        volume = wait_for_volume(
+            volume_manager=self.cinder.volumes,
+            expected_volume=attached_volume,
+            desired_state=u'in-use',
+        )
+        self.assertEqual(
+            FilePath(
+                '/dev/disk/by-id/virtio-{}'.format(volume.id[:20])
+            ).realpath(),
+            self.blockdevice_api.get_device_path(
+                volume.id
+            )
+        )

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -61,6 +61,7 @@ class Cluster(PRecord):
     control_node = field(mandatory=True)
     agent_nodes = field(mandatory=True)
     dataset_backend = field(mandatory=True)
+    default_volume_size = field(type=int, mandatory=True)
     certificates = field(type=Certificates, mandatory=True)
 
     @property


### PR DESCRIPTION
Merging Cinder device fix into master. This has already been merged into release/flocker-1.3.1 as part of FLOC-3009.

This was a bit tricky because of a conflict in flocker/acceptance/testtools.py. This PR removes the use of REALISTIC_BLOCKDEVICE_SIZE in function create_dataset, while another change adds a dataset_id parameter to that function. Since this removed the import of REALISTIC_BLOCKDEVICE_SIZE from the flocker.acceptance.testtools file, the test_leases module needed to be changed to import it from it's actual source, the flocker.testtools module.