### PR TITLE
[FLOC 977] add elk download file

### DIFF
--- a/docs/tutorials_examples/examples/linking.rst
+++ b/docs/tutorials_examples/examples/linking.rst
@@ -113,7 +113,9 @@ Now refresh the ``Kibana`` web interface and you should see those messages.
 Move ``ElasticSearch`` to Node2
 ===============================
 
-Download and save the following configuration files to the ``flocker-tutorial`` directory:
+Download and save the following configuration file to the ``flocker-tutorial`` directory:
+
+:download:`elk-deployment-moved.yml`
 
 .. literalinclude:: elk-deployment-moved.yml
    :language: yaml
@@ -122,7 +124,7 @@ Then run ``flocker-deploy`` to move the ``Elasticsearch`` application along with
 
 .. prompt:: bash alice@mercury:~/flocker-tutorial$
 
-   flocker-deploy 172.16.255.250 elk-deployment.yml elk-application.yml
+   flocker-deploy 172.16.255.250 elk-deployment-moved.yml elk-application.yml
    
 Now verify that the ``ElasticSearch`` application has moved to the other VM:
 


### PR DESCRIPTION
Fixes 977

An old issue which adds a downloadable elk file where the text suggests one should be. A few tweaks to the wording around this.

I've not manually tested this, as it was an obvious error (the contents of the elk file was always provided - this just adds a link for users to download the file)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2106)
<!-- Reviewable:end -->
