### PR TITLE
[FLOC-3050] Make leases API public

### DIFF
--- a/docs/reference/api_examples.yml
+++ b/docs/reference/api_examples.yml
@@ -641,13 +641,13 @@
 
 -
   id:
-    "remove a lease"
+    "release a lease"
 
   doc: |
     Release a lease on a dataset.
 
   request: |
-    DELETE /v1/configuration/leases/886ed03a-5606-453a-94a9-a1cbaf35164c
+    DELETE /v1/configuration/leases/886ed03a-5606-453a-94a9-a1cbaf35164c HTTP/1.1
 
   response: |
     HTTP/1.1 200 OK
@@ -666,7 +666,7 @@
     Notice how one lease expires in 30 seconds, and one will never expire.
 
   request: |
-    GET /v1/configuration/leases
+    GET /v1/configuration/leases HTTP/1.1
 
   response: |
     HTTP/1.1 200 OK
@@ -675,12 +675,12 @@
       {
         "dataset_id": "886ed03a-5606-453a-94a9-a1cbaf35164c",
         "node_uuid": "%(NODE_0)s",
-        "expires": null,
+        "expires": null
       },
       {
         "dataset_id": "47440eff-e933-4de0-b56c-d3469b61421f",
         "node_uuid": "%(NODE_1)s",
-        "expires": 30,
+        "expires": 30
       },
     ]
 
@@ -691,12 +691,12 @@
     Acquire a lease that does not expire.
 
   request: |
-    POST /v1/configuration/leases
+    POST /v1/configuration/leases HTTP/1.1
 
     {
       "dataset_id": "886ed03a-5606-453a-94a9-a1cbaf35164c",
       "node_uuid": "%(NODE_0)s",
-      "expires": null,
+      "expires": null
     }
 
   response: |
@@ -705,7 +705,7 @@
     {
       "dataset_id": "886ed03a-5606-453a-94a9-a1cbaf35164c",
       "node_uuid": "%(NODE_0)s",
-      "expires": null,
+      "expires": null
     }
 
 -
@@ -715,7 +715,7 @@
     Acquire a lease that expires in 30 seconds.
 
   request: |
-    POST /v1/configuration/leases
+    POST /v1/configuration/leases HTTP/1.1
 
     {
       "dataset_id": "47440eff-e933-4de0-b56c-d3469b61421f",
@@ -740,7 +740,7 @@
     lease on the same dataset on a different node.
 
   request: |
-    POST /v1/configuration/leases
+    POST /v1/configuration/leases HTTP/1.1
 
     {
       "dataset_id": "47440eff-e933-4de0-b56c-d3469b61421f",
@@ -763,7 +763,7 @@
     renew the lease and extend its expiration.
 
   request: |
-    POST /v1/configuration/leases
+    POST /v1/configuration/leases HTTP/1.1
 
     {
       "dataset_id": "47440eff-e933-4de0-b56c-d3469b61421f",

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,12 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+Next release
+============
+
+* The :ref:`dataset API <api>` added support for leases.
+  Leases prevent a dataset from being deleted or moved off a node.
+
 v1.3.1
 ======
 

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -869,8 +869,6 @@ class ConfigurationAPIUserV1(object):
             raise make_bad_request(code=BAD_REQUEST, description=unicode(e))
 
     @app.route("/configuration/leases", methods=['GET'])
-    # This can stop being private as part of FLOC-2741:
-    @private_api
     @user_documentation(
         u"""
         List the currently existing leases on datasets, including which
@@ -901,8 +899,6 @@ class ConfigurationAPIUserV1(object):
         return result
 
     @app.route("/configuration/leases/<dataset_id>", methods=['DELETE'])
-    # This can stop being private as part of FLOC-2741:
-    @private_api
     @user_documentation(
         u"""
         This will release a lease on a dataset, allowing the dataset to be
@@ -910,9 +906,9 @@ class ConfigurationAPIUserV1(object):
         lease does not modify the dataset in any way, it simply allows
         other operations to do so.
         """,
-        header=u"Delete a lease from the configuration",
+        header=u"Release a lease on a dataset",
         examples=[
-            u"delete a lease",
+            u"release a lease",
         ],
         section=u"dataset",
     )
@@ -950,9 +946,6 @@ class ConfigurationAPIUserV1(object):
             raise LEASE_NOT_FOUND
 
     @app.route("/configuration/leases", methods=['POST'])
-    # This can stop being private as part of FLOC-2741:
-    # We'll remove this once the end-to-end tests are proven.
-    @private_api
     @user_documentation(
         u"""
         Acquire a lease on a particular dataset on a particular

--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -238,7 +238,11 @@ def _formatSchema(data, incoming):
             required = '*(required)* '
         else:
             required = ''
-        yield ':%s %s %s: %s%s' % (param, attr['type'], property, required,
+        if isinstance(attr['type'], list):
+            types = "|".join(attr['type'])
+        else:
+            types = attr['type']
+        yield ':%s %s %s: %s%s' % (param, types, property, required,
                                    attr['title'])
         yield ''
         for line in attr['description']:


### PR DESCRIPTION
1. Make leases API endpoints public.
2. Fix various minor content and formatting issues in the examples and API endpoints.
3. Make the JSON API property documentation format correctly in the face of multi-type properties, in particular the "expires" property which supports both numbers and `null`.