### PR TITLE
[FLOC-3079] Intermittently failing lease test

### DIFF
--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -355,9 +355,10 @@ class FlockerClientTests(make_clientv1_tests()):
 
         :return: ``FlockerClient`` instance.
         """
+        clock = Clock()
         _, self.port = find_free_port()
         self.persistence_service = ConfigurationPersistenceService(
-            reactor, FilePath(self.mktemp()))
+            clock, FilePath(self.mktemp()))
         self.persistence_service.startService()
         self.cluster_state_service = ClusterStateService(reactor)
         self.cluster_state_service.startService()
@@ -375,7 +376,7 @@ class FlockerClientTests(make_clientv1_tests()):
                 credential_set.root.credential.certificate,
                 credential_set.control),
             # Use consistent fake time for API results:
-            Clock())
+            clock)
         api_service.startService()
         self.addCleanup(api_service.stopService)
 


### PR DESCRIPTION
Fixes FLOC-3079. The test was failing because the persistence service and API service in this test suite are instantiated using different `IReactorTime` implementations, one using `Clock` and the other using the global `reactor`. This meant that leases created via the API were being created with an expiry calculated as seconds from Unix time, whereas the leases expiry loop (which compares datetimes) was checking the expiry against the real current time. Hence leases that had seemingly expired over 40 years ago :scream: 