### PR TITLE
Remove unused `skip_except`

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -289,7 +289,7 @@ def _volume_field():
     )
 
 
-class BlockDeviceVolume(PRecord):
+class BlockDeviceVolume(PClass):
     """
     A block device that may be attached to a host.
 

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -38,7 +38,7 @@ from twisted.internet.interfaces import (
     IProcessTransport, IReactorProcess, IReactorCore,
 )
 from twisted.python.filepath import FilePath, Permissions
-from twisted.python.reflect import prefixedMethodNames, safe_repr
+from twisted.python.reflect import safe_repr
 from twisted.internet.task import Clock, deferLater
 from twisted.internet.defer import maybeDeferred, Deferred
 from twisted.internet.error import ConnectionDone
@@ -1049,43 +1049,3 @@ def run_process(command, *args, **kwargs):
                 returncode=status, cmd=command, output=output,
             )
     return result
-
-
-def skip_except(supported_tests):
-    """
-    Mark all the ``test_`` methods in ``TestCase`` as ``skip`` unless the test
-    method names are in ``supported_tests``.
-
-    :param list supported_tests: The names of the tests that are expected to
-        pass.
-    """
-    test_prefix = 'test_'
-    skip_or_todo = 'skip'
-    noskip = os.environ.get('NOSKIP')
-    if noskip is not None:
-        return lambda test_case: test_case
-
-    def decorator(test_case):
-        test_method_names = [
-            test_prefix + name
-            for name
-            in prefixedMethodNames(test_case, test_prefix)
-        ]
-        for test_method_name in test_method_names:
-            if test_method_name not in supported_tests:
-                test_method = getattr(test_case, test_method_name)
-                new_message = []
-                existing_message = getattr(test_method, skip_or_todo, None)
-                if existing_message is not None:
-                    new_message.append(existing_message)
-                new_message.append('Not implemented yet')
-                new_message = ' '.join(new_message)
-
-                @wraps(test_method)
-                def wrapper(*args, **kwargs):
-                    return test_method(*args, **kwargs)
-                setattr(wrapper, skip_or_todo, new_message)
-                setattr(test_case, test_method_name, wrapper)
-
-        return test_case
-    return decorator


### PR DESCRIPTION
It's unused & untested. Why keep it?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2097)
<!-- Reviewable:end -->
