### PR TITLE
[FLOC-3308] Attempt to fix intermittent test failure

### DIFF
--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -57,22 +57,36 @@ class ContainerAPITests(TestCase):
         """
         A container is restarted if it is stopped.
         """
+        responses = []
+        def query_and_save():
+            querying = query_http_server(
+                cluster.nodes[0].public_address, 8080
+            )
+            querying.addCallback(responses.append)
+            return querying
+
         created = self._create_container(
             cluster, SCRIPTS.child(b"exitinghttp.py")
         )
 
         # `query_http_server` will kill the server first time round.
-        created.addCallback(
-            lambda ignored: query_http_server(
-                cluster.nodes[0].public_address, 8080
-            )
-        )
+        created.addCallback(lambda ignored: query_and_save())
+
         # Call it again and see that the container is running again.
-        created.addCallback(
-            lambda ignored: query_http_server(
-                cluster.nodes[0].public_address, 8080
+        created.addCallback(lambda ignored: query_and_save())
+
+        # Verify one of the assumptions ... That the container restarted in
+        # between requests.  exitinghttp.py gives back a process-unique random
+        # value as the response body.
+        def check_different_response(ignored):
+            self.assertNotEqual(
+                responses[0],
+                responses[1],
+                "Responses to two requests were the same, "
+                "container probably did not restart.",
             )
-        )
+        created.addCallback(check_different_response)
+
         return created
 
     @require_cluster(1)

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -58,6 +58,7 @@ class ContainerAPITests(TestCase):
         A container is restarted if it is stopped.
         """
         responses = []
+
         def query_and_save():
             querying = query_http_server(
                 cluster.nodes[0].public_address, 8080

--- a/flocker/acceptance/scripts/exitinghttp.py
+++ b/flocker/acceptance/scripts/exitinghttp.py
@@ -8,6 +8,7 @@ from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 PROCESS_UNIQUE_VALUE = urandom(32).encode("hex")
 
+
 class Handler(BaseHTTPRequestHandler):
     def do_GET(s):
         s.send_response(200)

--- a/flocker/acceptance/scripts/exitinghttp.py
+++ b/flocker/acceptance/scripts/exitinghttp.py
@@ -2,18 +2,23 @@
 HTTP server that exits after responding to a GET request.
 """
 
+from os import urandom
+
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
+PROCESS_UNIQUE_VALUE = urandom(32).encode("hex")
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(s):
         s.send_response(200)
-        s.send_header("content-length", "2")
+        s.send_header(
+            b"content-length",
+            u"{}".format(len(PROCESS_UNIQUE_VALUE)).encode("ascii")
+        )
         s.end_headers()
-        s.wfile.write(b"hi")
+        s.wfile.write(PROCESS_UNIQUE_VALUE)
         s.wfile.flush()
         s.wfile.close()
-        raise SystemExit()
 
 httpd = HTTPServer((b"0.0.0.0", 8080), Handler)
-httpd.serve_forever()
+httpd.handle_request()

--- a/flocker/acceptance/scripts/exitinghttp.py
+++ b/flocker/acceptance/scripts/exitinghttp.py
@@ -4,14 +4,19 @@ HTTP server that exits after responding to a GET request.
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 import os
+import time
 
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(s):
         s.send_response(200)
+        s.send_header("content-length", "2")
         s.end_headers()
         s.wfile.write(b"hi")
+        s.wfile.flush()
         s.wfile.close()
+        # Try to ensure enough time for bytes to make it out before exiting:
+        time.sleep(0.1)
         os._exit(1)
 
 httpd = HTTPServer((b"0.0.0.0", 8080), Handler)

--- a/flocker/acceptance/scripts/exitinghttp.py
+++ b/flocker/acceptance/scripts/exitinghttp.py
@@ -3,8 +3,6 @@ HTTP server that exits after responding to a GET request.
 """
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-import os
-import time
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -15,9 +13,7 @@ class Handler(BaseHTTPRequestHandler):
         s.wfile.write(b"hi")
         s.wfile.flush()
         s.wfile.close()
-        # Try to ensure enough time for bytes to make it out before exiting:
-        time.sleep(0.1)
-        os._exit(1)
+        raise SystemExit()
 
 httpd = HTTPServer((b"0.0.0.0", 8080), Handler)
 httpd.serve_forever()

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -968,7 +968,12 @@ def query_http_server(host, port, path=b""):
         req = get(
             "http://{host}:{port}{path}".format(
                 host=host, port=port, path=path),
-            persistent=False
+            # Sometimes the TCP connection to the HTTP server gets stuck
+            # somewhere.  Avoid having to wait the full TCP timeout period
+            # before failing.  The query happens in a loop so it's better to
+            # give up early and try again.
+            timeout=2,
+            persistent=False,
         )
 
         def failed(failure):


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-3308

Observed several times that one of the polling iterations would get stuck for two minutes trying to query what should have been the second run of the container.  Filed an issue for whatever networking problem *that* represents... And updated this branch to use short timeouts where we do a polling loop that might get hit by this.