### PR TITLE
[FLOC-3272] Flongle profiles + acceptance test

### DIFF
--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -5,7 +5,6 @@ Tests for the datasets REST API.
 """
 
 from uuid import UUID
-from unittest import skipUnless
 
 from twisted.internet import reactor
 from twisted.trial.unittest import TestCase

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -16,8 +16,6 @@ from ..testtools import (
     require_cluster, require_moving_backend, create_dataset, DatasetBackend
 )
 
-STORAGE_PROFILES_IMPLEMENTED = False
-
 
 class DatasetAPITests(TestCase):
     """
@@ -30,8 +28,6 @@ class DatasetAPITests(TestCase):
         """
         return create_dataset(self, cluster)
 
-    @skipUnless(STORAGE_PROFILES_IMPLEMENTED,
-                "Flocker storage profiles are not implemented yet.")
     @require_cluster(1, required_backend=DatasetBackend.aws)
     def test_dataset_creation_with_gold_profile(self, cluster, backend):
         """

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -128,7 +128,7 @@ class DockerPluginTests(TestCase):
         """
         # XXX: replace with:
         #
-        # client.create_volume(name, u'flocker', driver_opts)
+        # return client.create_volume(name, u'flocker', driver_opts)
         #
         # Once version 1.5.1+ of docker-py is released. It is currently fixed
         # at head, but version 1.5.0 unfortunately has the wrong endpoint for
@@ -210,11 +210,16 @@ class DockerPluginTests(TestCase):
 
             volumes = backend.list_volumes()
 
-            for volume in volumes:
-                if volume.dataset_id == dataset.dataset_id:
+            volume = None
+            for v in volumes:
+                if v.dataset_id == dataset.dataset_id:
+                    volume = v
                     break
-            ebs_volume = backend._get_ebs_volume(volume.blockdevice_id)
-            self.assertEqual(u'gp2', ebs_volume.type)
+            volume_type = None
+            if volume:
+                ebs_volume = backend._get_ebs_volume(volume.blockdevice_id)
+                volume_type = ebs_volume.type
+            self.assertEqual(u'gp2', volume_type)
 
         datasets_deferred.addCallback(_evaluate_datasets)
 

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -193,7 +193,7 @@ class DockerPluginTests(TestCase):
         docker = get_docker_client(cluster, node.public_address)
         volume_name = random_name(self)
         self._create_volume(docker, volume_name,
-                           driver_opts={'profile': 'silver'})
+                            driver_opts={'profile': 'silver'})
 
         datasets_deferred = cluster.client.list_datasets_configuration()
 

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -126,9 +126,9 @@ class DockerPluginTests(TestCase):
             Docker.
         :returns: The result of the API call.
         """
-        # XXX: replace with:
+        # XXX: replace down to addCleanup with:
         #
-        # return client.create_volume(name, u'flocker', driver_opts)
+        # result = client.create_volume(name, u'flocker', driver_opts)
         #
         # Once version 1.5.1+ of docker-py is released. It is currently fixed
         # at head, but version 1.5.0 unfortunately has the wrong endpoint for
@@ -139,7 +139,9 @@ class DockerPluginTests(TestCase):
             'Driver': u'flocker',
             'DriverOpts': driver_opts,
         }
-        return client._result(client._post_json(url, data=data), True)
+        result = client._result(client._post_json(url, data=data), True)
+        self.addCleanup(client.remove_volume, name)
+        return result
 
     def _test_create_container(self, cluster):
         """
@@ -181,12 +183,11 @@ class DockerPluginTests(TestCase):
         return self._test_create_container(cluster)
 
     @require_cluster(1, required_backend=DatasetBackend.aws)
-    def test_create_profiled_container_with_v2_plugin_api(self, cluster,
-                                                          backend):
+    def test_create_silver_volume_with_v2_plugin_api(self, cluster, backend):
         """
         Docker >=1.9, using the v2 plugin API, can create a volume with the
-        volumes API, and pass a profile argument which is represented in the
-        backing volume created.
+        volumes API, and pass a profile argument of silver which is represented
+        in the backing volume created on EBS.
         """
         self.require_docker('1.9.0', cluster)
         node = cluster.nodes[0]

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -108,7 +108,7 @@ def get_docker_client(cluster, address):
         assert_hostname=False,
         verify=get_path(b"cluster.crt"))
     return Client(base_url="https://{}:{}".format(address, DOCKER_PORT),
-                  tls=tls, timeout=100)
+                  tls=tls, timeout=100, version='1.21')
 
 
 def get_mongo_application():

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -21,6 +21,7 @@ from klein import Klein
 from ..restapi import structured
 from ..control._config import dataset_id_from_name
 from ..apiclient import DatasetAlreadyExists
+from ..node.agents.blockdevice import PROFILE_METADATA_KEY
 
 
 SCHEMA_BASE = FilePath(__file__).sibling(b'schema')
@@ -167,9 +168,15 @@ class VolumePlugin(object):
                     raise DatasetAlreadyExists
         listing.addCallback(got_configured)
 
+        metadata = {u"name": Name}
+        opts = Opts or {}
+        profile = opts.get(u"profile")
+        if profile:
+            metadata[PROFILE_METADATA_KEY] = profile
+
         creating = listing.addCallback(
             lambda _: self._flocker_client.create_dataset(
-                self._node_id, DEFAULT_SIZE, metadata={u"name": Name},
+                self._node_id, DEFAULT_SIZE, metadata=metadata,
                 dataset_id=UUID(dataset_id_from_name(Name))))
         creating.addErrback(lambda reason: reason.trap(DatasetAlreadyExists))
         creating.addCallback(lambda _: {u"Err": None})

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -473,6 +473,7 @@ _DEFAULT_DEPLOYERS = {
         P2PManifestationDeployer(volume_service=api, **kw),
     DeployerType.block: lambda api, **kw:
         BlockDeviceDeployer(block_device_api=ProcessLifetimeCache(api),
+                            _profiled_blockdevice_api=api,
                             **kw),
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.1.2
 characteristic==14.3.0
 cryptography==0.9.1
 debtcollector==0.5.0
-docker-py==1.3.1
+docker-py==1.5.0
 effect==0.1a13
 eliot==0.9.0
 eliot-tree==15.3.0


### PR DESCRIPTION
This also completes FLOC-3274.

With this PR, the Flocker plugin for Docker can now accept a "profile" option if it is being used with docker version 1.9.0+. The added test verifies that if the 'silver' profile is chosen with the create_volume request using the EBS backend, we get the expected volume type for EBS u'silver' profile.

Unfortunately docker-py 1.5.0 does not have full support for create_volume (it is merged at head), so there is some odd code that explicitly uses internals to that library to construct the correct request to docker.

Also this turns on the acceptance test, which revealed that the proxy BlockDeviceAPI was hiding the fact that the EBS driver implemented IProfiledBlockDeviceAPI, so that is fixed as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2133)
<!-- Reviewable:end -->
