### PR TITLE
[FLOC-3124] Enforce bytes on public address returned from libcloud

### DIFF
--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -240,6 +240,9 @@ class LibcloudProvisioner(object):
         else:
             private_address = None
 
+        if isinstance(private_address, unicode):
+            private_address = private_address.encode("ascii")
+
         return LibcloudNode(
             provisioner=self,
             node=node, address=public_address,

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -232,6 +232,8 @@ class LibcloudProvisioner(object):
             [node], wait_period=15)[0]
 
         public_address = addresses[0]
+        if isinstance(public_address, unicode):
+            public_address = public_address.encode("ascii")
 
         if self.use_private_addresses:
             private_address = node.private_ips[0]


### PR DESCRIPTION
Fixes FLOC-3124. On PyPy, sometimes the resulting IP addresses returned from libcloud's rackspace driver (`wait_until_running`) are `unicode` instead of bytes. Our `run_remotely` helper uses a Pyrsistent record type that accepts `bytes`, therefore if the result from libcloud is unicode, encode it to ASCII.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2040)
<!-- Reviewable:end -->
