### PR TITLE
[FLOC-3090] Implement back-pressure on agents sending updates.

### DIFF
--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -356,13 +356,6 @@ class ConvergenceLoop(object):
         :type state_changes: tuple of IClusterStateChange
         """
         if self._last_acknowledged_state != state_changes:
-            # XXX If a prior attempt to send the state is still in progress,
-            # it's not a great idea to initiate a new attempt.  The control
-            # service should respond to requests in order, though, so it may
-            # not be catastrophic.  At the very least, the comparison above
-            # doesn't account for this case.  The last acknowledged state may
-            # be stale while state in the process of being sent could be fully
-            # up-to-date.
             return self._send_state_to_control_service(state_changes)
         else:
             return succeed(None)

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -332,7 +332,14 @@ class ConvergenceLoop(object):
             def record_acknowledged_state(ignored):
                 self._last_acknowledged_state = state_changes
 
-            d.addCallback(record_acknowledged_state)
+            def clear_acknowledged_state(failure):
+                # We don't know if the control service has processed the update
+                # or not. So we clear the last acknowledged state so that we
+                # always send the state on the next iteration.
+                self._last_acknowledged_state = None
+                return failure
+
+            d.addCallbacks(record_acknowledged_state, clear_acknowledged_state)
             d.addErrback(
                 writeFailure, self.fsm.logger,
                 u"Failed to send local state to control node.")

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -404,6 +404,10 @@ class ConvergenceLoop(object):
             return gather_deferreds([send_ack, state_ran])
         d.addCallback(got_local_state)
 
+        # If an error occurred we just want to log it and then try
+        # converging again; hopefully next time we'll have more success.
+        d.addErrback(writeFailure, self.fsm.logger)
+
         # It would be better to have a "quiet time" state in the FSM and
         # transition to that next, then have a timeout input kick the machine
         # back around to the beginning of the loop in the FSM.  However, we're

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -491,7 +491,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         self.assertTupleEqual(
             (deployer.calculate_inputs, client.calls),
             (
-                # Check that the loop has run twice
+                # Check that the loop has run thrice
                 [(local_state, configuration, state),
                  (changed_local_state, configuration, changed_state),
                  (local_state, configuration, state)],

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -20,7 +20,7 @@ from twisted.internet.task import Clock
 from twisted.internet.ssl import ClientContextFactory
 from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
 
-from ...testtools import FakeAMPClient, DelayedAMPClient
+from ...testtools.amp import FakeAMPClient, DelayedAMPClient
 from .._loop import (
     build_cluster_status_fsm, ClusterStatusInputs, _ClientStatusUpdate,
     _StatusUpdate, _ConnectedToControlService, ConvergenceLoopInputs,

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -623,7 +623,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         expected_cluster_state = DeploymentState(
             nodes=[local_state])
 
-        # Calculating actions happened and the result was run.
+        # Only one iteration of the covergence loop was run.
         self.assertTupleEqual(
             (deployer.calculate_inputs, client.calls),
             ([(local_state, configuration, expected_cluster_state)],
@@ -647,15 +647,20 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         reactor = Clock()
         loop = build_convergence_loop_fsm(reactor, deployer)
         loop.receive(_ClientStatusUpdate(
-            client=DelayedAMPClient(client), configuration=configuration,
+            # We don't want to receive the acknowledgment of the
+            # state update.
+            client=DelayedAMPClient(client),
+            configuration=configuration,
             state=received_state))
 
         expected_cluster_state = DeploymentState(
             nodes=[local_state])
 
+        # Wait for the delay in the converence loop to pass.  This won't do
+        # anything, since we are also waiting for state to be acknowledged.
         reactor.advance(1.0)
 
-        # Calculating actions happened and the result was run.
+        # Only one iteration of the covergence loop was run.
         self.assertTupleEqual(
             (deployer.calculate_inputs, client.calls),
             ([(local_state, configuration, expected_cluster_state)],

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -278,7 +278,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
             corresponding states should fail.  ``True`` to make a client which
             responds to requests with results, ``False`` to make a client which
             response with failures. Defaults to always succeeding.
-        :type successes: ``list`` of ``bool`` or ``None``
+        :type successes: ``None`` or ``list`` of ``bool``
 
         :return FakeAMPClient: Fake AMP client appropriately setup.
         """
@@ -440,13 +440,13 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         If sending state to the control node fails the next iteration will send
         state even if the state is the same as the last acknowledge state.
 
-        The situation this is intnded to model is the following sequence:
+        The situation this is intended to model is the following sequence:
         1. Agent sends original state to control node, which records and
            acknowledges it.
         2. Agent sends changed state to control node, which records it, but
            errors out before acknowledging it.
         3. State returns to original state. If we don't clear the acknowledged
-           state, the agent wont send a state update, but the control node
+           state, the agent won't send a state update, but the control node
            will think the state is still the changed state.
         """
         local_state = NodeState(
@@ -481,7 +481,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         loop.receive(_ClientStatusUpdate(
             client=client, configuration=configuration, state=state))
 
-        # Wait for all three iterations to occure.
+        # Wait for all three iterations to occur.
         reactor.advance(1.0)
         reactor.advance(1.0)
 
@@ -633,7 +633,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
     def test_convergence_done_delays_new_iteration_ack(self):
         """
         An FSM completing the changes from one convergence iteration doesn't
-        start another iteration, if the control node hasn't acknowledged the
+        start another iteration if the control node hasn't acknowledged the
         last state update.
         """
         self.local_state = local_state = NodeState(hostname=u'192.0.2.123')

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -450,6 +450,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
            will think the state is still the changed state.
         """
         local_state = NodeState(
+            uuid=uuid4(),
             hostname=u'192.0.2.123',
             used_ports=pset(), applications=pset(),
         )
@@ -636,7 +637,10 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         start another iteration if the control node hasn't acknowledged the
         last state update.
         """
-        self.local_state = local_state = NodeState(hostname=u'192.0.2.123')
+        self.local_state = local_state = NodeState(
+            uuid=uuid4(),
+            hostname=u'192.0.2.123',
+        )
         self.configuration = configuration = Deployment()
         self.cluster_state = received_state = DeploymentState(nodes=[])
         self.action = action = ControllableAction(result=succeed(None))

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -456,7 +456,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
              succeed(local_state)],
             [no_action(), no_action(), no_action()])
         client = self.make_amp_client(
-            [local_state, changed_local_state.copy()],
+            [local_state, changed_local_state],
             successes=[True, False],
         )
         reactor = Clock()

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -450,7 +450,6 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
            will think the state is still the changed state.
         """
         local_state = NodeState(
-            uuid=uuid4(),
             hostname=u'192.0.2.123',
             used_ports=pset(), applications=pset(),
         )
@@ -637,10 +636,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         start another iteration if the control node hasn't acknowledged the
         last state update.
         """
-        self.local_state = local_state = NodeState(
-            uuid=uuid4(),
-            hostname=u'192.0.2.123',
-        )
+        self.local_state = local_state = NodeState(hostname=u'192.0.2.123')
         self.configuration = configuration = Deployment()
         self.cluster_state = received_state = DeploymentState(nodes=[])
         self.action = action = ControllableAction(result=succeed(None))

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -920,6 +920,26 @@ class FakeAMPClient(object):
         return succeed(self._responses[self._makeKey(command, kwargs)])
 
 
+class DelayedAMPClient(object):
+    """
+    A wrapper for ``FakeAMPClient`` that allows responses to be delayed.
+    """
+
+    def __init__(self, client):
+        self._client = client
+        self._calls = []
+
+    def callRemote(self, command, **kwargs):
+        d = Deferred()
+        response = self._client.callRemote(command, **kwargs)
+        self._calls.append((d, response))
+        return d
+
+    def respond(self):
+        d, response = self._calls.pop(0)
+        response.chainDeferred(d)
+
+
 class CustomException(Exception):
     """
     An exception that will never be raised by real code, useful for

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -36,11 +36,10 @@ from zope.interface.verify import verifyClass, verifyObject
 from twisted.internet.interfaces import (
     IProcessTransport, IReactorProcess, IReactorCore,
 )
-from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath, Permissions
 from twisted.python.reflect import prefixedMethodNames, safe_repr
 from twisted.internet.task import Clock, deferLater
-from twisted.internet.defer import maybeDeferred, Deferred, succeed
+from twisted.internet.defer import maybeDeferred, Deferred
 from twisted.internet.error import ConnectionDone
 from twisted.internet import reactor
 from twisted.trial.unittest import SynchronousTestCase, SkipTest
@@ -48,7 +47,6 @@ from twisted.internet.protocol import Factory, ProcessProtocol, Protocol
 from twisted.test.proto_helpers import MemoryReactor
 from twisted.python.procutils import which
 from twisted.trial.unittest import TestCase
-from twisted.protocols.amp import AMP, InvalidSignature
 from twisted.python.logfile import LogFile
 
 from .. import __version__
@@ -848,96 +846,6 @@ def make_script_tests(executable):
             result = run_process([executable] + [b"--help"])
             self.assertIn(executable, result.output)
     return ScriptTests
-
-
-class FakeAMPClient(object):
-    """
-    Emulate an AMP client's ability to send commands.
-
-    A minimal amount of validation is done on registered responses and sent
-    requests, but this should not be relied upon.
-
-    :ivar list calls: ``(command, kwargs)`` tuples of commands that have
-        been sent using ``callRemote``.
-    """
-
-    def __init__(self):
-        """
-        Initialize a fake AMP client.
-        """
-        self._responses = {}
-        self.calls = []
-
-    def _makeKey(self, command, kwargs):
-        """
-        Create a key for the responses dictionary.
-
-        @param commandType: a subclass of C{amp.Command}.
-
-        @param kwargs: a dictionary.
-
-        @return: A value that can be used as a dictionary key.
-        """
-        return (command, tuple(sorted(kwargs.items())))
-
-    def register_response(self, command, kwargs, response):
-        """
-        Register a response to a L{callRemote} command.
-
-        @param commandType: a subclass of C{amp.Command}.
-
-        @param kwargs: Keyword arguments taken by the command, a C{dict}.
-
-        @param response: The response to the command.
-        """
-        if isinstance(response, Exception):
-            response = Failure(response)
-        else:
-            try:
-                command.makeResponse(response, AMP())
-            except KeyError:
-                raise InvalidSignature("Bad registered response")
-        self._responses[self._makeKey(command, kwargs)] = response
-
-    def callRemote(self, command, **kwargs):
-        """
-        Return a previously registered response.
-
-        @param commandType: a subclass of C{amp.Command}.
-
-        @param kwargs: Keyword arguments taken by the command, a C{dict}.
-
-        @return: A C{Deferred} that fires with the registered response for
-            this particular combination of command and arguments.
-        """
-        self.calls.append((command, kwargs))
-        command.makeArguments(kwargs, AMP())
-        # if an eliot_context is present, disregard it, because we cannot
-        # reliably determine this in advance in order to include it in the
-        # response register
-        if 'eliot_context' in kwargs:
-            kwargs.pop('eliot_context')
-        return succeed(self._responses[self._makeKey(command, kwargs)])
-
-
-class DelayedAMPClient(object):
-    """
-    A wrapper for ``FakeAMPClient`` that allows responses to be delayed.
-    """
-
-    def __init__(self, client):
-        self._client = client
-        self._calls = []
-
-    def callRemote(self, command, **kwargs):
-        d = Deferred()
-        response = self._client.callRemote(command, **kwargs)
-        self._calls.append((d, response))
-        return d
-
-    def respond(self):
-        d, response = self._calls.pop(0)
-        response.chainDeferred(d)
 
 
 class CustomException(Exception):

--- a/flocker/testtools/amp.py
+++ b/flocker/testtools/amp.py
@@ -83,6 +83,9 @@ class FakeAMPClient(object):
 class DelayedAMPClient(object):
     """
     A wrapper for ``FakeAMPClient`` that allows responses to be delayed.
+
+    :ivar _client: The underlying AMP client.
+    :ivar _calls: List of tuples of deferred and response.
     """
 
     def __init__(self, client):
@@ -90,11 +93,25 @@ class DelayedAMPClient(object):
         self._calls = []
 
     def callRemote(self, command, **kwargs):
+        """
+        Call the underlying AMP client, and delay the response until
+        :method:`respond` is called.
+
+        @param commandType: a subclass of C{amp.Command}.
+
+        @param kwargs: Keyword arguments taken by the command, a C{dict}.
+
+        @return: A C{Deferred} that fires when :method:`respond` is called,
+            with the response from the underlying cleint.
+        """
         d = Deferred()
         response = self._client.callRemote(command, **kwargs)
         self._calls.append((d, response))
         return d
 
     def respond(self):
+        """
+        Respond to the oldest outstanding remote call.
+        """
         d, response = self._calls.pop(0)
         response.chainDeferred(d)

--- a/flocker/testtools/amp.py
+++ b/flocker/testtools/amp.py
@@ -1,0 +1,100 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+# -*- test-case-name: flocker.testtools.test.test_amp -*-
+
+"""
+Fakes for interacting with AMP.
+"""
+
+from twisted.python.failure import Failure
+from twisted.internet.defer import Deferred, succeed
+from twisted.protocols.amp import AMP, InvalidSignature
+
+
+class FakeAMPClient(object):
+    """
+    Emulate an AMP client's ability to send commands.
+
+    A minimal amount of validation is done on registered responses and sent
+    requests, but this should not be relied upon.
+
+    :ivar list calls: ``(command, kwargs)`` tuples of commands that have
+        been sent using ``callRemote``.
+    """
+
+    def __init__(self):
+        """
+        Initialize a fake AMP client.
+        """
+        self._responses = {}
+        self.calls = []
+
+    def _makeKey(self, command, kwargs):
+        """
+        Create a key for the responses dictionary.
+
+        @param commandType: a subclass of C{amp.Command}.
+
+        @param kwargs: a dictionary.
+
+        @return: A value that can be used as a dictionary key.
+        """
+        return (command, tuple(sorted(kwargs.items())))
+
+    def register_response(self, command, kwargs, response):
+        """
+        Register a response to a L{callRemote} command.
+
+        @param commandType: a subclass of C{amp.Command}.
+
+        @param kwargs: Keyword arguments taken by the command, a C{dict}.
+
+        @param response: The response to the command.
+        """
+        if isinstance(response, Exception):
+            response = Failure(response)
+        else:
+            try:
+                command.makeResponse(response, AMP())
+            except KeyError:
+                raise InvalidSignature("Bad registered response")
+        self._responses[self._makeKey(command, kwargs)] = response
+
+    def callRemote(self, command, **kwargs):
+        """
+        Return a previously registered response.
+
+        @param commandType: a subclass of C{amp.Command}.
+
+        @param kwargs: Keyword arguments taken by the command, a C{dict}.
+
+        @return: A C{Deferred} that fires with the registered response for
+            this particular combination of command and arguments.
+        """
+        self.calls.append((command, kwargs))
+        command.makeArguments(kwargs, AMP())
+        # if an eliot_context is present, disregard it, because we cannot
+        # reliably determine this in advance in order to include it in the
+        # response register
+        if 'eliot_context' in kwargs:
+            kwargs.pop('eliot_context')
+        return succeed(self._responses[self._makeKey(command, kwargs)])
+
+
+class DelayedAMPClient(object):
+    """
+    A wrapper for ``FakeAMPClient`` that allows responses to be delayed.
+    """
+
+    def __init__(self, client):
+        self._client = client
+        self._calls = []
+
+    def callRemote(self, command, **kwargs):
+        d = Deferred()
+        response = self._client.callRemote(command, **kwargs)
+        self._calls.append((d, response))
+        return d
+
+    def respond(self):
+        d, response = self._calls.pop(0)
+        response.chainDeferred(d)

--- a/flocker/testtools/test/test_amp.py
+++ b/flocker/testtools/test/test_amp.py
@@ -1,0 +1,85 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for :module:`flocker.testtools.amp`.
+"""
+
+from ..amp import FakeAMPClient, DelayedAMPClient
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from twisted.protocols.amp import Command, Integer
+
+
+class TestCommand(Command):
+    """
+    Trivial command for testing.
+    """
+    arguments = [
+        ('argument', Integer()),
+    ]
+    response = [
+        ('response', Integer()),
+    ]
+
+
+class DelayedAMPClientTests(SynchronousTestCase):
+    """
+    Tests for :class:`DelayedAMPClient`.
+    """
+
+    def test_forwards_call(self):
+        """
+        Calling :method:`callRemote` forwards the call to the
+        underlying client.
+        """
+        expected_arguments = {'argument': 42}
+
+        client = FakeAMPClient()
+        client.register_response(
+            TestCommand, expected_arguments, {'response': 7})
+        delayed_client = DelayedAMPClient(client)
+
+        delayed_client.callRemote(TestCommand, argument=42)
+
+        self.assertEqual(
+            client.calls,
+            [(TestCommand, {'argument': 42})],
+        )
+
+    def test_delays_response(self):
+        """
+        The deferred returned by :method:`callRemote` hasn't fired.
+        """
+        expected_arguments = {'argument': 42}
+
+        client = FakeAMPClient()
+        client.register_response(
+            TestCommand, expected_arguments, {'response': 7})
+        delayed_client = DelayedAMPClient(client)
+
+        d = delayed_client.callRemote(TestCommand, **expected_arguments)
+
+        self.assertNoResult(d)
+
+    def test_forwards_response(self):
+        """
+        Calling :method:`respond` causes the deferred deferred returned by
+        :method:`callRemote` to fire with the result of the underlying client.
+        """
+        expected_arguments = {'argument': 42}
+        expected_response = {'response': 7}
+        client = FakeAMPClient()
+        client.register_response(
+            TestCommand, expected_arguments, expected_response)
+        delayed_client = DelayedAMPClient(client)
+
+        d = delayed_client.callRemote(TestCommand, **expected_arguments)
+
+        delayed_client.respond()
+        self.assertEqual(
+            self.successResultOf(d),
+            expected_response,
+        )
+
+    # Missing test: Handling of multiple calls.


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3090

This is the expedient solution. One issue with it, is that it delays convergence iterations after this one until after the control node acknowledges the state update.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1970)
<!-- Reviewable:end -->
