### PR TITLE
Reduce API list_volume in DestroyBlockDeviceDataset

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1133,8 +1133,6 @@ class LoopbackBlockDeviceAPI(object):
         if allocation_unit is None:
             allocation_unit = 1
         self._allocation_unit = allocation_unit
-        # XXX: remove before PR-hacky count of calls to list_volumes.
-        self._list_volume_calls = 0
 
     @classmethod
     def from_path(
@@ -1306,7 +1304,6 @@ class LoopbackBlockDeviceAPI(object):
         See ``IBlockDeviceAPI.list_volumes`` for parameter and return type
         documentation.
         """
-        self._list_volume_calls += 1
         volumes = []
         for child in self._root_path.child('unattached').children():
             blockdevice_id, size = self._parse_backing_file_name(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -345,8 +345,8 @@ class DestroyBlockDeviceDataset(PRecord):
 
     :ivar UUID dataset_id: The unique identifier of the dataset to which the
         volume to be destroyed belongs.
-    :ivar unicode blockdevice_id: The unique identifier of the mounted
-        block_device.
+    :ivar unicode blockdevice_id: The unique identifier of the block device to
+        be destroyed.
     """
     dataset_id = field(type=UUID, mandatory=True)
     blockdevice_id = field(type=unicode, mandatory=True)
@@ -533,7 +533,7 @@ class UnmountBlockDevice(PRecord):
     :ivar UUID dataset_id: The unique identifier of the dataset associated with
         the filesystem to unmount.
     :ivar unicode blockdevice_id: The unique identifier of the mounted
-        block_device.
+        block device to be unmounted.
     """
     dataset_id = field(type=UUID, mandatory=True)
     blockdevice_id = field(type=unicode, mandatory=True)
@@ -610,8 +610,8 @@ class DetachVolume(PRecord):
 
     :ivar UUID dataset_id: The unique identifier of the dataset associated with
         the volume to detach.
-    :ivar unicode blockdevice_id: The unique identifier of the mounted
-        block_device.
+    :ivar unicode blockdevice_id: The unique identifier of the block device to
+        be detached.
     """
     dataset_id = field(type=UUID, mandatory=True)
     blockdevice_id = field(type=unicode, mandatory=True)
@@ -634,8 +634,8 @@ class DestroyVolume(PRecord):
     """
     Destroy the storage (and therefore contents) of a volume.
 
-    :ivar unicode blockdevice_id: The unique identifier of the mounted
-        block_device.
+    :ivar unicode blockdevice_id: The unique identifier of the block device to
+        be destroyed.
     """
     blockdevice_id = field(type=unicode, mandatory=True)
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1156,6 +1156,8 @@ class LoopbackBlockDeviceAPI(object):
         if allocation_unit is None:
             allocation_unit = 1
         self._allocation_unit = allocation_unit
+        # XXX: remove before PR-hacky count of calls to list_volumes.
+        self._list_volume_calls = 0
 
     @classmethod
     def from_path(
@@ -1327,6 +1329,7 @@ class LoopbackBlockDeviceAPI(object):
         See ``IBlockDeviceAPI.list_volumes`` for parameter and return type
         documentation.
         """
+        self._list_volume_calls += 1
         volumes = []
         for child in self._root_path.child('unattached').children():
             blockdevice_id, size = self._parse_backing_file_name(

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3188,7 +3188,10 @@ class UnmountBlockDeviceTests(
         check_output([b"mount", device.path, mountpoint.path])
 
         change = UnmountBlockDevice(dataset_id=dataset_id)
+        initial_list_volumes = api._list_volume_calls
         self.successResultOf(run_state_change(change, deployer))
+        list_volumes_calls = api._list_volume_calls - initial_list_volumes
+        self.assertLess(list_volumes_calls, 2)
         self.assertNotIn(
             device,
             list(

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2791,10 +2791,7 @@ class DestroyBlockDeviceDatasetTests(
 
         change = DestroyBlockDeviceDataset(
             dataset_id=dataset_id, blockdevice_id=volume.blockdevice_id)
-        initial_list_volumes = api._list_volume_calls
         self.successResultOf(run_state_change(change, deployer))
-        list_volumes_calls = api._list_volume_calls - initial_list_volumes
-        self.assertLess(list_volumes_calls, 6)
 
         # It's only possible to destroy a volume that's been detached.  It's
         # only possible to detach a volume that's been unmounted.  If the

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2787,7 +2787,7 @@ class DestroyBlockDeviceDatasetTests(
         initial_list_volumes = api._list_volume_calls
         self.successResultOf(run_state_change(change, deployer))
         list_volumes_calls = api._list_volume_calls - initial_list_volumes
-        self.assertLess(list_volumes_calls, 7)
+        self.assertLess(list_volumes_calls, 6)
 
         # It's only possible to destroy a volume that's been detached.  It's
         # only possible to detach a volume that's been unmounted.  If the

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -87,6 +87,9 @@ LOOPBACK_MINIMUM_ALLOCATABLE_SIZE = int(MiB(16).to_Byte().value)
 
 EMPTY_NODE_STATE = NodeState(uuid=uuid4(), hostname=u"example.com")
 
+ARBITRARY_BLOCKDEVICE_ID = u'blockdevice_id_1'
+ARBITRARY_BLOCKDEVICE_ID_2 = u'blockdevice_id_1'
+
 # Eliot is transitioning away from the "Logger instances all over the place"
 # approach. So just use this global logger for now.
 _logger = Logger()
@@ -1659,7 +1662,10 @@ class BlockDeviceDeployerDetachCalculateChangesTests(
         assert_calculated_changes(
             self, node_state, node_config,
             {Dataset(dataset_id=unicode(self.DATASET_ID))},
-            in_parallel(changes=[DetachVolume(dataset_id=self.DATASET_ID)])
+            in_parallel(changes=[
+                DetachVolume(dataset_id=self.DATASET_ID,
+                             blockdevice_id=self.BLOCKDEVICE_ID)
+            ])
         )
 
 
@@ -3146,7 +3152,7 @@ class UnmountBlockDeviceInitTests(
     make_with_init_tests(
         record_type=UnmountBlockDevice,
         kwargs=dict(dataset_id=uuid4(),
-                    blockdevice_id=u'blockdevice_id_1'),
+                    blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
         expected_defaults=dict(),
     )
 ):
@@ -3158,8 +3164,8 @@ class UnmountBlockDeviceInitTests(
 class UnmountBlockDeviceTests(
     make_istatechange_tests(
         UnmountBlockDevice,
-        dict(dataset_id=uuid4(), blockdevice_id=u'blockdevice_id_1'),
-        dict(dataset_id=uuid4(), blockdevice_id=u'blockdevice_id_2'),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2),
     )
 ):
     """
@@ -3213,7 +3219,8 @@ class UnmountBlockDeviceTests(
 class DetachVolumeInitTests(
     make_with_init_tests(
         record_type=DetachVolume,
-        kwargs=dict(dataset_id=uuid4()),
+        kwargs=dict(dataset_id=uuid4(),
+                    blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
         expected_defaults=dict(),
     )
 ):
@@ -3225,8 +3232,8 @@ class DetachVolumeInitTests(
 class DetachVolumeTests(
     make_istatechange_tests(
         DetachVolume,
-        dict(dataset_id=uuid4()),
-        dict(dataset_id=uuid4()),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2),
     )
 ):
     """
@@ -3248,7 +3255,8 @@ class DetachVolumeTests(
             attach_to=api.compute_instance_id(),
         )
 
-        change = DetachVolume(dataset_id=dataset_id)
+        change = DetachVolume(dataset_id=dataset_id,
+                              blockdevice_id=volume.blockdevice_id)
         self.successResultOf(run_state_change(change, deployer))
 
         [listed_volume] = api.list_volumes()

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2778,7 +2778,10 @@ class DestroyBlockDeviceDatasetTests(
         mount(device, mountpoint)
 
         change = DestroyBlockDeviceDataset(dataset_id=dataset_id)
+        initial_list_volumes = api._list_volume_calls
         self.successResultOf(run_state_change(change, deployer))
+        list_volumes_calls = api._list_volume_calls - initial_list_volumes
+        self.assertLess(list_volumes_calls, 7)
 
         # It's only possible to destroy a volume that's been detached.  It's
         # only possible to detach a volume that's been unmounted.  If the
@@ -3196,10 +3199,7 @@ class UnmountBlockDeviceTests(
 
         change = UnmountBlockDevice(dataset_id=dataset_id,
                                     blockdevice_id=volume.blockdevice_id)
-        initial_list_volumes = api._list_volume_calls
         self.successResultOf(run_state_change(change, deployer))
-        list_volumes_calls = api._list_volume_calls - initial_list_volumes
-        self.assertLess(list_volumes_calls, 2)
         self.assertNotIn(
             device,
             list(


### PR DESCRIPTION
Now that we have the result of list_volumes() being passed from discover_state to calculate_changes, it is possible to use that information to map dataset_ids to blockdevice_ids prior to the construction of the IStateChanges.

This is helpful for the IStateChanges that start out by calling list_volumes just to map from dataset_id to blockdevice_id. This PR adds a blockdevice_id field to all of the IStateChanges that are used in DestroyBlockDeviceDataset, and removes many of the calls to list_volumes in that state change. The goal of this is to reduce over all API calls in the IStateChanges.

During development I added a hacky test to verify that list_volume calls were decreasing, but the test seemed brittle, so I have removed it for merging.

While I was in the code I did a drive by fix to FLOC-1818 (making DestroyVolume async), which was trivial given current infrastructure.
    
I also removed comment referencing  FLOC-1756 was already marked as 'Done' and certainly the comment was no longer accurate.
    
In addition I removed comment referencing FLOC-1616, which was also already marked as 'Done', and the comment was no longer accurate.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2057)
<!-- Reviewable:end -->
