### PR TITLE
[FLOC-3233] Make os_version a generated property of PackageSource

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -29,7 +29,6 @@ from effect import parallel
 from effect.twisted import perform
 
 from admin.vagrant import vagrant_version
-from flocker.common.version import make_rpm_version
 from flocker.provision import PackageSource, Variants, CLOUD_PROVIDERS
 import flocker
 from flocker.provision._ssh import (
@@ -683,17 +682,8 @@ class RunOptions(Options):
         provider = self['provider'].lower()
         provider_config = self['config'].get(provider, {})
 
-        if self['flocker-version']:
-            rpm_version = make_rpm_version(self['flocker-version'])
-            os_version = "%s-%s" % (rpm_version.version, rpm_version.release)
-            if os_version.endswith('.dirty'):
-                os_version = os_version[:-len('.dirty')]
-        else:
-            os_version = None
-
         package_source = PackageSource(
             version=self['flocker-version'],
-            os_version=os_version,
             branch=self['branch'],
             build_server=self['build-server'],
         )

--- a/admin/client.py
+++ b/admin/client.py
@@ -16,7 +16,6 @@ from twisted.python.usage import Options, UsageError
 from twisted.python.filepath import FilePath
 
 import flocker
-from flocker.common.version import make_rpm_version
 from flocker.provision import PackageSource
 from flocker.provision._effect import Sequence, perform_sequence
 from flocker.provision._install import (
@@ -220,17 +219,8 @@ class RunOptions(Options):
         else:
             self['config'] = {}
 
-        if self['flocker-version']:
-            rpm_version = make_rpm_version(self['flocker-version'])
-            os_version = "%s-%s" % (rpm_version.version, rpm_version.release)
-            if os_version.endswith('.dirty'):
-                os_version = os_version[:-len('.dirty')]
-        else:
-            os_version = None
-
         self['package_source'] = PackageSource(
             version=self['flocker-version'],
-            os_version=os_version,
             branch=self['branch'],
             build_server=self['build-server'],
         )

--- a/admin/test/test_acceptance.py
+++ b/admin/test/test_acceptance.py
@@ -33,7 +33,6 @@ class ManagedRunnerTests(SynchronousTestCase):
             node_addresses=[b'192.0.2.1'],
             package_source=PackageSource(
                 version=b"",
-                os_version=b"",
                 branch=b"",
                 build_server=b"",
             ),

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -16,18 +16,18 @@ from ._ca import Certificates
 ])
 class PackageSource(object):
     """
-    Source for the installation of a flocker package.
+    Source for the installation of a Flocker package.
 
-    :ivar bytes version: The version of flocker to install. If not specified,
+    :ivar bytes version: The version of Flocker to install. If not specified,
         install the most recent version.
-    :ivar bytes branch: The branch from which to install flocker.
+    :ivar bytes branch: The branch from which to install Flocker.
         If not specified, install from the release repository.
-    :ivar bytes build_server: The builderver to install from.
+    :ivar bytes build_server: The buildserver to install from.
         Only meaningful if a branch is specified.
     """
-    @property
+
     def os_version(self):
-        """The version of the OS package of flocker to install."""
+        """The version of the OS package of Flocker to install."""
         if self.version:
             rpm_version = make_rpm_version(self.version)
             os_version = "%s-%s" % (rpm_version.version, rpm_version.release)

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -29,7 +29,7 @@ class PackageSource(object):
     def os_version(self):
         """The version of the OS package of flocker to install."""
         if self.version:
-            rpm_version = make_rpm_version(self['flocker-version'])
+            rpm_version = make_rpm_version(self.version)
             os_version = "%s-%s" % (rpm_version.version, rpm_version.release)
             if os_version.endswith('.dirty'):
                 os_version = os_version[:-len('.dirty')]

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -4,12 +4,13 @@ from characteristic import attributes, Attribute
 from pyrsistent import PRecord, field
 from twisted.python.constants import Values, ValueConstant
 
+from flocker.common.version import make_rpm_version
+
 from ._ca import Certificates
 
 
 @attributes([
     Attribute('version', default_value=None),
-    Attribute('os_version', default_value=None),
     Attribute('branch', default_value=None),
     Attribute('build_server', default_value="http://build.clusterhq.com/"),
 ])
@@ -19,13 +20,22 @@ class PackageSource(object):
 
     :ivar bytes version: The version of flocker to install. If not specified,
         install the most recent version.
-    :ivar bytes os_version: The version of the OS package of flocker to
-        install.  If not specified, install the most recent version.
     :ivar bytes branch: The branch from which to install flocker.
         If not specified, install from the release repository.
     :ivar bytes build_server: The builderver to install from.
         Only meaningful if a branch is specified.
     """
+    @property
+    def os_version(self):
+        """The version of the OS package of flocker to install."""
+        if self.version:
+            rpm_version = make_rpm_version(self['flocker-version'])
+            os_version = "%s-%s" % (rpm_version.version, rpm_version.release)
+            if os_version.endswith('.dirty'):
+                os_version = os_version[:-len('.dirty')]
+        else:
+            os_version = None
+        return os_version
 
 
 class Variants(Values):

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -281,7 +281,7 @@ def install_commands_yum(package_name, distribution, package_source,
         repo_options = get_repo_options(
             flocker_version=get_installable_version(version))
 
-    os_version = package_source.os_version
+    os_version = package_source.os_version()
     if os_version:
         package_name += '-%s' % (os_version,)
 
@@ -351,7 +351,7 @@ def install_commands_ubuntu(package_name, distribution, package_source,
     # Update to read package info from new repos
     commands.append(run_from_args(["apt-get", "update"]))
 
-    os_version = package_source.os_version
+    os_version = package_source.os_version()
 
     if os_version:
         # Set the version of the top-level package

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -281,8 +281,9 @@ def install_commands_yum(package_name, distribution, package_source,
         repo_options = get_repo_options(
             flocker_version=get_installable_version(version))
 
-    if package_source.os_version:
-        package_name += '-%s' % (package_source.os_version,)
+    os_version = package_source.os_version
+    if os_version:
+        package_name += '-%s' % (os_version,)
 
     # Install package and all dependencies:
 
@@ -350,9 +351,11 @@ def install_commands_ubuntu(package_name, distribution, package_source,
     # Update to read package info from new repos
     commands.append(run_from_args(["apt-get", "update"]))
 
-    if package_source.os_version:
+    os_version = package_source.os_version
+
+    if os_version:
         # Set the version of the top-level package
-        package_name += '=%s' % (package_source.os_version,)
+        package_name += '=%s' % (os_version,)
 
         # If a specific version is required, ensure that the version for
         # all ClusterHQ packages is consistent.  This prevents conflicts
@@ -364,7 +367,7 @@ def install_commands_ubuntu(package_name, distribution, package_source,
             Package: clusterhq-*
             Pin: version {}
             Pin-Priority: 900
-        '''.format(package_source.os_version)), '/tmp/apt-pref'))
+        '''.format(os_version)), '/tmp/apt-pref'))
         commands.append(run_from_args([
             'mv', '/tmp/apt-pref', '/etc/apt/preferences.d/clusterhq-900']))
 

--- a/flocker/provision/test/test_common.py
+++ b/flocker/provision/test/test_common.py
@@ -1,0 +1,40 @@
+# Copyright ClusterHQ Inc. See LICENSE file for details.
+
+"""
+Tests for common provision code.
+"""
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from flocker.common.version import make_rpm_version
+from flocker.provision._common import PackageSource
+
+
+class PackageSourceTests(SynchronousTestCase):
+    """
+    Tests for ``PackageSource.os_version``.
+    """
+    def test_os_version(self):
+        """
+        os_version() returns an OS version for a FLocker version.
+        """
+        version = '1.2.3'
+        rpm_version = make_rpm_version(version)
+        expected = "%s-%s" % (rpm_version.version, rpm_version.release)
+        package_source = PackageSource(version=version)
+        self.assertEqual(expected, package_source.os_version())
+
+    def test_version_none(self):
+        """
+        Unset version gives no OS version.
+        """
+        package_source = PackageSource()
+        self.assertFalse(package_source.os_version())
+
+    def test_version_empty(self):
+        """
+        Empty version gives no OS version.  This is supported, due to
+        a previously undocumented behavior being useful.
+        """
+        package_source = PackageSource(version='')
+        self.assertFalse(package_source.os_version())


### PR DESCRIPTION
PR #2028 introduces a third location where `os_version` is generated from `version` and then both values are used to create a `PackageSource` object.

This PR makes `os_version` a property of `PackageSource`, allowing it to be generated on demand in one place, rather than by each piece of code that creates a `PackageSource` instance.

The code that uses `os_version` has been modified to call it once, to prevent frequent re-generation of the value.

Note, this changes the two existing locations where `PackageSource` instances are created.  The latter merge of this PR and #2028 should be updated to modify the third `PackageSource` creation.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2041)
<!-- Reviewable:end -->
