### PR TITLE
[FLOC-3140] Coalesce redundant cluster parameter updates to agents

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -370,20 +370,11 @@ def _serialize_agent(controlamp):
     """
     Serialize a connected ``ControlAMP`` to the address of its peer.
 
-    :raise TypeError: If the given protocol is not an instance of
-        ``ControlAMP``.
-
     :return: A string representation of the Twisted address object describing
         the remote address of the connection of the given protocol.
 
     :rtype str:
     """
-    if not isinstance(controlamp, ControlAMP):
-        raise TypeError(
-            "Logged agent field must be ControlAMP, not {}".format(
-                fullyQualifiedName(controlamp.__class__),
-            )
-        )
     return str(controlamp.transport.getPeer())
 
 
@@ -455,12 +446,11 @@ class ControlAMPService(Service):
         """
         configuration = self.configuration_service.get()
         state = self.cluster_state.as_deployment()
-        with LOG_SEND_CLUSTER_STATE(self.logger,
-                                    configuration=configuration,
+        with LOG_SEND_CLUSTER_STATE(configuration=configuration,
                                     state=state):
             with _caching_encoder.cache():
                 for connection in connections:
-                    action = LOG_SEND_TO_AGENT(self.logger, agent=connection)
+                    action = LOG_SEND_TO_AGENT(agent=connection)
                     with action.context():
                         # XXX If callRemote raises an exception, the loop won't
                         # finish and the rest of the connections won't receive

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -463,7 +463,7 @@ class ControlAMPService(Service):
                         ]
                     except KeyError:
                         current_command = self._update_connection(
-                            connection, configuration, state, action
+                            connection, configuration, state,
                         )
                         self._current_command_for_connection[connection] = (current_command, False)
 
@@ -478,7 +478,7 @@ class ControlAMPService(Service):
                             )
                             self._current_command_for_connection[connection] = (current_command, True)
 
-    def _update_connection(self, connection, configuration, state, action):
+    def _update_connection(self, connection, configuration, state):
         action = LOG_SEND_TO_AGENT(agent=connection)
         with action.context():
             d = DeferredContext(connection.callRemote(

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -1078,9 +1078,6 @@ class SendStateToConnectionsTests(SynchronousTestCase):
         server = LoopbackAMPClient(client.locator)
 
         control_amp_service.connected(server)
-
-        self.patch(control_amp_service, 'logger', logger)
-
         control_amp_service._send_state_to_connections(connections=[server])
 
         assertHasAction(

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -736,7 +736,6 @@ class ControlAMPServiceTests(ControlTestCase):
 
         server = LoopbackAMPClient(client.locator)
         delayed_server = DelayedAMPClient(server)
-        delayed_server.transport = StringTransport()
         # Send first update
         service.connected(delayed_server)
         first_agent_desired = agent.desired

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -595,7 +595,9 @@ class ControlAMPTests(ControlTestCase):
         servers = list(LoopbackAMPClient(client.locator) for client in clients)
 
         for server in servers:
-            self.control_amp_service.connected(server)
+            delayed = DelayedAMPClient(server)
+            self.control_amp_service.connected(delayed)
+            delayed.respond()
 
         self.successResultOf(
             self.client.callRemote(NodeStateCommand,

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -4,10 +4,8 @@
 Tests for ``flocker.control._protocol``.
 """
 
-from os import urandom
 from uuid import uuid4
 from json import loads
-from socket import AF_INET6, inet_ntop
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -54,10 +52,6 @@ from .._persistence import ConfigurationPersistenceService, wire_encode
 from .clusterstatetools import advance_some, advance_rest
 
 
-def random_ip():
-    return inet_ntop(AF_INET6, urandom(16))
-
-
 def arbitrary_transformation(deployment):
     """
     Make some change to a deployment configuration.  Any change.
@@ -71,7 +65,7 @@ def arbitrary_transformation(deployment):
     """
     return deployment.transform(
         ["nodes"],
-        lambda nodes: nodes.add(Node(hostname=random_ip(), uuid=uuid4())),
+        lambda nodes: nodes.add(Node(uuid=uuid4())),
     )
 
 class LoopbackAMPClient(object):

--- a/flocker/testtools/amp.py
+++ b/flocker/testtools/amp.py
@@ -8,6 +8,7 @@ Fakes for interacting with AMP.
 from twisted.python.failure import Failure
 from twisted.internet.defer import Deferred, succeed
 from twisted.protocols.amp import AMP, InvalidSignature
+from twisted.test.proto_helpers import StringTransport
 
 
 class FakeAMPClient(object):
@@ -91,6 +92,7 @@ class DelayedAMPClient(object):
     def __init__(self, client):
         self._client = client
         self._calls = []
+        self.transport = StringTransport()
 
     def callRemote(self, command, **kwargs):
         """


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3140

The general idea here is that because many different things trigger a full update of cluster parameters (state and configuration) to agents, it is often the case that several full updates will be sent to an agent before it has even had a chance to process the first update.  In these cases, the first update is unavoidable and the last update is useful but the intermediate updates are useless and we can avoid sending them.  So, do.

Since we only have manual, ad hoc benchmarking in place at the moment, here are some results from my manual, ad hoc benchmarks:

Without this change, it takes longer than 10 minutes (I didn't wait to see much much longer) for flocker-control to finish processing all of the events generated on the startup of a 40 node cluster.

With this change, it takes about 3 minutes.

With this change, on an empty 40 node cluster it takes slightly less than 6 minutes to configure 593 containers (out of an attempted 800, the difference is accounted for by errors from the API server).  Measuring from when the first container is configured, it takes a little less than 9 minutes to converge on this configuration.  While convergence is underway, it takes a little under 2 minutes for the control service to respond to a read-only API request.  Once the cluster has converged, it takes 14 seconds to add one more container to the configuration and an additional 16 seconds to converge on that configuration.

As a follow-up to this, I've made an additional change which cuts down the cost of some Eliot logging near the code changed by this PR.  That involved some refactoring which somewhat improves the readability of this code.  I didn't have a chance this evening to push that refactoring into this PR so what's here is a bit of a mess.  Please have a look at https://github.com/ClusterHQ/flocker/compare/coalesce-calls-probably-even-better-FLOC-3140...send_cluster_state_logging-FLOC-3151?expand=1 to see the improved factoring and don't count the mess in this PR as a reason not to accept this change (since it is required before send_cluster_state_logging-FLOC-3151 can be merged).

As far as I know, send_cluster_state_logging-FLOC-3151 is also ready for a PR but since it's stacked on this branch github will make a mess of the diff - so I'm aiming for this to be merged before creating that PR.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2002)
<!-- Reviewable:end -->
