### PR TITLE
[FLOC 3361] add introduction to Generating API Certs doc

### DIFF
--- a/docs/config/generate-api-certificates.rst
+++ b/docs/config/generate-api-certificates.rst
@@ -4,6 +4,8 @@
 Generating an API User Certificate
 ==================================
 
+If you wish to send instructions to the control service, by using the API directly, via the CLI, or any other method, you will need to follow the instructions below to generate an API user certificate:
+
 #. Generate an API user certificate.
 
    Run the following command from the directory which contains the certificate authority files generated when you first installed the cluster. For more information, see :ref:`authentication`.


### PR DESCRIPTION
Fixes 3361

Added an introduction, which clearly states that the API user certificates is mandatory, regardless of how you intend to communicate with the control service - please could someone in the know about this confirm this.

Many thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2116)
<!-- Reviewable:end -->
