### PR TITLE
[FLOC-3195] Use boto for provisioning AWS acceptance test nodes.

### DIFF
--- a/flocker/provision/__init__.py
+++ b/flocker/provision/__init__.py
@@ -4,7 +4,7 @@
 Provisioning for acceptance tests.
 """
 
-from ._common import PackageSource, Variants
+from ._common import PackageSource, Variants, INode, IProvisioner
 from ._install import provision, configure_cluster
 from ._rackspace import rackspace_provisioner
 from ._aws import aws_provisioner
@@ -17,6 +17,7 @@ CLOUD_PROVIDERS = {
 
 __all__ = [
     'PackageSource', 'Variants',
+    'INode', 'IProvisioner',
     'provision',
     'CLOUD_PROVIDERS',
     'configure_cluster',

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -63,6 +63,7 @@ def _wait_until_running(instance):
                 instance_state=instance.state,
             ):
                 sleep(1)
+            instance.update()
 
 
 @implementer(INode)

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -110,7 +110,7 @@ class AWSNode(PClass):
         # installation for a few more seconds:
         start = []
 
-        def for_ten_seconds(*args, **kwargs):
+        def for_thirty_seconds(*args, **kwargs):
             if not start:
                 start.append(time())
             return Effect(Constant((time() - start[0]) < 30))
@@ -118,7 +118,7 @@ class AWSNode(PClass):
         commands.append(run_remotely(
             username=username,
             address=self.address,
-            commands=retry(task_install_ssh_key(), for_ten_seconds),
+            commands=retry(task_install_ssh_key(), for_thirty_seconds),
         ))
 
         commands.append(run_remotely(

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -57,17 +57,12 @@ def _wait_until_running(instance):
         action_type=u"flocker:provision:aws:wait_until_running",
         instance_id=instance.id,
     ):
-        state = instance.state
-        while state != 'running':
+        while instance.state != 'running':
             with start_action(
                 action_type=u"flocker:provision:aws:wait_until_running:sleep",
                 instance_state=instance.state,
             ):
                 sleep(1)
-            instance.update()
-            new_state = instance.state
-            if new_state != state:
-                state = new_state
 
 
 @implementer(INode)

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -9,8 +9,12 @@ from time import time, sleep
 
 from pyrsistent import PClass, field
 
+from zope.interface import implementer
+
 from effect.retry import retry
 from effect import Effect, Constant
+
+from ._common import INode, IProvisioner
 
 from ._install import (
     provision,
@@ -36,6 +40,7 @@ IMAGE_NAMES = {
 }
 
 
+@implementer(INode)
 class AWSNode(PClass):
     _provisioner = field(mandatory=True)
     _instance = field(mandatory=True)
@@ -124,6 +129,7 @@ class AWSNode(PClass):
         ).on(success=do_reboot)
 
 
+@implementer(IProvisioner)
 class AWSProvisioner(PClass):
     connection = field(mandatory=True)
     keyname = field(mandatory=True)
@@ -145,6 +151,8 @@ class AWSProvisioner(PClass):
     def create_node(self, name, distribution,
                     size=None, disk_size=8,
                     metadata={}):
+        # Import these here, so that this can be imported without installng
+        # libcloud.
         from boto.ec2.blockdevicemapping import (
             EBSBlockDeviceType, BlockDeviceMapping,
         )
@@ -223,6 +231,8 @@ def aws_provisioner(access_key, secret_access_token, keyname,
     :param list security_groups: List of security groups to put created nodes
         in.
     """
+    # Import these here, so that this can be imported without installng
+    # libcloud.
     from boto.ec2 import connect_to_region
     conn = connect_to_region(
         region,

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -5,19 +5,22 @@ AWS provisioner.
 """
 
 from textwrap import dedent
-from time import time
+from time import time, sleep
+
+from pyrsistent import PClass, field
 
 from effect.retry import retry
 from effect import Effect, Constant
 
-from ._libcloud import LibcloudProvisioner
 from ._install import (
     provision,
     task_install_ssh_key,
 )
 
-from ._ssh import run_remotely
+from ._ssh import run_remotely, run_from_args
 from ._effect import sequence
+
+import boto.ec2
 
 
 _usernames = {
@@ -25,58 +28,6 @@ _usernames = {
     'ubuntu-14.04': 'ubuntu',
     'ubuntu-15.04': 'ubuntu',
 }
-
-
-def get_default_username(distribution):
-    """
-    Return the username available by default on a system.
-
-    :param str distribution: Name of the operating system distribution
-    :return str: The username made available by AWS for this distribution.
-    """
-    return _usernames[distribution]
-
-
-def provision_aws(node, package_source, distribution, variants):
-    """
-    Provision flocker on this node.
-
-    :param LibcloudNode node: Node to provision.
-    :param PackageSource package_source: See func:`task_install_flocker`
-    :param bytes distribution: See func:`task_install_flocker`
-    :param set variants: The set of variant configurations to use when
-        provisioning
-    """
-    username = get_default_username(distribution)
-
-    commands = []
-
-    # cloud-init may not have allowed sudo without tty yet, so try SSH key
-    # installation for a few more seconds:
-    start = []
-
-    def for_ten_seconds(*args, **kwargs):
-        if not start:
-            start.append(time())
-        return Effect(Constant((time() - start[0]) < 30))
-
-    commands.append(run_remotely(
-        username=username,
-        address=node.address,
-        commands=retry(task_install_ssh_key(), for_ten_seconds),
-    ))
-
-    commands.append(run_remotely(
-        username='root',
-        address=node.address,
-        commands=provision(
-            package_source=package_source,
-            distribution=node.distribution,
-            variants=variants,
-        ),
-    ))
-
-    return sequence(commands)
 
 
 IMAGE_NAMES = {
@@ -87,10 +38,179 @@ IMAGE_NAMES = {
 }
 
 
+class AWSNode(PClass):
+    _provisioner = field(mandatory=True)
+    _instance = field(mandatory=True)
+    distribution = field(mandatory=True)
+    name = field(mandatory=True)
+
+    @property
+    def address(self):
+        return self._instance.ip_address.encode('ascii')
+
+    @property
+    def private_address(self):
+        return self._instance.private_ip_address.encode('ascii')
+
+    def destroy(self):
+        self._instance.terminate()
+
+    def get_default_username(self):
+        """
+        Return the username available by default on a system.
+        """
+        return _usernames[self.distribution]
+
+    def provision(self, package_source, variants=()):
+        """
+        Provision flocker on this node.
+
+        :param LibcloudNode node: Node to provision.
+        :param PackageSource package_source: See func:`task_install_flocker`
+        :param set variants: The set of variant configurations to use when
+            provisioning
+        """
+        username = self.get_default_username()
+
+        commands = []
+
+        # cloud-init may not have allowed sudo without tty yet, so try SSH key
+        # installation for a few more seconds:
+        start = []
+
+        def for_ten_seconds(*args, **kwargs):
+            if not start:
+                start.append(time())
+            return Effect(Constant((time() - start[0]) < 30))
+
+        commands.append(run_remotely(
+            username=username,
+            address=self.address,
+            commands=retry(task_install_ssh_key(), for_ten_seconds),
+        ))
+
+        commands.append(run_remotely(
+            username='root',
+            address=self.address,
+            commands=provision(
+                package_source=package_source,
+                distribution=self.distribution,
+                variants=variants,
+            ),
+        ))
+
+        return sequence(commands)
+
+    def reboot(self):
+        """
+        Reboot the node.
+
+        :return Effect:
+        """
+
+        def do_reboot(_):
+            self._node.reboot()
+            state = self.instance.state
+            while state != 'running':
+                sleep(1)
+                self.instance.update()
+                new_state = self.instance.state
+                if new_state != state:
+                    state = new_state
+                    print 'Instance', state
+
+        return run_remotely(
+            username="root",
+            address=self.address,
+            commands=run_from_args(["sync"])
+        ).on(success=do_reboot)
+
+
+class AWSProvisioner(PClass):
+    connection = field(mandatory=True)
+    keyname = field(mandatory=True)
+    security_groups = field(mandatory=True)
+    zone = field(mandatory=True)
+    default_size = field(mandatory=True)
+
+    def get_ssh_key(self):
+        """
+        Return the public key associated with the provided keyname.
+
+        :return Key: The ssh public key or ``None`` if it can't be determined.
+        """
+        # EC2 only provides the SSH2 fingerprint (for uploaded keys)
+        # or the SHA-1 hash of the private key (for EC2 generated keys)
+        # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_KeyPairInfo.html
+        return None
+
+    def create_node(self, name, distribution,
+                    size=None, disk_size=8,
+                    metadata={}):
+        if size is None:
+            size = self.default_size
+
+        metadata = metadata.copy()
+        metadata['Name'] = name
+
+        disk1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
+        disk1.size = disk_size
+        disk1.delete_on_termination = True
+        diskmap = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+        diskmap['/dev/sda1'] = disk1
+
+        images = self.connection.get_all_images(
+            filters={'name': IMAGE_NAMES[distribution]},
+        )
+
+        reservation = self.connection.run_instances(
+            images[0].id,
+            key_name=self.keyname,
+            instance_type=size,
+            security_groups=self.security_groups,
+            block_device_map=diskmap,
+            placement=self.zone,
+            # On some operating systems, a tty is requried for sudo.
+            # Since AWS systems have a non-root user as the login,
+            # disable this, so we can use sudo with conch.
+            user_data=dedent("""\
+                #!/bin/sh
+                sed -i '/Defaults *requiretty/d' /etc/sudoers
+                """),
+        )
+
+        instance = reservation.instances[0]
+
+        self.connection.create_tags([instance.id], metadata)
+
+        state = instance.state
+        print 'Instance', state
+
+        # Display state as instance starts up, to keep user informed that
+        # things are happening.
+        while state != 'running':
+            sleep(1)
+            instance.update()
+            new_state = instance.state
+            if new_state != state:
+                state = new_state
+                print 'Instance', state
+
+        print 'Instance ID:', instance.id
+        print 'Instance IP:', instance.ip_address
+
+        return AWSNode(
+            name=name,
+            _provisioner=self,
+            _instance=instance,
+            distribution=distribution,
+        )
+
+
 def aws_provisioner(access_key, secret_access_token, keyname,
                     region, zone, security_groups):
     """
-    Create a LibCloudProvisioner for provisioning nodes on AWS EC2.
+    Create a IProvisioner for provisioning nodes on AWS EC2.
 
     :param bytes access_key: The access_key to connect to AWS with.
     :param bytes secret_access_token: The corresponding secret token.
@@ -102,45 +222,15 @@ def aws_provisioner(access_key, secret_access_token, keyname,
     :param list security_groups: List of security groups to put created nodes
         in.
     """
-    # Import these here, so that this can be imported without
-    # installing libcloud.
-    from libcloud.compute.providers import get_driver, Provider
-    driver = get_driver(Provider.EC2)(
-        key=access_key,
-        secret=secret_access_token,
-        region=region)
-
-    location = [loc for loc in driver.list_locations()
-                if loc.availability_zone.name == zone][0]
-
-    def create_arguments(disk_size):
-        return {
-            "location": location,
-            "ex_securitygroup": security_groups,
-            "ex_blockdevicemappings": [
-                {"DeviceName": "/dev/sda1",
-                 "Ebs": {"VolumeSize": disk_size,
-                         "DeleteOnTermination": True,
-                         "VolumeType": "gp2"}}
-            ],
-            # On some operating systems, a tty is requried for sudo.
-            # Since AWS systems have a non-root user as the login,
-            # disable this, so we can use sudo with conch.
-            "ex_userdata": dedent("""\
-                #!/bin/sh
-                sed -i '/Defaults *requiretty/d' /etc/sudoers
-                """)
-        }
-
-    provisioner = LibcloudProvisioner(
-        driver=driver,
-        keyname=keyname,
-        image_names=IMAGE_NAMES,
-        create_node_arguments=create_arguments,
-        provision=provision_aws,
-        default_size="m3.large",
-        get_default_user=get_default_username,
-        use_private_addresses=True,
+    conn = boto.ec2.connect_to_region(
+        region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_access_token,
     )
-
-    return provisioner
+    return AWSProvisioner(
+        connection=conn,
+        keyname=keyname,
+        security_groups=security_groups,
+        zone=zone,
+        default_size="m3.large",
+    )

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -14,6 +14,11 @@ from zope.interface import implementer
 from effect.retry import retry
 from effect import Effect, Constant
 
+from boto.ec2 import connect_to_region
+from boto.ec2.blockdevicemapping import (
+    EBSBlockDeviceType, BlockDeviceMapping,
+)
+
 from ._common import INode, IProvisioner
 
 from ._install import (
@@ -190,11 +195,6 @@ class AWSProvisioner(PClass):
     def create_node(self, name, distribution,
                     size=None, disk_size=8,
                     metadata={}):
-        # Import these here, so that this can be imported without installng
-        # libcloud.
-        from boto.ec2.blockdevicemapping import (
-            EBSBlockDeviceType, BlockDeviceMapping,
-        )
         if size is None:
             size = self._default_size
 
@@ -271,9 +271,6 @@ def aws_provisioner(access_key, secret_access_token, keyname,
     :param list security_groups: List of security groups to put created nodes
         in.
     """
-    # Import these here, so that this can be imported without installng
-    # libcloud.
-    from boto.ec2 import connect_to_region
     conn = connect_to_region(
         region,
         aws_access_key_id=access_key,

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -20,8 +20,6 @@ from ._install import (
 from ._ssh import run_remotely, run_from_args
 from ._effect import sequence
 
-import boto.ec2
-
 
 _usernames = {
     'centos-7': 'centos',
@@ -147,16 +145,19 @@ class AWSProvisioner(PClass):
     def create_node(self, name, distribution,
                     size=None, disk_size=8,
                     metadata={}):
+        from boto.ec2.blockdevicemapping import (
+            EBSBlockDeviceType, BlockDeviceMapping,
+        )
         if size is None:
             size = self.default_size
 
         metadata = metadata.copy()
         metadata['Name'] = name
 
-        disk1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
+        disk1 = EBSBlockDeviceType()
         disk1.size = disk_size
         disk1.delete_on_termination = True
-        diskmap = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+        diskmap = BlockDeviceMapping()
         diskmap['/dev/sda1'] = disk1
 
         images = self.connection.get_all_images(
@@ -222,7 +223,8 @@ def aws_provisioner(access_key, secret_access_token, keyname,
     :param list security_groups: List of security groups to put created nodes
         in.
     """
-    conn = boto.ec2.connect_to_region(
+    from boto.ec2 import connect_to_region
+    conn = connect_to_region(
         region,
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_access_token,

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -259,7 +259,7 @@ class AWSProvisioner(PClass):
 def aws_provisioner(access_key, secret_access_token, keyname,
                     region, zone, security_groups):
     """
-    Create a IProvisioner for provisioning nodes on AWS EC2.
+    Create an IProvisioner for provisioning nodes on AWS EC2.
 
     :param bytes access_key: The access_key to connect to AWS with.
     :param bytes secret_access_token: The corresponding secret token.

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -174,7 +174,7 @@ class AWSProvisioner(PClass):
     _keyname = field(type=bytes, mandatory=True)
     _security_groups = field(mandatory=True)
     _zone = field(type=bytes, mandatory=True)
-    default_size = field(type=bytes, mandatory=True)
+    _default_size = field(type=bytes, mandatory=True)
 
     def get_ssh_key(self):
         """
@@ -196,7 +196,7 @@ class AWSProvisioner(PClass):
             EBSBlockDeviceType, BlockDeviceMapping,
         )
         if size is None:
-            size = self.default_size
+            size = self._default_size
 
         with start_action(
             action_type=u"flocker:provision:aws:create_node",
@@ -280,9 +280,9 @@ def aws_provisioner(access_key, secret_access_token, keyname,
         aws_secret_access_key=secret_access_token,
     )
     return AWSProvisioner(
-        connection=conn,
-        keyname=keyname,
-        security_groups=security_groups,
-        zone=zone,
-        default_size=b"m3.large",
+        _connection=conn,
+        _keyname=keyname,
+        _security_groups=security_groups,
+        _zone=zone,
+        _default_size=b"m3.large",
     )

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -118,9 +118,6 @@ class IProvisioner(Interface):
     """
     A provisioner for creating nodes to run acceptance tests agasint.
     """
-    default_size = InterfaceAttribute(
-        'The default instance size created by this provisioner.')
-
     def get_ssh_key():
         """
         Return the public key associated with the provided keyname.

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -2,6 +2,9 @@
 
 from characteristic import attributes, Attribute
 from pyrsistent import PRecord, field
+from zope.interface import (
+    Attribute as InterfaceAttribute, Interface)
+
 from twisted.python.constants import Values, ValueConstant
 
 from ._ca import Certificates
@@ -69,3 +72,72 @@ class Cluster(PRecord):
     @property
     def certificates_path(self):
         return self.certificates.directory
+
+
+class INode(Interface):
+    """
+    Interface for node for running acceptance tests.
+    """
+    address = InterfaceAttribute('Public IP address for node')
+    private_address = InterfaceAttribute('Private IP address for node')
+    distribution = InterfaceAttribute('distribution on node')
+
+    def get_default_username():
+        """
+        Return the username available by default on a system.
+
+        Some cloud systems (e.g. AWS) provide a specific username, which
+        depends on the OS distribution started.  This method returns
+        the username based on the node distribution.
+        """
+
+    def provision(package_source, variants):
+        """
+        Provision flocker on this node.
+
+        :param PackageSource package_source: The source from which to install
+            flocker.
+        :param set variants: The set of variant configurations to use when
+            provisioning
+        """
+
+    def destroy():
+        """
+        Destroy the node.
+        """
+
+    def reboot():
+        """
+        Reboot the node.
+
+        :return Effect:
+        """
+
+
+class IProvisioner(Interface):
+    """
+    A provisioner for creating nodes to run acceptance tests agasint.
+    """
+
+    def get_ssh_key():
+        """
+        Return the public key associated with the provided keyname.
+
+        :return Key: The ssh public key or ``None`` if it can't be determined.
+        """
+
+    def create_node(name, distribution,
+                    size=None, disk_size=8,
+                    metadata={}):
+        """
+        Create a node.
+
+        :param str name: The name of the node.
+        :param str distribution: The name of the distribution to
+            install on the node.
+        :param str size: The name of the size to use.
+        :param int disk_size: The size of disk to allocate.
+        :param dict metadata: Metadata to associate with the node.
+
+        :return INode: The created node.
+        """

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -118,6 +118,8 @@ class IProvisioner(Interface):
     """
     A provisioner for creating nodes to run acceptance tests agasint.
     """
+    default_size = InterfaceAttribute(
+        'The default instance size created by this provisioner.')
 
     def get_ssh_key():
         """

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -124,7 +124,7 @@ class CloudKeyNotFound(Exception):
     Attribute('_image_names'),
     Attribute('_create_node_arguments'),
     Attribute('_provision'),
-    Attribute('default_size'),
+    Attribute('_default_size'),
     Attribute('_get_default_user'),
     Attribute('_use_private_addresses', instance_of=bool, default_value=False),
 ], apply_immutable=True)
@@ -139,7 +139,7 @@ class LibcloudProvisioner(object):
     :ivar callable _create_node_arguments: Extra arguments to pass to
         libcloud's ``create_node``.
     :ivar callable _provision: Function to call to provision a node.
-    :ivar str default_size: Name of the default size of node to create.
+    :ivar str _default_size: Name of the default size of node to create.
     :ivar callable get_default_user: Function to provide the default
         username on the node.
     :ivar bool _use_private_addresses: Whether the `private_address` of nodes
@@ -186,7 +186,7 @@ class LibcloudProvisioner(object):
         :return libcloud.compute.base.Node: The created node.
         """
         if size is None:
-            size = self.default_size
+            size = self._default_size
 
         image_name = self._image_names[distribution]
 

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -130,7 +130,7 @@ class CloudKeyNotFound(Exception):
 ], apply_immutable=True)
 class LibcloudProvisioner(object):
     """
-    :ivar libcloud.compute.base.NodeDriver driver: The libcloud driver to use.
+    :ivar libcloud.compute.base.NodeDriver _driver: The libcloud driver to use.
     :ivar bytes _keyname: The name of an existing ssh public key configured
         with the cloud provider. The provision step assumes the corresponding
         private key is available from an agent.

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -4,12 +4,13 @@
 Helpers for using libcloud.
 """
 
-from zope.interface import (
-    Attribute as InterfaceAttribute, Interface, implementer)
+from zope.interface import implementer
 from characteristic import attributes, Attribute
 from twisted.conch.ssh.keys import Key
 
 from flocker.provision._ssh import run_remotely, run_from_args
+
+from ._common import INode, IProvisioner
 
 
 def get_size(driver, size_id):
@@ -34,46 +35,6 @@ def get_image(driver, image_name):
         return [s for s in driver.list_images() if s.name == image_name][0]
     except IndexError:
         raise ValueError("Unknown image.", image_name)
-
-
-class INode(Interface):
-    """
-    Interface for node for running acceptance tests.
-    """
-    address = InterfaceAttribute('Public IP address for node')
-    private_address = InterfaceAttribute('Private IP address for node')
-    distribution = InterfaceAttribute('distribution on node')
-
-    def get_default_username():
-        """
-        Return the username available by default on a system.
-
-        Some cloud systems (e.g. AWS) provide a specific username, which
-        depends on the OS distribution started.  This method returns
-        the username based on the node distribution.
-        """
-
-    def provision(package_source, variants):
-        """
-        Provision flocker on this node.
-
-        :param PackageSource package_source: The source from which to install
-            flocker.
-        :param set variants: The set of variant configurations to use when
-            provisioning
-        """
-
-    def destroy():
-        """
-        Destroy the node.
-        """
-
-    def reboot():
-        """
-        Reboot the node.
-
-        :return Effect:
-        """
 
 
 @implementer(INode)
@@ -156,6 +117,7 @@ class CloudKeyNotFound(Exception):
     """
 
 
+@implementer(IProvisioner)
 @attributes([
     Attribute('_driver'),
     Attribute('_keyname'),

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -63,6 +63,18 @@ class INode(Interface):
             provisioning
         """
 
+    def destroy():
+        """
+        Destroy the node.
+        """
+
+    def reboot():
+        """
+        Reboot the node.
+
+        :return Effect:
+        """
+
 
 @implementer(INode)
 @attributes([

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -88,7 +88,7 @@ class LibcloudNode(object):
         """
         Return the default username on this provisioner.
         """
-        return self._provisioner.get_default_user(self.distribution)
+        return self._provisioner._get_default_user(self.distribution)
 
     def provision(self, package_source, variants=()):
         """
@@ -99,7 +99,7 @@ class LibcloudNode(object):
         :param set variants: The set of variant configurations to use when
             provisioning
         """
-        return self._provisioner.provision(
+        return self._provisioner._provision(
             node=self,
             package_source=package_source,
             distribution=self.distribution,
@@ -121,12 +121,12 @@ class CloudKeyNotFound(Exception):
 @attributes([
     Attribute('_driver'),
     Attribute('_keyname'),
-    Attribute('image_names'),
+    Attribute('_image_names'),
     Attribute('_create_node_arguments'),
-    Attribute('provision'),
+    Attribute('_provision'),
     Attribute('default_size'),
-    Attribute('get_default_user'),
-    Attribute('use_private_addresses', instance_of=bool, default_value=False),
+    Attribute('_get_default_user'),
+    Attribute('_use_private_addresses', instance_of=bool, default_value=False),
 ], apply_immutable=True)
 class LibcloudProvisioner(object):
     """
@@ -134,15 +134,15 @@ class LibcloudProvisioner(object):
     :ivar bytes _keyname: The name of an existing ssh public key configured
         with the cloud provider. The provision step assumes the corresponding
         private key is available from an agent.
-    :ivar dict image_names: Dictionary mapping distributions to cloud image
+    :ivar dict _image_names: Dictionary mapping distributions to cloud image
         names.
     :ivar callable _create_node_arguments: Extra arguments to pass to
         libcloud's ``create_node``.
-    :ivar callable provision: Function to call to provision a node.
+    :ivar callable _provision: Function to call to provision a node.
     :ivar str default_size: Name of the default size of node to create.
     :ivar callable get_default_user: Function to provide the default
         username on the node.
-    :ivar bool use_private_addresses: Whether the `private_address` of nodes
+    :ivar bool _use_private_addresses: Whether the `private_address` of nodes
         should be populated. This should be specified if the cluster nodes
         use the private address for inter-node communication.
     """
@@ -188,7 +188,7 @@ class LibcloudProvisioner(object):
         if size is None:
             size = self.default_size
 
-        image_name = self.image_names[distribution]
+        image_name = self._image_names[distribution]
 
         create_node_arguments = self._create_node_arguments(
             disk_size=disk_size)
@@ -207,7 +207,7 @@ class LibcloudProvisioner(object):
 
         public_address = addresses[0]
 
-        if self.use_private_addresses:
+        if self._use_private_addresses:
             private_address = node.private_ips[0]
         else:
             private_address = None


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3195

This allows us to take advantage of boto retrying calls that fail due to `RequestLimitExceeded`.

In theory, this should reduce the incidents of getting that error, but I don't have data to back that up.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2026)
<!-- Reviewable:end -->
