### PR TITLE
[FLOC-3270] Add a new interface for IBlockDeviceAPIs with storage profiles.

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -944,6 +944,42 @@ class IBlockDeviceAPI(Interface):
         """
 
 
+class IProfiledBlockDeviceAPI(IBlockDeviceAPI):
+    """
+    An interface for ``IBlockDeviceAPI`` implementers that are capable of
+    creating volumes with a specific profile.
+    """
+
+    def create_volume_with_profile(name, size, profile_name):
+        """
+        Create a new volume with the specified profile.
+
+        When called by ``IDeployer``, the supplied size will be
+        rounded up to the nearest
+        ``IBlockDeviceAPI.allocation_unit()``
+
+
+        :param UUID dataset_id: The Flocker dataset ID of the dataset on this
+            volume.
+        :param int size: The size of the new volume in bytes.
+        :param unicode profile_name: The name of the storage profile for this
+            volume.
+
+        :returns: A ``BlockDeviceVolume`` of the newly created volume.
+        """
+
+    def get_profile_for_volume(blockdevice_id):
+        """
+        Determine the name of the storage profile for a given blockdevice_id.
+
+        :param unicode blockdevice_id: The blockdevice_id of the volume to
+            query.
+
+        :returns unicode: The name of the profile that the volume currently
+            matches.
+        """
+
+
 @implementer(IBlockDeviceAsyncAPI)
 @auto_threaded(IBlockDeviceAPI, "_reactor", "_sync", "_threadpool")
 class _SyncToThreadedAsyncAPIAdapter(PRecord):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -985,17 +985,6 @@ class IProfiledBlockDeviceAPI(Interface):
         :returns: A ``BlockDeviceVolume`` of the newly created volume.
         """
 
-    def get_profile_for_volume(blockdevice_id):
-        """
-        Determine the name of the storage profile for a given blockdevice_id.
-
-        :param unicode blockdevice_id: The blockdevice_id of the volume to
-            query.
-
-        :returns unicode: The name of the profile that the volume currently
-            matches.
-        """
-
 
 @implementer(IBlockDeviceAsyncAPI)
 @auto_threaded(IBlockDeviceAPI, "_reactor", "_sync", "_threadpool")

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -28,6 +28,7 @@ from twisted.python.reflect import safe_repr
 from twisted.internet.defer import succeed, fail, gatherResults
 from twisted.python.filepath import FilePath
 from twisted.python.components import proxyForInterface
+from twisted.python.constants import Values, ValueConstant
 
 from .. import (
     IDeployer, ILocalState, IStateChange, sequentially, in_parallel,
@@ -944,10 +945,27 @@ class IBlockDeviceAPI(Interface):
         """
 
 
-class IProfiledBlockDeviceAPI(IBlockDeviceAPI):
+class MandatoryProfiles(Values):
     """
-    An interface for ``IBlockDeviceAPI`` implementers that are capable of
-    creating volumes with a specific profile.
+    Mandatory Storage Profiles to be implemented by ``IProfiledBlockDeviceAPI``
+    implementers.  These will have driver-specific meaning, with the following
+    desired meaning:
+
+    :ivar GOLD: The profile for fast storage.
+    :ivar SILVER: The profile for intermediate/default storage.
+    :ivar BRONZE: The profile for cheap storage.
+    :ivar DEFAULT: The default profile if none is specified.
+    """
+    GOLD = ValueConstant(u'gold')
+    SILVER = ValueConstant(u'silver')
+    BRONZE = ValueConstant(u'bronze')
+    DEFAULT = SILVER
+
+
+class IProfiledBlockDeviceAPI(Interface):
+    """
+    An interface for drivers that are capable of creating volumes with a
+    specific profile.
     """
 
     def create_volume_with_profile(name, size, profile_name):
@@ -955,8 +973,7 @@ class IProfiledBlockDeviceAPI(IBlockDeviceAPI):
         Create a new volume with the specified profile.
 
         When called by ``IDeployer``, the supplied size will be
-        rounded up to the nearest
-        ``IBlockDeviceAPI.allocation_unit()``
+        rounded up to the nearest ``IBlockDeviceAPI.allocation_unit()``.
 
 
         :param UUID dataset_id: The Flocker dataset ID of the dataset on this

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -41,11 +41,11 @@ from .. import blockdevice
 from ...test.istatechange import make_istatechange_tests
 from ..blockdevice import (
     BlockDeviceDeployerLocalState, BlockDeviceDeployer, LoopbackBlockDeviceAPI,
-    IBlockDeviceAPI, BlockDeviceVolume, UnknownVolume, AlreadyAttachedVolume,
-    CreateBlockDeviceDataset, UnattachedVolume, DatasetExists,
-    DestroyBlockDeviceDataset, UnmountBlockDevice, DetachVolume, AttachVolume,
-    CreateFilesystem, DestroyVolume, MountBlockDevice, _losetup_list_parse,
-    _losetup_list, _blockdevicevolume_from_dataset_id,
+    IBlockDeviceAPI, IProfiledBlockDeviceAPI, BlockDeviceVolume, UnknownVolume,
+    AlreadyAttachedVolume, CreateBlockDeviceDataset, UnattachedVolume,
+    DatasetExists, DestroyBlockDeviceDataset, UnmountBlockDevice, DetachVolume,
+    AttachVolume, CreateFilesystem, DestroyVolume, MountBlockDevice,
+    _losetup_list_parse, _losetup_list, _blockdevicevolume_from_dataset_id,
 
     DESTROY_BLOCK_DEVICE_DATASET, UNMOUNT_BLOCK_DEVICE, DETACH_VOLUME,
     DESTROY_VOLUME,
@@ -2277,6 +2277,45 @@ def make_iblockdeviceapi_tests(
             self.minimum_allocatable_size = minimum_allocatable_size
             self.device_allocation_unit = device_allocation_unit
             self.this_node = self.api.compute_instance_id()
+
+    return Tests
+
+
+class IProfiledBlockDeviceAPITestsMixin(object):
+    """
+    Tests to perform on ``IProfiledBlockDeviceAPI`` providers.
+    """
+    def test_interface(self):
+        """
+        The API object provides ``IProfiledBlockDeviceAPI``.
+        """
+        self.assertTrue(
+            verifyObject(IProfiledBlockDeviceAPI, self.api)
+        )
+
+    def test_profile_respected(self):
+        """
+        Verify that the profile for a volume created with one of the mandatory
+        profiles is respected.
+        """
+        for profile in [u'gold', u'silver', u'bronze']:
+            volume = self.api.create_volume_with_profile(profile)
+            self.assertEqual(profile, self.api.get_profile_for_volume(
+                volume.blockdevice_id))
+
+
+def make_iprofiledblockdeviceapi_tests(*args, **kwargs):
+    """
+    Create tests for classes that implement ``IProfiledBlockDeviceAPI``.
+
+    See make_iblockdeviceapi_tests for args.
+
+    :returns: A ``TestCase`` with tests that will be performed on the
+       supplied ``IProfiledBlockDeviceAPI`` provider.
+    """
+    class Tests(IProfiledBlockDeviceAPITestsMixin,
+                make_iblockdeviceapi_tests(*args, **kwargs)):
+        pass
 
     return Tests
 


### PR DESCRIPTION
Introduce a new interface for drivers that are capable of creating profiles.

In the long term drivers can choose to provide IProfiledBlockDeviceAPI, and if they do, then flocker will call create_volume_with_profile if the user attempts to create a volume with a specified storage profile over the control API.

I suppose this might be arguably more of a design review disguised as a tiny code review.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2066)
<!-- Reviewable:end -->
