### PR TITLE
[FLOC-3271] Acceptance test for Flocker for storage profiles.

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -99,6 +99,8 @@ def get_trial_environment(cluster):
         'FLOCKER_ACCEPTANCE_DEFAULT_VOLUME_SIZE': bytes(
             cluster.default_volume_size
         ),
+        'FLOCKER_ACCEPTANCE_TEST_VOLUME_BACKEND_CONFIG':
+            cluster.dataset_backend_config_file
     }
 
 
@@ -339,10 +341,30 @@ def generate_certificates(cluster_id, nodes):
     )
     return certificates
 
+def _save_backend_configuration(dataset_backend_name,
+                                dataset_backend_configuration):
+    """
+    Saves the backend configuration to a local file for consumption by the
+    trial process.
+
+    :param dataset_backend_name: The name of the dataset_backend.
+
+    :param dataset_backend_configuration: The configuration of the
+        dataset_backend.
+
+    :returns: The filepath in a string to the temporary file where the dataset
+        backend configuration was saved.
+    """
+    dataset_path = FilePath(mkdtemp()).child('dataset-backend.yml')
+    print("Saving dataset backend config to: {}".format(dataset_path.path))
+    dataset_path.setContent(yaml.safe_dump(
+            {dataset_backend_name.name: dataset_backend_configuration}))
+    return dataset_path.path
+
 
 def configured_cluster_for_nodes(
     reactor, certificates, nodes, dataset_backend,
-    dataset_backend_configuration
+    dataset_backend_configuration, dataset_backend_config_file
 ):
     """
     Get a ``Cluster`` with Flocker services running on the right nodes.
@@ -356,6 +378,8 @@ def configured_cluster_for_nodes(
         use when they are "started".
     :param dict dataset_backend_configuration: The backend-specific
         configuration the nodes will be given for their dataset backend.
+    :param str dataset_backend_config_file: A file that has the dataset_backend
+        info stored.
 
     :returns: A ``Deferred`` which fires with ``Cluster`` when it is
         configured.
@@ -386,7 +410,8 @@ def configured_cluster_for_nodes(
         agent_nodes=nodes,
         dataset_backend=dataset_backend,
         default_volume_size=int(default_volume_size.to_Byte().value),
-        certificates=certificates
+        certificates=certificates,
+        dataset_backend_config_file=dataset_backend_config_file
     )
 
     configuring = perform(
@@ -583,6 +608,8 @@ class LibcloudRunner(object):
             self.nodes,
             self.dataset_backend,
             self.dataset_backend_configuration,
+            _save_backend_configuration(self.dataset_backend,
+                                        self.dataset_backend_configuration)
         )
 
         returnValue(cluster)

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -5,6 +5,7 @@ Tests for the datasets REST API.
 """
 
 from uuid import UUID
+from unittest import skipUnless
 
 from twisted.trial.unittest import TestCase
 
@@ -13,6 +14,8 @@ from ...testtools import loop_until
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset, DatasetBackend
 )
+
+STORAGE_PROFILES_IMPLEMENTED = False
 
 
 class DatasetAPITests(TestCase):
@@ -26,6 +29,8 @@ class DatasetAPITests(TestCase):
         """
         return create_dataset(self, cluster)
 
+    @skipUnless(STORAGE_PROFILES_IMPLEMENTED,
+                "Flocker storage profiles are not implemented yet.")
     @require_cluster(1, required_backend=DatasetBackend.aws)
     def test_dataset_creation_with_gold_profile(self, cluster, backend):
         """

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -11,7 +11,7 @@ from twisted.trial.unittest import TestCase
 from ...testtools import loop_until
 
 from ..testtools import (
-    require_cluster, require_moving_backend, create_dataset,
+    require_cluster, require_moving_backend, create_dataset, DatasetBackend
 )
 
 
@@ -25,6 +25,30 @@ class DatasetAPITests(TestCase):
         A dataset can be created on a specific node.
         """
         return create_dataset(self, cluster)
+
+    @require_cluster(1, required_backend=DatasetBackend.aws)
+    def test_dataset_creation_with_gold_profile(self, cluster, backend):
+        """
+        A dataset created with the gold profile as specified in metadata on EBS
+        has EBS volume type 'io1'.
+
+        This is verified by constructing an EBS backend in this process, purely
+        for the sake of using it as a wrapper on the cloud API.
+        """
+        waiting_for_create = create_dataset(
+            self, cluster, maximum_size=4*1024*1024*1024,
+            metadata={u"clusterhq:flocker:profile": u"gold"})
+
+        def confirm_gold(dataset):
+            volumes = backend.list_volumes()
+            for volume in volumes:
+                if volume.dataset_id == dataset.dataset_id:
+                    break
+            ebs_volume = backend._get_ebs_volume(volume.blockdevice_id)
+            self.assertEqual('io1', ebs_volume.type)
+
+        waiting_for_create.addCallback(confirm_gold)
+        return waiting_for_create
 
     @require_moving_backend
     @require_cluster(2)

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -15,7 +15,7 @@ from ..testtools import (
     require_cluster, require_moving_backend, create_dataset, DatasetBackend
 )
 
-STORAGE_PROFILES_IMPLEMENTED = True
+STORAGE_PROFILES_IMPLEMENTED = False
 
 
 class DatasetAPITests(TestCase):

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -15,7 +15,7 @@ from ..testtools import (
     require_cluster, require_moving_backend, create_dataset, DatasetBackend
 )
 
-STORAGE_PROFILES_IMPLEMENTED = False
+STORAGE_PROFILES_IMPLEMENTED = True
 
 
 class DatasetAPITests(TestCase):

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -209,13 +209,10 @@ def get_backend_api(test_case, cluster_id):
             'in order to verify construction. Please set '
             'FLOCKER_ACCEPTANCE_TEST_VOLUME_BACKEND_CONFIG to a yaml filepath '
             'with the dataset configuration.')
-    print backend_config_filename
     backend_config_filepath = FilePath(backend_config_filename)
     full_backend_config = yaml.safe_load(
         backend_config_filepath.getContent())
-    print full_backend_config
     backend_config = full_backend_config.get(backend_name)
-    print backend_config
     if 'backend' in backend_config:
         backend_config.pop('backend')
     return aws_from_configuration(cluster_id=cluster_id, **backend_config)

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -7,11 +7,12 @@ from functools import wraps
 from json import dumps
 from os import environ, close
 from unittest import SkipTest, skipUnless
-from uuid import uuid4
+from uuid import uuid4, UUID
 from socket import socket
 from contextlib import closing
 from tempfile import mkstemp
 
+import yaml
 import json
 import ssl
 
@@ -39,9 +40,10 @@ from ..common import gather_deferreds
 from ..common.runner import download_file
 
 from ..control.httpapi import REST_API_PORT
-from ..ca import treq_with_authentication
+from ..ca import treq_with_authentication, UserCredential
 from ..testtools import loop_until, random_name
 from ..apiclient import FlockerClient, DatasetState
+from ..node.agents.ebs import aws_from_configuration
 
 try:
     from pymongo import MongoClient
@@ -177,6 +179,42 @@ def get_dataset_backend(test_case):
             "Set acceptance testing volume backend using the " +
             "FLOCKER_ACCEPTANCE_VOLUME_BACKEND environment variable.")
     return DatasetBackend.lookupByName(backend)
+
+
+def get_backend_api(test_case, cluster_id):
+    """
+    Get an appropriate BackendAPI for the specified dataset backend.
+
+    Note this is a backdoor that is useful to be able to interact with cloud
+    APIs in tests. For many dataset backends this does not make sense, but it
+    provides a convenient means to interact with cloud backends such as EBS or
+    cinder.
+
+    :param test_case: The test case that is being run.
+
+    :param cluster_id: The unique cluster_id, used for backend APIs that
+        require this in order to be constructed.
+    """
+    backend_type = get_dataset_backend(test_case)
+    if backend_type != DatasetBackend.aws:
+        raise SkipTest(
+            'This test is asking for backend type {} but only constructing '
+            'aws backends is currently supported'.format(backend_type.name))
+    backend_name = backend_type.name
+    backend_config_filename = environ.get(
+        "FLOCKER_ACCEPTANCE_TEST_VOLUME_BACKEND_CONFIG")
+    if backend_config_filename is None:
+        raise SkipTest(
+            'This test requires the ability to construct an IBlockDeviceAPI '
+            'in order to verify construction. Please set '
+            'FLOCKER_ACCEPTANCE_TEST_VOLUME_BACKEND_CONFIG to a yaml filepath '
+            'with the dataset configuration.')
+    backend_config_filepath = FilePath(backend_config_filename)
+    full_backend_config = yaml.safe_load(
+        backend_config_filepath.getContent())
+    backend_config = full_backend_config.get(backend_name)
+    backend_config.pop('backend')
+    return aws_from_configuration(cluster_id=cluster_id, **backend_config)
 
 
 def skip_backend(unsupported, reason):
@@ -370,6 +408,7 @@ class Cluster(PRecord):
     treq = field(mandatory=True)
     client = field(type=FlockerClient, mandatory=True)
     certificates_path = field(FilePath, mandatory=True)
+    cluster_uuid = field(mandatory=True, type=UUID)
 
     @property
     def base_url(self):
@@ -718,6 +757,7 @@ def _get_test_cluster(reactor, node_count):
     cluster_cert = certificates_path.child(b"cluster.crt")
     user_cert = certificates_path.child(b"user.crt")
     user_key = certificates_path.child(b"user.key")
+    user_credential = UserCredential.from_files(user_cert, user_key)
     cluster = Cluster(
         control_node=ControlService(public_address=control_node),
         nodes=[],
@@ -726,6 +766,7 @@ def _get_test_cluster(reactor, node_count):
         client=FlockerClient(reactor, control_node, REST_API_PORT,
                              cluster_cert, user_cert, user_key),
         certificates_path=certificates_path,
+        cluster_uuid=user_credential.cluster_uuid,
     )
 
     hostname_to_public_address_env_var = environ.get(
@@ -774,12 +815,21 @@ def _get_test_cluster(reactor, node_count):
     return agents_connected
 
 
-def require_cluster(num_nodes):
+def require_cluster(num_nodes, required_backend=None):
     """
     A decorator which will call the supplied test_method when a cluster with
     the required number of nodes is available.
 
     :param int num_nodes: The number of nodes that are required in the cluster.
+
+    :param required_backend: This optional parameter can be set to a
+        ``DatasetBackend`` constant in order to construct the requested backend
+        for use in the test. This is done in a backdoor sort of manner, and is
+        only for use by tests which want to interact with the specified backend
+        in order to verify the acceptance test should pass. If this is set, the
+        backend api will be sent as a keyword argument ``backend`` to the test,
+        and the test will be skipped if the cluster is not set up for the
+        specified backend.
     """
     def decorator(test_method):
         """
@@ -789,6 +839,15 @@ def require_cluster(num_nodes):
         """
         def call_test_method_with_cluster(cluster, test_case, args, kwargs):
             kwargs['cluster'] = cluster
+            if required_backend:
+                backend_type = get_dataset_backend(test_case)
+                if backend_type != required_backend:
+                    raise SkipTest(
+                        'This test requires backend type {} but is being run '
+                        'on {}.'.format(backend_type.name,
+                                        required_backend.name))
+                kwargs['backend'] = get_backend_api(test_case,
+                                                    cluster.cluster_uuid)
             return test_method(test_case, *args, **kwargs)
 
         @wraps(test_method)
@@ -849,7 +908,8 @@ def create_python_container(test_case, cluster, parameters, script,
     return creating
 
 
-def create_dataset(test_case, cluster, maximum_size=None, dataset_id=None):
+def create_dataset(test_case, cluster, maximum_size=None, dataset_id=None,
+                   metadata=None):
     """
     Create a dataset on a cluster (on its first node, specifically).
 
@@ -859,6 +919,8 @@ def create_dataset(test_case, cluster, maximum_size=None, dataset_id=None):
         cluster.
     :param UUID dataset_id: The v4 UUID of the dataset.
         Generated if not specified.
+    :param dict metadata: Additional metadata to be added to the create_dataset
+        request beyond the default "name": "my_volume" metadata.
     :return: ``Deferred`` firing with a ``flocker.apiclient.Dataset``
         dataset is present in actual cluster state.
     """
@@ -866,10 +928,12 @@ def create_dataset(test_case, cluster, maximum_size=None, dataset_id=None):
         maximum_size = get_default_volume_size()
     if dataset_id is None:
         dataset_id = uuid4()
-
+    if metadata is None:
+        metadata = {}
+    metadata[u"name"] = metadata.get(u"name", u"my_volume")
     configuring_dataset = cluster.client.create_dataset(
         cluster.nodes[0].uuid, maximum_size=maximum_size,
-        dataset_id=dataset_id, metadata={u"name": u"my_volume"}
+        dataset_id=dataset_id, metadata=metadata
     )
 
     # Wait for the dataset to be created

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -209,11 +209,15 @@ def get_backend_api(test_case, cluster_id):
             'in order to verify construction. Please set '
             'FLOCKER_ACCEPTANCE_TEST_VOLUME_BACKEND_CONFIG to a yaml filepath '
             'with the dataset configuration.')
+    print backend_config_filename
     backend_config_filepath = FilePath(backend_config_filename)
     full_backend_config = yaml.safe_load(
         backend_config_filepath.getContent())
+    print full_backend_config
     backend_config = full_backend_config.get(backend_name)
-    backend_config.pop('backend')
+    print backend_config
+    if 'backend' in backend_config:
+        backend_config.pop('backend')
     return aws_from_configuration(cluster_id=cluster_id, **backend_config)
 
 

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -844,8 +844,8 @@ def require_cluster(num_nodes, required_backend=None):
                 if backend_type != required_backend:
                     raise SkipTest(
                         'This test requires backend type {} but is being run '
-                        'on {}.'.format(backend_type.name,
-                                        required_backend.name))
+                        'on {}.'.format(required_backend.name,
+                                        backend_type.name))
                 kwargs['backend'] = get_backend_api(test_case,
                                                     cluster.cluster_uuid)
             return test_method(test_case, *args, **kwargs)
@@ -930,10 +930,11 @@ def create_dataset(test_case, cluster, maximum_size=None, dataset_id=None,
         dataset_id = uuid4()
     if metadata is None:
         metadata = {}
-    metadata[u"name"] = metadata.get(u"name", u"my_volume")
+    metadata_arg = {u"name": u"my_volume"}
+    metadata_arg.update(metadata)
     configuring_dataset = cluster.client.create_dataset(
         cluster.nodes[0].uuid, maximum_size=maximum_size,
-        dataset_id=dataset_id, metadata=metadata
+        dataset_id=dataset_id, metadata=metadata_arg
     )
 
     # Wait for the dataset to be created

--- a/flocker/ca/_ca.py
+++ b/flocker/ca/_ca.py
@@ -350,6 +350,8 @@ class UserCredential(PRecord):
     :ivar FlockerCredential credential: The certificate and key pair
         credential object.
     :ivar bytes username: A username.
+    :ivar UUID cluster_uuid: A unique identifier for the cluster this
+        certificate identifies, in the form of a version 4 UUID.
     """
     credential = field(mandatory=True, type=FlockerCredential)
     username = field(mandatory=True, type=unicode)
@@ -443,6 +445,10 @@ class UserCredential(PRecord):
         credential.write_credential_files(key_filename, cert_filename)
         instance = cls(credential=credential, username=username)
         return instance
+
+    @property
+    def cluster_uuid(self):
+        return UUID(hex=self.credential.certificate.getSubject().OU)
 
 
 class NodeCredential(PRecord):

--- a/flocker/ca/test/test_ca.py
+++ b/flocker/ca/test/test_ca.py
@@ -328,6 +328,16 @@ class UserCredentialTests(
         user_credential = UserCredential.from_files(certificate_path, key_path)
         self.assertEqual(u"alice", user_credential.username)
 
+    def test_certificate_ou_cluster_uuid(self):
+        """
+        A certificate written by ``UserCredential.initialize`` has the
+        organizational unit name exposed as the ``cluster_uuid``
+        attribute.
+        """
+        cert = self.credential.credential.certificate.original
+        subject = cert.get_subject()
+        self.assertEqual(UUID(hex=subject.OU), self.credential.cluster_uuid)
+
 
 class NodeCredentialTests(
         make_credential_tests(NodeCredential, NODE_UUID, uuid=NODE_UUID)):

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -71,6 +71,8 @@ class Cluster(PRecord):
     :ivar FilePath certificates_path: Directory where certificates can be
         found; specifically the directory used by ``Certificates``.
     :ivar Certificates certificates: Certificates to for the cluster.
+    :ivar unicode dataset_backend_config_file: File with the backend
+        configuration.
     """
     all_nodes = field(mandatory=True)
     control_node = field(mandatory=True)
@@ -78,6 +80,7 @@ class Cluster(PRecord):
     dataset_backend = field(mandatory=True)
     default_volume_size = field(type=int, mandatory=True)
     certificates = field(type=Certificates, mandatory=True)
+    dataset_backend_config_file = field(mandatory=True, type=str)
 
     @property
     def certificates_path(self):

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -6,6 +6,7 @@ from zope.interface import (
     Attribute as InterfaceAttribute, Interface)
 
 from twisted.python.constants import Values, ValueConstant
+from twisted.python.filepath import FilePath
 
 from flocker.common.version import make_rpm_version
 
@@ -71,7 +72,7 @@ class Cluster(PRecord):
     :ivar FilePath certificates_path: Directory where certificates can be
         found; specifically the directory used by ``Certificates``.
     :ivar Certificates certificates: Certificates to for the cluster.
-    :ivar unicode dataset_backend_config_file: File with the backend
+    :ivar FilePath dataset_backend_config_file: FilePath with the backend
         configuration.
     """
     all_nodes = field(mandatory=True)
@@ -80,7 +81,7 @@ class Cluster(PRecord):
     dataset_backend = field(mandatory=True)
     default_volume_size = field(type=int, mandatory=True)
     certificates = field(type=Certificates, mandatory=True)
-    dataset_backend_config_file = field(mandatory=True, type=str)
+    dataset_backend_config_file = field(mandatory=True, type=FilePath)
 
     @property
     def certificates_path(self):


### PR DESCRIPTION
This is the codified acceptance test for Flocker storage profiles basic support on EBS

It verifies that if a volume is created with the specific metadata that forces a profile for the volume, then the volume that is created has the correct EBS type for the given profile.

In the interest of keeping the acceptance tests lean, I've only added a test for gold rather than also testing for silver and bronze. I'm open to feedback on that decision. I figured this was enough to show the plumbing was there even if we aren't exhaustively testing every length of pipe at this level.

In order to validate the volume's performance characteristics from the acceptance test, this adds a backdoor to get the backend configuration from the process that sets up the acceptance test rig.  It then uses those credentials to verify the type of the volume created.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2094)
<!-- Reviewable:end -->
