### PR TITLE
[FLOC 2443] Add an introduction to choosing a backend

### DIFF
--- a/docs/introduction/flocker-supports.rst
+++ b/docs/introduction/flocker-supports.rst
@@ -24,6 +24,11 @@ Supported Cloud Providers
 List of Storage Backends
 ========================
 
+Flocker allows you to use either shared storage, like Amazon EBS or EMC ScaleIO, or local storage for your application’s storage layer.
+The best option for you depends on a combination of factors including where you run your application and the capabilities you are trying to achieve.
+
+For help determining which storage option is right for you, you will find a useful table in the `storage section of our About Flocker`_ page. 
+
 The following backends can be used with Flocker:
 
 * AWS EBS
@@ -44,3 +49,5 @@ Configuration details for each of the backends can be found in the :ref:`Configu
           For more information, see :ref:`contribute-flocker-driver`.
 
 .. XXX add link to 3rd party orchestration docs. See FLOC 2229
+
+.. _storage section of our About Flocker: https://clusterhq.com/flocker/introduction/#storage-options


### PR DESCRIPTION
Fixes 2443

Added info to the list of storage backends in the introduction, which points to the table in our marketing website, so that the user has some more information about their backend options.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2102)
<!-- Reviewable:end -->
