### PR TITLE
[FLOC-3226] Get rid of intersphinx so we don't get false positives on doc builds.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,6 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.extlinks',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.ifconfig',
     'flocker.provision._sphinx',
     'flocker.docs.version_extensions',
@@ -305,10 +304,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
-
-intersphinx_mapping = {
-    'latest': ('http://doc-dev.clusterhq.com/', None),
-}
 
 # Don't check anchors because many websites use #! for AJAX magic
 # http://sphinx-doc.org/config.html#confval-linkcheck_anchors

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -5,7 +5,7 @@ Release Process
 
 .. note::
 
-   Make sure to follow the :ref:`latest documentation <latest:release-process>` when doing a release.
+   Make sure to follow the `latest documentation <http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html>`_ when doing a release.
 
 Outcomes
 --------
@@ -174,7 +174,7 @@ So it is important to check that the code in the release branch is working befor
 
 .. note::
 
-   Make sure to follow the :ref:`latest review process <latest:pre-tag-review>` when reviewing a release.
+   Make sure to follow the `latest review process <http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html#pre-tag-review>`_ when reviewing a release.
 
 #. Check the changes in the Pull Request:
 


### PR DESCRIPTION
Fallback to intersphinx has caused builds that should've broken to pass, so get rid of it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2049)
<!-- Reviewable:end -->
