### PR TITLE
[FLOC 3132] Update the Installing Overview page

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -104,7 +104,7 @@
                     </div>
                 </div>
                 <!-- Menu area start -->
-                {{ toctree(collapse=true, maxdepth=3) }}
+                {{ toctree(collapse=true, maxdepth=2) }}
                 <!-- Menu area end -->
             </div>
 

--- a/docs/config/enabling-control-service.rst
+++ b/docs/config/enabling-control-service.rst
@@ -1,3 +1,5 @@
+.. _enabling-control-service:
+
 ====================================
 Enabling the Flocker control service 
 ====================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ You'll be able to find concept and reference material, and our :ref:`Labs sectio
 Flocker is an open-source project, and in our :ref:`Getting Involved section<getting-involved>`, there is information about how you can collaborate with ClusterHQ.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    introduction/index
    install/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ You'll be able to find concept and reference material, and our :ref:`Labs sectio
 Flocker is an open-source project, and in our :ref:`Getting Involved section<getting-involved>`, there is information about how you can collaborate with ClusterHQ.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    introduction/index
    install/index

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -4,7 +4,9 @@
 Installing Flocker
 ==================
 
-There are several installation options with which you can get up and running with Flocker:
+There are several installation options with which you can get up and running with Flocker.
+
+You can also try Flocker without installation, either in our live hosted environment or on virtual machines using our Vagrant image. For more information, see :ref:`get-started`.
 
 Quick Start Flocker Installer
 =============================

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -41,5 +41,3 @@ Once you have Flocker installed, you will need to complete the :ref:`post-instal
    :hidden:
 
    plugin-restrictions
-   
-.. _Try Flocker: https://clusterhq.com/flocker/try-flocker/live/

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -4,21 +4,7 @@
 Installing Flocker
 ==================
 
-There are several installation options with which you can get started with Flocker:
-
-No Installation!
-================
-
-Take Flocker for a spin using a free, live hosted environment. 
-No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
-
-* The live demo environment is hosted by ClusterHQ.
-* The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
-* You will have root access to this environment, so you can test Flocker however you want.
-* Follow a step-by-step tutorial.
-* To give you time to play, you’ll have access to the environment for 3 hours.
-
-For more information, see the `Try Flocker`_ page.
+There are several installation options with which you can get up and running with Flocker:
 
 Quick Start Flocker Installer
 =============================
@@ -32,17 +18,6 @@ The Installer is one of our :ref:`Labs projects <labs-projects>`, so is currentl
 * The :ref:`Labs Installer <labs-installer>` documentation includes several tutorials to make it easy to set up and manage a Flocker cluster.
 
 For more information, see the :ref:`Labs Installer <labs-installer>` page.
-
-.. _vagrant-install:
-
-Install Locally Using Vagrant
-=============================
-
-If you don’t want to use real servers, you can set up a cluster locally on virtual machines using our Vagrant image.
-
-Our MongoDB tutorial uses both VirtualBox and Vagrant to install Flocker and Docker, and walks you through an end-to-end example of using Flocker to create an application.
-
-For more information, see the :ref:`MongoDB tutorial <tutorial-mongo>`.
 
 Full Installation
 =================

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -12,7 +12,7 @@ No Installation!
 Take Flocker for a spin using a free, live demo environment. 
 No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
 
-* The live demo enviroment is hosted by ClusterHQ.
+* The live demo environment is hosted by ClusterHQ.
 * The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
 * You will have root access to this environment, and you can test Flocker however you want.
 * Follow a step-by-step tutorial that will show you how to deploy a multi-node application and migrate its data volumes between hosts.

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -10,7 +10,7 @@ No Installation!
 ================
 
 Take Flocker for a spin using a free, live demo environment. 
-No installation is required, and it’s great for understanding what Flocker’s all about.
+No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
 
 * The live demo enviroment is hosted by ClusterHQ.
 * The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
@@ -20,19 +20,18 @@ No installation is required, and it’s great for understanding what Flocker’s
 
 For more information, see the `Try Flocker`_ page.
 
-Quick Start
-===========
+Quick Start Flocker Installer
+=============================
 
-Want to get started with Flocker quickly?
-You can try the Labs Installer.
+If you want to get started with Flocker quickly, but in your own environment, you can use the Installer.
+The Installer is one of our :ref:`Labs projects <labs-projects>`, so is currently experimental.
 
-* It makes it easy to set up and manage a Flocker cluster.
-* It runs inside a Docker container on your local machine.
-* The :ref:`Flocker plugin for Docker <using-docker-plugin>` is installed.
+* The Installer runs locally in a Docker container on your machine.
+* It provisions nodes on AWS, and then installs Flocker, Docker, and the Flocker plugin for Docker.
+* You can reconfigure the cluster at any time.
+* The :ref:`Labs Installer <labs-installer>` documentation includes several tutorials to make it easy to set up and manage a Flocker cluster.
 
-:ref:`Try the Labs installer <labs-installer>`.
-
-If you'd rather install Flocker manually, read on.
+For more information, see the :ref:`Labs Installer <labs-installer>` page.
 
 Manual Installation
 ===================

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -4,6 +4,22 @@
 Installing Flocker
 ==================
 
+There are several installation options with which you can get started with Flocker:
+
+No Installation!
+================
+
+Take Flocker for a spin using a free, live demo environment. 
+No installation is required, and it’s great for understanding what Flocker’s all about.
+
+* The live demo enviroment is hosted by ClusterHQ.
+* The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
+* You will have root access to this environment, and you can test Flocker however you want.
+* Follow a step-by-step tutorial that will show you how to deploy a multi-node application and migrate its data volumes between hosts.
+* To give you time to play, you’ll have access to the environment for 3 hours.
+
+For more information, see the `Try Flocker`_ page.
+
 Quick Start
 ===========
 
@@ -50,3 +66,5 @@ It also describes how to get Vagrant nodes started which already have these serv
    :hidden:
 
    plugin-restrictions
+   
+.. _Try Flocker: https://clusterhq.com/flocker/try-flocker/live/

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -47,19 +47,7 @@ For more information, see the :ref:`MongoDB tutorial <tutorial-mongo>`.
 Full Installation
 =================
 
-These manual instructions take you through the full Flocker installation:
-
-* You will install the Flocker Client on your local machine, which provides the command line tools to control the cluster.
-
-  This includes the ``flocker-ca`` tool, which you will use to generate certificates for all the Flocker components.
-
-* You will install the Flocker Node services, on any number of nodes in the cluster where your containers will run.
-
-  The ``clusterhq-flocker-node`` package includes the Flocker agent software.
-
-* The Flocker control service is installed on one of the agent hosts, or on a separate machine.
-  
-  The Flocker control service is also included in the ``clusterhq-flocker-node`` package, but is activated separately later in :ref:`enabling-control-service`.
+For a full Flocker installation, including the Flocker plugin for Docker, the following manual instructions take you through everything you need to do:
 
 .. XXX this introduction could be improved with an image. See FLOC-2077
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -9,13 +9,13 @@ There are several installation options with which you can get started with Flock
 No Installation!
 ================
 
-Take Flocker for a spin using a free, live demo environment. 
+Take Flocker for a spin using a free, live hosted environment. 
 No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
 
 * The live demo environment is hosted by ClusterHQ.
 * The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
-* You will have root access to this environment, and you can test Flocker however you want.
-* Follow a step-by-step tutorial that will show you how to deploy a multi-node application and migrate its data volumes between hosts.
+* You will have root access to this environment, so you can test Flocker however you want.
+* Follow a step-by-step tutorial.
 * To give you time to play, you’ll have access to the environment for 3 hours.
 
 For more information, see the `Try Flocker`_ page.
@@ -52,11 +52,13 @@ For a full Flocker installation, including the Flocker plugin for Docker, the fo
 .. XXX this introduction could be improved with an image. See FLOC-2077
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    install-client
    install-node
    docker-plugin
+
+Once you have Flocker installed, you will need to complete the :ref:`post-installation-configuration` steps in order to use Flocker.
 
 .. note:: If you're interested in developing Flocker (as opposed to simply using it) see :ref:`contribute`.
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -33,6 +33,8 @@ The Installer is one of our :ref:`Labs projects <labs-projects>`, so is currentl
 
 For more information, see the :ref:`Labs Installer <labs-installer>` page.
 
+.. _vagrant-install:
+
 Install Locally Using Vagrant
 =============================
 
@@ -42,27 +44,24 @@ Our MongoDB tutorial uses both VirtualBox and Vagrant to install Flocker and Doc
 
 For more information, see the :ref:`MongoDB tutorial <tutorial-mongo>`.
 
-
 Full Installation
 =================
 
-The Flocker Client is installed on your local machine and provides command line tools to control the cluster.
-This also includes the ``flocker-ca`` tool, which you use to generate certificates for all the Flocker components.
+These manual instructions take you through the full Flocker installation:
 
-The Flocker agents are installed on any number of nodes in the cluster where your containers will run.
-The agent software is included in the ``clusterhq-flocker-node`` package.
+* You will install the Flocker Client on your local machine, which provides the command line tools to control the cluster.
 
-There is also a Flocker control service which you must install on one of the agent hosts, or on a separate machine.
-The control service is also included in the ``clusterhq-flocker-node`` package, but is activated separately later in these installation instructions.
+  This includes the ``flocker-ca`` tool, which you will use to generate certificates for all the Flocker components.
 
-.. note:: The agents and control service are pre-installed by the :ref:`Vagrant configuration in the tutorial <tutvagrant>`.
+* You will install the Flocker Node services, on any number of nodes in the cluster where your containers will run.
 
-.. note:: If you're interested in developing Flocker (as opposed to simply using it) see :ref:`contribute`.
+  The ``clusterhq-flocker-node`` package includes the Flocker agent software.
 
-This document will describe how to install the client locally and install the agents and control service on cloud infrastructure.
-It also describes how to get Vagrant nodes started which already have these services running.
+* The Flocker control service is installed on one of the agent hosts, or on a separate machine.
+  
+  The Flocker control service is also included in the ``clusterhq-flocker-node`` package, but is activated separately later in :ref:`enabling-control-service`.
 
-.. XXX We will improve this introduction with an image. See FLOC-2077
+.. XXX this introduction could be improved with an image. See FLOC-2077
 
 .. toctree::
    :maxdepth: 2
@@ -70,6 +69,8 @@ It also describes how to get Vagrant nodes started which already have these serv
    install-client
    install-node
    docker-plugin
+
+.. note:: If you're interested in developing Flocker (as opposed to simply using it) see :ref:`contribute`.
 
 .. toctree::
    :hidden:

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -33,8 +33,18 @@ The Installer is one of our :ref:`Labs projects <labs-projects>`, so is currentl
 
 For more information, see the :ref:`Labs Installer <labs-installer>` page.
 
-Manual Installation
-===================
+Install Locally Using Vagrant
+=============================
+
+If you don’t want to use real servers, you can set up a cluster locally on virtual machines using our Vagrant image.
+
+Our MongoDB tutorial uses both VirtualBox and Vagrant to install Flocker and Docker, and walks you through an end-to-end example of using Flocker to create an application.
+
+For more information, see the :ref:`MongoDB tutorial <tutorial-mongo>`.
+
+
+Full Installation
+=================
 
 The Flocker Client is installed on your local machine and provides command line tools to control the cluster.
 This also includes the ``flocker-ca`` tool, which you use to generate certificates for all the Flocker components.

--- a/docs/install/install-node.rst
+++ b/docs/install/install-node.rst
@@ -4,13 +4,7 @@
 Installing the Flocker Node Services
 ====================================
 
-There are a number of ways to install Flocker.
-
-These easiest way to get Flocker going is to use our Vagrant configuration.
-
-- :ref:`Vagrant <vagrant-install>`
-
-It is also possible to deploy Flocker in the cloud, on a number of different providers.
+It is possible to deploy Flocker in the cloud, on a number of different providers.
 
 - :ref:`Using Amazon Web Services <aws-install>`
 - :ref:`Using Rackspace <rackspace-install>`
@@ -19,14 +13,6 @@ It is also possible to install Flocker on any CentOS 7 or Ubuntu 14.04 machine.
 
 - :ref:`Installing on CentOS 7 <centos-7-install>`
 - :ref:`Installing on Ubuntu 14.04 <ubuntu-14.04-install>`
-
-.. _vagrant-install:
-
-Vagrant
-=======
-
-The easiest way to get Flocker going on a cluster is to run it on local virtual machines using the :ref:`Vagrant configuration in the tutorial <tutvagrant>`.
-You can therefore skip this section unless you want to run Flocker on a cluster you setup yourself.
 
 .. _aws-install:
 

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -160,12 +160,14 @@ Configuration details for each of the backends can be found in the :ref:`Configu
 
 .. XXX FLOC 3144 - add a link here to the instructions on how to create your own backend driver
 
+.. _get-started:
+
 Get Started with Flocker
 ========================
 
 Before you begin to install Flocker, there are a couple of ways in which you can try out Flocker without having to go through the full installation steps:
 
-Flocker in a Live Hosted Environment
+Flocker in a Live Hgosted Environment
 --------------------------------------
 
 You can take Flocker for a spin using a free, live hosted environment. 

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -189,3 +189,5 @@ If you don’t want to use real servers, you can set up a cluster locally on vir
 Our MongoDB tutorial uses both VirtualBox and Vagrant to install Flocker and Docker, and walks you through an end-to-end example of using Flocker to create an application.
 
 For more information, see the :ref:`MongoDB tutorial <tutorial-mongo>`.
+
+.. _Try Flocker: https://clusterhq.com/flocker/try-flocker/live/

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -159,3 +159,33 @@ The following backends can be used with Flocker:
 Configuration details for each of the backends can be found in the :ref:`Configuring the Nodes and Storage Backends<agent-yml>` topic.
 
 .. XXX FLOC 3144 - add a link here to the instructions on how to create your own backend driver
+
+Get Started with Flocker
+========================
+
+Before you begin to install Flocker, there are a couple of ways in which you can try out Flocker without having to go through the full installation steps:
+
+Flocker in a Live, Hosted, Environment
+--------------------------------------
+
+You can take Flocker for a spin using a free, live hosted environment. 
+No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
+
+* The live demo environment is hosted by ClusterHQ.
+* The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
+* You will have root access to this environment, so you can test Flocker however you want.
+* Follow a step-by-step tutorial.
+* To give you time to play, you’ll have access to the environment for 3 hours.
+
+For more information, see the `Try Flocker`_ page.
+
+.. _vagrant-install:
+
+Flocker Installed Locally Using Vagrant
+---------------------------------------
+
+If you don’t want to use real servers, you can set up a cluster locally on virtual machines using our Vagrant image.
+
+Our MongoDB tutorial uses both VirtualBox and Vagrant to install Flocker and Docker, and walks you through an end-to-end example of using Flocker to create an application.
+
+For more information, see the :ref:`MongoDB tutorial <tutorial-mongo>`.

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -167,8 +167,8 @@ Get Started with Flocker
 
 Before you begin to install Flocker, there are a couple of ways in which you can try out Flocker without having to go through the full installation steps:
 
-Flocker in a Live Hgosted Environment
---------------------------------------
+Flocker in a Live Hosted Environment
+------------------------------------
 
 You can take Flocker for a spin using a free, live hosted environment. 
 No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -186,7 +186,7 @@ For more information, see the `Try Flocker`_ page.
 Flocker Installed Locally Using Vagrant
 ---------------------------------------
 
-If you don’t want to use real servers, you can set up a cluster locally on virtual machines using our Vagrant image.
+For quick experiments, you can set up a cluster locally on virtual machines using our Vagrant image.
 
 Our MongoDB tutorial uses both VirtualBox and Vagrant to install Flocker and Docker, and walks you through an end-to-end example of using Flocker to create an application.
 

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -165,7 +165,7 @@ Get Started with Flocker
 
 Before you begin to install Flocker, there are a couple of ways in which you can try out Flocker without having to go through the full installation steps:
 
-Flocker in a Live, Hosted, Environment
+Flocker in a Live Hosted Environment
 --------------------------------------
 
 You can take Flocker for a spin using a free, live hosted environment. 


### PR DESCRIPTION
Fixes 3132

This PR moves the Flocker demo info (TrueAbility and Vagrant) into a section at the end of "Introduction to Flocker", and rewrites the overview of Installation to talk about the Labs Installer, and a simplified overview of the full install steps.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2033)
<!-- Reviewable:end -->
