### PR TITLE
[FLOC-3014] Link check for UserVoice is forbidden

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -328,7 +328,7 @@ linkcheck_ignore = [
     # Example Flocker GUI local URL
     r'http://localhost/client/#/nodes/list',
     # UserVoice forbids (403) Buildbot, but works for browsers and local runs
-    r'https://feedback.clusterhq.com/'
+    r'https://feedback.clusterhq.com/',
 
     # The following link checks fail because of a TLS handshake error.
     # The link checking should be fixed and these ignores should be removed.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -327,6 +327,8 @@ linkcheck_ignore = [
     r'https://docs.google.com/a/clusterhq.com/\S+',
     # Example Flocker GUI local URL
     r'http://localhost/client/#/nodes/list',
+    # UserVoice forbids (403) Buildbot, but works for browsers and local runs
+    r'https://feedback.clusterhq.com/'
 
     # The following link checks fail because of a TLS handshake error.
     # The link checking should be fixed and these ignores should be removed.
@@ -335,6 +337,7 @@ linkcheck_ignore = [
     r'https://docs.staging.clusterhq.com/',
     r'https://docs.docker.com/\S+',
 ]
+
 
 def setup(app):
     # This allows us to ignore spelling in any particular file


### PR DESCRIPTION
The UserVoice website hosted at https://feedback.clusterhq.com is sending 403 Forbidden to Buildbot requests, probably because it frequently performs robot requests.

This PR stops checking the single link to the forum, to prevent linkcheck tests being permanently orange, and to be nice to someone who apparently doesn't want us knocking.

Note, I haven't actually confirmed that this is why Buildbot is getting 403.  The check works when running `make linkcheck` from a laptop.