### PR TITLE
[FLOC-3135] Handle exceptions from IDeployer.discover_state in the convergence loop

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,12 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+
+Next Release
+============
+
+* Unexpected errors in agent state discovery no longer break the agent convergence loop.
+
 v1.4.0
 ======
 

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -28,7 +28,7 @@ from machinist import (
 
 from twisted.application.service import MultiService
 from twisted.python.constants import Names, NamedConstant
-from twisted.internet.defer import succeed
+from twisted.internet.defer import succeed, maybeDeferred
 from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.protocols.tls import TLSMemoryBIOFactory
 
@@ -366,8 +366,8 @@ class ConvergenceLoop(object):
 
         with LOG_CONVERGE(self.fsm.logger, cluster_state=self.cluster_state,
                           desired_configuration=self.configuration).context():
-            d = DeferredContext(
-                self.deployer.discover_state(known_local_state))
+            d = DeferredContext(maybeDeferred(
+                self.deployer.discover_state, known_local_state))
 
         def got_local_state(state_changes):
             # Current cluster state is likely out of date as regards the local


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3135

This ended up not being OpenStack specific.  As long as we actually retry the OpenStack operation, we'll eventually get results again.