### PR TITLE
[FLOC 431] remove $ from codeblock in tutorial

### DIFF
--- a/docs/tutorials_examples/tutorial/exposing-ports.rst
+++ b/docs/tutorials_examples/tutorial/exposing-ports.rst
@@ -42,7 +42,7 @@ If you get a connection refused error try again after a few seconds; the applica
 
 .. prompt:: bash alice@mercury:~/flocker-tutorial$ auto
 
-   alice@mercury:~/flocker-tutorial$ $ mongo 172.16.255.250
+   alice@mercury:~/flocker-tutorial$ mongo 172.16.255.250
    MongoDB shell version: 2.4.9
    connecting to: 172.16.255.250/test
    > use example;


### PR DESCRIPTION
Fixes FLOC 431

This is a really old issue, and I couldn't find the exact codeblock that the issue refers to. It did highlight a syntax error in one codeblock though, which this PR corrects.

I've not manually run through the tutorial following this change, as the correction was obviously a syntax error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2105)
<!-- Reviewable:end -->
