### PR TITLE
Better error messages for admin/run-acceptance-tests

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -393,12 +393,15 @@ class VagrantRunner(object):
         :raise UsageError: if no such distribution found.
         :return: ``FilePath`` of the vagrant directory.
         """
-        vagrant_path = top_level.descendant([
-            'admin', 'vagrant-acceptance-targets', distribution,
+        vagrant_dir = top_level.descendant([
+            'admin', 'vagrant-acceptance-targets'
         ])
+        vagrant_path = vagrant_dir.child(distribution)
         if not vagrant_path.exists():
-            raise UsageError("Distribution not found: %s."
-                             % (self.distribution,))
+            distributions = vagrant_dir.listdir()
+            raise UsageError(
+                "Distribution not found: %s. Valid distributions: %s."
+                % (self.distribution, ', '.join(distributions)))
         return vagrant_path
 
     def ensure_keys(self, reactor):

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -389,7 +389,7 @@ class VagrantRunner(object):
 
         :param FilePath top_level: the directory containing the ``admin``
             package.
-        :param str distribution: the name of a distribution
+        :param bytes distribution: the name of a distribution
         :raise UsageError: if no such distribution found.
         :return: ``FilePath`` of the vagrant directory.
         """

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -375,17 +375,31 @@ class VagrantRunner(object):
     NODE_ADDRESSES = ["172.16.255.250", "172.16.255.251"]
 
     def __init__(self):
-        self.vagrant_path = self.top_level.descendant([
-            'admin', 'vagrant-acceptance-targets', self.distribution,
-        ])
+        self.vagrant_path = self._get_vagrant_path(self.top_level, self.distribution)
+
         self.certificates_path = self.top_level.descendant([
             'vagrant', 'tutorial', 'credentials'])
-        if not self.vagrant_path.exists():
-            raise UsageError("Distribution not found: %s."
-                             % (self.distribution,))
 
         if self.variants:
             raise UsageError("Variants unsupported on vagrant.")
+
+    def _get_vagrant_path(self, top_level, distribution):
+        """
+        Get the path to the Vagrant directory for ``distribution``.
+
+        :param FilePath top_level: the directory containing the ``admin``
+            package.
+        :param str distribution: the name of a distribution
+        :raise UsageError: if no such distribution found.
+        :return: ``FilePath`` of the vagrant directory.
+        """
+        vagrant_path = top_level.descendant([
+            'admin', 'vagrant-acceptance-targets', distribution,
+        ])
+        if not vagrant_path.exists():
+            raise UsageError("Distribution not found: %s."
+                             % (self.distribution,))
+        return vagrant_path
 
     def ensure_keys(self, reactor):
         key = Key.fromFile(os.path.expanduser(


### PR DESCRIPTION
Raises a slightly more informative error message when running the acceptance tests on a non-existent distro.

Makes some assumptions about the layout of `admin`, but they seem consistent with the rest of the assumptions in the code base.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2018)
<!-- Reviewable:end -->
