### PR TITLE
[FLOC 2993] Adding Labs context to Installer docs

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -8,12 +8,12 @@ Quick Start
 ===========
 
 Want to get started with Flocker quickly?
-Try the :ref:`Installer <labs-installer>`.
+You can try the Labs Installer.
 
 * It makes it easy to set up and manage a Flocker cluster.
 * It runs inside a Docker container on your local machine.
 
-:ref:`Click here to proceed with the automatic installer <labs-installer>`.
+:ref:`Try the Labs installer <labs-installer>`.
 
 If you'd rather install Flocker manually, read on.
 

--- a/docs/install/install-client.rst
+++ b/docs/install/install-client.rst
@@ -1,15 +1,5 @@
 .. _installing-flocker-cli:
 
-.. note::
-
-    Want to get started with Flocker quickly?
-
-    Try the :ref:`Installer <labs-installer>`.
-    It makes it easy to set up and manage a Flocker cluster.
-    It runs inside a Docker container on your local machine.
-
-    If you use the Installer then you don't need to follow the instructions on this page.
-
 =============================
 Installing the Flocker Client
 =============================

--- a/docs/install/install-node.rst
+++ b/docs/install/install-node.rst
@@ -1,15 +1,5 @@
 .. _installing-flocker-node:
 
-.. note::
-
-    Want to get started with Flocker quickly?
-
-    Try the :ref:`Installer <labs-installer>`.
-    It makes it easy to set up and manage a Flocker cluster.
-    It runs inside a Docker container on your local machine.
-
-    If you use the Installer then you don't need to follow the instructions on this page.
-
 ====================================
 Installing the Flocker Node Services
 ====================================


### PR DESCRIPTION
An addition to previous PR from @lukemarsden - this amendment ensures that the user is aware that they are clicking a link that take them into the Labs installer instructions.