### PR TITLE
[FLOC-3015] Fix intermittent lease test failure

### DIFF
--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -30,7 +30,7 @@ from .._client import (
 )
 from ...ca import rest_api_context_factory
 from ...ca.testtools import get_credential_sets
-from ...testtools import find_free_port
+from ...testtools import find_free_port, loop_until
 from ...control._persistence import ConfigurationPersistenceService
 from ...control._clusterstate import ClusterStateService
 from ...control.httpapi import create_api_service
@@ -326,15 +326,24 @@ def make_clientv1_tests():
             """
             dataset_id = uuid4()
             d = self.client.acquire_lease(dataset_id, self.node_1, 60)
-            d.addCallback(lambda _: self.client.list_leases())
 
-            def check_lease(leases):
+            def check_lease(_):
                 expected_lease = Lease(
                     dataset_id=dataset_id,
                     node_uuid=self.node_1,
                     expires=60.0
                 )
-                self.assertIn(expected_lease, leases)
+
+                def acquired_lease():
+                    get_leases = self.client.list_leases()
+
+                    def got_leases(leases):
+                        return expected_lease in leases
+                    get_leases.addCallback(got_leases)
+                    return get_leases
+
+                looping = loop_until(acquired_lease)
+                return looping
 
             d.addCallback(check_lease)
             d.addCallback(lambda _: self.client.acquire_lease(

--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -325,7 +325,18 @@ def make_clientv1_tests():
             acquire a lease that is held by another node.
             """
             dataset_id = uuid4()
-            d = self.client.acquire_lease(dataset_id, self.node_1, 10)
+            d = self.client.acquire_lease(dataset_id, self.node_1, 60)
+            d.addCallback(lambda _: self.client.list_leases())
+
+            def check_lease(leases):
+                expected_lease = Lease(
+                    dataset_id=dataset_id,
+                    node_uuid=self.node_1,
+                    expires=60.0
+                )
+                self.assertIn(expected_lease, leases)
+
+            d.addCallback(check_lease)
             d.addCallback(lambda _: self.client.acquire_lease(
                 dataset_id, self.node_2, None))
             return self.assertFailure(d, LeaseAlreadyHeld)

--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -30,7 +30,7 @@ from .._client import (
 )
 from ...ca import rest_api_context_factory
 from ...ca.testtools import get_credential_sets
-from ...testtools import find_free_port, loop_until
+from ...testtools import find_free_port
 from ...control._persistence import ConfigurationPersistenceService
 from ...control._clusterstate import ClusterStateService
 from ...control.httpapi import create_api_service
@@ -326,26 +326,6 @@ def make_clientv1_tests():
             """
             dataset_id = uuid4()
             d = self.client.acquire_lease(dataset_id, self.node_1, 60)
-
-            def check_lease(_):
-                expected_lease = Lease(
-                    dataset_id=dataset_id,
-                    node_uuid=self.node_1,
-                    expires=60.0
-                )
-
-                def acquired_lease():
-                    get_leases = self.client.list_leases()
-
-                    def got_leases(leases):
-                        return expected_lease in leases
-                    get_leases.addCallback(got_leases)
-                    return get_leases
-
-                looping = loop_until(acquired_lease)
-                return looping
-
-            d.addCallback(check_lease)
             d.addCallback(lambda _: self.client.acquire_lease(
                 dataset_id, self.node_2, None))
             return self.assertFailure(d, LeaseAlreadyHeld)


### PR DESCRIPTION
Sometimes, it takes long enough to communicate with a real API that a shorthold lease has expired before we attempt to reacquire it, hence the intermittent failure. This change gives the lease a 60 second expiry and ensures we have successfully acquired it before attempting to acquire a lease on the same dataset on a different node.