### PR TITLE
Reduce API list_volume when Attaching and Mounting Volumes

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1121,7 +1121,6 @@ class LoopbackBlockDeviceAPI(object):
         if allocation_unit is None:
             allocation_unit = 1
         self._allocation_unit = allocation_unit
-        self._list_volumes_count = 0
 
     @classmethod
     def from_path(
@@ -1293,7 +1292,6 @@ class LoopbackBlockDeviceAPI(object):
         See ``IBlockDeviceAPI.list_volumes`` for parameter and return type
         documentation.
         """
-        self._list_volumes_count += 1
         volumes = []
         for child in self._root_path.child('unattached').children():
             blockdevice_id, size = self._parse_backing_file_name(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1133,6 +1133,7 @@ class LoopbackBlockDeviceAPI(object):
         if allocation_unit is None:
             allocation_unit = 1
         self._allocation_unit = allocation_unit
+        self._list_volumes_count = 0
 
     @classmethod
     def from_path(
@@ -1304,6 +1305,7 @@ class LoopbackBlockDeviceAPI(object):
         See ``IBlockDeviceAPI.list_volumes`` for parameter and return type
         documentation.
         """
+        self._list_volumes_count += 1
         volumes = []
         for child in self._root_path.child('unattached').children():
             blockdevice_id, size = self._parse_backing_file_name(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -54,7 +54,8 @@ class VolumeException(Exception):
     """
     A base class for exceptions raised by  ``IBlockDeviceAPI`` operations.
 
-    :param unicode blockdevice_id: The unique identifier of the block device.
+    :param unicode blockdevice_id: The unique identifier of the
+        ``IBlockDeviceAPI``-managed volume.
     """
     def __init__(self, blockdevice_id):
         if not isinstance(blockdevice_id, unicode):
@@ -327,8 +328,8 @@ class DestroyBlockDeviceDataset(PRecord):
 
     :ivar UUID dataset_id: The unique identifier of the dataset to which the
         volume to be destroyed belongs.
-    :ivar unicode blockdevice_id: The unique identifier of the block device to
-        be destroyed.
+    :ivar unicode blockdevice_id: The unique identifier of the
+        ``IBlockDeviceAPI``-managed volume to be destroyed.
     """
     dataset_id = field(type=UUID, mandatory=True)
     blockdevice_id = field(type=unicode, mandatory=True)
@@ -447,8 +448,8 @@ class MountBlockDevice(PRecord):
 
     :ivar UUID dataset_id: The unique identifier of the dataset associated with
         the filesystem to mount.
-    :ivar unicode blockdevice_id: The unique identifier of the block_device to
-        be mounted.
+    :ivar unicode blockdevice_id: The unique identifier of the
+        ``IBlockDeviceAPI``-managed volume to be mounted.
     :ivar FilePath mountpoint: The filesystem location at which to mount the
         volume's filesystem.  If this does not exist, it is created.
     """
@@ -514,7 +515,7 @@ class UnmountBlockDevice(PRecord):
     :ivar UUID dataset_id: The unique identifier of the dataset associated with
         the filesystem to unmount.
     :ivar unicode blockdevice_id: The unique identifier of the mounted
-        block device to be unmounted.
+        ``IBlockDeviceAPI``-managed volume to be unmounted.
     """
     dataset_id = field(type=UUID, mandatory=True)
     blockdevice_id = field(type=unicode, mandatory=True)
@@ -551,8 +552,8 @@ class AttachVolume(PRecord):
 
     :ivar UUID dataset_id: The unique identifier of the dataset associated with
         the volume to attach.
-    :ivar unicode blockdevice_id: The unique identifier of the block_device to
-        be attached.
+    :ivar unicode blockdevice_id: The unique identifier of the
+        ``IBlockDeviceAPI``-managed volume to be attached.
     """
     dataset_id = field(type=UUID, mandatory=True)
     blockdevice_id = field(type=unicode, mandatory=True)
@@ -585,8 +586,8 @@ class DetachVolume(PRecord):
 
     :ivar UUID dataset_id: The unique identifier of the dataset associated with
         the volume to detach.
-    :ivar unicode blockdevice_id: The unique identifier of the block device to
-        be detached.
+    :ivar unicode blockdevice_id: The unique identifier of the
+        ``IBlockDeviceAPI``-managed volume to be detached.
     """
     dataset_id = field(type=UUID, mandatory=True)
     blockdevice_id = field(type=unicode, mandatory=True)
@@ -609,8 +610,8 @@ class DestroyVolume(PRecord):
     """
     Destroy the storage (and therefore contents) of a volume.
 
-    :ivar unicode blockdevice_id: The unique identifier of the block device to
-        be destroyed.
+    :ivar unicode blockdevice_id: The unique identifier of the
+        ``IBlockDeviceAPI``-managed volume to be destroyed.
     """
     blockdevice_id = field(type=unicode, mandatory=True)
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -20,7 +20,6 @@ from eliot.serializers import identity
 from zope.interface import implementer, Interface
 
 from pyrsistent import PRecord, PClass, field
-from characteristic import attributes
 
 import psutil
 
@@ -49,17 +48,6 @@ _logger = Logger()
 # maximum_size.
 # XXX: Make this configurable. FLOC-2679
 DEFAULT_DATASET_SIZE = int(GiB(100).to_Byte().value)
-
-
-@attributes(["dataset_id"])
-class DatasetWithoutVolume(Exception):
-    """
-    An operation was attempted on a dataset that involves manipulating the
-    dataset's volume but that volume could not be found.
-
-    :ivar UUID dataset_id: The unique identifier of the dataset the operation
-        was meant to affect.
-    """
 
 
 class VolumeException(Exception):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3404,7 +3404,11 @@ class CreateBlockDeviceDatasetImplementationTests(SynchronousTestCase):
             dataset=dataset, mountpoint=expected_mountpoint
         )
 
+        api = self.deployer.block_device_api
+        initial_list_volumes = api._list_volumes_count
         run_state_change(change, self.deployer)
+        final_call_count = api._list_volumes_count - initial_list_volumes
+        self.assertLess(final_call_count, 6)
 
         [volume] = self.api.list_volumes()
         device_path = self.api.get_device_path(volume.blockdevice_id)

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3541,10 +3541,7 @@ class AttachVolumeTests(
         )
         change = AttachVolume(dataset_id=dataset_id,
                               blockdevice_id=volume.blockdevice_id)
-        initial_list_volumes = api._list_volumes_count
         self.successResultOf(run_state_change(change, deployer))
-        final_call_count = api._list_volumes_count - initial_list_volumes
-        self.assertLess(final_call_count, 2)
 
         expected_volume = volume.set(
             attached_to=api.compute_instance_id()

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3417,11 +3417,7 @@ class CreateBlockDeviceDatasetImplementationTests(SynchronousTestCase):
             dataset=dataset, mountpoint=expected_mountpoint
         )
 
-        api = self.deployer.block_device_api
-        initial_list_volumes = api._list_volumes_count
         run_state_change(change, self.deployer)
-        final_call_count = api._list_volumes_count - initial_list_volumes
-        self.assertLess(final_call_count, 6)
 
         [volume] = self.api.list_volumes()
         device_path = self.api.get_device_path(volume.blockdevice_id)
@@ -3542,7 +3538,10 @@ class AttachVolumeTests(
             dataset_id=dataset_id, size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
         )
         change = AttachVolume(dataset_id=dataset_id)
+        initial_list_volumes = api._list_volumes_count
         self.successResultOf(run_state_change(change, deployer))
+        final_call_count = api._list_volumes_count - initial_list_volumes
+        self.assertLess(final_call_count, 2)
 
         expected_volume = volume.set(
             attached_to=api.compute_instance_id()

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1143,6 +1143,7 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
                         mountpoint=FilePath('/flocker/').child(
                             unicode(self.DATASET_ID)
                         ),
+                        blockdevice_id=self.BLOCKDEVICE_ID,
                         dataset_id=self.DATASET_ID
                     )
                 ]
@@ -1236,6 +1237,7 @@ class BlockDeviceDeployerMountCalculateChangesTests(
             in_parallel(changes=[
                 MountBlockDevice(
                     dataset_id=self.DATASET_ID,
+                    blockdevice_id=self.BLOCKDEVICE_ID,
                     mountpoint=FilePath(b"/flocker/").child(
                         bytes(self.DATASET_ID)
                     )
@@ -2829,7 +2831,8 @@ class CreateFilesystemTests(
 class MountBlockDeviceInitTests(
     make_with_init_tests(
         MountBlockDevice,
-        dict(dataset_id=uuid4(), mountpoint=FilePath(b"/foo")),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
+             mountpoint=FilePath(b"/foo")),
         dict(),
     )
 ):
@@ -2928,8 +2931,10 @@ class _MountScenario(PRecord):
 class MountBlockDeviceTests(
     make_istatechange_tests(
         MountBlockDevice,
-        dict(dataset_id=uuid4(), mountpoint=FilePath(b"/foo")),
-        dict(dataset_id=uuid4(), mountpoint=FilePath(b"/bar")),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
+             mountpoint=FilePath(b"/foo")),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2,
+             mountpoint=FilePath(b"/bar")),
     )
 ):
     """
@@ -2945,7 +2950,9 @@ class MountBlockDeviceTests(
         self.successResultOf(scenario.create())
 
         change = MountBlockDevice(
-            dataset_id=scenario.dataset_id, mountpoint=scenario.mountpoint
+            dataset_id=scenario.dataset_id,
+            blockdevice_id=scenario.volume.blockdevice_id,
+            mountpoint=scenario.mountpoint
         )
         return scenario, run_state_change(change, scenario.deployer)
 
@@ -2973,6 +2980,7 @@ class MountBlockDeviceTests(
     def _mount(self, scenario, mountpoint):
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
+                             blockdevice_id=scenario.volume.blockdevice_id,
                              mountpoint=mountpoint),
             scenario.deployer))
 
@@ -3005,6 +3013,7 @@ class MountBlockDeviceTests(
         Running ``CreateFilesystem`` on a block device that already has a file
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
+                             blockdevice_id=scenario.volume.blockdevice_id,
                              mountpoint=mountpoint),
             scenario.deployer))
         system fails with an exception and preserves the data.
@@ -3081,6 +3090,7 @@ class MountBlockDeviceTests(
         check_call([b"umount", mountpoint.path])
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
+                             blockdevice_id=scenario.volume.blockdevice_id,
                              mountpoint=scenario.mountpoint),
             scenario.deployer))
 
@@ -3094,6 +3104,7 @@ class MountBlockDeviceTests(
         check_call([b"umount", mountpoint.path])
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
+                             blockdevice_id=scenario.volume.blockdevice_id,
                              mountpoint=scenario.mountpoint),
             scenario.deployer))
         self.assertEqual(mountpoint.children(), [])
@@ -3110,6 +3121,7 @@ class MountBlockDeviceTests(
         check_call([b"umount", mountpoint.path])
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
+                             blockdevice_id=scenario.volume.blockdevice_id,
                              mountpoint=scenario.mountpoint),
             scenario.deployer))
         self.assertItemsEqual(mountpoint.children(),
@@ -3129,6 +3141,7 @@ class MountBlockDeviceTests(
         mountpoint.restat()
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
+                             blockdevice_id=scenario.volume.blockdevice_id,
                              mountpoint=scenario.mountpoint),
             scenario.deployer))
         self.assertEqual(mountpoint.getPermissions().shorthand(),


### PR DESCRIPTION
With this PR these IStateChanges are constructed with blockdevice_ids. This means that they do not have to do the dataset_id -> blockdevice_id mapping as part of their execution. This enables the removal of list_volumes() calls at the beginning of the execution of either of them.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2065)
<!-- Reviewable:end -->
