### PR TITLE
[FLOC-3256] Fix typo in `_send_state_to_connections`.

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -560,7 +560,7 @@ class ControlAMPService(Service):
                 for connection in elided_update:
                     AGENT_UPDATE_ELIDED(agent=connection).write()
 
-                for conection in delayed_update:
+                for connection in delayed_update:
                     self._delayed_update_connection(connection)
 
     def _update_connection(self, connection, configuration, state):

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -742,6 +742,13 @@ class ControlAMPServiceTests(ControlTestCase):
         service = build_control_amp_service(self)
         service.startService()
 
+        # Add a second agent, to ensure that the delayed logic interacts with
+        # the correct connection.
+        confounding_agent = FakeAgent()
+        confounding_client = AgentAMP(Clock(), confounding_agent)
+        confounding_server = LoopbackAMPClient(confounding_client.locator)
+        service.connected(confounding_server)
+
         configuration = service.configuration_service.get()
         modified_configuration = arbitrary_transformation(configuration)
 
@@ -749,52 +756,6 @@ class ControlAMPServiceTests(ControlTestCase):
         delayed_server = DelayedAMPClient(server)
         # Send first update
         service.connected(delayed_server)
-
-        first_agent_desired = agent.desired
-
-        # Send second update
-        service.configuration_service.save(modified_configuration)
-        second_agent_desired = agent.desired
-
-        delayed_server.respond()
-        third_agent_desired = agent.desired
-
-        self.assertEqual(
-            dict(
-                first=configuration,
-                second=configuration,
-                third=modified_configuration,
-            ),
-            dict(
-                first=first_agent_desired,
-                second=second_agent_desired,
-                third=third_agent_desired,
-            ),
-        )
-
-    def test_typo(self):
-        """
-        A second configuration change is only transmitted after acknowledgement
-        of the first configuration change is received.
-        """
-        agent = FakeAgent()
-        client = AgentAMP(Clock(), agent)
-        service = build_control_amp_service(self)
-        service.startService()
-
-        second_agent = FakeAgent()
-        second_client = AgentAMP(Clock(), second_agent)
-
-        configuration = service.configuration_service.get()
-        modified_configuration = arbitrary_transformation(configuration)
-
-        server = LoopbackAMPClient(client.locator)
-        delayed_server = DelayedAMPClient(server)
-        second_server = LoopbackAMPClient(second_client.locator)
-        # Send first update
-        service.connected(delayed_server)
-        service.connected(second_server)
-
         first_agent_desired = agent.desired
 
         # Send second update
@@ -826,6 +787,13 @@ class ControlAMPServiceTests(ControlTestCase):
         client = AgentAMP(Clock(), agent)
         service = build_control_amp_service(self)
         service.startService()
+
+        # Add a second agent, to ensure that the delayed logic interacts with
+        # the correct connection.
+        confounding_agent = FakeAgent()
+        confounding_client = AgentAMP(Clock(), confounding_agent)
+        confounding_server = LoopbackAMPClient(confounding_client.locator)
+        service.connected(confounding_server)
 
         configuration = service.configuration_service.get()
         modified_configuration = arbitrary_transformation(configuration)


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3256

I think this might be causing a bunch of our intermittent failures.

I'm not sure what the best way to test this is, though.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2053)
<!-- Reviewable:end -->
