### PR TITLE
[FLOC-3262] Loop to destroy container

### DIFF
--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -161,6 +161,8 @@ def poll_until(predicate, steps, sleep=None):
     :param callable sleep: called with the interval to delay on.
         Defaults to `time.sleep`.
     :returns: the non-false result from the final call.
+    :raise LoopExceeded: If given a finite sequence of steps, and we exhaust
+        that sequence waiting for predicate to be truthy.
     """
     if sleep is None:
         sleep = time.sleep

--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -169,3 +169,7 @@ def poll_until(predicate, steps, sleep=None):
         if result:
             return result
         sleep(step)
+    result = predicate()
+    if result:
+        return result
+    raise LoopExceeded(predicate, result)

--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -148,7 +148,7 @@ def retry_failure(reactor, function, expected=None, steps=None):
     return d
 
 
-def poll_until(predicate, interval):
+def poll_until(predicate, interval, sleep=None):
     """
     Perform steps until a non-false result is returned.
 
@@ -158,10 +158,14 @@ def poll_until(predicate, interval):
     :param predicate: a function to be called until it returns a
         non-false result.
     :param interval: time in seconds between calls to the function.
+    :param callable sleep: called with the interval to delay on.
+        Defaults to `time.sleep`.
     :returns: the non-false result from the final call.
     """
+    if sleep is None:
+        sleep = time.sleep
     result = predicate()
     while not result:
-        time.sleep(interval)
+        sleep(interval)
         result = predicate()
     return result

--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -148,24 +148,24 @@ def retry_failure(reactor, function, expected=None, steps=None):
     return d
 
 
-def poll_until(predicate, interval, sleep=None):
+def poll_until(predicate, steps, sleep=None):
     """
     Perform steps until a non-false result is returned.
 
     This differs from ``loop_until`` in that it does not require a
-    Twisted reactor and it allows the interval to be set.
+    Twisted reactor.
 
     :param predicate: a function to be called until it returns a
         non-false result.
-    :param interval: time in seconds between calls to the function.
+    :param [float] steps: An iterable of delay intervals, measured in seconds.
     :param callable sleep: called with the interval to delay on.
         Defaults to `time.sleep`.
     :returns: the non-false result from the final call.
     """
     if sleep is None:
         sleep = time.sleep
-    result = predicate()
-    while not result:
-        sleep(interval)
+    for step in steps:
         result = predicate()
-    return result
+        if result:
+            return result
+        sleep(step)

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -356,13 +356,16 @@ class PollUntilTests(SynchronousTestCase):
         self.assertEqual((True, [1, 1]), (result, sleeps))
 
     def test_default_sleep(self):
+        """
+        The ``poll_until`` function can be called with two arguments.
+        """
         results = [False, True]
         result = poll_until(lambda: results.pop(0), repeat(0))
         self.assertEqual(True, result)
 
     def test_loop_exceeded(self):
         """
-        If the generator of intervals that we pass to ``poll_until`` is
+        If the iterable of intervals that we pass to ``poll_until`` is
         exhausted before we get a truthy return value, then we raise
         ``LoopExceeded``.
         """

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -21,6 +21,7 @@ from .._retry import (
     LoopExceeded,
     loop_until,
     retry_failure,
+    poll_until,
 )
 
 
@@ -327,3 +328,32 @@ class RetryFailureTests(SynchronousTestCase):
 
         clock.advance(0.1)
         self.assertEqual(self.failureResultOf(d), type_error)
+
+
+class PollUntilTests(SynchronousTestCase):
+    """
+    Tests for ``poll_until``.
+    """
+
+    def test_no_sleep_if_initially_true(self):
+        """
+        If the predicate starts off as True then we don't delay at all.
+        """
+        sleeps = []
+        poll_until(lambda: True, 1, sleeps.append)
+        self.assertEqual([], sleeps)
+
+    def test_polls_until_true(self):
+        """
+        The predicate is repeatedly call until the result is truthy, delaying
+        by the interval each time.
+        """
+        sleeps = []
+        results = [False, False, True]
+        result = poll_until(lambda: results.pop(0), 1, sleeps.append)
+        self.assertEqual((True, [1, 1]), (result, sleeps))
+
+    def test_default_sleep(self):
+        results = [False, True]
+        result = poll_until(lambda: results.pop(0), 0)
+        self.assertEqual(True, result)

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -4,6 +4,8 @@
 Tests for ``flocker.common._retry``.
 """
 
+from itertools import repeat
+
 from eliot.testing import (
     capture_logging,
     LoggedAction, LoggedMessage,
@@ -340,7 +342,7 @@ class PollUntilTests(SynchronousTestCase):
         If the predicate starts off as True then we don't delay at all.
         """
         sleeps = []
-        poll_until(lambda: True, 1, sleeps.append)
+        poll_until(lambda: True, repeat(1), sleeps.append)
         self.assertEqual([], sleeps)
 
     def test_polls_until_true(self):
@@ -350,10 +352,10 @@ class PollUntilTests(SynchronousTestCase):
         """
         sleeps = []
         results = [False, False, True]
-        result = poll_until(lambda: results.pop(0), 1, sleeps.append)
+        result = poll_until(lambda: results.pop(0), repeat(1), sleeps.append)
         self.assertEqual((True, [1, 1]), (result, sleeps))
 
     def test_default_sleep(self):
         results = [False, True]
-        result = poll_until(lambda: results.pop(0), 0)
+        result = poll_until(lambda: results.pop(0), repeat(0))
         self.assertEqual(True, result)

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -359,3 +359,27 @@ class PollUntilTests(SynchronousTestCase):
         results = [False, True]
         result = poll_until(lambda: results.pop(0), repeat(0))
         self.assertEqual(True, result)
+
+    def test_loop_exceeded(self):
+        """
+        If the generator of intervals that we pass to ``poll_until`` is
+        exhausted before we get a truthy return value, then we raise
+        ``LoopExceeded``.
+        """
+        results = [False] * 5
+        steps = [0.1] * 3
+        self.assertRaises(
+            LoopExceeded, poll_until, lambda: results.pop(0), steps,
+            lambda ignored: None)
+
+    def test_polls_one_last_time(self):
+        """
+        After intervals are exhausted, we poll one final time before
+        abandoning.
+        """
+        # Three sleeps, one value to poll after the last sleep.
+        results = [False, False, False, 42]
+        steps = [0.1] * 3
+        self.assertEqual(
+            42,
+            poll_until(lambda: results.pop(0), steps, lambda ignored: None))

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -808,9 +808,16 @@ class DockerClient(object):
         container_name = self._to_container_name(unit_name)
 
         def _remove():
+            # Previously, this looped forever and didn't pause between loops.
+            # We've arbitrarily chosen a wait interval of 0.001 seconds and
+            # 1000 retries (i.e. a second of polling). These values may need
+            # tuning.
             poll_until(
                 partial(self._stop_container, container_name),
                 repeat(0.001, 1000))
+
+            # XXX: Turn _remove_container into a predicate, and then wrap this
+            # in a poll_until as well.
             self._remove_container(container_name)
 
         d = deferToThread(_remove)

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -805,9 +805,8 @@ class DockerClient(object):
         container_name = self._to_container_name(unit_name)
 
         def _remove():
-            container_stopped = False
-            while not container_stopped:
-                container_stopped = self._stop_container(container_name)
+            while not self._stop_container(container_name):
+                pass
             self._remove_container(container_name)
 
         d = deferToThread(_remove)

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -17,7 +17,7 @@ from docker import Client
 from docker.errors import APIError, NotFound
 from docker.utils import create_host_config
 
-from eliot import Message, MessageType, Field, start_action
+from eliot import Message, MessageType, Field, start_action, write_traceback
 
 from repoze.lru import LRUCache
 
@@ -743,6 +743,7 @@ class DockerClient(object):
                     message_type="flocker:docker:container_not_found",
                     container=container_name
                 ).write()
+                write_traceback()
                 return True
             elif e.response.status_code == INTERNAL_SERVER_ERROR:
                 # Docker returns this if the process had died, but
@@ -751,6 +752,7 @@ class DockerClient(object):
                     message_type="flocker:docker:container_stop_internal_error",  # noqa
                     container=container_name
                 ).write()
+                write_traceback()
                 return False
             else:
                 raise
@@ -798,6 +800,7 @@ class DockerClient(object):
                     message_type="flocker:docker:container_not_found",
                     container=container_name
                 ).write()
+                write_traceback()
                 return True
             elif e.response.status_code == INTERNAL_SERVER_ERROR:
                 # Failure to remove container - see FLOC-3262 for an example.
@@ -805,6 +808,7 @@ class DockerClient(object):
                     message_type="flocker:docker:container_remove_internal_error",  # noqa
                     container=container_name
                 ).write()
+                write_traceback()
                 return False
             else:
                 raise

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -17,7 +17,7 @@ from docker import Client
 from docker.errors import APIError, NotFound
 from docker.utils import create_host_config
 
-from eliot import Message, MessageType, Field, start_action, write_traceback
+from eliot import Message, MessageType, Field, start_action
 
 from repoze.lru import LRUCache
 

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -4,6 +4,7 @@
 """
 A Cinder implementation of the ``IBlockDeviceAPI``.
 """
+from itertools import repeat
 import time
 from uuid import UUID
 
@@ -347,7 +348,7 @@ def wait_for_volume_state(volume_manager, expected_volume, desired_state,
     waiter = VolumeStateMonitor(
         volume_manager, expected_volume, desired_state, transient_states,
         time_limit)
-    return poll_until(waiter.reached_desired_state, 1)
+    return poll_until(waiter.reached_desired_state, repeat(1))
 
 
 def _extract_nova_server_addresses(addresses):


### PR DESCRIPTION
Container removal fails intermittently with a 500 error. To make this more reliable, any 500 error will be logged and the removal will be repeated. If the removal can be fixed simply by retrying, this will make the code more robust. If retries do not help, at least we have more logging info.

The container stopping and removal both run synchronously in a separate thread, so the `poll_until` function (synchronous version of `loop_until`) is modified to take a `steps` iterable for retry intervals (matching recent changes to `loop_until`).

Tests for `poll_until` are added, and to support the testing, the `sleep` function used in `poll_until` can be set to ensure tests do not take too much time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2107)
<!-- Reviewable:end -->
