### PR TITLE
[FLOC 3360] Reword the introduction to Configuring Flocker

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -4,7 +4,7 @@
 Configuring Flocker
 ===================
 
-The following topics describe how to complete the post-installation configuration:
+Once you have installed Flocker you will need to complete the following configuration steps in order to start using your cluster:
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Fixes 3360

Makes the wording clearer for users to understand that they must have installed Flocker before the config steps

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2118)
<!-- Reviewable:end -->
