### PR TITLE
[FLOC-1292] Make admonition links be visible.

### DIFF
--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -275,10 +275,6 @@ p {
     display: none;
 }
 
-.admonition a {
-    color: #000000;
-}
-
 .admonition p.last {
     padding-right: 15px;
     padding-bottom: 15px;


### PR DESCRIPTION
Before:

<img width="772" alt="screen shot 2015-09-26 at 14 33 19" src="https://cloud.githubusercontent.com/assets/264658/10117796/9893c56c-645b-11e5-87ef-5f0443cdaa38.png">

After:

<img width="768" alt="screen shot 2015-09-26 at 14 33 34" src="https://cloud.githubusercontent.com/assets/264658/10117797/9cef7a2a-645b-11e5-960b-bb288b605d1b.png">

@adamtheturtle You said you'd merge this.