### PR TITLE
[FLOC-3077] Retry `list` in client tests to avoid spurious failures

### DIFF
--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -789,6 +789,7 @@ class DockerClient(object):
         return d
 
     def list(self):
+        # XXX: This should use flocker.common.auto_threaded
         def _list():
             result = set()
             ids = [d[u"Id"] for d in

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
 # -*- test-case-name: flocker.node.test.test_docker -*-
 
 """

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -789,7 +789,6 @@ class DockerClient(object):
         return d
 
     def list(self):
-        # XXX: This should use flocker.common.auto_threaded
         def _list():
             result = set()
             ids = [d[u"Id"] for d in

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
 
 """
 Functional tests for :module:`flocker.node._docker`.

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -527,6 +527,7 @@ class GenericDockerClientTests(TestCase):
         """
         The Docker image is pulled if it is unavailable locally.
         """
+        # XXX: This test calls 'list'. But how?
         client = Client()
 
         path = FilePath(self.mktemp())

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -32,7 +32,7 @@ from pyrsistent import PClass, pvector, field
 
 from ...testtools import (
     loop_until, find_free_port, DockerImageBuilder, assertContainsAll,
-    random_name)
+    random_name, retry_failure)
 
 from ..test.test_docker import ANY_IMAGE, make_idockerclient_tests
 from .._docker import (
@@ -636,7 +636,12 @@ class GenericDockerClientTests(TestCase):
         )
 
         def extract_listening_port(client):
-            listing = client.list()
+            # FLOC-3077: Docker will sometimes raise a 500 when we inspect a
+            # container, due to race conditions with certain volume
+            # operations. Since there's no real user impact for flocker (the
+            # convergence loop will just retry anyway), retry here to avoid
+            # spurious test failures.
+            listing = retry_failure(client.list, APIError, steps=[0.1] * 5)
             listing.addCallback(
                 lambda applications: list(
                     next(iter(application.ports)).external_port

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -640,7 +640,7 @@ class GenericDockerClientTests(TestCase):
             # operations. Since there's no real user impact for flocker (the
             # convergence loop will just retry anyway), retry here to avoid
             # spurious test failures.
-            listing = retry_failure(client.list, APIError, steps=[0.1] * 5)
+            listing = retry_failure(client.list, [APIError], steps=[0.1] * 5)
             listing.addCallback(
                 lambda applications: list(
                     next(iter(application.ports)).external_port

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -527,7 +527,6 @@ class GenericDockerClientTests(TestCase):
         """
         The Docker image is pulled if it is unavailable locally.
         """
-        # XXX: This test calls 'list'. But how?
         client = Client()
 
         path = FilePath(self.mktemp())

--- a/flocker/test/test_testtools.py
+++ b/flocker/test/test_testtools.py
@@ -12,12 +12,15 @@ from eliot.testing import (
     assertContainsFields,
 )
 
+from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.task import Clock
+from twisted.python.failure import Failure
 
 from flocker.testtools import (
     run_process,
     loop_until, LOOP_UNTIL_ACTION, LOOP_UNTIL_ITERATION_MESSAGE,
+    retry_failure,
 )
 
 
@@ -187,3 +190,156 @@ class LoopUntilTests(SynchronousTestCase):
             [messages[0].message['result'], messages[1].message['result']],
             expected_results,
         )
+
+
+class RetryFailureTests(SynchronousTestCase):
+    """
+    Tests for :py:func:`retry_failure`.
+    """
+
+    def test_immediate_success(self):
+        """
+        If the function returns a successful value immediately, then
+        ``retry_failure`` returns a deferred that has already fired with that
+        value.
+        """
+        result = object()
+
+        def function():
+            return result
+
+        clock = Clock()
+        d = retry_failure(function, reactor=clock)
+        self.assertEqual(self.successResultOf(d), result)
+
+    def test_iterates_once(self):
+        """
+        If the function fails at first and then succeeds, ``retry_failure``
+        returns the success.
+        """
+        steps = [0.1]
+
+        result = object()
+        results = [Failure(ValueError("bad value")), succeed(result)]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(function, reactor=clock, steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.successResultOf(d), result)
+
+    def test_multiple_iterations(self):
+        """
+        If the function fails multiple times and then succeeds,
+        ``retry_failure`` returns the success.
+        """
+        steps = [0.1, 0.2]
+
+        result = object()
+        results = [
+            Failure(ValueError("bad value")),
+            Failure(ValueError("bad value")),
+            succeed(result),
+        ]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(function, reactor=clock, steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.successResultOf(d), result)
+
+    def test_too_many_iterations(self):
+        """
+        If ``retry_failure`` fails more times than there are steps provided, it
+        errors back with the last failure.
+        """
+        steps = [0.1]
+
+        result = object()
+        failure = Failure(ValueError("really bad value"))
+
+        results = [
+            Failure(ValueError("bad value")),
+            failure,
+            succeed(result),
+        ]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(function, reactor=clock, steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.failureResultOf(d), failure)
+
+    def test_no_steps(self):
+        """
+        Calling ``retry_failure`` with an empty iterator for ``steps`` is the
+        same as wrapping the function in ``maybeDeferred``.
+        """
+        steps = []
+
+        result = object()
+        failure = Failure(ValueError("really bad value"))
+
+        results = [
+            failure,
+            succeed(result),
+        ]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(function, reactor=clock, steps=steps)
+        self.assertEqual(self.failureResultOf(d), failure)
+
+    def test_limited_exceptions(self):
+        """
+        By default, ``retry_failure`` retries on any exception. However, if
+        it's given an iterable of expected exception types (exactly as one
+        might pass to ``Failure.check``), then it will only retry if one of
+        *those* exceptions is raised.
+        """
+        steps = [0.1, 0.2]
+
+        result = object()
+        type_error = Failure(TypeError("bad type"))
+
+        results = [
+            Failure(ValueError("bad value")),
+            type_error,
+            succeed(result),
+        ]
+
+        def function():
+            return results.pop(0)
+
+        clock = Clock()
+
+        d = retry_failure(
+            function, expected=[ValueError], reactor=clock, steps=steps)
+        self.assertNoResult(d)
+
+        clock.advance(0.1)
+        self.assertEqual(self.failureResultOf(d), type_error)

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -265,7 +265,8 @@ def retry_failure(function, expected=None, reactor=reactor, steps=None):
     If it raises one of the expected exceptions, then retry.
 
     :param callable function: A callable that returns a value.
-    :param expected: The exceptions that trigger a retry.
+    :param expected: Iterable of exceptions that trigger a retry. Passed
+        through to ``Failure.check``.
     :param reactor reactor: The reactor implementation to use to delay.
     :param [float] steps: An iterable of delay intervals, measured in seconds.
         If not provided, will default to retrying every 0.1 seconds.


### PR DESCRIPTION
Our centos-7 tests often fail with `docker.errors.APIError: 500: Internal Server Error: Unknown device`

This is *probably* due to a race condition in Docker. See [FLOC-3077](https://clusterhq.atlassian.net/browse/FLOC-3077) for discussion. 

The work-around is to retry the list operation in the test in order to avoid the race condition. 

Rather than putting all of that logic in the test, I added a new `retry_failure` helper which does this. I considered trying to shoe-horn `loop_until` to fit this purpose, but it seemed cleaner to do it this way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2076)
<!-- Reviewable:end -->
