### PR TITLE
[FLOC-3100] Memoize wire encode when sending updates to agents

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -55,6 +55,38 @@ from ._model import (
 PING_INTERVAL = timedelta(seconds=30)
 
 
+class CachingEncoder(object):
+    """
+    Cache results of ``wire_encode`` and re-use them, relying on the fact
+    we're encoding immutable objects.
+
+    Not thread-safe, so should only be used by Twisted code (or this
+    module).
+    """
+    def __init__(self):
+        self.clear()
+
+    def encode(self, obj):
+        """
+        Encode an object to bytes using ``wire_encode``, or return cached
+        result if available.
+
+        :param obj: Object to encode.
+        :return: Resulting ``bytes``.
+        """
+        if obj not in self.results:
+            self.results[obj] = wire_encode(obj)
+        return self.results[obj]
+
+    def clear(self):
+        """
+        Clear the cache.
+        """
+        self.results = {}
+
+_caching_encoder = CachingEncoder()
+
+
 class SerializableArgument(Argument):
     """
     AMP argument that takes an object that can be serialized by the

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -63,6 +63,9 @@ class CachingEncoder(object):
 
     Not thread-safe, so should only be used by a single thread (the
     Twisted reactor thread, presumably).
+
+    :var _cache: Either ``None`` indicating no caching or a dicitonary
+        with objects mapped to cached wire encoded values.
     """
     def __init__(self):
         self._cache = None

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -26,6 +26,9 @@ Interactions:
 Eliot contexts are transferred along with AMP commands, allowing tracing
 of logged actions across processes (see
 http://eliot.readthedocs.org/en/0.6.0/threads.html).
+
+:var _caching_encoder: ``CachingEncoder`` used by
+    ``SerializableArgument``, allowing for cached serialization.
 """
 
 from datetime import timedelta
@@ -64,7 +67,7 @@ class CachingEncoder(object):
     Not thread-safe, so should only be used by a single thread (the
     Twisted reactor thread, presumably).
 
-    :var _cache: Either ``None`` indicating no caching or a dicitonary
+    :attr _cache: Either ``None`` indicating no caching or a dicitonary
         with objects mapped to cached wire encoded values.
     """
     def __init__(self):

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -106,7 +106,8 @@ class SerializableArgument(Argument):
     def __init__(self, *classes):
         """
         :param *classes: The type or types of the objects we expect to
-            (de)serialize.
+            (de)serialize. Only immutable types should be used if encoding
+            caching will be enabled.
         """
         Argument.__init__(self)
         self._expected_classes = classes

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -167,11 +167,8 @@ class SerializationTests(SynchronousTestCase):
         ``SerializableArgument`` can be given multiple types to allow instances
         of any of those types to be serialized and deserialized.
         """
-        argument = SerializableArgument(list, dict)
-        objects = [
-            [u"foo"],
-            {u"bar": u"baz"},
-        ]
+        argument = SerializableArgument(NodeState, Deployment)
+        objects = [TEST_DEPLOYMENT, NODE_STATE]
         serialized = list(
             argument.toString(o)
             for o in objects

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -36,7 +36,7 @@ from .._protocol import (
     VersionCommand, ClusterStatusCommand, NodeStateCommand, IConvergenceAgent,
     NoOp, AgentAMP, ControlAMPService, ControlAMP, _AgentLocator,
     ControlServiceLocator, LOG_SEND_CLUSTER_STATE, LOG_SEND_TO_AGENT,
-    CachingEncoder,
+    CachingEncoder, _caching_encoder
 )
 from .._model import ChangeSource
 from .._clusterstate import ClusterStateService
@@ -196,6 +196,16 @@ class SerializationTests(SynchronousTestCase):
         as_bytes = argument.toString(TEST_DEPLOYMENT)
         self.assertRaises(
             TypeError, SerializableArgument(NodeState).fromString, as_bytes)
+
+    def test_caches(self):
+        """
+        Encoding results are cached when in the context of the caching
+        encoder's ``cache()`` call.
+        """
+        argument = SerializableArgument(Deployment)
+        with _caching_encoder.cache():
+            self.assertIs(argument.toString(TEST_DEPLOYMENT),
+                          argument.toString(TEST_DEPLOYMENT))
 
 
 def build_control_amp_service(test, reactor=None):


### PR DESCRIPTION
Instead of serializing config and state to JSON once for each destination, we only do it once.

The actual end-to-end result of this (lower CPU usage, i.e. the fact that we have caching enabled in `_send_state_to_connections`) is not tested, it's not clear to me how one would given current abstractions. Ideas welcome.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1972)
<!-- Reviewable:end -->
