### PR TITLE
[FLOC 3191] Add link to install from Plugin introduction

### DIFF
--- a/docs/introduction/flocker-plugin.rst
+++ b/docs/introduction/flocker-plugin.rst
@@ -68,6 +68,6 @@ More information on these integrations is :ref:`available in the Labs section <l
 Get Started with the Flocker Plugin for Docker
 ==============================================
 
-Before you can install the plugin, you'll need to complete the :ref:`full-installation` instructions.
+Before you install the plugin, you'll need to :ref:`install the Flocker node services<installing-flocker-node>`.
 
 For instructions specific to installing the plugin, see :ref:`install-docker-plugin`.

--- a/docs/introduction/flocker-plugin.rst
+++ b/docs/introduction/flocker-plugin.rst
@@ -34,7 +34,7 @@ The Flocker plugin for Docker depends on Docker 1.8 or later.
 .. _`Docker documentation on volume plugins`: `Docker volumes plugin`_
 
 How It Works
-------------
+============
 
 The Flocker plugin for Docker enables you to run containers with named volumes without worrying which server your data is on.
 
@@ -51,7 +51,7 @@ There are three main cases which the plugin handles:
 Multiple containers can use the same Flocker volume (by referencing the same volume name, or by using Docker's ``--volumes-from``) so long as they are running on the same host.
 
 Demo
-----
+====
 
 This demo shows both the Flocker plugin for Docker in conjunction with the :ref:`Volumes CLI <labs-volumes-cli>` and :ref:`Volumes GUI <labs-volumes-gui>`.
 

--- a/docs/introduction/flocker-plugin.rst
+++ b/docs/introduction/flocker-plugin.rst
@@ -64,3 +64,10 @@ This is the "ultimate integration demo", a pre-built demo environment that inclu
 
 Flocker also has planned integrations with major orchestration tools such as Docker Swarm, Kubernetes and Apache Mesos.
 More information on these integrations is :ref:`available in the Labs section <labs-projects>`.
+
+Get Started with the Flocker Plugin for Docker
+==============================================
+
+Before you can install the plugin, you'll need to complete the :ref:`full-installation` instructions.
+
+For instructions specific to installing the plugin, see :ref:`install-docker-plugin`.


### PR DESCRIPTION
Fixes 3191

Added a short section at the end of the Introduction/Flocker Plugin for Docker doc, which links forward to the installation steps.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2068)
<!-- Reviewable:end -->
