### PR TITLE
[Floc 3338] Use title case in Labs docs

### DIFF
--- a/docs/labs/compose.rst
+++ b/docs/labs/compose.rst
@@ -49,7 +49,7 @@ you can run a ``docker-compose up`` command as you would normally.
 
     docker-compose up -d
 
-Data volume format - standard
+Data Volume Format - Standard
 =============================
 
 When you use Flocker to manage data volumes with Compose the format of the data volume is slightly different than normal Docker volumes.
@@ -65,7 +65,7 @@ For a normal Docker volume - you would provide the ``host path`` and ``container
 
 In this example ``/var/lib/redis`` is the host path and ``/data`` is the container path.
 
-Data volume format - Flocker
+Data Volume Format - Flocker
 ============================
 
 For a Flocker managed volume - you still provide the container path but instead of a host path, you provide a global name for the volume.

--- a/docs/labs/index.rst
+++ b/docs/labs/index.rst
@@ -42,7 +42,7 @@ The goals of ClusterHQ Labs are to make it possible to:
 Our biggest step towards this goal so far is the Flocker plugin for Docker, which enables you to integrate Flocker with tools like :ref:`Swarm <labs-swarm>` and :ref:`Compose <labs-compose>`, and pluggable directly into the Docker Engine and directly usable from the ``docker run`` CLI.
 The Flocker plugin for Docker started out as an unofficial labs project, but is now supported in the :ref:`docker-plugin` documentation.
 
-Mega demo
+Mega Demo
 =========
 
 Also check out the `DockerCon Plugin Demos <https://plugins-demo-2015.github.io/>`_ site to see a joint project between ClusterHQ and Weaveworks.
@@ -50,14 +50,14 @@ This is the "ultimate integration demo" — a pre-built demo environment that in
 
 .. _labs-contact:
 
-Getting in touch with ClusterHQ Labs
-====================================
+ClusterHQ Labs Feedback
+=======================
 
 Come and talk to us on our IRC channel which is on Freenode ``#clusterhq``.
 
 Or, file an issue on GitHub for the `Unofficial Flocker Tools <https://github.com/clusterhq/unofficial-flocker-tools>`_ for CLI, GUI, or installer issues.
 
-List of Labs projects
+List of Labs Projects
 =====================
 
 .. toctree::

--- a/docs/labs/installer.rst
+++ b/docs/labs/installer.rst
@@ -6,7 +6,7 @@ Installer
 
 This document guides you through setting up a Flocker cluster and gives a simple example of deploying and moving around a service which includes a stateful container.
 
-Key points
+Key Points
 ==========
 
 * Flocker is a clustered container data volume manager.
@@ -93,7 +93,7 @@ This will work on Linux or OS X machines with Docker installed.
 
 .. _labs-installer-certs-directory:
 
-Make a local directory for your cluster files
+Make a Local Directory for your Cluster Files
 =============================================
 
 The tools will create some configuration files and certificate files for your cluster.
@@ -106,7 +106,7 @@ It is convenient to keep these in a directory, so let's make a directory on your
 
 Now we'll put some files in this directory.
 
-Get some nodes
+Get Some Nodes
 ==============
 
 So now let's use the tools we've just installed to deploy and configure a Flocker cluster.
@@ -177,8 +177,8 @@ This step should take about 5 minutes, and will:
 * start all the requisite Flocker services
 * install the Flocker plugin for Docker, so that you can control Flocker directly from the Docker CLI
 
-Check that Flocker cluster is active
-====================================
+Check that the Flocker Cluster is Active
+========================================
 
 Try the Flocker CLI to check that all your nodes came up:
 
@@ -189,7 +189,7 @@ Try the Flocker CLI to check that all your nodes came up:
 
 You can see that there are no volumes yet.
 
-Deploy and migrate a stateful app
+Deploy and Migrate a Stateful App
 =================================
 
 Now you will deploy a highly sophisticated stateful app to test out Flocker.
@@ -236,7 +236,7 @@ This may take up to a minute since Flocker is ensuring the volume is on the seco
 Now visit ``http://<node 2 public IP>/`` and you’ll see that the location of the Moby Docks has been preserved.
 Nice.
 
-Cleaning up your cluster
+Cleaning up your Cluster
 ========================
 
 When you're done, if you want to clean up, run the following steps to clean up your volumes, your instances and your local files:
@@ -259,7 +259,7 @@ When you're done, if you want to clean up, run the following steps to clean up y
 
     If you wish to clean up your cluster manually, be sure to delete the instances that were created in your AWS console and the ``flocker_rules`` security group.
 
-Further reading
+Further Reading
 ===============
 
 Now that you've installed your own Flocker cluster, you may want to learn more about Flocker:

--- a/docs/labs/swarm.rst
+++ b/docs/labs/swarm.rst
@@ -21,7 +21,7 @@ You can use the following commands to install swarm from our uploaded binary.
 
 Alternatively - you can `compile swarm from master <https://github.com/docker/swarm#development-installation>`_ and the resulting binary will also have ``--volume-driver`` support.
 
-Running a container via swarm
+Running a Container via Swarm
 =============================
 
 Here is an example of a docker run command that provisions a Flocker volume via Swarm.
@@ -34,7 +34,7 @@ Here is an example of a docker run command that provisions a Flocker volume via 
     docker run -v demo:/data --volume-driver flocker redis
 
 
-Targeting specific hosts
+Targeting Specific Hosts
 ========================
 
 You can use Swarm constraints to target containers to specific hosts.

--- a/docs/labs/volumes-gui.rst
+++ b/docs/labs/volumes-gui.rst
@@ -10,7 +10,7 @@ This is a very simple web interface to view the current state of the datasets (v
 
 You can also create volumes with sizes and metadata, and move datasets around between hosts by changing their primary.
 
-Trying out the volumes GUI
+Trying Out the Volumes GUI
 ==========================
 
 Prerequisites:
@@ -19,7 +19,7 @@ Prerequisites:
 * Docker (either locally or in `boot2docker <https://docs.docker.com/installation/mac/>`_ on OS X).
 * A web browser (tested on Google Chrome).
 
-Step 1 - run the container with your local keys
+Step 1 - Run the Container with your Local Keys
 ===============================================
 
 Run this command from the directory where you created your cluster configuration and certificates, for example ``~/clusters/test``:
@@ -45,7 +45,7 @@ Run this command from the directory where you created your cluster configuration
     You must substitute ``your.control.service`` with the name (or IP address, depending on how you configured it) of your control service and ``certuser`` with the name of an API user you generated a key and certificate for (where you have those files in your current working directory).
     Refer to the instructions in the :ref:`experimental installer <labs-installer>`.
 
-Step 2 - load up the experimental Flocker GUI
+Step 2 - Load Up the Experimental Flocker GUI
 =============================================
 
 Go to `http://localhost/client/#/nodes/list <http://localhost/client/#/nodes/list>`_ or, if you are using ``boot2docker``:


### PR DESCRIPTION
Fixes 3338

Quick fix to consistently use title case in all documentation headers (as per the WIP Doc style guide: https://docs.google.com/spreadsheets/d/11E38SvKX7ujJ95qs7rvzgh3vIVmPyiTOSsvjR8KWMoY/edit#gid=0)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2093)
<!-- Reviewable:end -->
