### PR TITLE
[FLOC-3192] Switch to newer pyrsistent

### DIFF
--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -6,6 +6,27 @@ Dockerized applications.
 """
 
 
+def _disable_pyrsistent_c_extensions():
+    """
+    Pyrsistent sometimes segfaults. Disabling the C extension reduces the
+    likelihood of this happening.
+
+    We do this first so it happens before pyrsistent is imported.
+
+    In theory this bug is fixed in pyrsistent 0.11.7, so this may no
+    longer be necessary and is likely worth risking for higher
+    performance. Once we have benchmarking framework we can assess
+    risk/benefit ratio better.
+
+    The mechanism for disabling extensions is documented at
+    https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt#L17-L19.
+    """
+    import os
+    os.environ[b"PYRSISTENT_NO_C_EXTENSION"] = b"1"
+_disable_pyrsistent_c_extensions()
+del _disable_pyrsistent_c_extensions
+
+
 def _suppress_warnings():
     """
     Suppress warnings when not running under trial.

--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -6,24 +6,6 @@ Dockerized applications.
 """
 
 
-def _disable_pyrsistent_c_extensions():
-    """
-    Pyrsistent sometimes segfaults. Disabling C extensions reduces the
-    likelihood of this happening.
-
-    We do this first so it happens before pyrsistent is imported.
-
-    See https://github.com/tobgu/pyrsistent/issues/52 and FLOC-2913.
-
-    The mechanism for disabling extensions is documented at
-    https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt#L17-L19.
-    """
-    import os
-    os.environ[b"PYRSISTENT_NO_C_EXTENSION"] = b"1"
-_disable_pyrsistent_c_extensions()
-del _disable_pyrsistent_c_extensions
-
-
 def _suppress_warnings():
     """
     Suppress warnings when not running under trial.

--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -6,6 +6,24 @@ Dockerized applications.
 """
 
 
+def _disable_pyrsistent_c_extensions():
+    """
+    Pyrsistent sometimes segfaults. Disabling C extensions reduces the
+    likelihood of this happening.
+
+    We do this first so it happens before pyrsistent is imported.
+
+    See https://github.com/tobgu/pyrsistent/issues/52 and FLOC-2913.
+
+    The mechanism for disabling extensions is documented at
+    https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt#L17-L19.
+    """
+    import os
+    os.environ[b"PYRSISTENT_NO_C_EXTENSION"] = b"1"
+_disable_pyrsistent_c_extensions()
+del _disable_pyrsistent_c_extensions
+
+
 def _suppress_warnings():
     """
     Suppress warnings when not running under trial.

--- a/flocker/control/test/test_model.py
+++ b/flocker/control/test/test_model.py
@@ -524,9 +524,9 @@ class DeploymentTests(SynchronousTestCase):
                 image=DockerImage.from_string(u"image"))}),
         )
         deployment = Deployment(nodes=frozenset([node, another_node]))
-        self.assertItemEqual(set(deployment.applications()),
-                             set(node.applications) +
-                             set(another_node.applications))
+        self.assertItemsEqual(set(deployment.applications()),
+                              set(node.applications) |
+                              set(another_node.applications))
 
     def test_update_node_retains_leases(self):
         """

--- a/flocker/control/test/test_model.py
+++ b/flocker/control/test/test_model.py
@@ -524,9 +524,9 @@ class DeploymentTests(SynchronousTestCase):
                 image=DockerImage.from_string(u"image"))}),
         )
         deployment = Deployment(nodes=frozenset([node, another_node]))
-        self.assertEqual(sorted(list(deployment.applications())),
-                         sorted(list(node.applications) +
-                                list(another_node.applications)))
+        self.assertItemEqual(set(deployment.applications()),
+                             set(node.applications) +
+                             set(another_node.applications))
 
     def test_update_node_retains_leases(self):
         """

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -100,7 +100,7 @@ class _InParallel(PRecord):
         # Sort the changes for the benefit of comparison.  Stick with a vector
         # (rather than, say, a set) in case someone wants to run the same
         # change multiple times in parallel.
-        factory=lambda changes: pvector(sorted(changes, key=lambda o: id(o))),
+        factory=lambda changes: pvector(sorted(changes, key=id)),
         mandatory=True
     )
 

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -100,7 +100,7 @@ class _InParallel(PRecord):
         # Sort the changes for the benefit of comparison.  Stick with a vector
         # (rather than, say, a set) in case someone wants to run the same
         # change multiple times in parallel.
-        factory=lambda changes: pvector(sorted(changes)),
+        factory=lambda changes: pvector(sorted(changes, key=lambda o: id(o))),
         mandatory=True
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pyasn1-modules==0.0.5
 pycparser==2.14
 pycrypto==2.6.1
 pyOpenSSL==0.15.1
-pyrsistent==0.10.3
+pyrsistent==0.11.6
 python-cinderclient==1.1.1
 python-keystoneclient==1.4.0
 python-keystoneclient-rackspace==0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pyasn1-modules==0.0.5
 pycparser==2.14
 pycrypto==2.6.1
 pyOpenSSL==0.15.1
-pyrsistent==0.11.6
+pyrsistent==0.11.7
 python-cinderclient==1.1.1
 python-keystoneclient==1.4.0
 python-keystoneclient-rackspace==0.1.3


### PR DESCRIPTION
In theory this version doesn't segfault when the C extension is used... and using the C extension speeds things up a lot. Also this new version has way less bugs, some of them serious.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2022)
<!-- Reviewable:end -->
