### PR TITLE
[FLOC-3046] Cleanups for virtio stuff

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -342,6 +342,9 @@ def configured_cluster_for_nodes(
         configured.
     """
     default_volume_size = GiB(1)
+    # XXX: TODO: This looks like it should come from
+    # node.agents.test.blockdevicefactory.MINIMUM_ALLOCATABLE_SIZES. Or maybe
+    # they should both come from a non-test file.
     if dataset_backend_configuration.get('auth_plugin') == 'rackspace':
         default_volume_size = GiB(100)
 

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -341,10 +341,23 @@ def configured_cluster_for_nodes(
     :returns: A ``Deferred`` which fires with ``Cluster`` when it is
         configured.
     """
+    # XXX: There is duplication between the values here and those in
+    # f.node.agents.test.blockdevicefactory.MINIMUM_ALLOCATABLE_SIZES. We want
+    # the default volume size to be greater than or equal to the minimum
+    # allocatable size.
+    #
+    # Ideally, the minimum allocatable size (and perhaps the default volume
+    # size) would be something known by an object that represents the dataset
+    # backend. Unfortunately:
+    #  1. There is no such object
+    #  2. There is existing confusion in the code around 'openstack' and
+    #     'rackspace'
+    #
+    # Here, we special-case Rackspace (presumably) because it has a minimum
+    # allocatable size that is different from other Openstack backends.
+    #
+    # FLOC-2584 also discusses this.
     default_volume_size = GiB(1)
-    # XXX: TODO: This looks like it should come from
-    # node.agents.test.blockdevicefactory.MINIMUM_ALLOCATABLE_SIZES. Or maybe
-    # they should both come from a non-test file.
     if dataset_backend_configuration.get('auth_plugin') == 'rackspace':
         default_volume_size = GiB(100)
 

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -607,12 +607,12 @@ class CinderBlockDeviceAPI(object):
         # 1. flocker-dataset-agent mounting volumes before udev has populated
         #    the by-id symlinks.
         # 2. Even if we mount with `/dev/disk/by-id/xxx`, the mounted
-        #    filesystems are listed (in e.g. `/proc/mounts`) with the **target**
-        #    (i.e. the real path) of the `/dev/disk/by-id/xxx` symlinks. This
-        #    confuses flocker-dataset-agent (which assumes path equality is
-        #    string equality), causing it to believe that `/dev/disk/by-id/xxx`
-        #    has not been mounted, leading it to repeatedly attempt to mount the
-        #    device.
+        #    filesystems are listed (in e.g. `/proc/mounts`) with the
+        #    **target** (i.e. the real path) of the `/dev/disk/by-id/xxx`
+        #    symlinks. This confuses flocker-dataset-agent (which assumes path
+        #    equality is string equality), causing it to believe that
+        #    `/dev/disk/by-id/xxx` has not been mounted, leading it to
+        #    repeatedly attempt to mount the device.
         if expected_path.exists():
             return expected_path.realpath()
         else:

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -602,6 +602,11 @@ class CinderBlockDeviceAPI(object):
         expected_path = FilePath(
             "/dev/disk/by-id/virtio-{}".format(volume.id[:20])
         )
+        # XXX: TODO: Is there a reason you chose to return the real device
+        # path, rather than the symbolic link? It would be good to document
+        # any reason, because the symbolic link has the advantage of being
+        # less ambiguous / more robust in the face of concurrent
+        # detaching/attaching activity.
         if expected_path.exists():
             return expected_path.realpath()
         else:
@@ -662,7 +667,7 @@ def _is_virtio_blk(device_path):
     """
     Check whether the supplied device path is a virtio_blk device.
 
-    XXX: We assume that virtio_blk device name always begin with `vd` where as
+    We assume that virtio_blk device name always begin with `vd` whereas
     Xen devices begin with `xvd`.
     See https://www.kernel.org/doc/Documentation/devices.txt
 

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -602,7 +602,7 @@ class CinderBlockDeviceAPI(object):
         expected_path = FilePath(
             "/dev/disk/by-id/virtio-{}".format(volume.id[:20])
         )
-        # Return the real path to avoid two problems:
+        # Return the real path instead of the symlink to avoid two problems:
         #
         # 1. flocker-dataset-agent mounting volumes before udev has populated
         #    the by-id symlinks.

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -73,7 +73,8 @@ from ..cinder import (
 #     FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE=$PWD/acceptance.yml \
 #     FLOCKER_FUNCTIONAL_TEST=TRUE \
 #     FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=devstack-openstack \
-#     $(type -p trial) flocker.node.agents.functional.test_cinder.CinderAttachmentTests
+#     $(type -p trial) \
+#     flocker.node.agents.functional.test_cinder.CinderAttachmentTests
 require_virtio = skipIf(
     not which('virsh'), "Tests require the ``virsh`` command.")
 
@@ -449,7 +450,6 @@ class CinderAttachmentTests(SynchronousTestCase):
                 transient_states=(u'available', u'attaching',),
             )
         self.assertEqual(e.exception.unexpected_state, u'available')
-
 
     @require_virtio
     def test_get_device_path_virtio_blk_error_without_udev(self):

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -74,7 +74,7 @@ from ..cinder import (
 #     FLOCKER_FUNCTIONAL_TEST=TRUE \
 #     FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=devstack-openstack \
 #     $(type -p trial) flocker.node.agents.functional.test_cinder.CinderAttachmentTests
-require_virsh = skipIf(
+require_virtio = skipIf(
     not which('virsh'), "Tests require the ``virsh`` command.")
 
 
@@ -367,7 +367,7 @@ class CinderAttachmentTests(SynchronousTestCase):
 
         self.assertEqual(device_path.realpath(), new_device)
 
-    @require_virsh
+    @require_virtio
     def test_get_device_path_correct_with_attached_disk(self):
         """
         get_device_path returns the correct device name even when a non-Cinder
@@ -412,7 +412,7 @@ class CinderAttachmentTests(SynchronousTestCase):
 
         self.assertEqual(device_path.realpath(), new_device)
 
-    @require_virsh
+    @require_virtio
     def test_disk_attachment_fails_with_conflicting_disk(self):
         """
         create_server_volume will raise an exception when Cinder attempts to
@@ -451,10 +451,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         self.assertEqual(e.exception.unexpected_state, u'available')
 
 
-    # XXX: TODO: This test doesn't require virsh. Either the decorator should
-    # be renamed, or maybe a different decorator for tests that require
-    # virtio, but not particularly virsh.
-    @require_virsh
+    @require_virtio
     def test_get_device_path_virtio_blk_error_without_udev(self):
         """
         ``get_device_path`` on systems using the virtio_blk driver raises
@@ -499,10 +496,7 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume.id,
         )
 
-    # XXX: TODO: This test doesn't require virsh. Either the decorator should
-    # be renamed, or maybe a different decorator for tests that require
-    # virtio, but not particularly virsh.
-    @require_virsh
+    @require_virtio
     def test_get_device_path_virtio_blk_symlink(self):
         """
         ``get_device_path`` on systems using the virtio_blk driver

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -47,7 +47,7 @@ from ..cinder import (
     wait_for_volume_state, UnexpectedStateException, UnattachedVolume
 )
 
-# Tests requiring virsh can currently only be run on a devstack installation
+# Tests requiring virtio can currently only be run on a devstack installation
 # that is not within our CI system. This will be addressed with FLOC-2972.
 #
 # In the meantime, you can do the following (provided you have access):

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -49,6 +49,31 @@ from ..cinder import (
 
 # Tests requiring virsh can currently only be run on a devstack installation
 # that is not within our CI system. This will be addressed with FLOC-2972.
+#
+# In the meantime, you can do the following (provided you have access):
+#
+# Connect to the devstack host:
+#   ssh -A root@104.130.19.104
+#
+# From the devstack host, connect to the guest:
+#   ssh -A ubuntu@10.0.0.3
+#
+# This is a shared machine that only ClusterHQ employees have access to. Make
+# sure that no one else is using it at the same time.
+#
+# On the devstack guest do the following:
+#   cd flocker
+#   workon flocker
+#
+# Then update the branch to match the code you want to test.
+#
+# Then run these tests:
+#
+#   sudo /usr/bin/env \
+#     FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE=$PWD/acceptance.yml \
+#     FLOCKER_FUNCTIONAL_TEST=TRUE \
+#     FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=devstack-openstack \
+#     $(type -p trial) flocker.node.agents.functional.test_cinder.CinderAttachmentTests
 require_virsh = skipIf(
     not which('virsh'), "Tests require the ``virsh`` command.")
 

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -425,6 +425,10 @@ class CinderAttachmentTests(SynchronousTestCase):
             )
         self.assertEqual(e.exception.unexpected_state, u'available')
 
+
+    # XXX: TODO: This test doesn't require virsh. Either the decorator should
+    # be renamed, or maybe a different decorator for tests that require
+    # virtio, but not particularly virsh.
     @require_virsh
     def test_get_device_path_virtio_blk_error_without_udev(self):
         """
@@ -470,6 +474,9 @@ class CinderAttachmentTests(SynchronousTestCase):
             volume.id,
         )
 
+    # XXX: TODO: This test doesn't require virsh. Either the decorator should
+    # be renamed, or maybe a different decorator for tests that require
+    # virtio, but not particularly virsh.
     @require_virsh
     def test_get_device_path_virtio_blk_symlink(self):
         """


### PR DESCRIPTION
Based on @jongiddy's comments in #1922. 
 
I've implemented most of his suggestions, but chickened out on re-using the minimum device sizes. It looks like the code is a great big tangle there (see [FLOC-2584](https://clusterhq.atlassian.net/browse/FLOC-2584)), and although I *do* think it's a good idea to disentangle it, I personally don't want to do it right now.

I pulled the comment on the symlink resolution from @wallrj's [insights on the original PR](https://github.com/ClusterHQ/flocker/pull/1921).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2025)
<!-- Reviewable:end -->
