### PR TITLE
[FLOC 3362] add context to Enabling control service doc

### DIFF
--- a/docs/config/enabling-control-service.rst
+++ b/docs/config/enabling-control-service.rst
@@ -1,7 +1,7 @@
 .. _enabling-control-service:
 
 ====================================
-Enabling the Flocker control service 
+Enabling the Flocker Control Service 
 ====================================
 
 The control service is the brain of Flocker; it can live anywhere in your cluster, and enabling it is an essential step in setting up your cluster.

--- a/docs/config/enabling-control-service.rst
+++ b/docs/config/enabling-control-service.rst
@@ -4,6 +4,8 @@
 Enabling the Flocker control service 
 ====================================
 
+The control service is the brain of Flocker; it can live anywhere in your cluster, and enabling it is an essential step in setting up your cluster.
+
 CentOS 7
 ========
 


### PR DESCRIPTION
Fixes 3362

Adds an explanation of why you need to enable the control service.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2119)
<!-- Reviewable:end -->
