### PR TITLE
[FLOC-3158] Re-raise `RequestLimitExceeded` instead of `CloudKeyNotFound`.

### DIFF
--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -181,7 +181,12 @@ class LibcloudProvisioner(object):
         """
         try:
             key_pair = self._driver.get_key_pair(self._keyname)
-        except Exception:
+        except Exception as e:
+            if "RequestLimitExceeded" in e.message:
+                # If we have run into API limits, we don't know if the key is
+                # available. Re-raise the the exception, so that we can
+                # accurately see the cause of the error.
+                raise
             raise CloudKeyNotFound(self._keyname)
         if key_pair.public_key is not None:
             return Key.fromString(key_pair.public_key, type='public_openssh')


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3158

My hypothesis is that https://clusterhq.atlassian.net/browse/FLOC-3152 is caused by `RequestLimitExceeded`. By propagating the error, we can see if that is in fact the case.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2005)
<!-- Reviewable:end -->
