### PR TITLE
[FLOC-3044] OS X client test fixes

### DIFF
--- a/admin/client.py
+++ b/admin/client.py
@@ -121,9 +121,6 @@ class DockerRunner:
         # http://doc-dev.clusterhq.com/gettinginvolved/client-testing.html
         # for details.
         params = docker.utils.kwargs_from_env(assert_hostname=False)
-        tls_config = params.get('tls')
-        if tls_config:
-            tls_config.verify = False
         self.docker = docker.Client(version='1.16', **params)
         self.image = image
 

--- a/admin/client.py
+++ b/admin/client.py
@@ -116,14 +116,25 @@ class DockerRunner:
     """
 
     def __init__(self, image):
-        self.docker = docker.Client(version='1.18')
+        # Getting Docker to work correctly on any client platform can
+        # be tricky.  See
+        # http://doc-dev.clusterhq.com/gettinginvolved/client-testing.html
+        # for details.
+        params = docker.utils.kwargs_from_env(assert_hostname=False)
+        tls_config = params.get('tls')
+        if tls_config:
+            tls_config.verify = False
+        self.docker = docker.Client(version='1.16', **params)
         self.image = image
 
     def start(self):
         """
         Start the Docker container.
         """
-        self.tmpdir = tempfile.mkdtemp()
+        # On OS X, shared volumes must be in /Users, so use the home directory.
+        # See 'Mount a host directory as a data volume' at
+        # https://docs.docker.com/userguide/dockervolumes/
+        self.tmpdir = tempfile.mkdtemp(dir=os.path.expanduser('~'))
         try:
             self.docker.pull(self.image)
             container = self.docker.create_container(

--- a/docs/gettinginvolved/client-testing.rst
+++ b/docs/gettinginvolved/client-testing.rst
@@ -7,7 +7,18 @@ Automated Testing
 -----------------
 
 Flocker includes client installation tests and a tool for running them in Docker containers.
-It is called like this:
+
+.. note::
+
+   On OS X, use the system Python together with Homebrew's OpenSSL.
+
+   .. prompt:: bash $
+
+      brew install libffi openssl
+      env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install -e .[dev]
+      mkvirtualenv --python=/usr/bin/python new_virtualenv
+
+The client tests are called like this:
 
 .. prompt:: bash $
 


### PR DESCRIPTION
Interacting with Boot2Docker / Docker-machine on OS X has a few foibles compared to Linux, due to the use of Virtual Machine.  The changes in this PR should fix the client tests for consistent behaviour between platforms.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2047)
<!-- Reviewable:end -->
