### PR TITLE
[FLOC 3228] lower the number of visible links from the left hand docs menu

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -104,7 +104,7 @@
                     </div>
                 </div>
                 <!-- Menu area start -->
-                {{ toctree(collapse=true, maxdepth=3) }}
+                {{ toctree(collapse=true, maxdepth=2) }}
                 <!-- Menu area end -->
             </div>
 


### PR DESCRIPTION
Fixes 3228

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2035)
<!-- Reviewable:end -->
