### PR TITLE
[FLOC-2977] Docker plugin tests

### DIFF
--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -98,7 +98,7 @@ def get_docker_client(cluster, address):
         assert_hostname=False,
         verify=get_path(b"cluster.crt"))
     return Client(base_url="https://{}:{}".format(address, DOCKER_PORT),
-                  tls=tls, timeout=30)
+                  tls=tls, timeout=60)
 
 
 def get_mongo_application():

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -98,7 +98,7 @@ def get_docker_client(cluster, address):
         assert_hostname=False,
         verify=get_path(b"cluster.crt"))
     return Client(base_url="https://{}:{}".format(address, DOCKER_PORT),
-                  tls=tls, timeout=100)
+                  tls=tls, timeout=30)
 
 
 def get_mongo_application():


### PR DESCRIPTION
Hopefully this fixes FLOC-2977; if we get a read timeout from docker-py when awaiting a response from the Docker daemon, let's just continuously retry starting the container again, since making multiple requests in this case won't hurt.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2048)
<!-- Reviewable:end -->
