### PR TITLE
update fpm cron jobs to use flocker AMI FLOC-3180

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -900,7 +900,7 @@ job_type:
   cronly_jobs:
     run_docker_build_centos7_fpm:
       at: '0 0 * * *'
-      on_nodes_with_labels: 'aws-centos-7-T2Medium'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *add_shell_functions,
@@ -911,7 +911,7 @@ job_type:
           }
     run_docker_build_ubuntu_trusty_fpm:
       at: '0 1 * * *'
-      on_nodes_with_labels: 'aws-centos-7-T2Medium'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *add_shell_functions,
@@ -922,7 +922,7 @@ job_type:
           }
     run_docker_build_ubuntu_vivid_fpm:
       at: '0 2 * * *'
-      on_nodes_with_labels: 'aws-centos-7-T2Medium'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *add_shell_functions,


### PR DESCRIPTION
Update fpm-cron nightly jobs to use the same AMIs as flocker.
This means one less AMI to maintain.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2015)
<!-- Reviewable:end -->
