### PR TITLE
Fixes Jenkins run_sphinx job (docs) -  FLOC-2857

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -341,11 +341,6 @@ common_cli:
     parse_logs sphinx-build -d _build/doctree -b linkcheck . _build/linkcheck
     # build html pages
     parse_logs sphinx-build -d _build/doctree -b html . _build/html
-    # TODO:
-    # upload html
-    #link-release-documentation
-    #upload-release-documentation
-    cd -
 
   # flocker artifacts contains the list of files we want to collect from our
   # _main_multijob. These are used to produce the coverage, test reports.
@@ -712,6 +707,23 @@ common_cli:
     wget https://raw.githubusercontent.com/AndrewDryga/vagrant-box-osx/master/Vagrantfile
     vagrant up
 
+  install_aws_cli: &install_aws_cli |
+    # installs the AWS python based cli
+    # we use the aws cli to upload the docs files to S3
+    \${PARSE_LOGS}  pip install awscli \${PIP_ADDITIONAL_OPTIONS}
+
+  get_s3_creds_for_bucket_staging_docs: &get_s3_creds_for_bucket_staging_docs |
+    # collects the S3 credentials that allows us to upload files to the S3
+    # staging bucket for our docs
+    . /tmp/s3_staging_docs_clusterhq_com.sh
+
+  upload_new_docs_html_to_s3_staging_docs: &upload_new_docs_html_to_s3_staging_docs |
+    # uploads the new generated html to a folder on the S3 staging-docs bucket
+    cd _build/html
+    aws s3 sync . s3://clusterhq-staging-docs/\$TRIGGERED_BRANCH
+    echo "This branch is available at :"
+    echo "http://clusterhq-staging-docs.s3.amazonaws.com/\$TRIGGERED_BRANCH/index.html"
+
 
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point
@@ -928,7 +940,9 @@ job_type:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
-                   *setup_aws_env_vars, *run_sphinx ]
+                   *install_aws_cli, *run_sphinx,
+                   *get_s3_creds_for_bucket_staging_docs,
+                   *upload_new_docs_html_to_s3_staging_docs]
           }
       timeout: 10
 

--- a/build.yaml
+++ b/build.yaml
@@ -335,17 +335,12 @@ common_cli:
   run_sphinx: &run_sphinx |
     parse_logs python setup.py --version
     cd docs
-    set +e #dont abort at the first failure
-    let status=0
     # check spelling
     parse_logs sphinx-build -d _build/doctree -b spelling . _build/spelling
-    let status=status+\$?
     # check links
     parse_logs sphinx-build -d _build/doctree -b linkcheck . _build/linkcheck
-    let status=status+\$?
     # build html pages
     parse_logs sphinx-build -d _build/doctree -b html . _build/html
-    exit \${status}
     # TODO:
     # upload html
     #link-release-documentation

--- a/build.yaml
+++ b/build.yaml
@@ -928,7 +928,7 @@ job_type:
   # http://build.clusterhq.com/builders/flocker-docs
   run_sphinx:
     run_sphinx:
-      on_nodes_with_labels: 'aws-centos-7-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,

--- a/build.yaml
+++ b/build.yaml
@@ -714,7 +714,9 @@ common_cli:
 
   get_s3_creds_for_bucket_staging_docs: &get_s3_creds_for_bucket_staging_docs |
     # collects the S3 credentials that allows us to upload files to the S3
-    # staging bucket for our docs
+    # staging bucket for our docs.
+    # the file with the credentials are deployed by the jenkins master to the
+    # /tmp of the slave when the slave is instantiated.
     . /tmp/s3_staging_docs_clusterhq_com.sh
 
   upload_new_docs_html_to_s3_staging_docs: &upload_new_docs_html_to_s3_staging_docs |

--- a/build.yaml
+++ b/build.yaml
@@ -930,7 +930,7 @@ job_type:
                    *cleanup, *setup_venv, *setup_flocker_modules,
                    *setup_aws_env_vars, *run_sphinx ]
           }
-      timeout: 30
+      timeout: 10
 
 
   # http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fcentos-7%2Faws


### PR DESCRIPTION
This PR fixes the issue where the run_sphinx job was failling.
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/master/job/run_sphinx/

And enables the uploads of the resulting html files to an S3 bucket on AWS.
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/jenkins-docs-FLOC-2857/job/run_sphinx/8/console

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2115)
<!-- Reviewable:end -->
