### PR TITLE
[FLOC 3371] Fix broken links in doc link checker

### DIFF
--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -207,5 +207,5 @@ For example:
 
 
 .. _`systemd's journal`: http://www.freedesktop.org/software/systemd/man/journalctl.html
-.. _`Eliot`: https://eliot.readthedocs.org
+.. _`Eliot`: https://eliot.readthedocs.org/en/0.9.0/
 .. _`eliot-tree`: https://github.com/jonathanj/eliottree

--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -207,5 +207,5 @@ For example:
 
 
 .. _`systemd's journal`: http://www.freedesktop.org/software/systemd/man/journalctl.html
-.. _`Eliot`: https://eliot.readthedocs.org/en/0.9.0/
+.. _`Eliot`: https://eliot.readthedocs.org
 .. _`eliot-tree`: https://github.com/jonathanj/eliottree

--- a/docs/control/cli/application-config.rst
+++ b/docs/control/cli/application-config.rst
@@ -163,4 +163,4 @@ Here's an example of a simple but complete configuration defining one applicatio
        "name": "on-failure"
        "maximum_retry_count": 10
 
-.. _`Docker Run reference`: http://docs.docker.com/reference/run/#runtime-constraints-on-cpu-and-memory
+.. _`Docker Run reference`: http://docs.docker.com/engine/reference/run/#runtime-constraints-on-cpu-and-memory

--- a/docs/control/cli/application-config.rst
+++ b/docs/control/cli/application-config.rst
@@ -163,4 +163,4 @@ Here's an example of a simple but complete configuration defining one applicatio
        "name": "on-failure"
        "maximum_retry_count": 10
 
-.. _`Docker Run reference`: http://docs.docker.com/engine/reference/run/#runtime-constraints-on-cpu-and-memory
+.. _`Docker Run reference`: http://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources

--- a/docs/tutorials_examples/examples/linking.rst
+++ b/docs/tutorials_examples/examples/linking.rst
@@ -10,7 +10,6 @@ Linking Containers
 ``Elasticsearch``, ``Logstash`` & ``Kibana``
 ============================================
 
-Flocker provides functionality similar to `Docker Container Linking`_.
 In this example you will learn how to deploy ``ElasticSearch``, ``Logstash``, and ``Kibana`` with Flocker, demonstrating how applications running in separate Docker containers can be linked together such that they can connect to one another, even when they are deployed on separate nodes.
 
 The three applications are connected as follows:
@@ -149,5 +148,3 @@ Now if you refresh the ``Kibana`` web interface, you should see the log messages
 
 This concludes the ``Elasticsearch-Logstash-Kibana`` example.
 Read more about linking containers in our :ref:`Configuring Flocker <configuration>` documentation.
-
-.. _`Docker Container Linking`: http://docs.docker.com/userguide/dockerlinks/

--- a/docs/tutorials_examples/tutorial/tutorial-requirements.rst
+++ b/docs/tutorials_examples/tutorial/tutorial-requirements.rst
@@ -71,4 +71,4 @@ See the official `MongoDB installation guide`_ for your system.
 .. _`Homebrew`: http://brew.sh/
 .. _`Vagrant`: https://docs.vagrantup.com/v2/
 .. _`VirtualBox`: https://www.virtualbox.org/
-.. _`MongoDB installation guide`: http://docs.mongodb.org/manual/installation/
+.. _`MongoDB installation guide`: https://docs.mongodb.org/manual/installation/


### PR DESCRIPTION
Fixes 3371

Note - the link to Docker Container Linking in the ElasticSearch/LogStash/Kilbana example has been removed, as Docker no longer publishes this page.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2125)
<!-- Reviewable:end -->
