### PR TITLE
[FLOC-3150] Add a delay before starting the container-agent loop

### DIFF
--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -4,7 +4,7 @@ After=docker.service
 Wants=docker.service
 
 [Service]
-ExecStart=echo "Sleeping 120s to ensure previous dataset state is expired."; sleep 120; /usr/sbin/flocker-container-agent --journald
+ExecStart=sh -c 'echo "Sleeping 120s to ensure previous dataset state is expired."; sleep 120; /usr/sbin/flocker-container-agent --journald'
 Restart=always
 
 [Install]

--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -4,7 +4,11 @@ After=docker.service
 Wants=docker.service
 
 [Service]
-ExecStart=sh -c 'echo "Sleeping 120s to ensure previous dataset state is expired."; sleep 120; /usr/sbin/flocker-container-agent --journald'
+ExecStart=/usr/bin/sh -c '\
+    echo "Sleeping 120s to ensure previous dataset state is expired."; \
+    sleep 120; \
+    exec /usr/sbin/flocker-container-agent --journald \
+'
 Restart=always
 
 [Install]

--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -4,7 +4,7 @@ After=docker.service
 Wants=docker.service
 
 [Service]
-ExecStart=/usr/sbin/flocker-container-agent --journald
+ExecStart=echo "Sleeping 120s to ensure previous dataset state is expired."; sleep 120; /usr/sbin/flocker-container-agent --journald
 Restart=always
 
 [Install]

--- a/admin/package-files/systemd/flocker-container-agent.service
+++ b/admin/package-files/systemd/flocker-container-agent.service
@@ -4,6 +4,7 @@ After=docker.service
 Wants=docker.service
 
 [Service]
+# See https://clusterhq.atlassian.net/browse/FLOC-3154
 ExecStart=/usr/bin/sh -c '\
     echo "Sleeping 120s to ensure previous dataset state is expired."; \
     sleep 120; \

--- a/admin/package-files/upstart/flocker-container-agent.conf
+++ b/admin/package-files/upstart/flocker-container-agent.conf
@@ -21,5 +21,7 @@ pre-start script
 end script
 
 script
-        exec sh -c 'echo "Sleeping 120s to ensure previous dataset state is expired."; sleep 120; /usr/sbin/flocker-container-agent --logfile=/var/log/flocker/flocker-container-agent.log'
+        echo "Sleeping 120s to ensure previous dataset state is expired."
+        sleep 120
+        exec /usr/sbin/flocker-container-agent --logfile=/var/log/flocker/flocker-container-agent.log
 end script

--- a/admin/package-files/upstart/flocker-container-agent.conf
+++ b/admin/package-files/upstart/flocker-container-agent.conf
@@ -9,8 +9,6 @@ stop on runlevel [016]
 respawn
 
 pre-start script
-        echo "Sleeping 120s to ensure previous dataset state is expired."
-        sleep 120
         if [ ! -r /etc/flocker/agent.yml ]; then
                 echo "Cannot read configuration file '/etc/flocker/agent.yml'."
                 exit 1
@@ -23,5 +21,5 @@ pre-start script
 end script
 
 script
-        exec /usr/sbin/flocker-container-agent --logfile=/var/log/flocker/flocker-container-agent.log
+        exec sh -c 'echo "Sleeping 120s to ensure previous dataset state is expired."; sleep 120; /usr/sbin/flocker-container-agent --logfile=/var/log/flocker/flocker-container-agent.log'
 end script

--- a/admin/package-files/upstart/flocker-container-agent.conf
+++ b/admin/package-files/upstart/flocker-container-agent.conf
@@ -9,6 +9,8 @@ stop on runlevel [016]
 respawn
 
 pre-start script
+        echo "Sleeping 120s to ensure previous dataset state is expired."
+        sleep 120
         if [ ! -r /etc/flocker/agent.yml ]; then
                 echo "Cannot read configuration file '/etc/flocker/agent.yml'."
                 exit 1

--- a/admin/package-files/upstart/flocker-container-agent.conf
+++ b/admin/package-files/upstart/flocker-container-agent.conf
@@ -20,6 +20,7 @@ pre-start script
         done
 end script
 
+# See https://clusterhq.atlassian.net/browse/FLOC-3154
 script
         echo "Sleeping 120s to ensure previous dataset state is expired."
         sleep 120

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -16,7 +16,7 @@ from jsonschema import FormatChecker, Draft4Validator
 
 from pyrsistent import PRecord, field, PMap, pmap, pvector
 
-from eliot import ActionType, fields, Message
+from eliot import ActionType, fields
 
 from zope.interface import implementer
 
@@ -25,7 +25,6 @@ from twisted.python.usage import Options, UsageError
 from twisted.internet.ssl import Certificate
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
-from twisted.internet.task import deferLater
 from twisted.python.constants import Names, NamedConstant
 from twisted.python.reflect import namedAny
 
@@ -47,7 +46,6 @@ from .agents.blockdevice import (
 )
 from ..ca import ControlServicePolicy, NodeCredential
 
-from ..control._clusterstate import EXPIRATION_TIME
 
 __all__ = [
     "flocker_dataset_agent_main",
@@ -86,16 +84,7 @@ def flocker_container_agent_main():
     service_factory = AgentServiceFactory(
         deployer_factory=deployer_factory
     ).get_service
-    # We start the container agent with a delay equal to that of the state
-    # wiper in the control service, so that after a reboot of a node, stale
-    # state from the pre-reboot dataset agent must be expired by the time this
-    # container agent starts up. This avoids a bug where the container agent
-    # starts containers before their datasets are ready because of such stale
-    # dataset state.
-    agent_script = AgentScript(
-        service_factory=service_factory,
-        startup_delay=EXPIRATION_TIME.total_seconds(),
-    )
+    agent_script = AgentScript(service_factory=service_factory)
     return FlockerScriptRunner(
         script=agent_script,
         options=ContainerAgentOptions()
@@ -274,28 +263,14 @@ class AgentScript(PRecord):
         provider that will get run when this script is run.  The arguments
         passed to it are the reactor being used and a ``AgentOptions``
         instance which has parsed any command line options that were given.
-
-    :ivar startup_delay: An optional startup delay before letting the agent
-        start up.
     """
     service_factory = field(mandatory=True)
-    startup_delay = field(initial=0)
 
     def main(self, reactor, options):
-        if self.startup_delay > 0:
-            Message.log(
-                message='Waiting {}s for cluster state to expire.'.format(
-                    EXPIRATION_TIME.total_seconds(),
-                )
-            )
-
-        def delay():
-            return main_for_service(
-                reactor,
-                self.service_factory(reactor, options)
-            )
-
-        return deferLater(reactor, self.startup_delay, delay)
+        return main_for_service(
+            reactor,
+            self.service_factory(reactor, options)
+        )
 
 
 class AgentServiceFactory(PRecord):


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-3150

Original plan was to modify systemd service files, but
* this alternative change means we don't have to add duplicate changes to upstart files, and
* that we can log the reason for the startup delay in Eliot format, and
* we can import the actual `EXPIRATION_TIME` used by the state wiper service.

After discussion with @exarkun we decided not to include our acceptance test for this change since it won't reliably run on Buildbot.

See reliable-reboot-acceptance-test-FLOC-3150 for the acceptance test for manual testing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2001)
<!-- Reviewable:end -->
