### PR TITLE
Design review: Use control serviceregistry to manage blockdevice_id <-> dataset_id mapping

### DIFF
--- a/flocker/control/_registry.py
+++ b/flocker/control/_registry.py
@@ -1,0 +1,41 @@
+"""
+Store information about relationships between configuration and state.
+"""
+
+
+class BlockDeviceOwnership(CheckedPMap):
+    """
+    Map dataset_id <-> blockdevice_id.
+    """
+
+
+class Registry(object):
+    """
+    XXX Wraps same on-disk persistence mechanism as _persistence.py, but
+    stores different information.
+    """
+
+    def record_ownership(self, dataset_id, blockdevice_id):
+        """
+        Record that blockdevice_id is the relevant one for given dataset_id.
+
+        Once a record is made no other entry can overwrite the existing
+        one; the relationship is hardcoded and permanent. XXX this may
+        interact badly with deletion of dataset where dataset_id is
+        auto-generated from name, e.g. flocker-deploy or Docker
+        plugin. That is pre-existing issue, though.
+
+        XXX having IBlockDeviceAPI specific method is kinda bogus. Some
+        sort of generic method for storing data moving forward?
+        """
+        # Check persisted value, if not already set override and save to
+        # disk, otherwise raise error.
+
+    def get_ownership(self):
+        """
+        Return ownership information, in class suitable for transmitting over
+        AMP, i.e. ``BlockDeviceOwnership``
+
+        XXX having IBlockDeviceAPI specific method is kinda bogus. Some
+        sort of generic method for storing data moving forward?
+        """

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -118,7 +118,7 @@ class IDeployer(Interface):
             method.
         """
 
-    def calculate_changes(configuration, cluster_state, local_state):
+    def calculate_changes(configuration, cluster_state, register, local_state):
         """
         Calculate the state changes necessary to make the local state match the
         desired cluster configuration.
@@ -131,6 +131,8 @@ class IDeployer(Interface):
 
         :param ILocalState local_state: The ``ILocalState`` provider returned
             from the most recent call to ``discover_state``.
+
+        :param XXX: Info from registry.
 
         :return: An ``IStateChange`` provider.
         """

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -388,7 +388,7 @@ class ConvergenceLoop(object):
                 cluster_state_changes)
 
             action = self.deployer.calculate_changes(
-                self.configuration, self.cluster_state, local_state
+                self.configuration, self.cluster_state, self.register, local_state
             )
             LOG_CALCULATED_ACTIONS(calculated_actions=action).write(
                 self.fsm.logger)
@@ -512,6 +512,7 @@ class AgentLoopService(MultiService, object):
         self.cluster_status.receive(
             ClusterStatusInputs.DISCONNECTED_FROM_CONTROL_SERVICE)
 
-    def cluster_updated(self, configuration, cluster_state):
+    def cluster_updated(self, configuration, cluster_state, register):
         self.cluster_status.receive(_StatusUpdate(configuration=configuration,
-                                                  state=cluster_state))
+                                                  state=cluster_state,
+                                                  register=register))

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -303,14 +303,19 @@ class BlockDeviceVolume(PRecord):
         identifier is supplied by the ``IBlockDeviceAPI.compute_instance_id``
         method based on the underlying infrastructure services (for example, if
         the cluster runs on AWS, this is very likely an EC2 instance id).
-    :ivar UUID dataset_id: The Flocker dataset ID associated with this volume.
+    :ivar UUID dataset_id: The Flocker dataset ID which the backend
+         believes is associated with this volume, or C{None} if
+         unknown. If set this is merely a hint (used for upgrades and
+         crash recovery), and not to be relied on given contrary
+         information in the contorl service which is the canonical
+         location.
     """
     blockdevice_id = field(type=unicode, mandatory=True)
     size = field(type=int, mandatory=True)
     attached_to = field(
         type=(unicode, type(None)), initial=None, mandatory=True
     )
-    dataset_id = field(type=UUID, mandatory=True)
+    dataset_id = field(type=optional(UUID), mandatory=True)
 
 
 def _blockdevice_volume_from_datasetid(volumes, dataset_id):
@@ -727,7 +732,7 @@ class CreateBlockDeviceDataset(PRecord):
             ),
         )
         # XXX send dataset_id and blockdevice_id over AMP to control service
-        # in next iteration calcualte_changes will get that info and rely on it; until we hear back official word from control service registry about ownership we can't actually proceed in rest of creation.
+        # in next iteration calculate_changes will get that info and rely on it; until we hear back official word from control service registry about ownership we can't actually proceed in rest of creation.
 
         # XXX The rest is going to be removed in FLOC-1771, which is prerequisite for above.
         
@@ -871,6 +876,10 @@ class IBlockDeviceAPI(Interface):
         newly created volume should be given a name that contains the
         dataset_id in order to ease debugging. Some implementations may
         choose not to do so or may not be able to do so.
+
+        The dataset_id *can* be stored by backend for debugging/human
+        readability, but it is not the canonical location of information
+        (which is the control service registry).
 
         :param UUID dataset_id: The Flocker dataset ID of the dataset on this
             volume.
@@ -1632,6 +1641,17 @@ class BlockDeviceDeployer(PRecord):
 
     def calculate_changes(self, configuration, cluster_state, register, local_state):
         # XXX use register for dataset_id <-> blockdevice_id mapping
+
+        # XXX also, if we have in output of list_volumes()
+        # (i.e. local_state.volumes) a volume with a mapping between
+        # dataset_id and blockdevice_id that is not in registry, send AMP
+        # command to control service indicating this mapping. Since
+        # control service registry won't allow more than one mapping, if
+        # there are two block device volumes we end up picking one,
+        # ensuring no ambiguity. This is both the crash recovery
+        # optimization (allowing us to reuse already created block
+        # devices) and also the upgrade mechanism from time when registry
+        # didn't exist.
         this_node_config = configuration.get_node(
             self.node_uuid, hostname=self.hostname)
         local_node_state = cluster_state.get_node(self.node_uuid,

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -726,7 +726,11 @@ class CreateBlockDeviceDataset(PRecord):
                 requested_size=self.dataset.maximum_size,
             ),
         )
+        # XXX send dataset_id and blockdevice_id over AMP to control service
+        # in next iteration calcualte_changes will get that info and rely on it; until we hear back official word from control service registry about ownership we can't actually proceed in rest of creation.
 
+        # XXX The rest is going to be removed in FLOC-1771, which is prerequisite for above.
+        
         # This duplicates AttachVolume now.
         volume = api.attach_volume(
             volume.blockdevice_id,
@@ -1626,7 +1630,8 @@ class BlockDeviceDeployer(PRecord):
         """
         return self.mountroot.child(dataset_id.encode("ascii"))
 
-    def calculate_changes(self, configuration, cluster_state, local_state):
+    def calculate_changes(self, configuration, cluster_state, register, local_state):
+        # XXX use register for dataset_id <-> blockdevice_id mapping
         this_node_config = configuration.get_node(
             self.node_uuid, hostname=self.hostname)
         local_node_state = cluster_state.get_node(self.node_uuid,


### PR DESCRIPTION
This presumes we've already done FLOC-1771, i.e. when we create a dataset we just do a single block device action of "create volume", and in later iterations of convergence loop follow up with attaching, creating filesystem etc..

The basic idea is that control service is in charge of remembering dataset_id<->blockdevice_id mapping, and that any info stored by block device backend can be used as hints for upgrade and crash recovery, but is not the canonical source of truth.

This feels like a very complex change for a simple problem. I am not sure what else can be done given AWS APIs are unreliable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2078)
<!-- Reviewable:end -->
