### PR TITLE
[FLOC-3310] Switch to explicit SLEEPING state in convergence loop

### DIFF
--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -201,6 +201,8 @@ class ConvergenceLoopInputs(Names):
     # Finished applying necessary changes to local state, a single
     # iteration of the convergence loop:
     ITERATION_DONE = NamedConstant()
+    # Sleep has ended due to hitting its timeout:
+    SLEEP_TIMEOUT = NamedConstant()
 
 
 @attributes(["client", "configuration", "state"])
@@ -216,6 +218,17 @@ class _ClientStatusUpdate(trivialInput(ConvergenceLoopInputs.STATUS_UPDATE)):
     """
 
 
+class _IterationDone(trivialInput(ConvergenceLoopInputs.ITERATION_DONE)):
+    """
+    Iteration is done, sleep for given amount.
+
+    :ivar float delay_seconds: How many seconds to delay until next iteration.
+    """
+    # For now this is hard coded, will become more flexible in followup
+    # parts of FLOC-3205:
+    delay_seconds = 1.0
+
+
 class ConvergenceLoopStates(Names):
     """
     Convergence loop FSM states.
@@ -227,6 +240,8 @@ class ConvergenceLoopStates(Names):
     # Local state is being converged, and once that is done we will
     # immediately stop:
     CONVERGING_STOPPING = NamedConstant()
+    # The loop is sleeping until the next iteration occurs:
+    SLEEPING = NamedConstant()
 
 
 class ConvergenceLoopOutputs(Names):
@@ -238,6 +253,10 @@ class ConvergenceLoopOutputs(Names):
     STORE_INFO = NamedConstant()
     # Start an iteration of the covergence loop:
     CONVERGE = NamedConstant()
+    # Schedule timeout for sleep so we don't sleep forever:
+    SCHEDULE_SLEEP_TIMEOUT = NamedConstant()
+    # Cancel the sleep timeout:
+    CANCEL_TIMEOUT = NamedConstant()
 
 
 _FIELD_CONNECTION = Field(
@@ -296,6 +315,9 @@ class ConvergenceLoop(object):
         acknowledged by the control service over the most recent connection
         to the control service.
     :type _last_acknowledged_state: tuple of IClusterStateChange
+
+    :ivar _sleep_timeout: Current ``IDelayedCall`` for sleep timeout, or
+        ``None`` if not in SLEEPING state.
     """
     def __init__(self, reactor, deployer):
         """
@@ -309,6 +331,7 @@ class ConvergenceLoop(object):
         self.cluster_state = None
         self.client = None
         self._last_acknowledged_state = None
+        self._sleep_timeout = None
 
     def output_STORE_INFO(self, context):
         old_client = self.client
@@ -405,20 +428,18 @@ class ConvergenceLoop(object):
         # converging again; hopefully next time we'll have more success.
         d.addErrback(writeFailure, self.fsm.logger)
 
-        # It would be better to have a "quiet time" state in the FSM and
-        # transition to that next, then have a timeout input kick the machine
-        # back around to the beginning of the loop in the FSM.  However, we're
-        # not going to keep this sleep-for-a-bit solution in the long term.
-        # Instead, we'll be more event driven.  So just going with the simple
-        # solution and inserting a side-effect-y delay directly here.
-
-        d.addCallback(
-            lambda _:
-                self.reactor.callLater(
-                    1.0, self.fsm.receive, ConvergenceLoopInputs.ITERATION_DONE
-                )
-        )
+        # We're done with the iteration:
+        d.addCallback(lambda _: self.fsm.receive(_IterationDone()))
         d.addActionFinish()
+
+    def output_SCHEDULE_SLEEP_TIMEOUT(self, context):
+        self._sleep_timeout = self.reactor.callLater(
+            context.delay_seconds,
+            lambda: self.fsm.receive(ConvergenceLoopInputs.SLEEP_TIMEOUT))
+
+    def output_CANCEL_TIMEOUT(self, context):
+        self._sleep_timeout.cancel()
+        self._sleep_timeout = None
 
 
 def build_convergence_loop_fsm(reactor, deployer):
@@ -441,18 +462,27 @@ def build_convergence_loop_fsm(reactor, deployer):
         S.CONVERGING, {
             I.STATUS_UPDATE: ([O.STORE_INFO], S.CONVERGING),
             I.STOP: ([], S.CONVERGING_STOPPING),
-            I.ITERATION_DONE: ([O.CONVERGE], S.CONVERGING),
+            I.ITERATION_DONE: ([O.SCHEDULE_SLEEP_TIMEOUT], S.SLEEPING),
         })
     table = table.addTransitions(
         S.CONVERGING_STOPPING, {
             I.STATUS_UPDATE: ([O.STORE_INFO], S.CONVERGING),
             I.ITERATION_DONE: ([], S.STOPPED),
         })
+    table = table.addTransitions(
+        S.SLEEPING, {
+            I.SLEEP_TIMEOUT: ([O.CONVERGE], S.CONVERGING),
+            I.STOP: ([O.CANCEL_TIMEOUT], S.STOPPED),
+            # At some point in FLOC-3205 might want to make this interrupt
+            # sleep, but at the moment that would increase polling which
+            # we don't want.
+            I.STATUS_UPDATE: ([O.STORE_INFO], S.SLEEPING),
+            })
 
     loop = ConvergenceLoop(reactor, deployer)
     fsm = constructFiniteStateMachine(
         inputs=I, outputs=O, states=S, initial=S.STOPPED, table=table,
-        richInputs=[_ClientStatusUpdate], inputContext={},
+        richInputs=[_ClientStatusUpdate, _IterationDone], inputContext={},
         world=MethodSuffixOutputer(loop))
     loop.fsm = fsm
     return fsm

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -655,8 +655,9 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         loop = self.convergence_iteration()
         loop.receive(ConvergenceLoopInputs.STOP)
         # Stopped with no scheduled calls left hanging:
-        self.assertEqual((loop.state, self.reactor.getDelayedCalls()),
-                         (ConvergenceLoopStates.STOPPED, []))
+        self.assertEqual(
+            dict(state=loop.state, calls=self.reactor.getDelayedCalls()),
+            dict(state=ConvergenceLoopStates.STOPPED, calls=[]))
 
     def test_convergence_iteration_status_update(self):
         """

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -16,8 +16,8 @@ from twisted.trial.unittest import SynchronousTestCase
 from twisted.test.proto_helpers import StringTransport, MemoryReactorClock
 from twisted.internet.protocol import Protocol, ReconnectingClientFactory
 from twisted.internet.defer import succeed, Deferred, fail
-from twisted.internet.task import Clock
 from twisted.internet.ssl import ClientContextFactory
+from twisted.internet.task import Clock
 from twisted.protocols.tls import TLSMemoryBIOFactory, TLSMemoryBIOProtocol
 
 from ...testtools.amp import FakeAMPClient, DelayedAMPClient
@@ -28,7 +28,7 @@ from .._loop import (
     ConvergenceLoopStates, build_convergence_loop_fsm, AgentLoopService,
     LOG_SEND_TO_CONTROL_SERVICE,
     LOG_CONVERGE, LOG_CALCULATED_ACTIONS,
-    _IterationDone,
+    _Sleep,
     )
 from ..testtools import ControllableDeployer, ControllableAction, to_node
 from ...control import (
@@ -677,7 +677,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         # Action finally finishes, and we can move on to next iteration,
         # which happens with second set of client, desired configuration
         # and cluster state:
-        self.reactor.advance(_IterationDone.delay_seconds)
+        self.reactor.advance(_Sleep.delay_seconds)
 
         self.assertEqual(
             self.deployer.calculate_inputs[-1],

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -650,8 +650,8 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
 
     def test_convergence_iteration_sleeping_stop(self):
         """
-        If after a convergence iteration in the sleeping state a STOP is
-        received the loop stops.
+        When a convergence loop in the sleeping state receives a STOP the loop
+        stops.
         """
         loop = self.convergence_iteration()
         loop.receive(ConvergenceLoopInputs.STOP)
@@ -662,8 +662,8 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
 
     def test_convergence_iteration_status_update(self):
         """
-        If after a convergence iteration in the sleeping state a status update
-        is received the next iteration of the event loop uses it.
+        When a convergence loop in the sleeping state receives a status update
+        the next iteration of the event loop uses it.
         """
         loop = self.convergence_iteration()
         node_state = NodeState(hostname=u'192.0.3.5')


### PR DESCRIPTION
The convergence loop needs to be improved such that sleeps in between iterations can be modified (different durations, for exampe) and interrupted (e.g. config updates should perhaps interrupt sleep). A preliminary step is making sleep an explicit state machine step.

http://build.clusterhq.com/boxes-flocker?branch=explicit-convergence-loop-sleep-state-FLOC-3310

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2081)
<!-- Reviewable:end -->
