### PR TITLE
[FLOC-3318] Wakeup convergence loop if changes matter

### DIFF
--- a/flocker/node/__init__.py
+++ b/flocker/node/__init__.py
@@ -5,7 +5,7 @@ Local node manager for Flocker.
 """
 
 from ._change import (
-    IStateChange, in_parallel, sequentially, run_state_change
+    IStateChange, in_parallel, sequentially, run_state_change, NoOp,
 )
 
 from ._deploy import (
@@ -21,6 +21,7 @@ from .script import BackendDescription, DeployerType
 
 __all__ = [
     'IDeployer', 'ILocalState', 'NodeLocalState', 'IStateChange',
+    'NoOp',
     'P2PManifestationDeployer',
     'ApplicationNodeDeployer',
     'run_state_change', 'in_parallel', 'sequentially',

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -121,6 +121,9 @@ def in_parallel(changes):
     The order in which execution of the changes is started is unspecified.
     Comparison of the resulting object disregards the ordering of the changes.
     """
+    changes = [c for c in changes if c != NoOp()]
+    if not changes:
+        return NoOp()
     return _InParallel(changes=changes)
 
 
@@ -142,4 +145,13 @@ def sequentially(changes):
 
     Failures in earlier changes stop later changes.
     """
+    changes = [c for c in changes if c != NoOp()]
+    if not changes:
+        return NoOp()
     return _Sequentially(changes=changes)
+
+
+@implementer(IStateChange):
+class NoOp(object):
+    def run(self, deployer):
+        return succeed(None)

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -16,11 +16,12 @@ changes.
 
 from zope.interface import Interface, Attribute, implementer
 
-from pyrsistent import PVector, PRecord, pvector, field
+from pyrsistent import PVector, PRecord, pvector, field, PClass
 
 from twisted.internet.defer import maybeDeferred, succeed
 
 from eliot.twisted import DeferredContext
+from eliot import ActionType
 
 from ..common import gather_deferreds
 
@@ -121,8 +122,7 @@ def in_parallel(changes):
     The order in which execution of the changes is started is unspecified.
     Comparison of the resulting object disregards the ordering of the changes.
     """
-    changes = [c for c in changes if c != NoOp()]
-    if not changes:
+    if not any(c for c in changes if c != NoOp()):
         return NoOp()
     return _InParallel(changes=changes)
 
@@ -145,13 +145,22 @@ def sequentially(changes):
 
     Failures in earlier changes stop later changes.
     """
-    changes = [c for c in changes if c != NoOp()]
-    if not changes:
+    if not any(c for c in changes if c != NoOp()):
         return NoOp()
     return _Sequentially(changes=changes)
 
 
-@implementer(IStateChange):
-class NoOp(object):
+LOG_NOOP = ActionType("flocker:change:noop", [], [], "We've done nothing.")
+
+
+@implementer(IStateChange)
+class NoOp(PClass):
+    """
+    Do nothing.
+    """
+    @property
+    def eliot_action(self):
+        return LOG_NOOP()
+
     def run(self, deployer):
         return succeed(None)

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -121,8 +121,14 @@ def in_parallel(changes):
 
     The order in which execution of the changes is started is unspecified.
     Comparison of the resulting object disregards the ordering of the changes.
+
+    @param changes: A sequence of ``IStateChange`` providers.
+
+    @return: ``IStateChange`` provider that will run given changes in
+        parallel, or ``NoOp`` instance if changes are empty or all
+        ``NoOp``.
     """
-    if not any(c for c in changes if c != NoOp()):
+    if all(c == NoOp() for c in changes):
         return NoOp()
     return _InParallel(changes=changes)
 
@@ -144,8 +150,14 @@ def sequentially(changes):
     Run a series of changes in sequence, one after the other.
 
     Failures in earlier changes stop later changes.
+
+    @param changes: A sequence of ``IStateChange`` providers.
+
+    @return: ``IStateChange`` provider that will run given changes
+        serially, or ``NoOp`` instance if changes are empty or all
+        ``NoOp``.
     """
-    if not any(c for c in changes if c != NoOp()):
+    if all(c == NoOp() for c in changes):
         return NoOp()
     return _Sequentially(changes=changes)
 

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -123,6 +123,9 @@ class IDeployer(Interface):
         Calculate the state changes necessary to make the local state match the
         desired cluster configuration.
 
+        If no state changes are needed then ``flocker.node.NoOp`` should
+        be returned.
+
         :param Deployment configuration: The intended configuration of all
             nodes.
 

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -511,9 +511,6 @@ def build_convergence_loop_fsm(reactor, deployer):
         S.SLEEPING, {
             I.WAKEUP: ([O.CLEAR_WAKEUP, O.CONVERGE], S.CONVERGING),
             I.STOP: ([O.CLEAR_WAKEUP], S.STOPPED),
-            # At some point in FLOC-3205 might want to make this interrupt
-            # sleep, but at the moment that would increase polling which
-            # we don't want.
             I.STATUS_UPDATE: (
                 [O.STORE_INFO, O.UPDATE_MAYBE_WAKEUP], S.SLEEPING),
             })

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -514,7 +514,8 @@ def build_convergence_loop_fsm(reactor, deployer):
             # At some point in FLOC-3205 might want to make this interrupt
             # sleep, but at the moment that would increase polling which
             # we don't want.
-            I.STATUS_UPDATE: ([O.STORE_INFO, O.UPDATE_MAYBE_WAKEUP], S.SLEEPING),
+            I.STATUS_UPDATE: (
+                [O.STORE_INFO, O.UPDATE_MAYBE_WAKEUP], S.SLEEPING),
             })
 
     loop = ConvergenceLoop(reactor, deployer)

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -64,7 +64,7 @@ from ..blockdevice import (
     UnknownInstanceID,
 )
 
-from ... import run_state_change, in_parallel, ILocalState
+from ... import run_state_change, in_parallel, ILocalState, NoOp
 from ...testtools import (
     ideployer_tests_factory, to_node, assert_calculated_changes_for_deployer,
     compute_cluster_state
@@ -925,7 +925,7 @@ class BlockDeviceDeployerAlreadyConvergedCalculateChangesTests(
 
         assert_calculated_changes(
             self, local_state, local_config, set(),
-            in_parallel(changes=[])
+            NoOp(),
         )
 
     def test_deleted_ignored(self):

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -171,16 +171,24 @@ class InParallelIStateChangeTests(
 class NoOpIStateChangeTests(make_istatechange_tests(NoOp, {}, {})):
     """
     Tests for the ``IStateChange`` implementation provided by ``NoOp``.
+
+    Inherits some equality/inequality tests we need to override because
+    they assume instances can be different, which is not the case for
+    ``NoOp``.
     """
     def test_equality(self):
         """
         All instances are equal.
+
+        Overrides test in base class.
         """
         self.assertTrue(NoOp() == NoOp())
 
     def test_notequality(self):
         """
         Not relevant for ``NoOp``.
+
+        Overrides test in base class.
         """
         raise SkipTest("All NoOp instances are equal.")
 

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -4,6 +4,8 @@
 Tests for ``flocker.node._change``.
 """
 
+from unittest import SkipTest
+
 from zope.interface import implementer
 
 from pyrsistent import PRecord, field
@@ -21,7 +23,7 @@ from ..testtools import (
 )
 from ...testtools import CustomException
 
-from .. import IStateChange, sequentially, in_parallel, run_state_change
+from .. import IStateChange, sequentially, in_parallel, run_state_change, NoOp
 
 from .istatechange import (
     DummyStateChange, RunSpyStateChange, make_istatechange_tests,
@@ -166,6 +168,29 @@ class InParallelIStateChangeTests(
         self.assertEqual(2, the_change.value)
 
 
+class NoOpIStateChangeTests(make_istatechange_tests(NoOp, {}, {})):
+    """
+    Tests for the ``IStateChange`` implementation provided by ``NoOp``.
+    """
+    def test_equality(self):
+        """
+        All instances are equal.
+        """
+        self.assertTrue(NoOp() == NoOp())
+
+    def test_notequality(self):
+        """
+        Not relevant for ``NoOp``.
+        """
+        raise SkipTest("All NoOp instances are equal.")
+
+    def test_run(self):
+        """
+        ``NoOp.run`` returns a fired ``Deferred``.
+        """
+        self.assertEqual(self.successResultOf(NoOp().run(None)), None)
+
+
 def _test_nested_change(case, outer_factory, inner_factory):
     """
     Assert that ``IChangeState`` providers wrapped inside ``inner_factory``
@@ -285,6 +310,18 @@ class SequentiallyTests(SynchronousTestCase):
         nested within a ``sequentially``.
         """
         _test_nested_change(self, sequentially, in_parallel)
+
+    def test_empty(self):
+        """
+        ``sequentially`` with no sub-changes becomes a ``NoOp``.
+        """
+        self.assertEqual(sequentially(changes=[]), NoOp())
+
+    def test_noops(self):
+        """
+        ``sequentially`` with only ``NoOp`` sub-changes becomes a ``NoOp``.
+        """
+        self.assertEqual(sequentially(changes=[NoOp(), NoOp()]), NoOp())
 
 
 class InParallelTests(SynchronousTestCase):
@@ -418,6 +455,18 @@ class InParallelTests(SynchronousTestCase):
         nested within an ``in_parallel``.
         """
         _test_nested_change(self, in_parallel, sequentially)
+
+    def test_empty(self):
+        """
+        ``in_parallel`` with no sub-changes becomes a ``NoOp``.
+        """
+        self.assertEqual(in_parallel(changes=[]), NoOp())
+
+    def test_noops(self):
+        """
+        ``in_parallel`` with only ``NoOp`` sub-changes becomes a ``NoOp``.
+        """
+        self.assertEqual(in_parallel(changes=[NoOp(), NoOp()]), NoOp())
 
 
 class RunStateChangeTests(SynchronousTestCase):

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -24,7 +24,7 @@ from twisted.python.filepath import FilePath
 from zope.interface.verify import verifyObject
 
 from .. import (
-    ApplicationNodeDeployer, P2PManifestationDeployer,
+    ApplicationNodeDeployer, P2PManifestationDeployer, NoOp,
 )
 from ..testtools import (
     ControllableAction, ControllableDeployer, ideployer_tests_factory, EMPTY,
@@ -1067,7 +1067,7 @@ def no_change():
     Construct the exact ``IStateChange`` that ``ApplicationNodeDeployer``
     returns when it doesn't want to make any changes.
     """
-    return sequentially(changes=[])
+    return NoOp()
 
 
 class ApplicationNodeDeployerCalculateVolumeChangesTests(SynchronousTestCase):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -611,12 +611,14 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
     @validate_logging(assert_full_logging)
     def convergence_iteration(
             self, logger,
-            later_action=ControllableAction(result=succeed(None))):
+            later_actions=[ControllableAction(result=succeed(None)),
+                           ControllableAction(result=succeed(None))]):
         """
         Do one iteration of a convergence loop.
 
-        :param later_action: ``IStateChange`` to return second and third
-            times discovery is done, i.e. after first iteration.
+        :param later_actions: List of ``IStateChange``, to be returned
+            second and third times discovery is done, i.e. after first
+            iteration.
 
         :return: ``ConvergenceLoop`` in SLEEPING state.
         """
@@ -626,7 +628,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         self.action = action = ControllableAction(result=succeed(None))
         self.deployer = deployer = ControllableDeployer(
             local_state.hostname, [succeed(local_state), succeed(local_state)],
-            [action, later_action, later_action]
+            [action] + later_actions,
         )
         client = self.make_amp_client([local_state])
         self.reactor = reactor = Clock()
@@ -675,7 +677,7 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
         """
         # Later calculations will return a NoOp(), indicating no need to
         # wake up:
-        loop = self.convergence_iteration(later_action=NoOp())
+        loop = self.convergence_iteration(later_actions=[NoOp(), NoOp()])
         node_state = NodeState(hostname=u'192.0.3.5')
         changed_configuration = Deployment(
             nodes=frozenset([to_node(node_state)]))


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3318
http://build.clusterhq.com/boxes-flocker?branch=wakeup-loop-if-changes-matter-FLOC-3318

1. Update sequentially/in_parallel so they indicate a no-op if they're not going to take any action.
2. Whenever the convergence loop receives an update from the control service while sleeping, it calculates what changes need to be made given that update, without doing any local discovery. If the result is not a no-op this means we should wake up, since the update apparently required some action on our part. Since `calculate_changes` is supposed to be purely in-memory operation this additional check should have limited no impact on system load, e.g. no cloud API calls involved.
3. Demonstrate that individual deployers return `NoOp` when no changes are needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2087)
<!-- Reviewable:end -->
