### PR TITLE
[FLOC-3357] sequentially() and in_parallel() now have eliot actions

### DIFF
--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -31,9 +31,15 @@ class IStateChange(Interface):
     An operation that changes local state.
     """
     eliot_action = Attribute(
-        "An ``eliot.ActionType`` within the context of which to execute this "
-        "state change's run method."
-    )
+        """
+        A hack whereby getting this attributes has a side-effect: a
+        ``eliot.ActionType`` is started and return. This state change's
+        run method should be run within the context of the returned
+        action.
+
+        At some point we should fix this so it's a method instead of a
+        attribute-which-must-always-be-a-property.
+        """)
 
     def run(deployer):
         """
@@ -70,30 +76,16 @@ def run_state_change(change, deployer):
 
     :return: ``Deferred`` firing when the change is done.
     """
-    if isinstance(change, _InParallel):
-        return gather_deferreds(list(
-            run_state_change(subchange, deployer)
-            for subchange in change.changes
-        ))
-    if isinstance(change, _Sequentially):
-        d = succeed(None)
-        for subchange in change.changes:
-            d.addCallback(
-                lambda _, subchange=subchange: run_state_change(
-                    subchange, deployer
-                )
-            )
-        return d
-
     with change.eliot_action.context():
         context = DeferredContext(maybeDeferred(change.run, deployer))
         context.addActionFinish()
         return context.result
 
 
-# run_state_change doesn't use the IStateChange implementation provided by
-# _InParallel and _Sequentially but those types provide it anyway because
-# certain other areas of the test suite depend on it.
+LOG_SEQUENTIALLY = ActionType("flocker:node:sequentially", [], [])
+LOG_IN_PARALLEL = ActionType("flocker:node:in_parallel", [], [])
+
+
 @implementer(IStateChange)
 class _InParallel(PRecord):
     changes = field(
@@ -105,12 +97,15 @@ class _InParallel(PRecord):
         mandatory=True
     )
 
-    # Supplied so we technically conform to the interface.  This won't actually
-    # be used.
-    eliot_action = None
+    @property
+    def eliot_action(self):
+        return LOG_IN_PARALLEL()
 
     def run(self, deployer):
-        return run_state_change(self, deployer)
+        return gather_deferreds(list(
+            run_state_change(subchange, deployer)
+            for subchange in self.changes
+        ))
 
 
 def in_parallel(changes):
@@ -133,16 +128,23 @@ def in_parallel(changes):
     return _InParallel(changes=changes)
 
 
-# See comment above _InParallel.
 @implementer(IStateChange)
 class _Sequentially(PRecord):
     changes = field(type=PVector, factory=pvector, mandatory=True)
 
-    # See comment for _InParallel.eliot_action.
-    eliot_action = None
+    @property
+    def eliot_action(self):
+        return LOG_SEQUENTIALLY()
 
     def run(self, deployer):
-        return run_state_change(self, deployer)
+        d = DeferredContext(succeed(None))
+        for subchange in self.changes:
+            d.addCallback(
+                lambda _, subchange=subchange: run_state_change(
+                    subchange, deployer
+                )
+            )
+        return d.result
 
 
 def sequentially(changes):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -2887,7 +2887,7 @@ class DestroyBlockDeviceDatasetTests(
             blockdevice_id=ARBITRARY_BLOCKDEVICE_ID
         )
 
-    @validate_logging(multistep_change_log(
+    @capture_logging(multistep_change_log(
         LOG_SEQUENTIALLY,
         [UNMOUNT_BLOCK_DEVICE, DETACH_VOLUME, DESTROY_VOLUME]
     ))

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -38,6 +38,7 @@ from eliot.testing import (
     LoggedAction, assertHasMessage, assertHasAction
 )
 
+from ..._change import LOG_SEQUENTIALLY
 from .. import blockdevice
 from ...test.istatechange import make_istatechange_tests
 from ..blockdevice import (
@@ -51,7 +52,7 @@ from ..blockdevice import (
 
     PROFILE_METADATA_KEY,
 
-    DESTROY_BLOCK_DEVICE_DATASET, UNMOUNT_BLOCK_DEVICE, DETACH_VOLUME,
+    UNMOUNT_BLOCK_DEVICE, DETACH_VOLUME,
     DESTROY_VOLUME,
     CREATE_BLOCK_DEVICE_DATASET,
     INVALID_DEVICE_PATH,
@@ -2887,7 +2888,7 @@ class DestroyBlockDeviceDatasetTests(
         )
 
     @validate_logging(multistep_change_log(
-        DESTROY_BLOCK_DEVICE_DATASET,
+        LOG_SEQUENTIALLY,
         [UNMOUNT_BLOCK_DEVICE, DETACH_VOLUME, DESTROY_VOLUME]
     ))
     def test_run(self, logger):

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -28,6 +28,7 @@ from ...testtools import (
     random_name, DockerImageBuilder, assertContainsAll)
 from ...volume.testtools import create_volume_service
 from ...route import make_memory_network
+from .. import run_state_change
 
 
 class P2PNodeDeployer(object):
@@ -109,7 +110,7 @@ def change_node_state(deployer, desired_configuration):
             return deployer.calculate_changes(
                 desired_configuration, cluster_state, local_state)
         d.addCallback(got_changes)
-        d.addCallback(lambda change: change.run(deployer))
+        d.addCallback(lambda change: run_state_change(change, deployer))
         return d
     # Repeat a few times until things settle down:
     result = converge()

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -532,7 +532,7 @@ class RunStateChangeTests(SynchronousTestCase):
 
         :param combo: ``sequentially`` or ``in_parallel``.
         :param action_type: ``eliot.ActionType`` we expect to be parent of
-            sub-changes logs.
+            sub-changes' log entries.
         :param logger: A ``MemoryLogger`` where messages go.
         """
         actions = [ControllableAction(result=Deferred()),

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -15,7 +15,8 @@ from twisted.internet.defer import FirstError, Deferred, succeed, fail
 from twisted.python.components import proxyForInterface
 
 from eliot import ActionType
-from eliot.testing import validate_logging, assertHasAction
+from eliot.testing import (
+    validate_logging, assertHasAction, capture_logging, LoggedAction)
 
 from ..testtools import (
     CONTROLLABLE_ACTION_TYPE, ControllableAction, ControllableDeployer,
@@ -24,6 +25,7 @@ from ..testtools import (
 from ...testtools import CustomException
 
 from .. import IStateChange, sequentially, in_parallel, run_state_change, NoOp
+from .._change import LOG_IN_PARALLEL, LOG_SEQUENTIALLY
 
 from .istatechange import (
     DummyStateChange, RunSpyStateChange, make_istatechange_tests,
@@ -521,3 +523,47 @@ class RunStateChangeTests(SynchronousTestCase):
         action._logger = logger
         failure = self.failureResultOf(run_state_change(action, DEPLOYER))
         self.assertEqual(failure.getErrorMessage(), "Oh no")
+
+    def assert_nested_logging(self, combo, action_type, logger):
+        """
+        All the underlying ``IStateChange`` will be run in Eliot context in
+        which the sequential ``IStateChange`` is run, even if they are not
+        run immediately.
+
+        :param combo: ``sequentially`` or ``in_parallel``.
+        :param action_type: ``eliot.ActionType`` we expect to be parent of
+            sub-changes logs.
+        :param logger: A ``MemoryLogger`` where messages go.
+        """
+        actions = [ControllableAction(result=Deferred()),
+                   ControllableAction(result=succeed(None))]
+        for action in actions:
+            self.patch(action, "_logger", logger)
+        run_state_change(combo(actions), None)
+        # For sequentially this will ensure second action doesn't
+        # automatically run in context of LOG_ACTION:
+        actions[0].result.callback(None)
+
+        parent = assertHasAction(self, logger, action_type, succeeded=True)
+        self.assertEqual(
+            dict(messages=parent.children, length=len(parent.children)),
+            dict(
+                messages=LoggedAction.ofType(
+                    logger.messages, CONTROLLABLE_ACTION_TYPE),
+                length=2))
+
+    @capture_logging(None)
+    def test_sequential_logging(self, logger):
+        """
+        All the underlying ``IStateChange`` will be run in Eliot context in
+        which the sequential ``IStateChange`` is run.
+        """
+        self.assert_nested_logging(sequentially, LOG_SEQUENTIALLY, logger)
+
+    @capture_logging(None)
+    def test_parallel_logging(self, logger):
+        """
+        All the underlying ``IStateChange`` will be run in Eliot context in
+        which the parallel ``IStateChange`` is run.
+        """
+        self.assert_nested_logging(in_parallel, LOG_IN_PARALLEL, logger)


### PR DESCRIPTION
1. Added explicit eliot actions for in-parallel and sequential runs.
2. Minorly refactored the code to be more object-oriented.
3. Fixed the bug which is the point of the exercise: sub-statechanges of `sequentially` are now run in correct Eliot context so it's possible to see them in appropriate place when reading logs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2126)
<!-- Reviewable:end -->
