### PR TITLE
[FLOC 3390] Remove broken link from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,3 @@
-Want to get your hands dirty? Skip ahead to the `tutorial`_.
-
 Flocker
 =======
 


### PR DESCRIPTION
Fixes 3390.

This link has been broken in a recent PR, when the tutorial URL was removed. Due to additional installation and configuration options, it might not be the best practice for a user to jump directly to the Mongo tutorial.

I think this sentence can now be removed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2136)
<!-- Reviewable:end -->
