### PR TITLE
FLOC-3273 Modify the Node agent to plumb flocker profiles to the driver.

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -50,6 +50,9 @@ _logger = Logger()
 # XXX: Make this configurable. FLOC-2679
 DEFAULT_DATASET_SIZE = int(GiB(100).to_Byte().value)
 
+# The metadata key for flocker profiles.
+PROFILE_METADATA_KEY = u"clusterhq:flocker:profile"
+
 
 class VolumeException(Exception):
     """
@@ -733,7 +736,7 @@ class CreateBlockDeviceDataset(PRecord):
         except:
             return fail()
 
-        profile_name = self.dataset.metadata.get(u"clusterhq:flocker:profile")
+        profile_name = self.dataset.metadata.get(PROFILE_METADATA_KEY)
         dataset_id = UUID(self.dataset.dataset_id)
         size = allocated_size(allocation_unit=api.allocation_unit(),
                               requested_size=self.dataset.maximum_size)

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -186,7 +186,7 @@ BLOCK_DEVICE_PATH = Field(
 
 PROFILE_NAME = Field(
     u"profile_name",
-    lambda dataset_id: unicode(dataset_id),
+    identity,
     u"The name of a profile for a volume."
 )
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1031,6 +1031,8 @@ class ProfiledBlockDeviceAPIAdapter(PClass):
         backends that do not implement ``IProfiledBlockDeviceAPI``, but do
         implement ``IBlockDeviceAPI``.
         """
+        CREATE_VOLUME_PROFILE_DROPPED(dataset_id=dataset_id,
+                                      profile_name=profile_name).write(_logger)
         return self._blockdevice_api.create_volume(dataset_id=dataset_id,
                                                    size=size)
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -734,7 +734,7 @@ class CreateBlockDeviceDataset(PRecord):
             return fail()
 
         profile_name = self.dataset.metadata.get(u"clusterhq:flocker:profile")
-        if False and profile_name:
+        if profile_name:
             volume = (
                 deployer.profiled_blockdevice_api.create_volume_with_profile(
                     dataset_id=UUID(self.dataset.dataset_id),

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -734,7 +734,7 @@ class CreateBlockDeviceDataset(PRecord):
             return fail()
 
         profile_name = self.dataset.metadata.get(u"clusterhq:flocker:profile")
-        if profile_name:
+        if False and profile_name:
             volume = (
                 deployer.profiled_blockdevice_api.create_volume_with_profile(
                     dataset_id=UUID(self.dataset.dataset_id),

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3522,11 +3522,9 @@ class CreateBlockDeviceDatasetImplementationTests(SynchronousTestCase):
             u"This test assumes the API does not provide "
             u"IProfiledBlockDeviceAPI. If the API now does provide that "
             u"interface, this test needs a bit of love.")
+        self.patch(blockdevice, "_logger", logger)
         dataset_id = uuid4()
-        (volume,
-         device_path,
-         expected_mountpoint,
-         compute_instance_id) = self._create_blockdevice_dataset(
+        (volume, _, _, compute_instance_id) = self._create_blockdevice_dataset(
             dataset_id=dataset_id,
             maximum_size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE,
             metadata={u"clusterhq:flocker:profile": u"gold"}

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2758,28 +2758,10 @@ def fakeprofiledloopbackblockdeviceapi_for_test(test_case,
             test_case, allocation_unit=allocation_unit))
 
 
-_fake_profiled_loopback_block_device_api = partial(
-    fakeprofiledloopbackblockdeviceapi_for_test,
-    allocation_unit=LOOPBACK_ALLOCATION_UNIT)
-
-
-class FakeProfiledLoopbackBlockDeviceIBlockDeviceTests(
-    make_iblockdeviceapi_tests(
-        blockdevice_api_factory=_fake_profiled_loopback_block_device_api,
-        minimum_allocatable_size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE,
-        device_allocation_unit=None,
-        unknown_blockdevice_id_factory=lambda test: unicode(uuid4()),
-    )
-):
-    """
-    ``IBlockDeviceAPI`` interface adherence Tests for
-    ``FakeProfiledLoopbackBlockDevice``.
-    """
-
-
 class FakeProfiledLoopbackBlockDeviceIProfiledBlockDeviceTests(
     make_iprofiledblockdeviceapi_tests(
-        _fake_profiled_loopback_block_device_api,
+        partial(fakeprofiledloopbackblockdeviceapi_for_test,
+                allocation_unit=LOOPBACK_ALLOCATION_UNIT),
         LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
     )
 ):
@@ -3538,6 +3520,10 @@ def make_createblockdevicedataset_mixin(profiled_api):
 
     The mixin holds utility functions that are useful in both configurations,
     and takes care of initializing the two different versions of the API.
+
+    :param bool profiled_api: True if you want self.api to be an implementation
+        of ``IBlockDeviceAPI`` that provides ``IProfiledBlockDeviceAPI``. False
+        if you want self.api not to provide ``IProfiledBlockDeviceAPI``.
     """
     class Mixin(CreateBlockDeviceDatasetImplementationMixin,
                 SynchronousTestCase):
@@ -3641,7 +3627,6 @@ class CreateBlockDeviceDatasetImplementationTests(
             u"This test assumes the API does not provide "
             u"IProfiledBlockDeviceAPI. If the API now does provide that "
             u"interface, this test needs a bit of love.")
-        self.patch(blockdevice, "_logger", logger)
         dataset_id = uuid4()
         (volume, _, _, compute_instance_id) = self._create_blockdevice_dataset(
             dataset_id=dataset_id,

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -49,6 +49,8 @@ from ..blockdevice import (
     CreateFilesystem, DestroyVolume, MountBlockDevice, _losetup_list_parse,
     _losetup_list, _blockdevicevolume_from_dataset_id,
 
+    PROFILE_METADATA_KEY,
+
     DESTROY_BLOCK_DEVICE_DATASET, UNMOUNT_BLOCK_DEVICE, DETACH_VOLUME,
     DESTROY_VOLUME,
     CREATE_BLOCK_DEVICE_DATASET,
@@ -3644,7 +3646,7 @@ class CreateBlockDeviceDatasetImplementationTests(
         (volume, _, _, compute_instance_id) = self._create_blockdevice_dataset(
             dataset_id=dataset_id,
             maximum_size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE,
-            metadata={u"clusterhq:flocker:profile": u"gold"}
+            metadata={PROFILE_METADATA_KEY: u"gold"}
         )
 
         expected_volume = _blockdevicevolume_from_dataset_id(

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3781,10 +3781,10 @@ class AttachVolumeTests(
             dataset_id=dataset_id, size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
         )
         change = AttachVolume(dataset_id=dataset_id,
-                              blockdevice_id=volume_info.volume.blockdevice_id)
+                              blockdevice_id=volume.blockdevice_id)
         self.successResultOf(run_state_change(change, deployer))
 
-        expected_volume = volume_info.volume.set(
+        expected_volume = volume.set(
             attached_to=api.compute_instance_id()
         )
         self.assertEqual([expected_volume], api.list_volumes())


### PR DESCRIPTION
This PR modifies the Node agent on create requests.

After this PR, if the dataset being created has a metadata key "clusterhq:flocker:profile" and the backend supports creating volumes with a profile, then the value of that metadata will be handed down as the profile for the volume.

If that metadata entry exists but the backend does not support creating volumes with profiles, the agent will log that the profile was dropped, and will simply call create_volume on the backend without passing the profile down.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2103)
<!-- Reviewable:end -->
