### PR TITLE
[FLOC-3343] No default reactor in retry helpers

### DIFF
--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -6,6 +6,7 @@ Tests for the datasets REST API.
 
 from uuid import UUID
 
+from twisted.internet import reactor
 from twisted.trial.unittest import TestCase
 
 from ...common import loop_until
@@ -69,7 +70,7 @@ class DatasetAPITests(TestCase):
                     lambda actual_datasets: dataset.dataset_id not in
                     (d.dataset_id for d in actual_datasets))
                 return request
-            deleted.addCallback(lambda _: loop_until(not_exists))
+            deleted.addCallback(lambda _: loop_until(reactor, not_exists))
             return deleted
         created.addCallback(delete_dataset)
         return created

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -5,13 +5,11 @@ Tests for the Flocker Docker plugin.
 """
 
 from twisted.internet import reactor
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SkipTest, TestCase
 
 from docker.utils import create_host_config
 
 from distutils.version import LooseVersion
-from twisted.internet import reactor
-from twisted.trial.unittest import SkipTest
 
 from ...common import loop_until
 from ...common.runner import run_ssh

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -10,6 +10,7 @@ from twisted.trial.unittest import TestCase
 from docker.utils import create_host_config
 
 from distutils.version import LooseVersion
+from twisted.internet import reactor
 from twisted.trial.unittest import SkipTest
 
 from ...common import loop_until
@@ -198,7 +199,7 @@ class DockerPluginTests(TestCase):
                 ds = check_http_server(node.public_address, host_port)
                 ds.addCallback(lambda succeeded: not succeeded)
                 return ds
-            looping = loop_until(http_closed)
+            looping = loop_until(reactor, http_closed)
             return looping
 
         d.addCallback(poll_http_server_stopped)

--- a/flocker/acceptance/integration/test_postgres.py
+++ b/flocker/acceptance/integration/test_postgres.py
@@ -6,6 +6,7 @@ Tests for interoperability between Postgres and Flocker datasets.
 
 from unittest import skipUnless
 
+from twisted.internet import reactor
 from twisted.python.filepath import FilePath
 
 from eliot import Message
@@ -45,7 +46,7 @@ def get_postgres_connection(host, port, database=None):
                 exception=unicode(e.__class__), reason=unicode(e)).write()
             return False
 
-    d = loop_until(connect_to_postgres)
+    d = loop_until(reactor, connect_to_postgres)
     return d
 
 

--- a/flocker/acceptance/obsolete/test_cli.py
+++ b/flocker/acceptance/obsolete/test_cli.py
@@ -7,6 +7,7 @@ Tests for the ``flocker-deploy`` command line tool.
 from copy import deepcopy
 from subprocess import check_call
 
+from twisted.internet import reactor
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import TestCase
 from yaml import safe_dump
@@ -101,7 +102,7 @@ class FlockerDeployTests(TestCase):
             d.addCallback(got_results)
             return d
 
-        return loop_until(configuration_matches_state)
+        return loop_until(reactor, configuration_matches_state)
 
     @require_flocker_cli
     @require_cluster(1)

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -6,8 +6,9 @@ Tests for the control service REST API.
 
 from json import loads, dumps
 
-from twisted.trial.unittest import TestCase
+from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
+from twisted.trial.unittest import TestCase
 
 from ...common import loop_until
 from ...testtools import random_name
@@ -224,7 +225,7 @@ class ContainerAPITests(TestCase):
                 current = cluster.current_containers()
                 current.addCallback(lambda result: data in result)
                 return current
-            return loop_until(in_current)
+            return loop_until(reactor, in_current)
         creating.addCallback(created)
         return creating
 

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -248,7 +248,7 @@ def get_mongo_client(host, port=27017):
         except PyMongoError:
             return False
 
-    d = loop_until(create_mongo_client)
+    d = loop_until(reactor, create_mongo_client)
     return d
 
 
@@ -413,7 +413,7 @@ class Cluster(PRecord):
             request.addCallback(got_results)
             return request
 
-        waiting = loop_until(deleted)
+        waiting = loop_until(reactor, deleted)
         waiting.addCallback(lambda _: deleted_dataset)
         return waiting
 
@@ -449,7 +449,7 @@ class Cluster(PRecord):
             request.addCallback(got_results)
             return request
 
-        waiting = loop_until(created)
+        waiting = loop_until(reactor, created)
         waiting.addCallback(lambda ignored: expected_dataset)
         return waiting
 
@@ -581,7 +581,7 @@ class Cluster(PRecord):
             request.addCallback(got_response)
             return request
 
-        return loop_until(created)
+        return loop_until(reactor, created)
 
     @log_method
     def current_nodes(self):
@@ -635,7 +635,7 @@ class Cluster(PRecord):
                 get_items.addCallback(delete_items)
                 get_items.addCallback(
                     lambda ignored: loop_until(
-                        lambda: state_method().addCallback(
+                        reactor, lambda: state_method().addCallback(
                             lambda result: [] == result
                         )
                     )
@@ -764,7 +764,7 @@ def _get_test_cluster(reactor, node_count):
                        # Control service may not be up yet, keep trying:
                        failed_query)
         return d
-    agents_connected = loop_until(nodes_available)
+    agents_connected = loop_until(reactor, nodes_available)
 
     # Extract node hostnames from API that lists nodes. Currently we
     # happen know these in advance, but in FLOC-1631 node identification
@@ -911,7 +911,7 @@ def verify_socket(host, port):
             ).write()
             return conn == 0
 
-    dl = loop_until(can_connect)
+    dl = loop_until(reactor, can_connect)
     return dl
 
 
@@ -940,7 +940,7 @@ def post_http_server(test, host, port, data, expected_response=b"ok"):
         request.addCallbacks(content, failed)
         return request
     d = verify_socket(host, port)
-    d.addCallback(lambda _: loop_until(lambda: make_post(
+    d.addCallback(lambda _: loop_until(reactor, lambda: make_post(
         host, port, data)))
     d.addCallback(test.assertEqual, expected_response)
     return d
@@ -1002,7 +1002,7 @@ def query_http_server(host, port, path=b""):
         return req
 
     d = verify_socket(host, port)
-    d.addCallback(lambda _: loop_until(query))
+    d.addCallback(lambda _: loop_until(reactor, query))
     return d
 
 

--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -17,7 +17,6 @@ from eliot.twisted import DeferredContext
 from twisted.python.reflect import safe_repr
 from twisted.internet.task import deferLater
 from twisted.internet.defer import maybeDeferred
-from twisted.internet import reactor
 
 
 def function_serializer(function):
@@ -65,14 +64,14 @@ LOOP_UNTIL_ITERATION_MESSAGE = MessageType(
     description="Predicate failed, trying again.")
 
 
-def loop_until(predicate, reactor=reactor, steps=None):
+def loop_until(reactor, predicate, steps=None):
     """Repeatedly call ``predicate``, until it returns something ``Truthy``.
-
-    :param predicate: Callable returning termination condition.
-    :type predicate: 0-argument callable returning a Deferred.
 
     :param reactor: The reactor implementation to use to delay.
     :type reactor: ``IReactorTime``.
+
+    :param predicate: Callable returning termination condition.
+    :type predicate: 0-argument callable returning a Deferred.
 
     :param steps: An iterable of delay intervals, measured in seconds.
         If not provided, will default to retrying every 0.1 seconds forever.

--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -109,16 +109,16 @@ def loop_until(predicate, reactor=reactor, steps=None):
     return d.addActionFinish()
 
 
-def retry_failure(function, expected=None, reactor=reactor, steps=None):
+def retry_failure(reactor, function, expected=None, steps=None):
     """
     Retry ``function`` until it returns successfully.
 
     If it raises one of the expected exceptions, then retry.
 
+    :param IReactorTime reactor: The reactor implementation to use to delay.
     :param callable function: A callable that returns a value.
     :param expected: Iterable of exceptions that trigger a retry. Passed
         through to ``Failure.check``.
-    :param reactor reactor: The reactor implementation to use to delay.
     :param [float] steps: An iterable of delay intervals, measured in seconds.
         If not provided, will default to retrying every 0.1 seconds.
 

--- a/flocker/common/functional/test_script.py
+++ b/flocker/common/functional/test_script.py
@@ -19,6 +19,7 @@ from eliot import Message
 from eliot.testing import assertContainsFields
 
 from twisted.trial.unittest import TestCase
+from twisted.internet import reactor
 from twisted.internet.utils import getProcessOutput
 from twisted.internet.defer import succeed, Deferred
 from twisted.python.log import msg, err
@@ -338,7 +339,7 @@ class FlockerScriptRunnerJournaldTests(TestCase):
         d.addCallback(lambda result: msg("systemd-run output: " + result))
         # systemd-run doesn't wait for process to exit, so we need to ask
         # systemd when it's done:
-        d.addCallback(lambda _: loop_until(lambda: Popen(
+        d.addCallback(lambda _: loop_until(reactor, lambda: Popen(
             [b"systemctl", b"--quiet", b"is-active", name]).wait() != 0))
         d.addCallback(lambda _: getProcessOutput(
             b"journalctl", [b"--unit", name, b"--output", b"cat"]))

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -41,7 +41,7 @@ class LoopUntilTests(SynchronousTestCase):
         def predicate():
             return result
         clock = Clock()
-        d = loop_until(predicate, reactor=clock)
+        d = loop_until(clock, predicate)
         self.assertEqual(
             self.successResultOf(d),
             result)
@@ -68,7 +68,7 @@ class LoopUntilTests(SynchronousTestCase):
             return results.pop(0)
         clock = Clock()
 
-        d = loop_until(predicate, reactor=clock)
+        d = loop_until(clock, predicate)
 
         self.assertNoResult(d)
 
@@ -106,7 +106,7 @@ class LoopUntilTests(SynchronousTestCase):
             return results.pop(0)
         clock = Clock()
 
-        d = loop_until(predicate, reactor=clock)
+        d = loop_until(clock, predicate)
 
         clock.advance(0.1)
         self.assertNoResult(d)
@@ -144,7 +144,7 @@ class LoopUntilTests(SynchronousTestCase):
             return results.pop(0)
         clock = Clock()
 
-        d = loop_until(predicate, reactor=clock, steps=[1, 2, 3])
+        d = loop_until(clock, predicate, steps=[1, 2, 3])
 
         clock.advance(1)
         self.assertNoResult(d)
@@ -167,7 +167,7 @@ class LoopUntilTests(SynchronousTestCase):
             return results.pop(0)
         clock = Clock()
 
-        d = loop_until(predicate, reactor=clock, steps=steps)
+        d = loop_until(clock, predicate, steps=steps)
 
         clock.advance(0.1)
         self.assertNoResult(d)

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -194,7 +194,7 @@ class RetryFailureTests(SynchronousTestCase):
             return result
 
         clock = Clock()
-        d = retry_failure(function, reactor=clock)
+        d = retry_failure(clock, function)
         self.assertEqual(self.successResultOf(d), result)
 
     def test_iterates_once(self):
@@ -212,7 +212,7 @@ class RetryFailureTests(SynchronousTestCase):
 
         clock = Clock()
 
-        d = retry_failure(function, reactor=clock, steps=steps)
+        d = retry_failure(clock, function, steps=steps)
         self.assertNoResult(d)
 
         clock.advance(0.1)
@@ -237,7 +237,7 @@ class RetryFailureTests(SynchronousTestCase):
 
         clock = Clock()
 
-        d = retry_failure(function, reactor=clock, steps=steps)
+        d = retry_failure(clock, function, steps=steps)
         self.assertNoResult(d)
 
         clock.advance(0.1)
@@ -270,7 +270,7 @@ class RetryFailureTests(SynchronousTestCase):
 
         clock = Clock()
 
-        d = retry_failure(function, reactor=clock, steps=steps)
+        d = retry_failure(clock, function, steps=steps)
         self.assertNoResult(d)
 
         clock.advance(0.1)
@@ -296,7 +296,7 @@ class RetryFailureTests(SynchronousTestCase):
 
         clock = Clock()
 
-        d = retry_failure(function, reactor=clock, steps=steps)
+        d = retry_failure(clock, function, steps=steps)
         self.assertEqual(self.failureResultOf(d), failure)
 
     def test_limited_exceptions(self):
@@ -322,8 +322,7 @@ class RetryFailureTests(SynchronousTestCase):
 
         clock = Clock()
 
-        d = retry_failure(
-            function, expected=[ValueError], reactor=clock, steps=steps)
+        d = retry_failure(clock, function, expected=[ValueError], steps=steps)
         self.assertNoResult(d)
 
         clock.advance(0.1)

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -10,6 +10,7 @@ from pyrsistent import pmap, pvector, pset
 
 from eliot import Message
 
+from twisted.internet import reactor
 from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
 
@@ -186,7 +187,7 @@ class DeployerTests(TestCase):
             list(volumes)[0].get_filesystem().get_path().child(b'env'))
 
         def got_result_path(result_path):
-            d = loop_until(result_path.exists)
+            d = loop_until(reactor, result_path.exists)
             d.addCallback(lambda _: result_path)
             return d
         d.addCallback(got_result_path)
@@ -263,7 +264,7 @@ class DeployerTests(TestCase):
                           b'env'))
 
         def got_result_path(result_path):
-            d = loop_until(result_path.exists)
+            d = loop_until(reactor, result_path.exists)
             d.addCallback(lambda _: result_path)
             return d
         d.addCallback(got_result_path)

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -375,6 +375,7 @@ class DeployerTests(TestCase):
 
         d = change_node_state(deployer, desired_state)
         d.addCallback(lambda _: wait_for_unit_state(
+            reactor,
             docker_client,
             application_name,
             [u'active'])
@@ -421,6 +422,7 @@ class DeployerTests(TestCase):
 
         d = change_node_state(deployer, desired_state)
         d.addCallback(lambda _: wait_for_unit_state(
+            reactor,
             docker_client,
             application_name,
             [u'active'])

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -641,7 +641,8 @@ class GenericDockerClientTests(TestCase):
             # operations. Since there's no real user impact for flocker (the
             # convergence loop will just retry anyway), retry here to avoid
             # spurious test failures.
-            listing = retry_failure(client.list, [APIError], steps=[0.1] * 5)
+            listing = retry_failure(
+                reactor, client.list, [APIError], steps=[0.1] * 5)
             listing.addCallback(
                 lambda applications: list(
                     next(iter(application.ports)).external_port

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -21,6 +21,7 @@ Client = partial(Client, version="1.15")
 
 from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
+from twisted.internet import reactor
 from twisted.internet.defer import succeed, gatherResults
 from twisted.internet.error import ConnectionRefusedError
 from twisted.web.client import ResponseNeverReceived
@@ -423,7 +424,7 @@ class GenericDockerClientTests(TestCase):
             response.addErrback(check_error)
             return response
 
-        return loop_until(send_request)
+        return loop_until(reactor, send_request)
 
     def test_non_docker_port_collision(self):
         """
@@ -1055,7 +1056,7 @@ class GenericDockerClientTests(TestCase):
             # TODO: if the `run` script fails for any reason,
             # then this will loop forever.
 
-            d.addCallback(lambda ignored: loop_until(marker.exists))
+            d.addCallback(lambda ignored: loop_until(reactor, marker.exists))
 
         d.addCallback(lambda ignored: count.getContent())
         return d

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -173,7 +173,7 @@ class GenericDockerClientTests(TestCase):
         )
         self.addCleanup(client.remove, unit_name)
 
-        d.addCallback(lambda _: wait_for_unit_state(client, unit_name,
+        d.addCallback(lambda _: wait_for_unit_state(reactor, client, unit_name,
                                                     expected_states))
         d.addCallback(lambda _: client)
 

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -96,10 +96,12 @@ def require_docker_version(minimum_docker_version, message):
     return decorator
 
 
-def wait_for_unit_state(docker_client, unit_name, expected_activation_states):
+def wait_for_unit_state(reactor, docker_client, unit_name,
+                        expected_activation_states):
     """
     Wait until a unit is in the requested state.
 
+    :param IReactorTime reactor: The reactor implementation to use to delay.
     :param docker_client: A ``DockerClient`` instance.
     :param unicode unit_name: The name of the unit.
     :param expected_activation_states: Activation states to wait for.
@@ -117,7 +119,7 @@ def wait_for_unit_state(docker_client, unit_name, expected_activation_states):
         responded.addCallback(is_in_states)
         return responded
 
-    return loop_until(check_if_in_states)
+    return loop_until(reactor, check_if_in_states)
 
 
 CONTROLLABLE_ACTION_TYPE = ActionType(u"test:controllableaction", [], [])

--- a/flocker/provision/_ssh/_conch.py
+++ b/flocker/provision/_ssh/_conch.py
@@ -23,7 +23,6 @@ from twisted.conch.endpoints import (
 )
 
 from twisted.conch.client.knownhosts import KnownHostsFile
-from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.endpoints import UNIXClientEndpoint, connectProtocol
 from twisted.internet.error import ConnectionDone
@@ -118,11 +117,12 @@ def get_ssh_dispatcher(connection, context):
     })
 
 
-def get_connection_helper(address, username, port):
+def get_connection_helper(reactor, address, username, port):
     """
     Get a :class:`twisted.conch.endpoints._ISSHConnectionCreator` to connect to
     the given remote.
 
+    :param reactor: Reactor to connect with.
     :param bytes address: The address of the remote host to connect to.
     :param bytes username: The user to connect as.
     :param int port: The port of the ssh server to connect to.
@@ -148,6 +148,7 @@ def get_connection_helper(address, username, port):
 @inlineCallbacks
 def perform_run_remotely(reactor, base_dispatcher, intent):
     connection_helper = get_connection_helper(
+        reactor,
         username=intent.username, address=intent.address, port=intent.port)
 
     context = Message.new(


### PR DESCRIPTION
**This PR depends on FLOC-3340 (#2095)**

One of the review comments in FLOC-3340 (#2095) was that it's unsafe to have a reactor parameter that defaults to the global reactor. 

This patch addresses that concern by:
1. making `reactor` a non-optional parameter
2. making it the _first_ parameter of `loop_until` and `retry_failure`
3. updating all call sites to pass `reactor` explicitly

As a general principle, I've tried to only pass a concrete reactor in at the leafs. Thus, I've updated `flocker.provision._ssh._conch` to pass `reactor` through from its entry point, `make_dispatcher`, and also `flocker.node.testtools.wait_for_unit_state` to take a reactor.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2098)
<!-- Reviewable:end -->
