### PR TITLE
[FLOC-3110] Support big cluster configurations and numbers of nodes

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -232,7 +232,7 @@ class ClusterStatusCommand(Command):
     Having both as a single command simplifies the decision making process
     in the convergence agent during startup.
     """
-    arguments = [('configuration', SerializableArgument(Deployment)),
+    arguments = [('configuration', Big(SerializableArgument(Deployment))),
                  ('state', SerializableArgument(DeploymentState)),
                  ('eliot_context', _EliotActionArgument())]
     response = []

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -233,7 +233,7 @@ class ClusterStatusCommand(Command):
     in the convergence agent during startup.
     """
     arguments = [('configuration', Big(SerializableArgument(Deployment))),
-                 ('state', SerializableArgument(DeploymentState)),
+                 ('state', Big(SerializableArgument(DeploymentState))),
                  ('eliot_context', _EliotActionArgument())]
     response = []
 

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -19,7 +19,8 @@ from twisted.test.iosim import connectedServerAndClient
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.test.proto_helpers import StringTransport, MemoryReactor
 from twisted.protocols.amp import (
-    UnknownRemoteError, RemoteAmpError, CommandLocator, AMP,
+    MAX_VALUE_LENGTH, IArgumentType, Command, String, ListOf, Integer,
+    UnknownRemoteError, RemoteAmpError, CommandLocator, AMP, parseString,
 )
 from twisted.python.failure import Failure
 from twisted.internet.error import ConnectionLost
@@ -31,7 +32,7 @@ from twisted.internet.ssl import ClientContextFactory
 from twisted.internet.task import Clock
 
 from .._protocol import (
-    PING_INTERVAL, SerializableArgument,
+    PING_INTERVAL, Big, SerializableArgument,
     VersionCommand, ClusterStatusCommand, NodeStateCommand, IConvergenceAgent,
     NoOp, AgentAMP, ControlAMPService, ControlAMP, _AgentLocator,
     ControlServiceLocator, LOG_SEND_CLUSTER_STATE, LOG_SEND_TO_AGENT,
@@ -121,6 +122,78 @@ NONMANIFEST = NonManifestDatasets(
     datasets={dataset.dataset_id: dataset}
 )
 del dataset
+
+
+class BigArgumentTests(SynchronousTestCase):
+    class CommandWithBigArgument(Command):
+        arguments = [
+            ("big", Big(String())),
+        ]
+
+    class CommandWithTwoBigArgument(Command):
+        arguments = [
+            ("big", Big(String())),
+            ("large", Big(String())),
+        ]
+
+    class CommandWithBigAndRegularArgument(Command):
+        arguments = [
+            ("big", Big(String())),
+            ("regular", String()),
+        ]
+
+    class CommandWithBigListArgument(Command):
+        arguments = [
+            ("big", Big(ListOf(Integer()))),
+        ]
+
+    def test_interface(self):
+        """
+        ``Big`` instances provide ``IArgumentType``.
+        """
+        big = dict(self.CommandWithBigArgument.arguments)["big"]
+        self.assertTrue(verifyObject(IArgumentType, big))
+
+    def assert_roundtrips(self, command, **kwargs):
+        amp_protocol = None
+        argument_box = command.makeArguments(kwargs, amp_protocol)
+        [roundtripped] = parseString(argument_box.serialize())
+        parsed_objects = command.parseArguments(roundtripped, amp_protocol)
+        self.assertEqual(kwargs, parsed_objects)
+
+    def test_roundtrip_non_string(self):
+        some_list = range(10)
+        self.assert_roundtrips(self.CommandWithBigListArgument, big=some_list)
+
+    def test_roundtrip_small(self):
+        small_bytes = b"hello world"
+        self.assert_roundtrips(self.CommandWithBigArgument, big=small_bytes)
+
+    def test_roundtrip_medium(self):
+        medium_bytes = b"x" * (MAX_VALUE_LENGTH + 1)
+        self.assert_roundtrips(self.CommandWithBigArgument, big=medium_bytes)
+
+    def test_roundtrip_large(self):
+        big_bytes = u"\n".join(
+            u"{value}".format(value=value)
+            for value
+            in range(MAX_VALUE_LENGTH)
+        ).encode("ascii")
+        self.assert_roundtrips(self.CommandWithBigArgument, big=big_bytes)
+
+    def test_two_big_arguments(self):
+        self.assert_roundtrips(
+            self.CommandWithTwoBigArgument,
+            big=b"hello world",
+            large=b"goodbye world",
+        )
+
+    def test_big_and_regular_arguments(self):
+        self.assert_roundtrips(
+            self.CommandWithBigAndRegularArgument,
+            big=b"hello world",
+            regular=b"goodbye world",
+        )
 
 
 class SerializationTests(SynchronousTestCase):

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -140,14 +140,18 @@ MANIFESTATION = Manifestation(dataset=Dataset(dataset_id=unicode(uuid4())),
 _MANY_CONTAINERS = 800
 
 
-def _huge(deployment_prototype, node_prototype):
+def huge_node(node_prototype):
     image = DockerImage.from_string(u'postgresql')
     applications = [
         Application(name=u'postgres-{}'.format(i), image=image)
         for i in range(_MANY_CONTAINERS)
     ]
+    return node_prototype.set(applications=applications)
+
+
+def _huge(deployment_prototype, node_prototype):
     return deployment_prototype.update_node(
-        node_prototype.set(applications=applications),
+        huge_node(node_prototype),
     )
 
 

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -125,6 +125,9 @@ del dataset
 
 
 class BigArgumentTests(SynchronousTestCase):
+    """
+    Tests for ``Big``.
+    """
     class CommandWithBigArgument(Command):
         arguments = [
             ("big", Big(String())),
@@ -155,6 +158,9 @@ class BigArgumentTests(SynchronousTestCase):
         self.assertTrue(verifyObject(IArgumentType, big))
 
     def assert_roundtrips(self, command, **kwargs):
+        """
+        ``kwargs`` supplied to ``command`` can be serialized and unserialized.
+        """
         amp_protocol = None
         argument_box = command.makeArguments(kwargs, amp_protocol)
         [roundtripped] = parseString(argument_box.serialize())
@@ -162,26 +168,47 @@ class BigArgumentTests(SynchronousTestCase):
         self.assertEqual(kwargs, parsed_objects)
 
     def test_roundtrip_non_string(self):
+        """
+        When ``Big`` wraps a non-string argument, it can serialize and
+        unserialize it.
+        """
         some_list = range(10)
         self.assert_roundtrips(self.CommandWithBigListArgument, big=some_list)
 
     def test_roundtrip_small(self):
+        """
+        ``Big`` can serialize and unserialize argmuments which are smaller then
+        MAX_VALUE_LENGTH.
+        """
         small_bytes = b"hello world"
         self.assert_roundtrips(self.CommandWithBigArgument, big=small_bytes)
 
     def test_roundtrip_medium(self):
+        """
+        ``Big`` can serialize and unserialize argmuments which are larger than
+        MAX_VALUE_LENGTH.
+        """
         medium_bytes = b"x" * (MAX_VALUE_LENGTH + 1)
         self.assert_roundtrips(self.CommandWithBigArgument, big=medium_bytes)
 
     def test_roundtrip_large(self):
+        """
+        ``Big`` can serialize and unserialize argmuments which are larger than
+        MAX_VALUE_LENGTH.
+        """
         big_bytes = u"\n".join(
             u"{value}".format(value=value)
             for value
             in range(MAX_VALUE_LENGTH)
         ).encode("ascii")
+
         self.assert_roundtrips(self.CommandWithBigArgument, big=big_bytes)
 
     def test_two_big_arguments(self):
+        """
+        AMP can serialize and unserialize a ``Command`` with multiple ``Big``
+        arguments.
+        """
         self.assert_roundtrips(
             self.CommandWithTwoBigArgument,
             big=b"hello world",
@@ -189,6 +216,10 @@ class BigArgumentTests(SynchronousTestCase):
         )
 
     def test_big_and_regular_arguments(self):
+        """
+        AMP can serialize and unserialize a ``Command`` with a combination of
+        ``Big`` and regular arguments.
+        """
         self.assert_roundtrips(
             self.CommandWithBigAndRegularArgument,
             big=b"hello world",

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -158,6 +158,16 @@ def huge_deployment():
     return _huge(Deployment(), Node(hostname=u'192.0.2.31'))
 
 
+def huge_state():
+    """
+    Return a state with many containers.
+    """
+    return _huge(
+        DeploymentState(),
+        NodeState(hostname=u'192.0.2.31', applications=[], used_ports=[]),
+    )
+
+
 # A very simple piece of node state that makes for nice-looking, easily-read
 # test failures.  It arbitrarily supplies only ports because integers have a
 # very simple representation.
@@ -735,6 +745,19 @@ class AgentClientTests(SynchronousTestCase):
             eliot_context=TEST_ACTION
         )
 
+        self.successResultOf(d)
+
+    def test_too_long_state(self):
+        """
+        AMP protocol can transmit states with 800 applications.
+        """
+        self.client.makeConnection(StringTransport())
+        d = self.server.callRemote(
+            ClusterStatusCommand,
+            configuration=Deployment(),
+            state=huge_state(),
+            eliot_context=TEST_ACTION,
+        )
         self.successResultOf(d)
 
     def test_cluster_updated(self):

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -141,6 +141,15 @@ _MANY_CONTAINERS = 800
 
 
 def huge_node(node_prototype):
+    """
+    Return a node with many applications.
+
+    :param node_prototype: A ``Node`` or ``NodeState`` to use as a template for
+        the resulting node.
+
+    :return: An object like ``node_prototype`` but with its applications
+        replaced by a large collection of applications.
+    """
     image = DockerImage.from_string(u'postgresql')
     applications = [
         Application(name=u'postgres-{}'.format(i), image=image)
@@ -150,6 +159,17 @@ def huge_node(node_prototype):
 
 
 def _huge(deployment_prototype, node_prototype):
+    """
+    Return a deployment with many applications.
+
+    :param deployment_prototype: A ``Deployment`` or ``DeploymentState`` to use
+        as a template for the resulting deployment.
+    :param node_prototype: See ``huge_node``.
+
+    :return: An object like ``deployment_prototype`` but with a node like
+        ``node_prototype`` added (or modified) so as to include a large number
+        of applications.
+    """
     return deployment_prototype.update_node(
         huge_node(node_prototype),
     )
@@ -158,6 +178,8 @@ def _huge(deployment_prototype, node_prototype):
 def huge_deployment():
     """
     Return a configuration with many containers.
+
+    :rtype: ``Deployment``
     """
     return _huge(Deployment(), Node(hostname=u'192.0.2.31'))
 
@@ -165,6 +187,8 @@ def huge_deployment():
 def huge_state():
     """
     Return a state with many containers.
+
+    :rtype: ``DeploymentState``
     """
     return _huge(
         DeploymentState(),


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3110

This allows arbitrarily large (more or less) `Deployment` objects to be passed around as cluster configuration (using the recently introduced `Big` argument type).  It does likewise for `DeploymentState` objects.

Note that arbitrarily large `NodeState` objects passed from agents to the control service in `NodeStateCommand` are not supported.  They have a small serialization quirk and will need a slightly different strategy applied.