### PR TITLE
Flocker venv random FLOC-3179

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -931,3 +931,21 @@ job_type:
                    *build_docker_image,
                    *push_image_to_dockerhub ]
           }
+    build_vagrant_basebox_for_flocker_tutorial:
+      at: '0 2 * * *'
+      on_nodes_with_labels: 'mesos-vbox'
+      with_steps:
+        - { type: 'shell',
+            cli: [ *add_shell_functions, *setup_pip_cache,
+                   *cleanup, *setup_venv, *setup_flocker_modules,
+                   *setup_aws_env_vars, *check_version,
+                   'export DISTRIBUTION_NAME=centos-7',
+                   *build_sdist, *build_package,
+                   *build_repo_metadata,
+                   'export HOME=/root',
+                   'vagrant destroy -f',
+                   'parse_logs $venv/bin/python admin/build-vagrant-box --box tutorial --branch ${TRIGGERED_BRANCH} --build-server  http://188.165.193.39',
+                   'parse_logs vagrant box add --force "clusterhq/flocker-tutorial" vagrant/tutorial/flocker-tutorial-${FLOCKER_VERSION}.box',
+                   *clean_packages]
+          }
+

--- a/build.yaml
+++ b/build.yaml
@@ -944,8 +944,8 @@ job_type:
                    *build_repo_metadata,
                    'export HOME=/root',
                    'vagrant destroy -f',
-                   'parse_logs $venv/bin/python admin/build-vagrant-box --box tutorial --branch ${TRIGGERED_BRANCH} --build-server  http://188.165.193.39',
-                   'parse_logs vagrant box add --force "clusterhq/flocker-tutorial" vagrant/tutorial/flocker-tutorial-${FLOCKER_VERSION}.box',
+                   'parse_logs $venv/bin/python admin/build-vagrant-box --box tutorial --branch \${TRIGGERED_BRANCH} --build-server  http://188.165.193.39',
+                   'parse_logs vagrant box add --force "clusterhq/flocker-tutorial" vagrant/tutorial/flocker-tutorial-\${FLOCKER_VERSION}.box',
                    *clean_packages]
           }
 

--- a/build.yaml
+++ b/build.yaml
@@ -426,7 +426,7 @@ common_cli:
     sudo /usr/sbin/setenforce 0
 
   check_version: &check_version |
-    export FLOCKER_VERSION=\$(/tmp/v/bin/python setup.py --version)
+    export FLOCKER_VERSION=\$(\${venv}/bin/python setup.py --version)
 
   build_sdist: &build_sdist  |
     # package the goodies

--- a/build.yaml
+++ b/build.yaml
@@ -86,11 +86,9 @@ common_cli:
     # https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/issues/20
     # http://stackoverflow.com/questions/10813538/shebang-line-limit-in-bash-and-linux-kernel
     # https://github.com/spotify/dh-virtualenv/issues/10
-    # so we set our virtualenv dir to live in /tmp/v. We avoid any race
-    # conditions by only executing one build per jenkins_slave at any moment
-    # in time, and cleaning up old virtualenvs at the begining of the build.
+    # so we set our virtualenv dir to live in /tmp/<random number>
     #
-    export venv=/tmp/v
+    export venv=/tmp/\${RANDOM}
 
     function os {
       # Let's figure out if this is OSX or Linux

--- a/build.yaml
+++ b/build.yaml
@@ -936,7 +936,7 @@ job_type:
       on_nodes_with_labels: 'mesos-vbox'
       with_steps:
         - { type: 'shell',
-            cli: [ *add_shell_functions, *setup_pip_cache,
+            cli: [ *add_shell_functions,
                    *cleanup, *setup_venv, *setup_flocker_modules,
                    *setup_aws_env_vars, *check_version,
                    'export DISTRIBUTION_NAME=centos-7',

--- a/build.yaml
+++ b/build.yaml
@@ -944,7 +944,7 @@ job_type:
                    *build_repo_metadata,
                    'export HOME=/root',
                    'vagrant destroy -f',
-                   'parse_logs $venv/bin/python admin/build-vagrant-box --box tutorial --branch \${TRIGGERED_BRANCH} --build-server  http://188.165.193.39',
+                   'parse_logs \$venv/bin/python admin/build-vagrant-box --box tutorial --branch \${TRIGGERED_BRANCH} --build-server  http://188.165.193.39',
                    'parse_logs vagrant box add --force "clusterhq/flocker-tutorial" vagrant/tutorial/flocker-tutorial-\${FLOCKER_VERSION}.box',
                    *clean_packages]
           }


### PR DESCRIPTION
Allow multiple builds on the same slave.
One point of contention was the placement of virtualenv under /tmp/v/, this change uses a random short number under /tmp

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2016)
<!-- Reviewable:end -->
