### PR TITLE
[FLOC 647] Standardise space - no space before units

### DIFF
--- a/docs/concepts/clustering.rst
+++ b/docs/concepts/clustering.rst
@@ -9,11 +9,11 @@ Minimal Downtime Volume Migration
 
 Flocker's cluster management logic uses the volume manager (see :ref:`volume`) to efficiently move containers' data between nodes.
 
-Consider a MongoDB application with a 20GB volume being moved from node A to node B.
+Consider a MongoDB application with a 20 GB volume being moved from node A to node B.
 The naive implementation would be:
 
 #. Shut down MongoDB on node A.
-#. :ref:`Push<volume-push>` all 20GB of data to node B with no database running.
+#. :ref:`Push<volume-push>` all 20 GB of data to node B with no database running.
 #. :ref:`Hand off<volume-handoff>` ownership of the volume to node B, a quick operation.
 #. Start MongoDB on node B.
 
@@ -21,11 +21,11 @@ This method would cause significant downtime.
 
 Instead Flocker uses a superior two-phase push:
 
-#. Push the full 20GB of data in the volume from node A to a node B.
+#. Push the full 20 GB of data in the volume from node A to a node B.
    Meanwhile MongoDB continues to run on node A.
 #. Shut down MongoDB on node A.
 #. Push only the changes that were made to the volume since the last push happened.
-   This will likely be orders of magnitude less than 20GB, depending on what database activity happened in the interim.
+   This will likely be orders of magnitude less than 20 GB, depending on what database activity happened in the interim.
 #. Hand off ownership of the volume to node B, a quick operation.
 #. Start MongoDB on node B.
 

--- a/docs/install/install-node.rst
+++ b/docs/install/install-node.rst
@@ -15,7 +15,7 @@ Before you begin to install the Flocker node services, you will need the followi
   
   * We support installing the Flocker node services on either :ref:`CentOS 7<centos-7-install>` or :ref:`Ubuntu 14.04<ubuntu-14.04-install>`.
   * If you do not have any nodes, see our :ref:`helpful-guides` which can be used to help you set up nodes using either :ref:`Amazon Web Services<aws-install>` or :ref:`Rackspace<rackspace-install>`.
-  * To avoid potential disk space problems (for example, when storing popular Docker images), we recommend a minimum of 16GB storage on each node.
+  * To avoid potential disk space problems (for example, when storing popular Docker images), we recommend a minimum of 16 GB storage on each node.
 
 * You will need permission for SSH access from your laptop.
 * Depending on your usage of Flocker, you will require access to a range of ports.

--- a/docs/install/setup-aws.rst
+++ b/docs/install/setup-aws.rst
@@ -31,7 +31,7 @@ Setting Up Nodes Using Amazon Web Services
    * Configure instance details.
      You will need to configure a minimum of 2 instances.
    * Add storage.
-     It is important to note that the default storage of an AWS image can be too small to store popular Docker images, so we recommend choosing at least 16GB to avoid potential disk space problems.
+     It is important to note that the default storage of an AWS image can be too small to store popular Docker images, so we recommend choosing at least 16 GB to avoid potential disk space problems.
    * Tag instance.
    * Configure security group.
       

--- a/docs/tutorials_examples/tutorial/vagrant-setup.rst
+++ b/docs/tutorials_examples/tutorial/vagrant-setup.rst
@@ -18,7 +18,7 @@ To replicate the steps demonstrated in this tutorial, you will need:
 * Linux, FreeBSD, or OS X
 * `Vagrant`_ (1.6.2 or newer)
 * `VirtualBox`_
-* At least 10GB disk space available for the two virtual machines
+* At least 10 GB disk space available for the two virtual machines
 * The OpenSSH client (the ``ssh``, ``ssh-agent``, and ``ssh-add`` command line programs)
 * bash
 * The ``mongo`` MongoDB interactive shell (see below for installation instructions)
@@ -94,9 +94,9 @@ These two IP addresses will be used throughout the tutorial and configuration fi
    On some versions of Vagrant and VirtualBox, restarting the tutorial virtual machines via the ``vagrant halt`` and ``vagrant up`` commands can result in losing the static IP configuration, making the nodes unreachable on the assigned ``172.15.255.25x`` addresses.
    In this case you should destroy and recreate the machines with the ``vagrant destroy`` and ``vagrant up`` commands.
 
-.. note:: The two virtual machines are each assigned a 10GB virtual disk.
-          The underlying disk files grow to about 5GB.
-          So you will need at least 10GB of free disk space on your workstation.
+.. note:: The two virtual machines are each assigned a 10 GB virtual disk.
+          The underlying disk files grow to about 5 GB.
+          So you will need at least 10 GB of free disk space on your workstation.
 
 #. Create a tutorial directory:
 


### PR DESCRIPTION
Fixes 647

An old issue, but was updated due to ongoing work on creating a style guide for documentation. 

Note - there is no current use of "Mb" in the docs
