### PR TITLE
[FLOC 3363] add context to Enabling agent service doc

### DIFF
--- a/docs/config/enabling-agent-service.rst
+++ b/docs/config/enabling-agent-service.rst
@@ -2,7 +2,7 @@
 Enabling the Flocker Agent Service
 ==================================
 
-The Flocker agents, the `flocker-dataset-agent` and the `flocker-container-agent`, are the workhorses of Flocker; you have them on each node in your cluster, and enabling them is an essential step in setting up your cluster:
+The Flocker agents, the ``flocker-dataset-agent`` and the ``flocker-container-agent``, are the workhorses of Flocker; you have them on each node in your cluster, and enabling them is an essential step in setting up your cluster:
 
 CentOS 7
 ========

--- a/docs/config/enabling-agent-service.rst
+++ b/docs/config/enabling-agent-service.rst
@@ -2,7 +2,7 @@
 Enabling the Flocker Agent Service
 ==================================
 
-The Flocker agents are the workhorses of Flocker; you have one on each node in your cluster, and enabling them is an essential step in setting up your cluster:
+The Flocker agents, the `flocker-dataset-agent` and the `flocker-container-agent`, are the workhorses of Flocker; you have them on each node in your cluster, and enabling them is an essential step in setting up your cluster:
 
 CentOS 7
 ========

--- a/docs/config/enabling-agent-service.rst
+++ b/docs/config/enabling-agent-service.rst
@@ -1,5 +1,5 @@
 ==================================
-Enabling the Flocker agent service
+Enabling the Flocker Agent Service
 ==================================
 
 The Flocker agents are the workhorses of Flocker; you have one on each node in your cluster, and enabling them is an essential step in setting up your cluster:

--- a/docs/config/enabling-agent-service.rst
+++ b/docs/config/enabling-agent-service.rst
@@ -2,6 +2,8 @@
 Enabling the Flocker agent service
 ==================================
 
+The Flocker agents are the workhorses of Flocker; you have one on each node in your cluster, and enabling them is an essential step in setting up your cluster:
+
 CentOS 7
 ========
 


### PR DESCRIPTION
Fixes 3363

Adds an explanation of why you need to enable the agent service.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2120)
<!-- Reviewable:end -->
