### PR TITLE
[FLOC-3203] Raise error if we can't compute instance ID

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -120,7 +120,9 @@ class UnknownInstanceID(Exception):
     Could not compute instance ID for block device.
     """
     def __init__(self, blockdevice):
-        Exception.__init__(self, blockdevice)
+        Exception.__init__(
+            self,
+            'Could not find valid instance ID for {}'.format(blockdevice))
         self.blockdevice = blockdevice
 
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -115,6 +115,15 @@ class FilesystemExists(Exception):
         self.device = device
 
 
+class UnknownInstanceID(Exception):
+    """
+    Could not compute instance ID for block device.
+    """
+    def __init__(self, blockdevice):
+        Exception.__init__(self, blockdevice)
+        self.blockdevice = blockdevice
+
+
 DATASET = Field(
     u"dataset",
     lambda dataset: dataset.dataset_id,
@@ -806,7 +815,8 @@ class IBlockDeviceAsyncAPI(Interface):
 
         :returns: A ``Deferred`` that fires with ``unicode`` of a
             provider-specific node identifier which identifies the node where
-            the method is run.
+            the method is run, or fails with ``UnknownInstanceID`` if we cannot
+            determine the identifier.
         """
 
     def create_volume(dataset_id, size):
@@ -879,6 +889,8 @@ class IBlockDeviceAPI(Interface):
         to determine which volumes are locally attached and it will be used
         with ``attach_volume`` to locally attach volumes.
 
+        :raise UnknownInstanceID: If we cannot determine the identifier of the
+            node.
         :returns: A ``unicode`` object giving a provider-specific node
             identifier which identifies the node where the method is run.
         """
@@ -1206,6 +1218,8 @@ class LoopbackBlockDeviceAPI(object):
         return self._allocation_unit
 
     def compute_instance_id(self):
+        if not self._compute_instance_id:
+            raise UnknownInstanceID(self)
         return self._compute_instance_id
 
     def _parse_backing_file_name(self, filename):

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -34,7 +34,7 @@ from ...common import (
 )
 from .blockdevice import (
     IBlockDeviceAPI, BlockDeviceVolume, UnknownVolume, AlreadyAttachedVolume,
-    UnattachedVolume, get_blockdevice_volume,
+    UnattachedVolume, UnknownInstanceID, get_blockdevice_volume,
 )
 from ._logging import (
     NOVA_CLIENT_EXCEPTION, KEYSTONE_HTTP_ERROR, COMPUTE_INSTANCE_ID_NOT_FOUND,
@@ -449,13 +449,14 @@ class CinderBlockDeviceAPI(object):
 
         # If we've got this correct there should only be one matching instance.
         # But we don't currently test this directly. See FLOC-2281.
-        if len(matching_instances) == 1:
+        if len(matching_instances) == 1 and matching_instances[0]:
             return matching_instances[0]
         # If there was no match, or if multiple matches were found, log an
         # error containing all the local and remote IPs.
         COMPUTE_INSTANCE_ID_NOT_FOUND(
             local_ips=local_ips, api_ips=api_ip_map
         ).write()
+        raise UnknownInstanceID(self)
 
     def create_volume(self, dataset_id, size):
         """

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -29,7 +29,7 @@ from eliot import Message
 
 from .blockdevice import (
     IBlockDeviceAPI, BlockDeviceVolume, UnknownVolume, AlreadyAttachedVolume,
-    UnattachedVolume,
+    UnattachedVolume, UnknownInstanceID,
 )
 from ...control import pmap_field
 
@@ -609,7 +609,10 @@ class EBSBlockDeviceAPI(object):
         """
         Look up the EC2 instance ID for this node.
         """
-        return get_instance_metadata()['instance-id'].decode("ascii")
+        instance_id = get_instance_metadata().get('instance-id', None)
+        if not instance_id:
+            raise UnknownInstanceID(self)
+        return instance_id.decode("ascii")
 
     def _get_ebs_volume(self, blockdevice_id):
         """

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -610,7 +610,7 @@ class EBSBlockDeviceAPI(object):
         Look up the EC2 instance ID for this node.
         """
         instance_id = get_instance_metadata().get('instance-id', None)
-        if not instance_id:
+        if instance_id is None:
             raise UnknownInstanceID(self)
         return instance_id.decode("ascii")
 

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -306,25 +306,11 @@ class CinderAttachmentTests(SynchronousTestCase):
             self._detach(instance_id, volume)
         self.cinder.volumes.delete(volume.id)
 
-    def compute_blockdevice_instance_id(self):
-        """
-        Compute the instance ID for the block device API.
-
-        :raise ValueError: if we cannot determine the instance ID
-        :return: the computed instance id
-        """
-        # FLOC-3203: Really, compute_instance_id should raise an error in this
-        # case.
-        instance_id = self.blockdevice_api.compute_instance_id()
-        if not instance_id:
-            raise ValueError('Could not determine instance_id')
-        return instance_id
-
     def test_get_device_path_no_attached_disks(self):
         """
         get_device_path returns the most recently attached device
         """
-        instance_id = self.compute_blockdevice_instance_id()
+        instance_id = self.blockdevice_api.compute_instance_id()
 
         cinder_volume = self.cinder.volumes.create(
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
@@ -362,7 +348,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         get_device_path returns the correct device name even when a non-Cinder
         volume has been attached. See FLOC-2859.
         """
-        instance_id = self.compute_blockdevice_instance_id()
+        instance_id = self.blockdevice_api.compute_instance_id()
 
         host_device = "/dev/null"
         tmpdir = FilePath(self.mktemp())
@@ -407,7 +393,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         create_server_volume will raise an exception when Cinder attempts to
         attach a device to a path that is in use by a non-Cinder volume.
         """
-        instance_id = self.compute_blockdevice_instance_id()
+        instance_id = self.blockdevice_api.compute_instance_id()
 
         host_device = "/dev/null"
         tmpdir = FilePath(self.mktemp())

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
 
 """
 Functional tests for ``flocker.node.agents.cinder`` using a real OpenStack
@@ -306,11 +306,25 @@ class CinderAttachmentTests(SynchronousTestCase):
             self._detach(instance_id, volume)
         self.cinder.volumes.delete(volume.id)
 
+    def compute_blockdevice_instance_id(self):
+        """
+        Compute the instance ID for the block device API.
+
+        :raise ValueError: if we cannot determine the instance ID
+        :return: the computed instance id
+        """
+        # FLOC-3203: Really, compute_instance_id should raise an error in this
+        # case.
+        instance_id = self.blockdevice_api.compute_instance_id()
+        if not instance_id:
+            raise ValueError('Could not determine instance_id')
+        return instance_id
+
     def test_get_device_path_no_attached_disks(self):
         """
         get_device_path returns the most recently attached device
         """
-        instance_id = self.blockdevice_api.compute_instance_id()
+        instance_id = self.compute_blockdevice_instance_id()
 
         cinder_volume = self.cinder.volumes.create(
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
@@ -348,7 +362,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         get_device_path returns the correct device name even when a non-Cinder
         volume has been attached. See FLOC-2859.
         """
-        instance_id = self.blockdevice_api.compute_instance_id()
+        instance_id = self.compute_blockdevice_instance_id()
 
         host_device = "/dev/null"
         tmpdir = FilePath(self.mktemp())
@@ -393,7 +407,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         create_server_volume will raise an exception when Cinder attempts to
         attach a device to a path that is in use by a non-Cinder volume.
         """
-        instance_id = self.blockdevice_api.compute_instance_id()
+        instance_id = self.compute_blockdevice_instance_id()
 
         host_device = "/dev/null"
         tmpdir = FilePath(self.mktemp())

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2047,10 +2047,7 @@ def make_iblockdeviceapi_tests(
             )
             self.minimum_allocatable_size = minimum_allocatable_size
             self.device_allocation_unit = device_allocation_unit
-            this_node = self.api.compute_instance_id()
-            if not this_node:
-                raise ValueError('Could not determine instance_id')
-            self.this_node = this_node
+            self.this_node = self.api.compute_instance_id()
 
     return Tests
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
 
 """
 Tests for ``flocker.node.agents.blockdevice``.
@@ -2047,7 +2047,10 @@ def make_iblockdeviceapi_tests(
             )
             self.minimum_allocatable_size = minimum_allocatable_size
             self.device_allocation_unit = device_allocation_unit
-            self.this_node = self.api.compute_instance_id()
+            this_node = self.api.compute_instance_id()
+            if not this_node:
+                raise ValueError('Could not determine instance_id')
+            self.this_node = this_node
 
     return Tests
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -61,6 +61,7 @@ from ..blockdevice import (
     _backing_file_name,
     ProcessLifetimeCache,
     FilesystemExists,
+    UnknownInstanceID,
 )
 
 from ... import run_state_change, in_parallel
@@ -2349,6 +2350,17 @@ class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
             None,
             self.api.get_device_path(volume.blockdevice_id),
         )
+
+    def test_missing_instance_id(self):
+        """
+        ``compute_instance_id`` raises an error when it cannot return a valid
+        instance ID.
+        """
+        root_path = None  # Unused in this code.
+        api = LoopbackBlockDeviceAPI(root_path, compute_instance_id=None)
+        e = self.assertRaises(UnknownInstanceID, api.compute_instance_id)
+        self.assertEqual(
+            'Could not find valid instance ID for %r' % (api,), str(e))
 
 
 class LosetupListTests(SynchronousTestCase):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
 
 """
 Generate a Flocker package that can be deployed onto cluster nodes.


### PR DESCRIPTION
In some circumstances, `compute_instance_id` can return `None`. This is not a valid response according to the documentation, and most of our code base assumes that `compute_instance_id` returns a valid instance ID.

Thus, rather than returning `None`, we here raise an error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2024)
<!-- Reviewable:end -->
