### PR TITLE
[FLOC-3155] Add 'available' as a possible transient state when attaching Cinder volumes

### DIFF
--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -527,7 +527,7 @@ class CinderBlockDeviceAPI(object):
             volume_manager=self.cinder_volume_manager,
             expected_volume=nova_volume,
             desired_state=u'in-use',
-            transient_states=(u'attaching',),
+            transient_states=(u'available', u'attaching',),
         )
 
         attached_volume = unattached_volume.set('attached_to', attach_to)

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -331,7 +331,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
             desired_state=u'in-use',
-            transient_states=(u'attaching',),
+            transient_states=(u'available', u'attaching',),
         )
 
         devices_after = set(FilePath('/dev').children())
@@ -376,7 +376,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
             desired_state=u'in-use',
-            transient_states=(u'attaching',),
+            transient_states=(u'available', u'attaching',),
         )
 
         devices_after = set(FilePath('/dev').children())
@@ -421,7 +421,7 @@ class CinderAttachmentTests(SynchronousTestCase):
                 volume_manager=self.cinder.volumes,
                 expected_volume=attached_volume,
                 desired_state=u'in-use',
-                transient_states=(u'attaching',),
+                transient_states=(u'available', u'attaching',),
             )
         self.assertEqual(e.exception.unexpected_state, u'available')
 
@@ -461,7 +461,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
             desired_state=u'in-use',
-            transient_states=(u'attaching',),
+            transient_states=(u'available', u'attaching',),
         )
 
         self.assertRaises(
@@ -499,7 +499,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume_manager=self.cinder.volumes,
             expected_volume=attached_volume,
             desired_state=u'in-use',
-            transient_states=(u'attaching',),
+            transient_states=(u'available', u'attaching',),
         )
         self.assertEqual(
             FilePath(


### PR DESCRIPTION
This PR adds 'available' as an expected state when attaching volumes using the Cinder client. Although the volume goes through the sequence `('available', 'attaching', 'in-use')`, the state 'available' was missing as an expected state because we have never seen 'available' occur in the attachment sequence. 

For detaching, we had seen the state 'in-use' occur at the start of the sequence `('in-use', 'detaching', 'available')`.  Hence, the equivalent detach code includes the initial state. 

Perhaps due to speedups introduced through recent patches, we have now seen the unexpected 'available' state occur in attachment.  Hence, we add it to the code as an expected state.

This has the nice effect of making the `attach_volume` and `detach_volume` functions more symmetric.

Note, there is another sequence that can occur `('available', 'attaching', (some inability of Cinder to attach), 'available')`.  If this occurs, one of two things will happen:
1. If the 'attaching' state is seen, then 'available' is no longer a valid state, and the unexpected state exception will be raised, correctly this time.
2. If the 'attaching' state is not seen, it is ambiguous whether we are seeing the first or second 'available' state. In this case, the client will hang until a timeout exception is raised. Since we regard failure to attach within the timeout as an error, it is appropriate to raise an exception, and try again on the next convergence loop.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2003)
<!-- Reviewable:end -->
