### PR TITLE
Adds lint flake8 checks jenkins job FLOC-2858

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -717,6 +717,10 @@ common_cli:
     wget https://raw.githubusercontent.com/AndrewDryga/vagrant-box-osx/master/Vagrantfile
     vagrant up
 
+  run_lint: &run_lint |
+    # run flake8 lint tests on Flocker source code
+    tox -e lint
+
 
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point
@@ -1087,6 +1091,18 @@ job_type:
           }
       clean_repo: false
       timeout: 30
+
+  run_lint:
+    run_lint:
+      on_nodes_with_labels: 'aws-centos-7-T2Small'
+      with_steps:
+        - { type: 'shell',
+            cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
+                   *cleanup, *setup_venv, #*setup_flocker_modules,
+                   *run_lint ]
+          }
+      timeout: 10
+
 
   cronly_jobs:
     run_docker_build_centos7_fpm:

--- a/build.yaml
+++ b/build.yaml
@@ -718,8 +718,16 @@ common_cli:
     vagrant up
 
   run_lint: &run_lint |
+    # we need to unset PIP_INDEX_URL since it causes tox to fail.
+    # in order to use our pip caching we need to append --trusted-hosts
+    # which we currently can't do through tox.
+    unset PIP_INDEX_URL
     # run flake8 lint tests on Flocker source code
     tox -e lint
+
+  install_flake8: &install_flake8 |
+    # flake8 is used by lint tests on Flocker source code
+    \${PARSE_LOGS} pip install flake8 \${PIP_ADDITIONAL_OPTIONS}
 
 
 #-----------------------------------------------------------------------------#
@@ -1093,6 +1101,7 @@ job_type:
       clean_repo: false
       timeout: 30
 
+
   run_lint:
     run_lint:
       on_nodes_with_labels: 'aws-centos-7-T2Small'
@@ -1100,7 +1109,7 @@ job_type:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
-                   *run_lint ]
+                   *install_flake8, *run_lint ]
           }
       timeout: 10
 

--- a/build.yaml
+++ b/build.yaml
@@ -1099,7 +1099,7 @@ job_type:
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
-                   *cleanup, *setup_venv, #*setup_flocker_modules,
+                   *cleanup, *setup_venv, *setup_flocker_modules,
                    *run_lint ]
           }
       timeout: 10

--- a/build.yaml
+++ b/build.yaml
@@ -1025,6 +1025,7 @@ job_type:
       clean_repo: true
       timeout: 30
 
+
   run_client:
     run_client_installation_on_Ubuntu_Trusty:
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -460,6 +460,7 @@ branches.each {
     {{ steps(job_values.with_steps) }}
   }
 {%    endif                                                                  %}
+
 {%  endfor                                                                   %}
 {% endfor                                                                    %}
 

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -1,3 +1,4 @@
+// vim: ai ts=2 sts=2 et sw=2 ft=jinja fdm=indent et foldlevel=0
 {# jobs.groovy.j2
 
   This jinja2 template is used to produce a jobs.groovy file containing the
@@ -550,7 +551,7 @@ branches.each {
 {# make sure we don't kill the parent multijob, when we fail                 #}
                 killPhaseCondition("NEVER")
               }
-{%      endfor                                                                -%}
+{%      endfor                                                              -%}
 {%    endfor                                                                -%}
 {%  endif                                                                    %}
 

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -447,9 +447,20 @@ branches.each {
     {{ steps(job_values.with_steps) }}
   }
 {%    endif                                                                  %}
+
+{# apply config related to 'run_lint' jobs                                   #}
+{%    if job_type == 'run_lint'                                             -%}
+{%        set _job_name = job_name                                          -%}
+  job("${dashProject}/${dashBranchName}/{{ _job_name }}") {
+{# limit execution to jenkins slaves with a particular label                 #}
+    label("{{ job_values.on_nodes_with_labels }}")
+    {{ wrappers(job_values, 'none') }}
+    {{ scm("${git_url}", "${branchName}") }}
+    {{ steps(job_values.with_steps) }}
+  }
+{%    endif                                                                  %}
 {%  endfor                                                                   %}
 {% endfor                                                                    %}
-
 
 {# ------------------------------------------------------------------------- #}
 {# MULTIJOB CONFIGURATION BELOW                                              #}
@@ -565,8 +576,19 @@ branches.each {
 {%    endfor                                                                -%}
 {%  endif                                                                    %}
 
+{# add the 'run_lint' style jobs                                             #}
+{%  if job_type == 'run_lint'                                               -%}
+{%    for job_name, job_values  in job_type_values.iteritems()              -%}
+{%      set _job_name = job_name                                             %}
+              job("${dashProject}/${dashBranchName}/{{_job_name }}")  {
+{# make sure we don't kill the parent multijob, when we fail                 #}
+                killPhaseCondition("NEVER")
+              }
+{%    endfor                                                                -%}
+{%  endif                                                                    %}
 {% endfor                                                                    %}
-          }
+          } {# ends parallel phase #}
+
 {# we've added the jobs to the multijob, we now need to fetch and archive all
    the artifacts produced by the different jobs                              #}
 {% for job_type, job_type_values  in cfg.job_type.iteritems()               -%}


### PR DESCRIPTION
This PR adds a new Jenkins Job for the missing flake8 lint checks.
It simply runs tox -e lint just like the BB builder

Jenkins job:
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/add_lint_FLOC-2858/job/run_lint/7/console

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2110)
<!-- Reviewable:end -->
