### PR TITLE
Avoid trying to log kwargs which are not serializable by instead logg…

### DIFF
--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -331,10 +331,18 @@ def log_method(function):
 
     @wraps(function)
     def wrapper(self, *args, **kwargs):
+
+        serializable_kwargs = kwargs.copy()
+        for kwarg in kwargs:
+            try:
+                json.dumps(kwargs[kwarg])
+            except TypeError:
+                serializable_kwargs[kwarg] = repr(kwargs[kwarg])
+
         context = start_action(
             Logger(),
             action_type=label,
-            args=args, kwargs=kwargs,
+            args=args, kwargs=serializable_kwargs,
         )
         with context.context():
             d = DeferredContext(function(self, *args, **kwargs))


### PR DESCRIPTION
This has been tested by running the following simple test:

```python
from uuid import uuid4
from twisted.trial.unittest import TestCase
from twisted.internet.defer import succeed

from ..testtools import log_method


class FooTests(TestCase):
    @log_method
    def foo(self, argument):
        return succeed(True)

    def test_foo(self):
        self.foo(argument=uuid4())
```

and seeing the trial log with no TypeError:

```json
flocker.acceptance.endtoend.test_simple.FooTests.test_foo <--
2015-10-20 14:58:15+0100 [-] ELIOT: {"task_uuid": "2372c19d-b479-4591-b64a-65dcff2741d6", "task_level": [1], "action_type": "acceptance:foo", "kwargs": {"argument": "UUID('e005a24d-d779-4da2-8230-62fa030f33e4')"}, "timestamp": 1445349495.43049, "args": [], "action_status": "started"}
2015-10-20 14:58:15+0100 [-] ELIOT: {"timestamp": 1445349495.430914, "task_uuid": "2372c19d-b479-4591-b64a-65dcff2741d6", "message_type": "acceptance:foo:result", "task_level": [2], "value": true}
2015-10-20 14:58:15+0100 [-] ELIOT: {"timestamp": 1445349495.431244, "task_uuid": "2372c19d-b479-4591-b64a-65dcff2741d6", "action_type": "acceptance:foo", "action_status": "succeeded", "task_level": [3]}
 ```
 
 @jongiddy had two concerns:
 
 1. Should this be a change somewhere in `eliot` instead?
 2. This is wasteful, and perhaps changing this to only look for non-serializable objects when an exception occurs would be better. Also, checking if the object has type `instance` is a more efficient check for whether something cannot be dumped.
 
I'll wait for an answer on (1) before working on (2). Or perhaps there is a more eliot-y way to do this.