### PR TITLE
[FLOC-3038] Release Flocker 1.3.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Flocker 1.3.1 (2015-09-16)
+=====================================
+
+- Fixed a bug in previous fix where OpenStack Cinder volumes failed to mount. (FLOC-2991)
+- Documentation change to support ZFS 0.6.5. (FLOC-3016)
+
 Flocker 1.3.0 (2015-09-04)
 =====================================
 

--- a/docs/config/zfs-configuration.rst
+++ b/docs/config/zfs-configuration.rst
@@ -39,6 +39,8 @@ Installing ZFS on Ubuntu 14.04
    :prompt: [root@ubuntu-14.04]#
 
 
+.. _zfs-creating-pool:
+
 Creating a ZFS Pool
 ===================
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,12 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.3.1
+======
+
+* Fixed a bug in previous fix where OpenStack Cinder volumes failed to mount.
+* Creation of a ZFS pool using ZFS 0.6.5 or later requires the setting of a :ref:`ZFS_MODULE_LOADING environment variable<zfs-creating-pool>`.
+
 v1.3
 ====
 


### PR DESCRIPTION
The broken link in linkcheck only affects Buildbot - the link itself is working.

There is a merge conflict in the NEWS file between this PR and master, due to 1.4.0dev1 having already been merged into master. It doesn't appear that this can be resolved before tagging, as we don't want the 1.4.0dev1 news in this release.