### PR TITLE
[FLOC-3260] Update AWS base images.

### DIFF
--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -40,10 +40,9 @@ _usernames = {
 
 
 IMAGE_NAMES = {
-    'centos-7': 'CentOS 7 x86_64 (2014_09_29) EBS HVM'
-                '-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-d2a117ba.2',
-    'ubuntu-14.04': 'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20150325',  # noqa
-    'ubuntu-15.04': 'ubuntu/images/hvm-ssd/ubuntu-vivid-15.04-amd64-server-20150422',  # noqa
+    'centos-7': 'CentOS Linux 7 x86_64 HVM EBS 20150928_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-69327e0c.2',  # noqa
+    'ubuntu-14.04': 'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20151019',  # noqa
+    'ubuntu-15.04': 'ubuntu/images/hvm-ssd/ubuntu-vivid-15.04-amd64-server-20151015',  # noqa
 }
 
 

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -40,7 +40,12 @@ _usernames = {
 
 
 IMAGE_NAMES = {
+    # Find an image for the appropriate version at the following URL, then get
+    # the name of the image. Both CentOS and Ubuntu use consistent names across
+    # all regions.
+    # https://wiki.centos.org/Cloud/AWS
     'centos-7': 'CentOS Linux 7 x86_64 HVM EBS 20150928_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-69327e0c.2',  # noqa
+    # https://cloud-images.ubuntu.com/locator/ec2/
     'ubuntu-14.04': 'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20151019',  # noqa
     'ubuntu-15.04': 'ubuntu/images/hvm-ssd/ubuntu-vivid-15.04-amd64-server-20151015',  # noqa
 }


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3260?jql=text%20~%20%22update%20centos%22

Both CentOS and Ubuntu have newer cloud images in AWS. Since we install all updates anyway, upgrade the base image to reduce the updates we need to install.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2072)
<!-- Reviewable:end -->
