### PR TITLE
[FLOC-1796] Fix problem where log messages were being wrapped

### DIFF
--- a/admin/package-files/docker-plugin/systemd/flocker-docker-plugin.service
+++ b/admin/package-files/docker-plugin/systemd/flocker-docker-plugin.service
@@ -3,7 +3,7 @@ Description=Flocker Docker Plugin
 Before=docker.service
 
 [Service]
-ExecStart=/usr/sbin/flocker-docker-plugin
+ExecStart=/usr/sbin/flocker-docker-plugin --journald
 Restart=always
 
 [Install]

--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -4,7 +4,7 @@ After=docker.service
 Wants=docker.service
 
 [Service]
-ExecStart=/usr/sbin/flocker-container-agent
+ExecStart=/usr/sbin/flocker-container-agent --journald
 Restart=always
 
 [Install]

--- a/admin/package-files/systemd/flocker-control.service
+++ b/admin/package-files/systemd/flocker-control.service
@@ -2,7 +2,7 @@
 Description=Flocker Control Service
 
 [Service]
-ExecStart=/usr/sbin/flocker-control -p systemd:INET:0 -a systemd:INET:1
+ExecStart=/usr/sbin/flocker-control -p systemd:INET:0 -a systemd:INET:1 --journald
 Sockets=flocker-control-api.socket flocker-control-agent.socket
 NonBlocking=true
 Restart=always

--- a/admin/package-files/systemd/flocker-dataset-agent.service
+++ b/admin/package-files/systemd/flocker-dataset-agent.service
@@ -2,7 +2,7 @@
 Description=Flocker Dataset Agent
 
 [Service]
-ExecStart=/usr/sbin/flocker-dataset-agent
+ExecStart=/usr/sbin/flocker-dataset-agent --journald
 Restart=always
 
 # We can't have a private mount namespace, since we need to create mounts visible to Docker.

--- a/flocker/common/_journald.py
+++ b/flocker/common/_journald.py
@@ -1,0 +1,26 @@
+"""
+Minimal journald logging support.
+
+Eventually should be moved into eliot with more extensive functionality:
+https://github.com/ClusterHQ/eliot/issues/207
+"""
+
+from cffi import FFI
+
+_ffi = FFI()
+_ffi.cdef("""
+int sd_journal_send(const char *format, ...);
+""")
+_journald = _ffi.dlopen("libsystemd-journal.so")
+
+
+def sd_journal_send(message):
+    """
+    Send a message to the journald log.
+
+    :param bytes message: Some bytes to log.
+    """
+    # The function uses printf formatting, so we need to quote
+    # percentages.
+    _journald.sd_journal_send(b"MESSAGE=" + message.replace(b"%", b"%%"),
+                              _ffi.NULL)

--- a/flocker/common/_journald.py
+++ b/flocker/common/_journald.py
@@ -11,7 +11,7 @@ _ffi = FFI()
 _ffi.cdef("""
 int sd_journal_send(const char *format, ...);
 """)
-_journald = _ffi.dlopen("libsystemd-journal.so")
+_journald = _ffi.dlopen("libsystemd-journal.so.0")
 
 
 def sd_journal_send(message):

--- a/flocker/common/functional/test_script.py
+++ b/flocker/common/functional/test_script.py
@@ -13,7 +13,7 @@ from bitmath import MiB
 
 from zope.interface import implementer
 
-from eliot import Logger, Message
+from eliot import Message
 from eliot.testing import assertContainsFields
 
 from twisted.trial.unittest import TestCase
@@ -23,14 +23,24 @@ from twisted.python.log import msg, err
 from twisted.python.filepath import FilePath
 
 from ..script import ICommandLineScript
+from ...testtools import random_name, if_root
 
 
 @implementer(ICommandLineScript)
 class EliotScript(object):
+    key = 123
+
     def main(self, reactor, options):
-        logger = Logger()
-        Message.new(key=123).write(logger)
+        Message.log(key=self.key)
         return succeed(None)
+
+
+class EliotPercentScript(EliotScript):
+    key = u"hello%s"
+
+
+class EliotLargeScript(object):
+    key = u"1234 " * 20000 + u" ends here"
 
 
 @implementer(ICommandLineScript)
@@ -67,6 +77,20 @@ class SigintScript(object):
         reactor.callLater(0.05, os.kill, os.getpid(), SIGINT)
         return Deferred()
 
+# Code to run a minimal script:
+_SCRIPT_CODE = b'''\
+from twisted.python.usage import Options
+from flocker.common.script import FlockerScriptRunner, flocker_standard_options
+
+from flocker.common.functional.test_script import {}
+
+@flocker_standard_options
+class StandardOptions(Options):
+    pass
+
+FlockerScriptRunner({}(), StandardOptions()).main()
+'''
+
 
 class FlockerScriptRunnerTests(TestCase):
     """
@@ -84,18 +108,7 @@ class FlockerScriptRunnerTests(TestCase):
         """
         if options is None:
             options = []
-        code = b'''\
-from twisted.python.usage import Options
-from flocker.common.script import FlockerScriptRunner, flocker_standard_options
-
-from flocker.common.functional.test_script import {}
-
-@flocker_standard_options
-class StandardOptions(Options):
-    pass
-
-FlockerScriptRunner({}(), StandardOptions()).main()
-'''.format(script.__name__, script.__name__)
+        code = _SCRIPT_CODE.format(script.__name__, script.__name__)
         d = getProcessOutput(
             sys.executable, [b"-c", code] + options,
             env=os.environ,
@@ -271,4 +284,56 @@ FlockerScriptRunner({}(), StandardOptions()).main()
             )
         d.addCallback(verify_logfiles, logfile=logfile)
 
+        return d
+
+    @if_root
+    def run_journald_script(self, script):
+        """
+        Run a script that logs messages to journald and uses
+        ``FlockerScriptRunner``.
+
+        :param ICommandLineScript: Script to run. Must be class in this module.
+
+        :return: ``Deferred`` that fires with decoded JSON messages from the
+            journal for the process.
+        """
+        name = random_name(self).encode("utf-8")
+        code = _SCRIPT_CODE.format(script.__name__, script.__name__)
+        d = getProcessOutput(
+            b"systemd-run", [b"--unit=" + name,
+                             sys.executable, b"-c", code, b"--journald"],
+            env=os.environ,
+        )
+        d.addCallback(lambda _: getProcessOutput(b"journalctl", [b"-u", name]))
+        d.addCallback(lambda data: map(loads, data.splitlines()))
+        return d
+
+    def test_journald(self):
+        """
+        When ``--journald`` option is used messages end up in the journal.
+        """
+        d = self.run_journald_script(EliotScript)
+        d.addCallback(lambda messages: assertContainsFields(self, messages[1],
+                                                            {u"key": 123}))
+        return d
+
+    def test_journald_percent(self):
+        """
+        When ``--journald`` option is used messages with a ``%`` in them can
+        be logged correctly.
+        """
+        d = self.run_journald_script(EliotPercentScript)
+        d.addCallback(lambda messages: assertContainsFields(
+            self, messages[1], {u"key": u"hello%s"}))
+        return d
+
+    def test_journald_large_message(self):
+        """
+        When ``--journald`` option is used large messages end up in the
+        journal and are not broken up, demonstrating we're not hitting
+        https://bugs.freedesktop.org/show_bug.cgi?id=86465
+        """
+        d = self.run_journald_script(EliotLargeScript)
+        d.addCallback(lambda messages: assertContainsFields(
+            self, messages[1], {u"key": EliotLargeScript.key}))
         return d

--- a/flocker/common/functional/test_script.py
+++ b/flocker/common/functional/test_script.py
@@ -40,7 +40,7 @@ class EliotPercentScript(EliotScript):
     key = u"hello%s"
 
 
-class EliotLargeScript(object):
+class EliotLargeScript(EliotScript):
     key = u"1234 " * 20000 + u" ends here"
 
 

--- a/flocker/common/functional/test_script.py
+++ b/flocker/common/functional/test_script.py
@@ -395,4 +395,5 @@ class JournaldOptionsTests(TestCase):
 
         exc = self.assertRaises(
             UsageError, MyOptions().parseOptions, ["--journald"])
-        self.assertEqual(str(exc), "Journald unavailable on this machine.")
+        self.assertTrue(str(exc).startswith(
+            "Journald unavailable on this machine: "))

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -112,11 +112,6 @@ def flocker_standard_options(cls):
         """
         # Log messages are written line by line, so pretend we're a file...
         self['logfile'] = JournaldFile()
-        # XXX tests for these:
-        # 1. raise exception if --logfile was passed in
-        # 2. set flag disabling logging to stdout
-        # 3. set flag enabling logging to journald
-        pass
     cls.opt_journald = opt_journald
 
     return cls

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -24,10 +24,11 @@ from .. import __version__
 
 try:
     from ._journald import sd_journal_send
-except OSError:
+except OSError as e:
     # This platform doens't have journald.
     sd_journal_send = None
-
+    _missing_journald_reason = str(e)
+    del e
 
 __all__ = [
     'flocker_standard_options',
@@ -111,7 +112,8 @@ def flocker_standard_options(cls):
         Log to journald.
         """
         if sd_journal_send is None:
-            raise usage.UsageError("Journald unavailable on this machine.")
+            raise usage.UsageError("Journald unavailable on this machine: "
+                                   + _missing_journald_reason)
         # Log messages are written line by line, so pretend we're a file...
         self['logfile'] = JournaldFile()
     cls.opt_journald = opt_journald

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -85,6 +85,16 @@ def flocker_standard_options(cls):
         )
     cls.opt_logfile = opt_logfile
 
+    def opt_journald(self):
+        """
+        Log to journald.
+        """
+        # 1. raise exception if --logfile was passed in
+        # 2. set flag disabling logging to stdout
+        # 3. set flag enabling logging to journald
+        pass
+    cls.opt_journald = opt_journald
+
     return cls
 
 

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -26,7 +26,7 @@ try:
     from ._journald import sd_journal_send
 except OSError:
     # This platform doens't have journald.
-    pass
+    sd_journal_send = None
 
 
 __all__ = [
@@ -110,6 +110,8 @@ def flocker_standard_options(cls):
         """
         Log to journald.
         """
+        if sd_journal_send is None:
+            raise usage.UsageError("Journald unavailable on this machine.")
         # Log messages are written line by line, so pretend we're a file...
         self['logfile'] = JournaldFile()
     cls.opt_journald = opt_journald


### PR DESCRIPTION
By logging directly using the journald APIs we can avoid a bug where log messages are line wrapped on 2048 byte boundaries. This means log messages will now be much easier to process with tools like `eliot-tree`.

The `sleep` in the tests is problematic; not sure what else to do about fact that logging takes a little bit of time to show up in `journalctl` output. Maybe retry a few times?