### PR TITLE
[FLOC-3107] Include CPU shares and memory limit in Applications

### DIFF
--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -757,6 +757,8 @@ class ApplicationNodeDeployer(object):
                 volume=volume,
                 environment=environment if environment else None,
                 links=frozenset(links),
+                memory_limit=container.mem_limit,
+                cpu_shares=container.cpu_shares,
                 restart_policy=container.restart_policy,
                 running=(container.activation_state == u"active"),
                 command_line=container.command_line,

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -693,6 +693,49 @@ class ApplicationNodeDeployerDiscoverNodeConfigurationTests(
         self.assertItemsEqual(pset(applications),
                               self.successResultOf(d)[0].applications)
 
+    def test_discover_application_with_cpushares(self):
+        """
+        An ``Application`` with a cpu_shares value is discovered from a
+        ``Unit`` with a cpu_shares value.
+        """
+        unit1 = UNIT_FOR_APP.set("cpu_shares", 512)
+        units = {unit1.name: unit1}
+
+        fake_docker = FakeDockerClient(units=units)
+        applications = [APP.set("cpu_shares", 512)]
+        api = ApplicationNodeDeployer(
+            u'example.com',
+            node_uuid=self.node_uuid,
+            docker_client=fake_docker,
+            network=self.network
+        )
+        d = api.discover_state(self.EMPTY_NODESTATE)
+
+        self.assertEqual(sorted(applications),
+                         sorted(self.successResultOf(d)[0].applications))
+
+    def test_discover_application_with_memory_limit(self):
+        """
+        An ``Application`` with a memory_limit value is discovered from a
+        ``Unit`` with a mem_limit value.
+        """
+        memory_limit = 104857600
+        unit1 = UNIT_FOR_APP.set("mem_limit", memory_limit)
+        units = {unit1.name: unit1}
+
+        fake_docker = FakeDockerClient(units=units)
+        applications = [APP.set("memory_limit", memory_limit)]
+        api = ApplicationNodeDeployer(
+            u'example.com',
+            node_uuid=self.node_uuid,
+            docker_client=fake_docker,
+            network=self.network
+        )
+        d = api.discover_state(self.EMPTY_NODESTATE)
+
+        self.assertEqual(sorted(applications),
+                         sorted(self.successResultOf(d)[0].applications))
+
     def test_discover_application_with_environment(self):
         """
         An ``Application`` with ``Environment`` objects is discovered from a


### PR DESCRIPTION
Fixes FLOC-3107. Previously we overlooked the memory limit and CPU shares coming back from a Unit when listing container state and didn't include these in the Applications we construct when discovering node state, hence erroneously constructing a model that represented a different state than that desired from the configuration and calculating changes accordingly - so containers were continuously created, destroyed and recreated when using these options.