### PR TITLE
[FLOC-3173] Document eliot/journald support

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -811,6 +811,8 @@ def omnibus_package_builder(
     if target_dir is None:
         target_dir = FilePath(mkdtemp())
 
+    flocker_shared_path = target_dir.child('flocker-shared')
+    flocker_shared_path.makedirs()
     flocker_cli_path = target_dir.child('flocker-cli')
     flocker_cli_path.makedirs()
     flocker_node_path = target_dir.child('flocker-node')
@@ -843,10 +845,19 @@ def omnibus_package_builder(
             # get_package_version_step must be run before steps that reference
             # rpm_version
             get_package_version_step,
+            CreateLinks(
+                links=[
+                    (FilePath('/opt/flocker/bin/eliot-prettyprint'),
+                     flocker_shared_path),
+                    (FilePath('/opt/flocker/bin/eliot-tree'),
+                     flocker_shared_path),
+                ],
+            ),
             BuildPackage(
                 package_type=distribution.package_type(),
                 destination_path=destination_path,
-                source_paths={virtualenv_dir: virtualenv_dir},
+                source_paths={virtualenv_dir: virtualenv_dir,
+                              flocker_shared_path: FilePath("/usr/bin")},
                 name='clusterhq-python-flocker',
                 prefix=FilePath('/'),
                 epoch=PACKAGE.EPOCH.value,

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -868,6 +868,7 @@ class OmnibusPackageBuilderTests(TestCase):
         flocker_cli_path = target_path.child('flocker-cli')
         flocker_node_path = target_path.child('flocker-node')
         flocker_docker_plugin_path = target_path.child('flocker-docker-plugin')
+        flocker_shared_path = target_path.child('flocker-shared')
         empty_path = target_path.child('empty')
 
         expected_virtualenv_path = FilePath('/opt/flocker')
@@ -898,11 +899,20 @@ class OmnibusPackageBuilderTests(TestCase):
                     package_uri=b'https://www.example.com/foo/Bar-1.2.3.whl',
                 ),
                 expected_package_version_step,
+                CreateLinks(
+                    links=[
+                        (FilePath('/opt/flocker/bin/eliot-prettyprint'),
+                         flocker_shared_path),
+                        (FilePath('/opt/flocker/bin/eliot-tree'),
+                         flocker_shared_path),
+                    ],
+                ),
                 BuildPackage(
                     package_type=expected_package_type,
                     destination_path=expected_destination_path,
                     source_paths={
-                        expected_virtualenv_path: expected_virtualenv_path
+                        expected_virtualenv_path: expected_virtualenv_path,
+                        flocker_shared_path: FilePath("/usr/bin"),
                     },
                     name='clusterhq-python-flocker',
                     prefix=expected_prefix,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,7 @@ GitPython==1.0.1
 humanfriendly==1.33
 hypothesis==1.10.3
 Jinja2==2.7.3
-jmespath==0.7.1
+jmespath==0.9.0
 MarkupSafe==0.23
 mccabe==0.3.1
 ndg-httpsclient==0.4.0

--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -12,7 +12,7 @@ Logging
 Flocker processes use the `Eliot`_ framework for logging.
 Eliot structures logs as a tree of actions, which means given an error you can see what Flocker actions caused the errors by finding the other messages in the tree.
 The tree of actions can also span processes; thus you can trace API calls from within the Docker plugin and see the effects in the control service logs.
-Messages can be rendered into a human-readable tree using the `eliot-tree`_ command-line tool, which is pre-installed with Flocker.
+Messages can be rendered into a human-readable tree using the `eliot-tree`_ command line tool, which is pre-installed with Flocker.
 Eliot also includes a tool called ``eliot-prettyprint`` which renders messages into a more human-readable format but does not present them in a tree structure.
 
 Logs from the Docker containers can be viewed using `the Docker CLI <https://docs.docker.com/reference/commandline/cli/#logs>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,13 @@ debtcollector==0.5.0
 docker-py==1.3.1
 effect==0.1a13
 eliot==0.9.0
+eliot-tree==15.3.0
 enum34==1.0.4
 idna==2.0
 ipaddr==2.1.11
 ipaddress==1.0.7
 iso8601==0.1.10
+jmespath==0.9.0
 jsonschema==2.4.0
 klein==0.2.3
 machinist==0.2.0
@@ -48,6 +50,7 @@ setuptools==18.0.1
 simplejson==3.7.3
 six==1.9.0
 stevedore==1.5.0
+toolz==0.7.4
 treq==0.2.1
 Twisted==15.1.0
 websocket-client==0.32.0


### PR DESCRIPTION
1. Install eliot-tree package.
2. Include eliot-tree and eliot-prettyprint as public binaries installed by the shared Python package so that they are always available.
3. Document how to use journalctl and eliot to extract useful information from Flocker logs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2043)
<!-- Reviewable:end -->
