### PR TITLE
[FLOC-3261] Design review: use node eras to identify nodes, so reboots invalidate node state

### DIFF
--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -102,6 +102,7 @@ class Node(PClass):
         type=(IPv4Address, IPv6Address),
         mandatory=True,
     )
+    era = field(type=UUID, mandatory=True)
 
 
 class DatasetAlreadyExists(Exception):
@@ -517,6 +518,7 @@ class FlockerClient(object):
         )
 
     def list_nodes(self):
+        # XXX will also need to do /state/node_eras
         request = self._request(
             b"GET", b"/state/nodes", None, {OK}
         )

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -856,6 +856,7 @@ class NodeState(PRecord):
     The current state of a node.
 
     :ivar UUID uuid: The node's UUID.
+    :ivar UUID era: The node's era. Each reboot is a new era.
     :ivar unicode hostname: The IP of the node.
     :ivar applications: A ``PSet`` of ``Application`` instances on this node,
         or ``None`` if the information is not known.

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -868,6 +868,19 @@ class ConfigurationAPIUserV1(object):
         except ConfigurationError as e:
             raise make_bad_request(code=BAD_REQUEST, description=unicode(e))
 
+    @app.route("/state/node_eras", methods=['GET'])
+    @user_documentation(
+        u"""
+        List the currently known nodes and their eras.
+
+        A node's era can be looked up by reading
+        /proc/sys/kernel/random/boot_id. If possible use eras to identify
+        nodes rather than IP addresses.
+        """)
+    def node_eras(self):
+        # ... etc... returns list of {"node_id": id, "era": era} dicts
+        pass
+
     @app.route("/configuration/leases", methods=['GET'])
     @user_documentation(
         u"""

--- a/flocker/dockerplugin/_script.py
+++ b/flocker/dockerplugin/_script.py
@@ -69,7 +69,8 @@ class DockerPluginScript(object):
         # some information we need:
         agent_config = get_configuration(options)
         control_host = agent_config['control-service']['hostname']
-        node_id = agent_config['node-credential'].uuid
+
+        # XXX read era from /proc/sys/kernel/random/boot_id, then use client to lookup node_id with matching era. will need to loop until that info is available I guess.
 
         certificates_path = options["agent-config"].parent()
         control_port = options["rest-api-port"]


### PR DESCRIPTION
The idea is that if each reboot you have new era for a node, and clients of the REST API identify the node using its era (easily obtainable from `/proc`), the clients will never get stale data from previous reboots.

This also means clients don't have to read our TLS certificates to find node identity, a minor benefit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2127)
<!-- Reviewable:end -->
