### PR TITLE
Runremotely floc 3124

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -946,7 +946,7 @@ def main(reactor, args, base_path, top_level):
                 parallel([
                     run_remotely(
                         username='root',
-                        address=node.address,
+                        address=node.address.encode('ascii'),
                         commands=task_pull_docker_images()
                     ) for node in cluster.agent_nodes
                 ]),

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -1242,7 +1242,7 @@ def configure_cluster(cluster, dataset_backend_configuration):
             sequence([
                 run_remotely(
                     username='root',
-                    address=node.address,
+                    address=node.address.encode('ascii'),
                     commands=sequence([
                         task_install_node_certificates(
                             cluster.certificates.cluster.certificate,

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -1229,7 +1229,7 @@ def configure_cluster(cluster, dataset_backend_configuration):
     return sequence([
         run_remotely(
             username='root',
-            address=cluster.control_node.address,
+            address=cluster.control_node.address.encode('ascii'),
             commands=sequence([
                 task_install_control_certificates(
                     cluster.certificates.cluster.certificate,

--- a/flocker/provision/_rackspace.py
+++ b/flocker/provision/_rackspace.py
@@ -38,7 +38,7 @@ def provision_rackspace(node, package_source, distribution, variants):
     commands = []
     commands.append(run_remotely(
         username=get_default_username(distribution),
-        address=node.address,
+        address=node.address.encode('ascii'),
         commands=sequence([
             provision(
                 package_source=package_source,


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3124

Without this, some acceptance tests don't run with `pypy`, and we were passing unicode to a function which has a docstring explaining that it expects bytes.

See http://52.25.42.219/builders/flocker%2Facceptance%2Frackspace%2Fcentos-7%2Frackspace/builds/6 for a failure on master and http://52.25.42.219/builders/flocker%2Facceptance%2Frackspace%2Fcentos-7%2Frackspace/builds/10 for a success on this branch.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/1992)
<!-- Reviewable:end -->
