### PR TITLE
Fixes Jenkins Builds of the vagrant basebox for flocker -  FLOC-3365

### DIFF
--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -646,7 +646,7 @@ branches.each {
     label("{{ job_values.on_nodes_with_labels }}")
     {{ wrappers(job_values, 'none') }}
     {{ triggers('cron', job_values.at, "${branchName}") }}
-    {{ scm("${git_url}", "master") }}
+    {{ scm("${git_url}", "${branchName}") }}
     {{ steps(job_values.with_steps) }}
   }
 {%    endif                                                                  %}

--- a/vagrant/tutorial/Vagrantfile
+++ b/vagrant/tutorial/Vagrantfile
@@ -84,7 +84,7 @@ module UpdateCentOSKernel
           @@rebooted[@vm.id] = true
 
           @ui.info 'Updating kernel'
-          @vm.communicate.sudo('yum install -y kernel kernel-devel') do |type, data|
+          @vm.communicate.sudo('yum -y install kernel kernel-devel') do |type, data|
             if type == :stderr
               @ui.error(data);
             else
@@ -100,7 +100,7 @@ module UpdateCentOSKernel
               @ui.info(data);
             end
           end
-          @vm.communicate.sudo('yum groupinstall -y "Development Tools"') do |type, data|
+          @vm.communicate.sudo('yum -y groupinstall "Development Tools"') do |type, data|
             if type == :stderr
               @ui.error(data);
             else
@@ -115,7 +115,7 @@ module UpdateCentOSKernel
 
       def reboot()
         @ui.info('Rebooting after updating kernel')
-        simle_reboot = Vagrant::Action::Builder.new.tap do |b|
+        simple_reboot = Vagrant::Action::Builder.new.tap do |b|
           b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::GracefulHalt, :poweroff, :running do |env2, b2|
             if !env2[:result]
               b2.use VagrantPlugins::ProviderVirtualBox::Action::ForcedHalt
@@ -128,7 +128,7 @@ module UpdateCentOSKernel
           end
           b.use VagrantVbguest::Middleware
         end
-        @env[:action_runner].run(simle_reboot, @env)
+        @env[:action_runner].run(simple_reboot, @env)
       end
     end
   end

--- a/vagrant/tutorial/Vagrantfile
+++ b/vagrant/tutorial/Vagrantfile
@@ -93,6 +93,13 @@ module UpdateCentOSKernel
           end
 
           @ui.info 'Installing Development Tools'
+          @vm.communicate.sudo('yum -y groups mark convert') do |type, data|
+            if type == :stderr
+              @ui.error(data);
+            else
+              @ui.info(data);
+            end
+          end
           @vm.communicate.sudo('yum groupinstall -y "Development Tools"') do |type, data|
             if type == :stderr
               @ui.error(data);

--- a/vagrant/tutorial/Vagrantfile
+++ b/vagrant/tutorial/Vagrantfile
@@ -49,3 +49,80 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.cache.scope = :box if Vagrant.has_plugin?('vagrant-cachier')
 end
+
+
+# make sure we can install the VBox guest utils
+# https://github.com/dotless-de/vagrant-vbguest/issues/141#issuecomment-101071914
+#
+module UpdateCentOSKernel
+  class UpdateCentOSKernelPlugin < Vagrant.plugin('2')
+    name 'update_centos_kernel_plugin'
+
+    # update yum after first boot when provisioning
+    action_hook(:update_yum, :machine_action_up) do |hook|
+      hook.after(VagrantPlugins::ProviderVirtualBox::Action::CheckGuestAdditions, UpdateCentOSKernel::Middleware::KernelUpdater)
+    end
+  end
+
+  module Middleware
+    class KernelUpdater
+      @@rebooted = {};
+
+      def initialize(app, env)
+        @app = app
+      end
+
+      def call(env)
+        @env = env
+        @vm = env[:machine]
+        @ui = env[:ui]
+        self.update_kernel()
+      end
+
+      def update_kernel()
+        if !@@rebooted[@vm.id]
+          @@rebooted[@vm.id] = true
+
+          @ui.info 'Updating kernel'
+          @vm.communicate.sudo('yum install -y kernel kernel-devel') do |type, data|
+            if type == :stderr
+              @ui.error(data);
+            else
+              @ui.info(data);
+            end
+          end
+
+          @ui.info 'Installing Development Tools'
+          @vm.communicate.sudo('yum groupinstall -y "Development Tools"') do |type, data|
+            if type == :stderr
+              @ui.error(data);
+            else
+              @ui.info(data);
+            end
+          end
+
+
+          self.reboot()
+        end
+      end
+
+      def reboot()
+        @ui.info('Rebooting after updating kernel')
+        simle_reboot = Vagrant::Action::Builder.new.tap do |b|
+          b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::GracefulHalt, :poweroff, :running do |env2, b2|
+            if !env2[:result]
+              b2.use VagrantPlugins::ProviderVirtualBox::Action::ForcedHalt
+            end
+          end
+
+          b.use VagrantPlugins::ProviderVirtualBox::Action::Boot
+          if defined?(Vagrant::Action::Builtin::WaitForCommunicator)
+            b.use Vagrant::Action::Builtin::WaitForCommunicator, [:starting, :running]
+          end
+          b.use VagrantVbguest::Middleware
+        end
+        @env[:action_runner].run(simle_reboot, @env)
+      end
+    end
+  end
+end

--- a/vagrant/tutorial/bootstrap.py
+++ b/vagrant/tutorial/bootstrap.py
@@ -29,11 +29,6 @@ def main():
     # Install a repository that provides epel packages/updates.
     yum_install("epel-release")
 
-    # The kernel was just upgraded which means the existing VirtualBox Guest
-    # Additions will no longer work.  Build them again against the new version
-    # of the kernel.
-    check_output(["/etc/init.d/vboxadd", "setup"])
-
     # Create the 'docker' group.  The Vagrant feature for pulling Docker images
     # (used in the Vagrant file) wants to be able to add the `vagrant` user to
     # the `docker` group (so that it can use the `docker` CLI, presumably).


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3365

This PR fixes multiple issues with the builds of the vagrant basebox tutorial on Jenkins.
* updates the job definitions so that the branch that is built is the correct branch and not master
* Adds a chunk of code to the Vagrantfile allowing it to build the VB guest modules when the kernel is updated from upstream.
* Removes the step where vboxadd is executed as the VBguest modules are handled  by vagrant-vgbuest

Jenkins build:
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/flocker-fix-vagrant-basebox-FLOC-3365/job/_build_vagrant_basebox_for_flocker_tutorial/10/console

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2123)
<!-- Reviewable:end -->
