### PR TITLE
[FLOC-3248] Encode args as well as kwargs 

### DIFF
--- a/flocker/acceptance/test/__init__.py
+++ b/flocker/acceptance/test/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for flocker.acceptance.
+"""

--- a/flocker/acceptance/test/test_testtools.py
+++ b/flocker/acceptance/test/test_testtools.py
@@ -4,16 +4,128 @@
 Tests for flocker.acceptance.testtools.
 """
 
+from eliot import ActionType
+from eliot.testing import (
+    assertContainsFields,
+    assertHasAction,
+    capture_logging,
+)
+from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from ..testtools import (log_method, _ensure_encodeable)
 
 
-class TestLogMethod(SynchronousTestCase):
+class EnsureEncodeableTests(SynchronousTestCase):
+    """
+    Tests for ``_ensure_encodeable``.
 
-    def test_nothing(self):
+    ``_ensure_encodeable`` is an implementation detail of ``log_method``, so
+    these tests are not strictly necessary. They were written because we were
+    seeing unexpected behavior and wanted to make sure that
+    ``_ensure_encodeable`` wasn't the cause.
+    """
+
+    def test_encodeable(self):
         """
-        We can run tests.
+        If given an encodeable object, _ensure_encodeable just returns it.
         """
-        log_method
-        _ensure_encodeable
+        value = {'foo': 'bar'}
+        self.assertEqual(value, _ensure_encodeable(value))
+
+    def test_unencodeable(self):
+        """
+        If given an unencodeable object, _ensure_encodeable returns its repr.
+        """
+        value = object()
+        self.assertEqual(repr(value), _ensure_encodeable(value))
+
+    def test_circular(self):
+        """
+        If given an object with a circular reference, _ensure_encodeable
+        returns its repr.
+        """
+        value = []
+        value.append(value)
+        self.assertEqual(repr(value), _ensure_encodeable(value))
+
+
+class LogMethodTests(SynchronousTestCase):
+    """
+    Tests for ``log_method``.
+    """
+
+    def make_action_type(self, action_type):
+        """
+        Eliot makes it tricky to create ``ActionType`` objects. Here's a
+        helper to declutter our tests.
+        """
+        return ActionType(action_type, [], [])
+
+    def _logs_action_test(self, logger, arg, kwarg, result):
+        """
+        Call a method ``f`` wrapped in ``log_method`` passing it ``arg`` as an
+        argument, ``kwarg`` as a keyword argument and returning ``result`` as
+        its result.
+
+        :return: The logged action.
+        """
+        class Foo(object):
+            @log_method
+            def f(self, foo, bar):
+                return succeed(result)
+
+        foo = Foo()
+        d = foo.f(arg, bar=kwarg)
+        self.assertEqual(result, self.successResultOf(d))
+
+        action_type = self.make_action_type('acceptance:f')
+        return assertHasAction(
+            self, logger, action_type, True,
+        )
+
+    def assert_call_parameters_logged(self, action, arg, kwarg, result):
+        """
+        Assert 'action' has start message that includes the argument and
+        keyword argument given, and an end message that includes the result.
+        """
+        assertContainsFields(
+            self, action.start_message,
+            {'args': (arg,), 'kwargs': {'bar': kwarg}})
+        assertContainsFields(
+            self, action.end_message,
+            {'result': result})
+
+    @capture_logging(None)
+    def test_logs_action_unserializable(self, logger):
+        """
+        Methods decorated with ``log_method`` have their start and end points
+        logged as actions.
+
+        When the args, kwargs, or return value are unserializable, we log the
+        repr of same.
+        """
+        result = object()
+        arg = object()
+        kwarg = object()
+
+        action = self._logs_action_test(logger, arg, kwarg, result)
+        self.assert_call_parameters_logged(
+            action, repr(arg), repr(kwarg), repr(result))
+
+    @capture_logging(None)
+    def test_logs_action_serializable(self, logger):
+        """
+        Methods decorated with ``log_method`` have their start and end points
+        logged as actions.
+
+        When the args, kwargs, or return value are serializable, we let eliot
+        take care of serializing them. "Serializable" means json.dumps doesn't
+        explode.
+        """
+        result = 42
+        arg = b"hello"
+        kwarg = {u'foo': 37}
+
+        action = self._logs_action_test(logger, arg, kwarg, result)
+        self.assert_call_parameters_logged(action, arg, kwarg, result)

--- a/flocker/acceptance/test/test_testtools.py
+++ b/flocker/acceptance/test/test_testtools.py
@@ -1,0 +1,19 @@
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
+
+"""
+Tests for flocker.acceptance.testtools.
+"""
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from ..testtools import (log_method, _ensure_encodeable)
+
+
+class TestLogMethod(SynchronousTestCase):
+
+    def test_nothing(self):
+        """
+        We can run tests.
+        """
+        log_method
+        _ensure_encodeable

--- a/flocker/acceptance/test/test_testtools.py
+++ b/flocker/acceptance/test/test_testtools.py
@@ -28,14 +28,15 @@ class EnsureEncodeableTests(SynchronousTestCase):
 
     def test_encodeable(self):
         """
-        If given an encodeable object, _ensure_encodeable just returns it.
+        If given a JSON-encodeable object, _ensure_encodeable just returns it.
         """
         value = {'foo': 'bar'}
         self.assertEqual(value, _ensure_encodeable(value))
 
     def test_unencodeable(self):
         """
-        If given an unencodeable object, _ensure_encodeable returns its repr.
+        If given an object that cannot be JSON encoded, _ensure_encodeable
+        returns its repr.
         """
         value = object()
         self.assertEqual(repr(value), _ensure_encodeable(value))

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -355,6 +355,10 @@ def _ensure_encodeable(value):
     """
     Return a version of ``value`` that is guaranteed to be able to be logged.
 
+    Catches ``TypeError``, which is raised for intrinsically unserializable
+    values, and ``ValueError``, which catches ValueError, which is raised on
+    circular references and also invalid dates.
+
     If normal encoding fails, return ``repr(value)``.
     """
     try:

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -332,12 +332,9 @@ def log_method(function):
     @wraps(function)
     def wrapper(self, *args, **kwargs):
 
-        serializable_kwargs = kwargs.copy()
+        serializable_kwargs = {}
         for kwarg in kwargs:
-            try:
-                json.dumps(kwargs[kwarg])
-            except TypeError:
-                serializable_kwargs[kwarg] = repr(kwargs[kwarg])
+            serializable_kwargs[kwarg] = _ensure_encodeable(kwargs[kwarg])
 
         context = start_action(
             Logger(),
@@ -350,6 +347,19 @@ def log_method(function):
             d.addActionFinish()
             return d.result
     return wrapper
+
+
+def _ensure_encodeable(value):
+    """
+    Return a version of ``value`` that is guaranteed to be able to be logged.
+
+    If normal encoding fails, return ``repr(value)``.
+    """
+    try:
+        json.dumps(value)
+    except TypeError:
+        return repr(value)
+    return value
 
 
 class Cluster(PRecord):

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -358,7 +358,7 @@ def _ensure_encodeable(value):
     """
     try:
         json.dumps(value)
-    except TypeError:
+    except (ValueError, TypeError):
         return repr(value)
     return value
 

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
 
 """
 Testing utilities for ``flocker.acceptance``.

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -39,6 +39,7 @@ from ..common import gather_deferreds
 from ..common.runner import download_file
 
 from ..control.httpapi import REST_API_PORT
+from ..control._persistence import wire_encode
 from ..ca import treq_with_authentication
 from ..testtools import loop_until, random_name
 from ..apiclient import FlockerClient, DatasetState
@@ -357,7 +358,7 @@ def _ensure_encodeable(value):
     If normal encoding fails, return ``repr(value)``.
     """
     try:
-        json.dumps(value)
+        wire_encode(value)
     except (ValueError, TypeError):
         return repr(value)
     return value

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -332,6 +332,7 @@ def log_method(function):
     @wraps(function)
     def wrapper(self, *args, **kwargs):
 
+        serializable_args = tuple(_ensure_encodeable(a) for a in args)
         serializable_kwargs = {}
         for kwarg in kwargs:
             serializable_kwargs[kwarg] = _ensure_encodeable(kwargs[kwarg])
@@ -339,7 +340,7 @@ def log_method(function):
         context = start_action(
             Logger(),
             action_type=label,
-            args=args, kwargs=serializable_kwargs,
+            args=serializable_args, kwargs=serializable_kwargs,
         )
         with context.context():
             d = DeferredContext(function(self, *args, **kwargs))


### PR DESCRIPTION
Applies almost all of the suggestions from #2052 and [FLOC-3248](https://clusterhq.atlassian.net/browse/FLOC-3248)

* uses `wire_encode` instead of `json.dumps`
* catches `ValueError`, which can be raised on circular references and also invalid dates
* checks `args` for serializability as well as kwargs

Does this by extracting an `_ensure_encodeable` function, which in turn allows for a more functional implementation within `log_method`.

Did not implement the "force all arguments to be keyword arguments" suggestion. That can be done as a separate clean-up ticket, outside of the Green CI epic.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2077)
<!-- Reviewable:end -->
