### PR TITLE
[FLOC 3350] fix broken links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ We're looking forward to working on this project with you.
 Documentation
 -------------
 
-You can read more about `installing Flocker`_, follow a `tutorial`_ and learn about the `features of Flocker and its architecture`_ in the docs.
+You can read more about installing Flocker, follow a tutorial and learn about the features of Flocker and its architecture in the `Flocker docs`_.
 
 
 Feature Requests
@@ -53,9 +53,7 @@ Flocker is also tested using `continuous integration`_.
 
 .. _ClusterHQ: https://clusterhq.com/
 .. _Twisted: https://twistedmatrix.com/trac/
-.. _installing Flocker: https://docs.clusterhq.com/en/latest/install/index.html
-.. _tutorial: https://docs.clusterhq.com/en/latest/using/tutorial/index.html
-.. _features of Flocker and its architecture: https://docs.clusterhq.com/en/latest/introduction/index.html
+.. _Flocker docs: https://docs.clusterhq.com/
 .. _unittest: https://docs.python.org/2/library/unittest.html
 .. _Twisted Trial: https://twistedmatrix.com/trac/wiki/TwistedTrial
 .. _tox: https://tox.readthedocs.org/


### PR DESCRIPTION
Fixes 3350

The links in the readme directly to the docs have been removed in favour of a direct link to the docs - this ensures that this problem shouldn't occur again due to changing/new URLs

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2108)
<!-- Reviewable:end -->
