### PR TITLE
[FLOC-3234] Refactor IDeploy to enable state transfer from discover_state to calculate_changes.

### DIFF
--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -16,11 +16,10 @@ from ._config import (
     model_from_configuration,
 )
 from ._model import (
-    IClusterStateChange,
-    Application, Deployment, DockerImage, Node, Port, Link, AttachedVolume,
-    NodeState, Manifestation, Dataset, RestartNever, RestartOnFailure,
-    RestartAlways, DeploymentState, NonManifestDatasets, same_node,
-    IClusterStateWipe, Leases, Lease, LeaseError, pmap_field
+    IClusterStateChange, Application, Deployment, DockerImage, Node, Port,
+    Link, AttachedVolume, NodeState, Manifestation, Dataset, RestartNever,
+    RestartOnFailure, RestartAlways, DeploymentState, NonManifestDatasets,
+    same_node, IClusterStateWipe, Leases, Lease, LeaseError, pmap_field
 )
 from ._protocol import (
     IConvergenceAgent,

--- a/flocker/node/__init__.py
+++ b/flocker/node/__init__.py
@@ -11,7 +11,7 @@ from ._change import (
 from ._deploy import (
     IDeployer,
     ILocalState,
-    FullySharedLocalState,
+    NodeLocalState,
     P2PManifestationDeployer,
     ApplicationNodeDeployer,
 )
@@ -20,7 +20,7 @@ from .script import BackendDescription, DeployerType
 
 
 __all__ = [
-    'IDeployer', 'ILocalState', 'FullySharedLocalState', 'IStateChange',
+    'IDeployer', 'ILocalState', 'NodeLocalState', 'IStateChange',
     'P2PManifestationDeployer',
     'ApplicationNodeDeployer',
     'run_state_change', 'in_parallel', 'sequentially',

--- a/flocker/node/__init__.py
+++ b/flocker/node/__init__.py
@@ -10,6 +10,8 @@ from ._change import (
 
 from ._deploy import (
     IDeployer,
+    ILocalState,
+    FullySharedLocalState,
     P2PManifestationDeployer,
     ApplicationNodeDeployer,
 )
@@ -18,7 +20,7 @@ from .script import BackendDescription, DeployerType
 
 
 __all__ = [
-    'IDeployer', 'IStateChange',
+    'IDeployer', 'ILocalState', 'FullySharedLocalState', 'IStateChange',
     'P2PManifestationDeployer',
     'ApplicationNodeDeployer',
     'run_state_change', 'in_parallel', 'sequentially',

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -14,7 +14,7 @@ from zope.interface import Interface, implementer, Attribute
 
 from characteristic import attributes
 
-from pyrsistent import PRecord, field, CheckedPVector, PClass
+from pyrsistent import PRecord, field, PClass
 
 from eliot import Message, write_failure, Logger, start_action
 
@@ -25,8 +25,8 @@ from . import IStateChange, in_parallel, sequentially
 
 from ..control._model import (
     Application, DatasetChanges, AttachedVolume, DatasetHandoff,
-    IClusterStateChange, NodeState, DockerImage, Port, Link, Manifestation,
-    Dataset, pset_field, ip_to_uuid, RestartNever,
+    NodeState, DockerImage, Port, Link, Manifestation, Dataset, pset_field,
+    ip_to_uuid, RestartNever,
     )
 from ..route import make_host_network, Proxy, OpenPort
 from ..volume._ipc import RemoteVolumeManager, standard_node

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -11,9 +11,10 @@ from uuid import UUID
 
 from zope.interface import Interface, implementer, Attribute
 
+
 from characteristic import attributes
 
-from pyrsistent import PRecord, field
+from pyrsistent import PRecord, field, CheckedPVector, PClass
 
 from eliot import Message, write_failure, Logger, start_action
 
@@ -24,8 +25,8 @@ from . import IStateChange, in_parallel, sequentially
 
 from ..control._model import (
     Application, DatasetChanges, AttachedVolume, DatasetHandoff,
-    NodeState, DockerImage, Port, Link, Manifestation, Dataset,
-    pset_field, ip_to_uuid, RestartNever,
+    IClusterStateChange, NodeState, DockerImage, Port, Link, Manifestation,
+    Dataset, pset_field, ip_to_uuid, RestartNever,
     )
 from ..route import make_host_network, Proxy, OpenPort
 from ..volume._ipc import RemoteVolumeManager, standard_node
@@ -49,6 +50,55 @@ def _to_volume_name(dataset_id):
     :return: ``VolumeName`` with default namespace.
     """
     return VolumeName(namespace=u"default", dataset_id=dataset_id)
+
+
+class ILocalState(Interface):
+    """
+    An ``ILocalState`` is the result from discovering state. It must provide
+    the state that will be sent to the control service, but can store
+    additional state that is useful in calculate_changes.
+    """
+
+    def shared_state_changes():
+        """
+        Calculate the part of the local state that needs to be sent to the
+        control service.
+
+        :return: A tuple of ``IClusterStateChange`` providers that describe
+            the local state that needs to be shared. These objects will be
+            passed to the control service (see ``flocker.control._protocol``).
+        """
+
+
+class ClusterStateChangePVector(CheckedPVector):
+    """
+    ``CheckedPVector`` for objects that provide ``IClusterStateChange``.
+    """
+    def __invariant__(o):
+        """
+        Invariant check for providing ``IClusterStateChange``.
+        """
+        return (IClusterStateChange.providedBy(o),
+                'Does not provide IClusterStateChange.')
+
+
+@implementer(ILocalState)
+class FullySharedLocalState(PClass):
+    """
+    An ``ILocalState`` provider that
+
+    :ivar cluster_state_changes: A ``ClusterStateChangePVector`` of
+        ``IClusterStateChange`` providers describing local state. These objects
+        will all be shared.
+    """
+    cluster_state_changes = field(type=ClusterStateChangePVector,
+                                  mandatory=True)
+
+    def shared_state_changes(self):
+        """
+        All state is shared in this implementation of LocalState.
+        """
+        return tuple(self.cluster_state_changes)
 
 
 class IDeployer(Interface):
@@ -75,14 +125,13 @@ class IDeployer(Interface):
             into the result; the return result should include only
             information discovered by this particular deployer.
 
-        :return: A ``Deferred`` which fires with a tuple of
-            ``IClusterStateChange`` providers describing
-            local state. These objects will be passed to the control
-            service (see ``flocker.control._protocol``) and may also be
-            passed to this object's ``calculate_changes()`` method.
+        :return: A ``Deferred`` which fires with a ``ILocalState``. The
+            state_changes will be passed to the control service (see
+            ``flocker.control._protocol``), and the entire opaque object will
+            be passed to this object's ``calculate_changes()`` method.
         """
 
-    def calculate_changes(configuration, cluster_state):
+    def calculate_changes(configuration, cluster_state, local_state):
         """
         Calculate the state changes necessary to make the local state match the
         desired cluster configuration.
@@ -92,6 +141,9 @@ class IDeployer(Interface):
 
         :param DeploymentState cluster_state: The current state of all nodes
             already updated with recent output of ``discover_state``.
+
+        :param ILocalState local_state: The ``ILocalState`` provider returned
+            from the most recent call to ``discover_state``.
 
         :return: An ``IStateChange`` provider.
         """
@@ -537,19 +589,21 @@ class P2PManifestationDeployer(object):
                 for (dataset_id, maximum_size) in
                 available_manifestations.values())
 
-            return [NodeState(
-                uuid=self.node_uuid,
-                hostname=self.hostname,
-                applications=None,
-                manifestations={manifestation.dataset_id: manifestation
-                                for manifestation in manifestations},
-                paths=manifestation_paths,
-                devices={},
-            )]
+            return FullySharedLocalState(
+                cluster_state_changes=[NodeState(
+                    uuid=self.node_uuid,
+                    hostname=self.hostname,
+                    applications=None,
+                    manifestations={manifestation.dataset_id: manifestation for
+                                    manifestation in manifestations},
+                    paths=manifestation_paths,
+                    devices={},
+                )]
+            )
         volumes.addCallback(got_volumes)
         return volumes
 
-    def calculate_changes(self, configuration, cluster_state):
+    def calculate_changes(self, configuration, cluster_state, local_state):
         """
         Calculate necessary changes to peer-to-peer manifestations.
 
@@ -772,16 +826,20 @@ class ApplicationNodeDeployer(object):
         :param list applications: ``Application`` instances representing the
             applications on this node.
 
-        :return: A ``list`` of a single ``NodeState`` representing the
-            application state only of this node.
+        :return: A ``FullySharedLocalState`` with shared_state_changes() that
+            are composed of a single ``NodeState`` representing the application
+            state only of this node.
         """
-        return [NodeState(
-            uuid=self.node_uuid,
-            hostname=self.hostname,
-            applications=applications,
-            manifestations=None,
-            paths=None,
-        )]
+        return FullySharedLocalState(
+            cluster_state_changes=[
+                NodeState(
+                    uuid=self.node_uuid,
+                    hostname=self.hostname,
+                    applications=applications,
+                    manifestations=None,
+                    paths=None,
+                )]
+        )
 
     def discover_state(self, local_state):
         """
@@ -810,13 +868,19 @@ class ApplicationNodeDeployer(object):
             # convergence actions, just declare ignorance. Eventually the
             # convergence agent for datasets will discover the information
             # and then we can proceed.
-            return succeed([NodeState(
-                uuid=self.node_uuid,
-                hostname=self.hostname,
-                applications=None,
-                manifestations=None,
-                paths=None,
-            )])
+            return succeed(
+                FullySharedLocalState(
+                    cluster_state_changes=[
+                        NodeState(
+                            uuid=self.node_uuid,
+                            hostname=self.hostname,
+                            applications=None,
+                            manifestations=None,
+                            paths=None,
+                        ),
+                    ]
+                )
+            )
 
         path_to_manifestations = {
             path: local_state.manifestations[dataset_id]
@@ -967,7 +1031,8 @@ class ApplicationNodeDeployer(object):
             )
         )
 
-    def calculate_changes(self, desired_configuration, current_cluster_state):
+    def calculate_changes(self, desired_configuration, current_cluster_state,
+                          local_state):
         """
         Work out which changes need to happen to the local state to match
         the given desired state.

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -85,7 +85,10 @@ class ClusterStateChangePVector(CheckedPVector):
 @implementer(ILocalState)
 class FullySharedLocalState(PClass):
     """
-    An ``ILocalState`` provider that
+    An ``ILocalState`` provider that shares all of the state. This can be used
+    by ``IDeployer`` implementations that do not need to pass any data from
+    discover_state to calculate_changes that cannot also be sent to the control
+    service.
 
     :ivar cluster_state_changes: A ``ClusterStateChangePVector`` of
         ``IClusterStateChange`` providers describing local state. These objects
@@ -96,7 +99,7 @@ class FullySharedLocalState(PClass):
 
     def shared_state_changes(self):
         """
-        All state is shared in this implementation of LocalState.
+        All state is shared in this implementation of ``ILocalState``.
         """
         return tuple(self.cluster_state_changes)
 
@@ -126,9 +129,10 @@ class IDeployer(Interface):
             information discovered by this particular deployer.
 
         :return: A ``Deferred`` which fires with a ``ILocalState``. The
-            state_changes will be passed to the control service (see
-            ``flocker.control._protocol``), and the entire opaque object will
-            be passed to this object's ``calculate_changes()`` method.
+            result of shared_state_changes() will be passed to the control
+            service (see ``flocker.control._protocol``), and the entire opaque
+            object will be passed to this object's ``calculate_changes()``
+            method.
         """
 
     def calculate_changes(configuration, cluster_state, local_state):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1581,7 +1581,7 @@ class BlockDeviceDeployer(PRecord):
                 applications=None,
             ),
             nonmanifest_datasets=NonManifestDatasets(datasets=nonmanifest),
-            volumes=[],
+            volumes=volumes,
         )
 
         return succeed(local_state)

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -56,13 +56,13 @@ class P2PNodeDeployer(object):
             def got_app_local_state(app_local_state):
                 app_state = app_local_state.shared_state_changes()
                 new_app_local_state = app_local_state.set(
-                    "cluster_state_changes",
-                    [app_state[0].evolver()
-                        .set("manifestations",
-                             manifestations_state.manifestations)
-                        .set("paths", manifestations_state.paths)
-                        .set("devices",
-                             manifestations_state.devices).persistent()])
+                    "node_state",
+                    app_state[0].evolver()
+                    .set("manifestations",
+                         manifestations_state.manifestations)
+                    .set("paths", manifestations_state.paths)
+                    .set("devices",
+                         manifestations_state.devices).persistent())
                 return new_app_local_state
             app_discovery.addCallback(got_app_local_state)
             return app_discovery

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -689,9 +689,9 @@ class ApplicationNodeDeployerDiscoverNodeConfigurationTests(
                 ).run(api)
         d = api.discover_state(current_state)
 
-        self.assertEqual((NodeState(uuid=api.node_uuid, hostname=api.hostname,
-                                    applications=expected_applications),),
-                         self.successResultOf(d).shared_state_changes())
+        self.assertEqual(NodeState(uuid=api.node_uuid, hostname=api.hostname,
+                                   applications=expected_applications),
+                         self.successResultOf(d).node_state)
 
     def test_discover_none(self):
         """
@@ -930,11 +930,11 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
             u'example.com', self.volume_service, node_uuid=self.node_uuid)
         self.assertEqual(
             self.successResultOf(deployer.discover_state(
-                self.EMPTY_NODESTATE)).shared_state_changes(),
-            (NodeState(hostname=deployer.hostname,
-                       uuid=deployer.node_uuid,
-                       manifestations={}, paths={}, devices={},
-                       applications=None),))
+                self.EMPTY_NODESTATE)).node_state,
+            NodeState(hostname=deployer.hostname,
+                      uuid=deployer.node_uuid,
+                      manifestations={}, paths={}, devices={},
+                      applications=None))
 
     def _setup_datasets(self):
         """
@@ -962,9 +962,9 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
         deployer.
         """
         deployer = self._setup_datasets()
-        nodes = self.successResultOf(deployer.discover_state(
-            self.EMPTY_NODESTATE)).shared_state_changes()
-        self.assertEqual(nodes[0].uuid, deployer.node_uuid)
+        node_state = self.successResultOf(deployer.discover_state(
+            self.EMPTY_NODESTATE)).node_state
+        self.assertEqual(node_state.uuid, deployer.node_uuid)
 
     def test_discover_datasets(self):
         """
@@ -980,7 +980,7 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
              self.DATASET_ID2: Manifestation(
                  dataset=Dataset(dataset_id=self.DATASET_ID2),
                  primary=True)},
-            self.successResultOf(d).shared_state_changes()[0].manifestations)
+            self.successResultOf(d).node_state.manifestations)
 
     def test_discover_manifestation_paths(self):
         """
@@ -997,7 +997,7 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
              self.DATASET_ID2:
              self.volume_service.get(_to_volume_name(
                  self.DATASET_ID2)).get_filesystem().get_path()},
-            self.successResultOf(d).shared_state_changes()[0].paths)
+            self.successResultOf(d).node_state.paths)
 
     def test_discover_manifestation_with_size(self):
         """
@@ -1026,7 +1026,7 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
         d = api.discover_state(self.EMPTY_NODESTATE)
 
         self.assertItemsEqual(
-            self.successResultOf(d).shared_state_changes()[0].manifestations[
+            self.successResultOf(d).node_state.manifestations[
                 self.DATASET_ID],
             manifestation)
 

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -669,7 +669,21 @@ class ApplicationNodeDeployerDiscoverNodeConfigurationTests(
             self, units, expected_applications,
             current_state=None, start_applications=False):
         """
-        Utility method for common code across the test cases in this class.
+        Given Docker units, verifies that the correct applications are
+        discovered on the node by ``discover_state``.
+
+        :param units: ``units`` to pass into the constructor of the
+            ``FakeDockerClient``.
+
+        :param expected_applications: A ``PSet`` of ``Application`` instances
+            expected to be in the ``NodeState`` returned by ``discover_state``
+            given the ``units`` in the ``FakeDockerClient``.
+
+        :param NodeState current_state: The local_state to pass into the call
+            of ``discover_state``.
+
+        :param bool start_applications: Whether to run ``StartApplication`` on
+            each of the applications before running ``discover_state``.
         """
         if current_state is None:
             current_state = self.EMPTY_NODESTATE

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -46,7 +46,7 @@ from .._deploy import (
 from ...testtools import CustomException
 from .. import _deploy
 from ...control._model import (
-    AttachedVolume, Dataset, Manifestation, Leases, NonManifestDatasets
+    AttachedVolume, Dataset, Manifestation, Leases
 )
 from .._docker import (
     FakeDockerClient, AlreadyExists, Unit, PortMap, Environment,
@@ -125,6 +125,7 @@ def assert_application_calculated_changes(
     return assert_calculated_changes_for_deployer(
         case, deployer, node_state, node_config, nonmanifest_datasets,
         additional_node_states, additional_node_config, expected_changes,
+        NodeLocalState(node_state=node_state)
     )
 
 
@@ -2257,8 +2258,8 @@ class P2PManifestationDeployerCalculateChangesTests(SynchronousTestCase):
         api = P2PManifestationDeployer(current_node.hostname,
                                        create_volume_service(self))
 
-        changes = api.calculate_changes(desired, current,
-                                        NodeLocalState(node_state=current_node))
+        changes = api.calculate_changes(
+            desired, current, NodeLocalState(node_state=current_node))
 
         expected = sequentially(changes=[])
         self.assertEqual(expected, changes)
@@ -2392,8 +2393,8 @@ class P2PManifestationDeployerCalculateChangesTests(SynchronousTestCase):
             current_node.hostname, create_volume_service(self),
         )
 
-        changes = api.calculate_changes(desired, current,
-                                        NodeLocalState(node_state=current_node))
+        changes = api.calculate_changes(
+            desired, current, NodeLocalState(node_state=current_node))
         expected = sequentially(changes=[])
         self.assertEqual(expected, changes)
 
@@ -2500,8 +2501,8 @@ class P2PManifestationDeployerCalculateChangesTests(SynchronousTestCase):
             create_volume_service(self),
         )
 
-        changes = api.calculate_changes(desired, current,
-                                        NodeLocalState(node_state=current_node))
+        changes = api.calculate_changes(
+            desired, current, NodeLocalState(node_state=current_node))
 
         expected = sequentially(changes=[
             in_parallel(

--- a/flocker/node/test/test_testtools.py
+++ b/flocker/node/test/test_testtools.py
@@ -12,16 +12,7 @@ from .. import sequentially
 from ..testtools import (
     DummyDeployer, ControllableDeployer, ideployer_tests_factory,
 )
-from ...control import IClusterStateChange
-
-
-@implementer(IClusterStateChange)
-class DummyClusterStateChange(object):
-    """
-    A non-implementation of ``IClusterStateChange``.
-    """
-    def update_cluster_state(self, cluster_state):
-        return cluster_state
+from ...control import IClusterStateChange, NodeState
 
 
 class DummyDeployerIDeployerTests(
@@ -31,12 +22,13 @@ class DummyDeployerIDeployerTests(
     Tests for the ``IDeployer`` implementation of ``DummyDeployer``.
     """
 
+_HOSTNAME=u"10.0.0.1"
 
 class ControllableDeployerIDeployerTests(
     ideployer_tests_factory(
         lambda case: ControllableDeployer(
-            hostname=u"10.0.0.1",
-            local_states=[succeed(DummyClusterStateChange())],
+            hostname=_HOSTNAME,
+            local_states=[succeed(NodeState(hostname=_HOSTNAME))],
             calculated_actions=[sequentially(changes=[])],
         )
     )

--- a/flocker/node/test/test_testtools.py
+++ b/flocker/node/test/test_testtools.py
@@ -4,15 +4,13 @@
 Tests for ``flocker.node.testtools``.
 """
 
-from zope.interface import implementer
-
 from twisted.internet.defer import succeed
 
 from .. import sequentially
 from ..testtools import (
     DummyDeployer, ControllableDeployer, ideployer_tests_factory,
 )
-from ...control import IClusterStateChange, NodeState
+from ...control import NodeState
 
 
 class DummyDeployerIDeployerTests(
@@ -22,7 +20,9 @@ class DummyDeployerIDeployerTests(
     Tests for the ``IDeployer`` implementation of ``DummyDeployer``.
     """
 
-_HOSTNAME=u"10.0.0.1"
+
+_HOSTNAME = u"10.0.0.1"
+
 
 class ControllableDeployerIDeployerTests(
     ideployer_tests_factory(

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -258,8 +258,8 @@ def ideployer_tests_factory(fixture):
 
         def test_discover_state_iclusterstatechange(self):
             """
-            The elements of the ``list`` that ``discover_state``\ 's
-            ``Deferred`` fires with provide ``IClusterStateChange``.
+            The elements of the ``tuple`` that ``shared_state_changes`` returns
+            will provide ``IClusterStateChange``.
             """
             def discovered(local_state):
                 changes = local_state.shared_state_changes()

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -175,7 +175,7 @@ class DummyDeployer(object):
 @implementer(IDeployer)
 class ControllableDeployer(object):
     """
-    ``IDeployer`` whose results can be controlled.
+    ``IDeployer`` whose results can be controlled for any ``NodeLocalState``.
     """
     def __init__(self, hostname, local_states, calculated_actions):
         """
@@ -183,7 +183,8 @@ class ControllableDeployer(object):
             ``discover_state``.  Each call to ``discover_state`` pops the first
             element from this list and uses it as its result.  If the element
             is an exception, it is raised.  Otherwise it must be a
-            ``Deferred``.
+            ``Deferred`` that resolves to a ``NodeState``. This ``IDeployer``
+            always returns a ``NodeLocalState`` from ``discover_state``.
         """
         self.node_uuid = ip_to_uuid(hostname)
         self.hostname = hostname

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -151,7 +151,7 @@ class DummyDeployer(object):
     hostname = u"127.0.0.1"
     node_uuid = uuid4()
 
-    def discover_state(self, node_stat):
+    def discover_state(self, node_state):
         return succeed(FullySharedLocalState(cluster_state_changes=()))
 
     def calculate_changes(self, desired_configuration, cluster_state,


### PR DESCRIPTION
This refactors IDeploy to enable state to go from discover_state to calculate_changes without requiring that the state be transferred to the control service.

It does so by introducing a new interface ILocalState. discover_state is modified to return a provider of this interface. This interface has a shared_state_changes() method that returns the tuple of IClusterStateChanges that discover_state would have returned prior to this PR. The entire opaque ILocalState is also handed to calculate_changes in addition to being used to send updates to the control service.

Implementations of IDeployer can use this to transfer data from discover_state to calculate_changes, and I've added BlockDeviceDeployerLocalState as an example of how the information from api.list_volumes() can be transferred (required for upcoming changes to reduce API calls).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2046)
<!-- Reviewable:end -->
