### PR TITLE
Increase timeout for OSX builds of the vagrant OSX box FLOC-3373

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1196,4 +1196,4 @@ job_type:
                    *run_build_sh_script_on_vagrant_box,
                    *package_jenkins_osx_yosemite_box ]
           }
-      timeout: 90
+      timeout: 120

--- a/build.yaml
+++ b/build.yaml
@@ -1196,4 +1196,4 @@ job_type:
                    *run_build_sh_script_on_vagrant_box,
                    *package_jenkins_osx_yosemite_box ]
           }
-      timeout: 60
+      timeout: 90


### PR DESCRIPTION
oneliner,
it increases the timeout from 60min to 120min for the nightly cron job that refreshes the OSX vagrant basebox for OSX run client tests

<!-- Reviewable:start -->

<!-- Reviewable:end -->
