### PR TITLE
Osx 10 11 floc 3164

### DIFF
--- a/admin/homebrew.py
+++ b/admin/homebrew.py
@@ -172,6 +172,8 @@ class {class_name} < Formula
   depends_on "openssl"
 {resources}
   def install
+    ENV["LDFLAGS"] = "-L#{{opt_prefix}}/openssl/lib"
+    ENV["CFLAGS"] = "-I#{{opt_prefix}}/openssl/include"
     ENV.prepend_create_path "PYTHONPATH", "#{{libexec}}/vendor/lib/python2.7/site-packages"
     %w[{dependencies}].each do |r|
       resource(r).stage do

--- a/admin/homebrew.py
+++ b/admin/homebrew.py
@@ -169,6 +169,7 @@ class {class_name} < Formula
   url "{sdist_url}"
   sha1 "{sha1}"
   depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "openssl"
 {resources}
   def install
     ENV.prepend_create_path "PYTHONPATH", "#{{libexec}}/vendor/lib/python2.7/site-packages"

--- a/admin/homebrew.py
+++ b/admin/homebrew.py
@@ -172,8 +172,12 @@ class {class_name} < Formula
   depends_on "openssl"
 {resources}
   def install
+    # XXX These environment variables are necessary until cryptography has
+    # wheels for OS X 10.11.
+    # See https://github.com/pyca/cryptography/issues/2350
     ENV["LDFLAGS"] = "-L#{{opt_prefix}}/openssl/lib"
     ENV["CFLAGS"] = "-I#{{opt_prefix}}/openssl/include"
+
     ENV.prepend_create_path "PYTHONPATH", "#{{libexec}}/vendor/lib/python2.7/site-packages"
     %w[{dependencies}].each do |r|
       resource(r).stage do

--- a/admin/test/test_homebrew.py
+++ b/admin/test/test_homebrew.py
@@ -224,6 +224,8 @@ class Flocker030 < Formula
   end
 
   def install
+    ENV["LDFLAGS"] = "-L#{opt_prefix}/openssl/lib"
+    ENV["CFLAGS"] = "-I#{opt_prefix}/openssl/include"
     ENV.prepend_create_path "PYTHONPATH", "#{libexec}/vendor/lib/python2.7/site-packages"
     %w[six].each do |r|
       resource(r).stage do

--- a/admin/test/test_homebrew.py
+++ b/admin/test/test_homebrew.py
@@ -216,6 +216,7 @@ class Flocker030 < Formula
   url "https://example.com/flocker_sdist"
   sha1 "fc19b107d0cd6660f797ec6f82c3a61d5e2a768a"
   depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "openssl"
 
   resource "six" do
     url "https://example.com/six/six-1.9.0.tar.gz"

--- a/admin/test/test_homebrew.py
+++ b/admin/test/test_homebrew.py
@@ -224,8 +224,12 @@ class Flocker030 < Formula
   end
 
   def install
+    # XXX These environment variables are necessary until cryptography has
+    # wheels for OS X 10.11.
+    # See https://github.com/pyca/cryptography/issues/2350
     ENV["LDFLAGS"] = "-L#{opt_prefix}/openssl/lib"
     ENV["CFLAGS"] = "-I#{opt_prefix}/openssl/include"
+
     ENV.prepend_create_path "PYTHONPATH", "#{libexec}/vendor/lib/python2.7/site-packages"
     %w[six].each do |r|
       resource(r).stage do


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3164

This has been manually tested on OS X 10.11 (output below).

A new issue has been created to choose supported OS X platforms and set up CI for those which are supported: https://clusterhq.atlassian.net/browse/FLOC-3171.

```
~$ flocker-deploy --version
-bash: flocker-deploy: command not found
~$ brew uninstall openssl
Error: No such keg: /usr/local/Cellar/openssl
~$ curl -O http://build.clusterhq.com/results/homebrew/osx-10-11-FLOC-3164/Flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70.rb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11642  100 11642    0     0  13894      0 --:--:-- --:--:-- --:--:-- 13892
~$ brew install Flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70.rb
==> Installing dependencies for flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70:
==> Installing flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70 dependency:
==> Downloading https://homebrew.bintray.com/bottles/openssl-1.0.2d_1.el_capitan
Already downloaded: /Library/Caches/Homebrew/openssl-1.0.2d_1.el_capitan.bottle.tar.gz
==> Pouring openssl-1.0.2d_1.el_capitan.bottle.tar.gz
==> Caveats
A CA file has been bootstrapped using certificates from the system
keychain. To add additional certificates, place .pem files in
  /usr/local/etc/openssl/certs

and run
  /usr/local/opt/openssl/bin/c_rehash

This formula is keg-only, which means it was not symlinked into /usr/local.

Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries

Generally there are no consequences of this for you. If you build your
own software and it requires this formula, you'll need to add to your
build variables:

    LDFLAGS:  -L/usr/local/opt/openssl/lib
    CPPFLAGS: -I/usr/local/opt/openssl/include

==> Summary
🍺  /usr/local/Cellar/openssl/1.0.2d_1: 464 files, 17M
==> Installing flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70
==> Downloading http://build.clusterhq.com/results/python/osx-10-11-FLOC-3164/Fl
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70-9169.tar.gz
==> Downloading https://pypi.python.org/packages/source/B/Babel/Babel-1.3.tar.gz
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--Babel-1.3.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/P/PyYAML/PyYAML-3.10.tar
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--PyYAML-3.10.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/T/Twisted/Twisted-15.1.0
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--Twisted-15.1.0.tar.bz2
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/W/Werkzeug/Werkzeug-0.10
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--Werkzeug-0.10.4.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/a/argparse/argparse-1.3.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--argparse-1.3.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/b/backports.ssl_match_ho
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--backports.ssl-match-hostname-3.4.0.2.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/b/bitmath/bitmath-1.2.3-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--bitmath-1.2.3-4.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/b/boto/boto-2.38.0.tar.g
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--boto-2.38.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/c/cffi/cffi-1.1.2.tar.gz
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--cffi-1.1.2.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/c/characteristic/charact
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--characteristic-14.3.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/c/cryptography/cryptogra
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--cryptography-0.9.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/d/debtcollector/debtcoll
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--debtcollector-0.5.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/d/docker-py/docker-py-1.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--docker-py-1.3.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/e/effect/effect-0.1a13.t
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--effect-0.1a13.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/e/eliot/eliot-0.8.0.tar.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--eliot-0.8.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.ta
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--enum34-1.0.4.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/i/idna/idna-2.0.tar.gz
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--idna-2.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/i/ipaddr/ipaddr-2.1.11.t
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--ipaddr-2.1.11.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/i/ipaddress/ipaddress-1.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--ipaddress-1.0.7.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/i/iso8601/iso8601-0.1.10
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--iso8601-0.1.10.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/j/jsonschema/jsonschema-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--jsonschema-2.4.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/k/klein/klein-0.2.3.tar.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--klein-0.2.3.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/m/machinist/machinist-0.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--machinist-0.2.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/m/msgpack-python/msgpack
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--msgpack-python-0.4.6.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/n/netaddr/netaddr-0.7.14
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--netaddr-0.7.14.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/n/netifaces/netifaces-0.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--netifaces-0.10.4.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/o/oslo.config/oslo.confi
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--oslo.config-1.12.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/o/oslo.i18n/oslo.i18n-1.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--oslo.i18n-1.7.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/o/oslo.serialization/osl
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--oslo.serialization-1.6.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/o/oslo.utils/oslo.utils-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--oslo.utils-1.6.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pbr/pbr-0.11.0.tar.gz
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pbr-0.11.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pip/pip-7.1.0.tar.gz
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pip-7.1.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/P/PrettyTable/prettytabl
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--prettytable-0.7.2.tar.bz2
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/psutil/psutil-2.1.2.ta
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--psutil-2.1.2.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-0.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pyOpenSSL-0.15.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.7.ta
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pyasn1-0.1.7.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pyasn1-modules/pyasn1-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pyasn1-modules-0.0.5.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pycparser/pycparser-2.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pycparser-2.14.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pycrypto-2.6.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pyrsistent/pyrsistent-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pyrsistent-0.10.3.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/python-cinderclient/py
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--python-cinderclient-1.1.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/python-keystoneclient/
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--python-keystoneclient-1.4.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/python-keystoneclient-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--python-keystoneclient-rackspace-0.1.3.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/python-novaclient/pyth
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--python-novaclient-2.24.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/p/pytz/pytz-2015.4.tar.b
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--pytz-2015.4.tar.bz2
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/r/repoze.lru/repoze.lru-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--repoze.lru-0.6.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/r/requests/requests-2.7.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--requests-2.7.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/s/service_identity/servi
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--service-identity-14.0.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/s/setuptools/setuptools-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--setuptools-18.0.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/s/simplejson/simplejson-
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--simplejson-3.7.3.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--six-1.9.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/s/stevedore/stevedore-1.
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--stevedore-1.5.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/t/treq/treq-0.2.1.tar.gz
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--treq-0.2.1.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/w/websocket-client/webso
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--websocket-client-0.32.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/w/wheel/wheel-0.24.0.tar
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--wheel-0.24.0.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/w/wrapt/wrapt-1.10.4.tar
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--wrapt-1.10.4.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> Downloading https://pypi.python.org/packages/source/z/zope.interface/zope.in
Already downloaded: /Library/Caches/Homebrew/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70--zope.interface-4.1.2.tar.gz
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
==> python -c import setuptools... --no-user-cfg install --prefix=/usr/local/Cel
🍺  /usr/local/Cellar/flocker4eb91690e0df4459dbb1e8d4ae994e065ab63d70/9169: 8150 files, 111M, built in 84 seconds
~$
```