### PR TITLE
[FLOC-3185] Reset reconnection delay upon succesful connection

### DIFF
--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -502,6 +502,9 @@ class AgentLoopService(MultiService, object):
     # IConvergenceAgent methods:
 
     def connected(self, client):
+        # Reduce reconnect delay back to normal, since we've successfully
+        # connected:
+        self.reconnecting_factory.resetDelay()
         self.cluster_status.receive(_ConnectedToControlService(client=client))
 
     def disconnected(self):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -959,6 +959,20 @@ class AgentLoopServiceTests(SynchronousTestCase):
         self.assertEqual(fsm.inputted,
                          [_ConnectedToControlService(client=client)])
 
+    def test_connected_resets_factory_delay(self):
+        """
+        When ``connected()`` is called the reconnect delay on the client
+        factory is reset.
+        """
+        factory = self.service.reconnecting_factory
+        # A series of retries have caused the delay to grow (so that we
+        # don't hammer the server with reconnects):
+        factory.delay += 500000
+        # But now we successfully connect!
+        client = factory.buildProtocol(None)
+        self.service.connected(client)
+        self.assertEqual(factory.delay, factory.initialDelay)
+
     def test_disconnected(self):
         """
         When ``connnected()`` is called a


### PR DESCRIPTION
Before this the reconnect delay would grow on every reconnect and never go back down.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2044)
<!-- Reviewable:end -->
