### PR TITLE
[FLOC-2819] Docker 1.9 plugin compatibility

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,7 +13,7 @@ You can learn more about where we might be going with future releases by:
 Next Release
 ============
 
-* The :ref:`Flocker plugin for Docker<docker-plugin>` is now compatible with Docker 1.9
+* The :ref:`Flocker plugin for Docker<docker-plugin>` is now compatible with Docker 1.9.
 * New EBS and OpenStack Cinder volumes created by Flocker will now have ``flocker-<dataset ID>`` as their name, to make it easier to find them in their respective cloud administration UIs.
   Existing volumes created by older versions of Flocker will continue to have no name.
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -13,6 +13,7 @@ You can learn more about where we might be going with future releases by:
 Next Release
 ============
 
+* The :ref:`Flocker plugin for Docker<docker-plugin>` is now compatible with Docker 1.9
 * New EBS and OpenStack Cinder volumes created by Flocker will now have ``flocker-<dataset ID>`` as their name, to make it easier to find them in their respective cloud administration UIs.
   Existing volumes created by older versions of Flocker will continue to have no name.
 

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -29,6 +29,9 @@ class DockerPluginTests(TestCase):
     Tests for the Docker plugin.
     """
     def require_docker(self, required_version, cluster):
+        """
+        Check for a specific minimum version of Docker on a remote node.
+        """
         client = get_docker_client(cluster, cluster.nodes[0].public_address)
         client_version = LooseVersion(client.version()['Version'])
         minimum_version = LooseVersion(required_version)
@@ -113,6 +116,11 @@ class DockerPluginTests(TestCase):
         return cid
 
     def _test_create_container(self, cluster):
+        """
+        Create a container running a simple HTTP server that writes to
+        its volume on POST and reads the same data back from the volume
+        on GET.
+        """
         data = random_name(self).encode("utf-8")
         node = cluster.nodes[0]
         http_port = 8080

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -28,6 +28,16 @@ class DockerPluginTests(TestCase):
     """
     Tests for the Docker plugin.
     """
+    def require_docker(self, required_version, cluster):
+        client = get_docker_client(cluster, cluster.nodes[0].public_address)
+        client_version = LooseVersion(client.version()['Version'])
+        minimum_version = LooseVersion(required_version)
+        if client_version < minimum_version:
+            raise SkipTest(
+                'This test requires at least Docker {}. '
+                'Actual version: {}'.format(minimum_version, client_version)
+            )
+
     def docker_service(self, address, action):
         """
         Restart the Docker daemon on the specified address.
@@ -109,15 +119,7 @@ class DockerPluginTests(TestCase):
         the request body received by the Flocker plugin results in a
         successful running container.
         """
-        required_version = '1.9.0'
-        client = get_docker_client(cluster, cluster.nodes[0].public_address)
-        client_version = LooseVersion(client._client.version()['Version'])
-        minimum_version = LooseVersion(required_version)
-        if client_version < minimum_version:
-            raise SkipTest(
-                'This test requires at least Docker {}. '
-                'Actual version: {}'.format(minimum_version, client_version)
-            )
+        self.require_docker('1.9.0', cluster)
         self.fail("not implemented yet")
 
     @require_cluster(1)

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -11,6 +11,8 @@ from docker.utils import create_host_config
 
 from ...common.runner import run_ssh
 
+from ...node.testtools import require_docker_version
+
 from ...testtools import (
     random_name, find_free_port, loop_until
 )
@@ -98,6 +100,19 @@ class DockerPluginTests(TestCase):
         if cleanup:
             self.addCleanup(client.remove_container, cid, force=True)
         return cid
+
+    @require_docker_version(
+        '1.9.0',
+        'This test uses the v2 plugin API, which requires Docker >=1.9.0'
+    )
+    @require_cluster(1)
+    def test_create_container_with_volume_opts(self, cluster):
+        """
+        Creating a container with a volume and an ``Opts`` value in
+        the request body received by the Flocker plugin results in a
+        successful running container.
+        """
+        self.fail("not implemented yet")
 
     @require_cluster(1)
     def test_volume_persists_restart(self, cluster):

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -132,7 +132,7 @@ class VolumePlugin(object):
 
     @app.route("/VolumeDriver.Create", methods=["POST"])
     @_endpoint(u"Create")
-    def volumedriver_create(self, Name):
+    def volumedriver_create(self, Name, Opts=None):
         """
         Create a volume with the given name.
 

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -151,6 +151,12 @@ class VolumePlugin(object):
 
         :param unicode Name: The name of the volume.
 
+        :param dict Opts: Options passed from Docker for the volume
+            at creation. ``None`` if not supplied in the request body.
+            Currently ignored. ``Opts`` is a parameter introduced in the
+            v2 plugins API introduced in Docker 1.9, it is not supplied
+            in earlier Docker versions.
+
         :return: Result indicating success.
         """
         listing = self._flocker_client.list_datasets_configuration()


### PR DESCRIPTION
Fixes FLOC-2819. Looking at https://github.com/docker/docker/blob/master/docs/extend/plugins_volume.md versus https://docs.docker.com/extend/plugins_volume/ it seems that the only difference in how the plugin API needs to work is that `/VolumeDriver.Create` now takes an `Opts` mapping of custom options passed through from Docker, e.g. as a result of `docker volume create --driver flocker --opt foo=bar --opt maxsize=10G`

It is unclear whether this `Opts` map is optional or not, I am inclined to suspect Docker will make the POST request to our plugin with `Opts` as an empty mapping `{}` if no `opt` flags were specified through the CLI/API on Docker's end - we also want compatibility with our existing previous Docker versions, so this design makes `Opts` on our endpoint optional with a default of `None`. We ignore `Opts` at this stage anyway.

A new test has been written requiring Docker >=1.9.0 that exercises the case that `Opts` can be passed to `VolumeDriver.Create` and that a dataset is still created

A new end-to-end acceptance test also exercises that we are able to successfully create and run a container with a volume provisioned via the Flocker plugin.

NOTE: We do not have CI for Docker 1.9, this test will be skipped on Buildbot. I am raising a separate ticket to address the CI side.

I have decided not to explicitly test passing `Opts` through `docker-py`, as the test we have sufficiently exercises that we have the basic Docker 1.9 compatibility asked for by the JIRA issue - and `docker-py` doesn't have a way of passing an options dictionary at this stage anyway, plus we have a unit test establishing the plugin code will safely accept and ignore `Opts`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2062)
<!-- Reviewable:end -->
