### PR TITLE
[FLOC 3198] Use correct name for the plugin

### DIFF
--- a/docs/install/installer.rst
+++ b/docs/install/installer.rst
@@ -4,7 +4,7 @@
 Quick Start Flocker Installer
 =============================
 
-.. note:: For a full Flocker installation, including the Flocker plugin for Docker, see the :ref:`full-installation` instructions.
+.. note:: For a full Flocker installation, including :ref:`docker-plugin`, see the :ref:`full-installation` instructions.
 
 If you want to get started with Flocker quickly, but in your own environment, you can use the Quick Start Flocker Installer.
 The Installer is one of our :ref:`Labs projects <labs-projects>`, so is currently experimental.

--- a/docs/introduction/what-is-flocker.rst
+++ b/docs/introduction/what-is-flocker.rst
@@ -12,7 +12,7 @@ Flocker manages Docker containers and data volumes together.
 When you use Flocker to manage your stateful microservice, your volumes will follow your containers when they move between different hosts in your cluster.
 
 You can also use Flocker to manage only your volumes, while continuing to manage your containers however you choose.
-To use Flocker to manage your volumes while tools like Docker, Docker Swarm or Mesos manage your containers, you can :ref:`use the Flocker plugin for Docker <docker-plugin>`.
+To use Flocker to manage your volumes while tools like Docker, Docker Swarm or Mesos manage your containers, you can use :ref:`docker-plugin`.
 
 .. image:: images/flocker-v-native-containers.svg
    :alt: Migrating data: Native Docker versus Flocker.

--- a/docs/labs/compose.rst
+++ b/docs/labs/compose.rst
@@ -4,9 +4,9 @@
 Flocker with Compose
 ====================
 
-With the :ref:`Flocker plugin for Docker <docker-plugin>`, and with Compose support for the ``volume_driver`` field, you can use Flocker together with Docker Compose.
+With the :ref:`docker-plugin`, and with Compose support for the ``volume_driver`` field, you can use Flocker together with Docker Compose.
 
-First, you need to :ref:`install Flocker <labs-installer>` and the :ref:`Flocker plugin for Docker <docker-plugin>`.
+First, you need to :ref:`install Flocker <labs-installer>` and the :ref:`docker-plugin`.
 You can use our experimental  :ref:`Flocker Installer <labs-installer>` to do this.
 
 Then, you need a version of Compose that supports Flocker volumes.

--- a/docs/labs/compose.rst
+++ b/docs/labs/compose.rst
@@ -4,9 +4,9 @@
 Flocker with Compose
 ====================
 
-With the :ref:`Flocker Docker plugin <docker-plugin>`, and with Compose support for the ``volume_driver`` field, you can use Flocker together with Docker Compose.
+With the :ref:`Flocker plugin for Docker <docker-plugin>`, and with Compose support for the ``volume_driver`` field, you can use Flocker together with Docker Compose.
 
-First, you need to :ref:`install Flocker <labs-installer>` and the :ref:`Flocker Docker plugin <docker-plugin>`.
+First, you need to :ref:`install Flocker <labs-installer>` and the :ref:`Flocker plugin for Docker <docker-plugin>`.
 You can use our experimental  :ref:`Flocker Installer <labs-installer>` to do this.
 
 Then, you need a version of Compose that supports Flocker volumes.

--- a/docs/labs/index.rst
+++ b/docs/labs/index.rst
@@ -18,7 +18,7 @@ If we get lots of positive feedback about any one of these projects then we will
 Flocker Plugin for Docker with CLI and GUI
 ==========================================
 
-By way of example, here is a 55 second demo of the :ref:`Flocker plugin for Docker <docker-plugin>` provisioning portable Flocker volumes and moving them between hosts directly from the Docker CLI.
+By way of example, here is a 55 second demo of :ref:`docker-plugin` provisioning portable Flocker volumes and moving them between hosts directly from the Docker CLI.
 
 The video shows our experimental :ref:`Volumes GUI <labs-volumes-gui>` and :ref:`Volumes CLI <labs-volumes-cli>` which both give insight into what Flocker is doing while this happens.
 

--- a/docs/labs/index.rst
+++ b/docs/labs/index.rst
@@ -39,8 +39,8 @@ The goals of ClusterHQ Labs are to make it possible to:
 
 **We believe that Flocker will be more successful if, as well as focusing on making it useful for managing data volumes, we work on integrating it with other components in the emerging Docker and container ecosystem.**
 
-Our biggest step towards this goal so far is the Flocker Docker plugin, which enables you to integrate Flocker with tools like :ref:`Swarm <labs-swarm>` and :ref:`Compose <labs-compose>`, and pluggable directly into the Docker Engine and directly usable from the ``docker run`` CLI.
-The Flocker Docker plugin started out as an unofficial labs project, but is now supported in the :ref:`official Flocker Docker plugin <docker-plugin>` documentation.
+Our biggest step towards this goal so far is the Flocker plugin for Docker, which enables you to integrate Flocker with tools like :ref:`Swarm <labs-swarm>` and :ref:`Compose <labs-compose>`, and pluggable directly into the Docker Engine and directly usable from the ``docker run`` CLI.
+The Flocker plugin for Docker started out as an unofficial labs project, but is now supported in the :ref:`official Flocker plugin for Docker <docker-plugin>` documentation.
 
 Mega demo
 =========

--- a/docs/labs/index.rst
+++ b/docs/labs/index.rst
@@ -40,7 +40,7 @@ The goals of ClusterHQ Labs are to make it possible to:
 **We believe that Flocker will be more successful if, as well as focusing on making it useful for managing data volumes, we work on integrating it with other components in the emerging Docker and container ecosystem.**
 
 Our biggest step towards this goal so far is the Flocker plugin for Docker, which enables you to integrate Flocker with tools like :ref:`Swarm <labs-swarm>` and :ref:`Compose <labs-compose>`, and pluggable directly into the Docker Engine and directly usable from the ``docker run`` CLI.
-The Flocker plugin for Docker started out as an unofficial labs project, but is now supported in the :ref:`official Flocker plugin for Docker <docker-plugin>` documentation.
+The Flocker plugin for Docker started out as an unofficial labs project, but is now supported in the :ref:`docker-plugin` documentation.
 
 Mega demo
 =========

--- a/docs/labs/installer.rst
+++ b/docs/labs/installer.rst
@@ -175,7 +175,7 @@ This step should take about 5 minutes, and will:
 * install the OS packages on your nodes required to run Flocker, including Docker
 * configure certificates, push them to your nodes, set up firewall rules for the control service
 * start all the requisite Flocker services
-* install the Flocker Docker plugin, so that you can control Flocker directly from the Docker CLI
+* install the Flocker plugin for Docker, so that you can control Flocker directly from the Docker CLI
 
 Check that Flocker cluster is active
 ====================================

--- a/docs/labs/swarm.rst
+++ b/docs/labs/swarm.rst
@@ -4,7 +4,7 @@
 Flocker with Swarm
 ==================
 
-With the :ref:`Flocker Docker plugin <docker-plugin>`, and with Swarm support for the ``--volume-driver`` option, you can use Flocker together with Docker Swarm.
+With the :ref:`Flocker plugin for Docker <docker-plugin>`, and with Swarm support for the ``--volume-driver`` option, you can use Flocker together with Docker Swarm.
 
 First, you need to :ref:`install Flocker <labs-installer>` and the :ref:`Flocker plugin for Docker <docker-plugin>`.
 You can use our experimental  :ref:`Flocker Installer <labs-installer>` to do this.

--- a/docs/labs/swarm.rst
+++ b/docs/labs/swarm.rst
@@ -6,7 +6,7 @@ Flocker with Swarm
 
 With the :ref:`docker-plugin`, and with Swarm support for the ``--volume-driver`` option, you can use Flocker together with Docker Swarm.
 
-First, you need to :ref:`install Flocker <labs-installer>` and :ref:`<docker-plugin>`.
+First, you need to :ref:`install Flocker <labs-installer>` and :ref:`docker-plugin`.
 You can use our experimental  :ref:`Flocker Installer <labs-installer>` to do this.
 
 Then, you need a version of Swarm that supports Flocker volumes.

--- a/docs/labs/swarm.rst
+++ b/docs/labs/swarm.rst
@@ -4,7 +4,7 @@
 Flocker with Swarm
 ==================
 
-With the :ref:`Flocker plugin for Docker <docker-plugin>`, and with Swarm support for the ``--volume-driver`` option, you can use Flocker together with Docker Swarm.
+With the :ref:`docker-plugin`, and with Swarm support for the ``--volume-driver`` option, you can use Flocker together with Docker Swarm.
 
 First, you need to :ref:`install Flocker <labs-installer>` and the :ref:`Flocker plugin for Docker <docker-plugin>`.
 You can use our experimental  :ref:`Flocker Installer <labs-installer>` to do this.

--- a/docs/labs/swarm.rst
+++ b/docs/labs/swarm.rst
@@ -6,7 +6,7 @@ Flocker with Swarm
 
 With the :ref:`docker-plugin`, and with Swarm support for the ``--volume-driver`` option, you can use Flocker together with Docker Swarm.
 
-First, you need to :ref:`install Flocker <labs-installer>` and the :ref:`Flocker plugin for Docker <docker-plugin>`.
+First, you need to :ref:`install Flocker <labs-installer>` and :ref:`<docker-plugin>`.
 You can use our experimental  :ref:`Flocker Installer <labs-installer>` to do this.
 
 Then, you need a version of Swarm that supports Flocker volumes.

--- a/docs/labs/volumes-cli.rst
+++ b/docs/labs/volumes-cli.rst
@@ -8,7 +8,7 @@ Flocker includes a powerful volumes API.
 However it does not yet include a native CLI.
 
 This prototype demonstrates such a CLI, which has simple commands for listing nodes, creating volumes, and moving them around.
-This can be used in conjunction with the Flocker Docker plugin, see :ref:`this demo <labs-demo>` (the volumes CLI makes an appearance at the end).
+This can be used in conjunction with the Flocker plugin for Docker, see :ref:`this demo <labs-demo>` (the volumes CLI makes an appearance at the end).
 
 Install & Configure
 ===================

--- a/docs/labs/weave.rst
+++ b/docs/labs/weave.rst
@@ -13,7 +13,7 @@ Installation
 ============
 
 Flocker and Weave both have Docker plugins.
-So you can simply install the :ref:`Flocker plugin for Docker <docker-plugin>` and install the `Weave Docker plugin <https://github.com/weaveworks/docker-plugin>`_ and it should Just Work.
+So you can simply install the :ref:`docker-plugin` and install the `Weave Docker plugin <https://github.com/weaveworks/docker-plugin>`_ and it should Just Work.
 
 Demo
 ====

--- a/docs/labs/weave.rst
+++ b/docs/labs/weave.rst
@@ -13,7 +13,7 @@ Installation
 ============
 
 Flocker and Weave both have Docker plugins.
-So you can simply install the :ref:`Flocker Docker plugin <docker-plugin>` and install the `Weave Docker plugin <https://github.com/weaveworks/docker-plugin>`_ and it should Just Work.
+So you can simply install the :ref:`Flocker plugin for Docker <docker-plugin>` and install the `Weave Docker plugin <https://github.com/weaveworks/docker-plugin>`_ and it should Just Work.
 
 Demo
 ====

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -80,7 +80,7 @@ Upgrading is strongly recommended for all users of v1.0.0.
 
 * The EBS storage driver now more reliably selects the correct OS device file corresponding to an EBS volume being used.
 * Additional safety checks were added to ensure only empty volumes are formatted.
-* ClusterHQ Labs projects, including the Flocker Docker Plugin and an experimental Volumes CLI and GUI are now documented in the :ref:`Labs section <labs-projects>`.
+* ClusterHQ Labs projects, including the Flocker plugin for Docker and an experimental Volumes CLI and GUI are now documented in the :ref:`Labs section <labs-projects>`.
 
 v1.0
 ====

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -80,7 +80,7 @@ Upgrading is strongly recommended for all users of v1.0.0.
 
 * The EBS storage driver now more reliably selects the correct OS device file corresponding to an EBS volume being used.
 * Additional safety checks were added to ensure only empty volumes are formatted.
-* ClusterHQ Labs projects, including the Flocker plugin for Docker and an experimental Volumes CLI and GUI are now documented in the :ref:`Labs section <labs-projects>`.
+* ClusterHQ Labs projects, including the Flocker Docker Plugin and an experimental Volumes CLI and GUI are now documented in the :ref:`Labs section <labs-projects>`.
 
 v1.0
 ====


### PR DESCRIPTION
Fixes 3198

The Flocker plugin for Docker was named Flocker Docker plugin when it was part of Labs. Now that this is supported, the rest of the docs should use the new name.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2067)
<!-- Reviewable:end -->
