### PR TITLE
[FLOC 3359] Extra info for Installing plugin doc

### DIFF
--- a/docs/install/docker-plugin.rst
+++ b/docs/install/docker-plugin.rst
@@ -4,6 +4,8 @@
 Installing the Flocker Plugin for Docker
 ========================================
 
+:ref:`docker-plugin` allows Flocker to manage your data volumes while using other tools such as Docker, Docker Swarm, or Mesos to manage your containers.
+
 Before installing the Flocker plugin for Docker, you will need to have installed Flocker on some nodes, using the :ref:`node installation instructions <installing-flocker-node>`.
 
 The Flocker plugin for Docker requires access to the Flocker REST API.


### PR DESCRIPTION
Fixes 3359

Added info (with a link back to the FPD introduction page) to the Installing the plugin docs, so that the user is aware of what the plugin does.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2117)
<!-- Reviewable:end -->
