### PR TITLE
[FLOC-3391] Docs feedback

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -162,7 +162,7 @@
                                 // populate the current URL field
                                 document.querySelector("#currenturl").value = window.location.href;
                             </script>
-                            <textarea class="form-control" rows="3" name="field37192409" placeholder="Your Feedback"></textarea>
+                            <textarea class="form-control" rows="3" name="field37192409" placeholder="Your Feedback" required="required"></textarea>
                             <input type="text" name="field37192455" placeholder="Your email address (optional)" class="form-control"/>
                             <input type="submit" class="button" />
                         </form>

--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -147,12 +147,28 @@
                     </div>
                 </div>
 
-                <!-- Disqus -->
-                {% if theme_disqus_shortname %}
-                    <div id="disqus_thread"></div>
-                    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-                {% endif %}
-                <!-- End of Disqus -->
+                <!-- Feedback form -->
+                <div class="row">
+                    <div class="col-sm-8 feedback-form">
+                        <h3>How could we improve this page?</h3>
+                        <form method="post" action="https://www.formstack.com/forms/index.php">
+                            <!-- Form ID and keys are from formstack for this specific form -->
+                            <input type="hidden" name="form" value="2174054" />
+                            <input type="hidden" name="viewkey" value="ErUKrnw85k" />
+                            <input type="hidden" name="_submit" value="1" />
+                            <!-- The field names here are the field names as produced by Formstack for our form -->
+                            <input type="hidden" name="field37192831" value="UNKNOWN" id="currenturl" />
+                            <script>
+                                // populate the current URL field
+                                document.querySelector("#currenturl").value = window.location.href;
+                            </script>
+                            <textarea class="form-control" rows="3" name="field37192409" placeholder="Your Feedback"></textarea>
+                            <input type="text" name="field37192455" placeholder="Your email address (optional)" class="form-control"/>
+                            <input type="submit" class="button" />
+                        </form>
+                    </div>
+                </div>
+                <!-- End of Feedback form -->
             </div>
         </div>
     </div>

--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -151,7 +151,7 @@
                 <div class="row">
                     <div class="col-sm-8 feedback-form">
                         <h3>How could we improve this page?</h3>
-                        <form method="post" action="https://www.formstack.com/forms/index.php">
+                        <form method="post" action="https://www.formstack.com/forms/index.php" id="feedback">
                             <!-- Form ID and keys are from formstack for this specific form -->
                             <input type="hidden" name="form" value="2174054" />
                             <input type="hidden" name="viewkey" value="ErUKrnw85k" />
@@ -255,5 +255,8 @@
             }
         });
     </script>
+
+    <!-- Javascript include for form feedback submit -->
+    <script type="text/javascript" src="{{ pathto('_static/js/feedback.js', 1) }}"></script>
   </body>
 </html>

--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -326,6 +326,10 @@ a.download:before {
     margin-top:10px;
 }
 
+.feedback-form {
+    font-family: lato;
+}
+
 
 @media all and (min-width: 768px) {
     /* sm */

--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -190,7 +190,7 @@ h1:hover > a.headerlink, h2:hover > a.headerlink, h3:hover > a.headerlink, h4:ho
     line-height: 47px;
 }
 
-a.button {
+a.button, input.button {
     font-family: "Soho Gothic W01 Medium";
     border-radius: 8px;
     text-decoration: none;
@@ -199,9 +199,10 @@ a.button {
     padding: 10px;
     cursor: pointer;
     width: 150px;
+    border: 0;
 }
 
-a.button:hover {
+a.button:hover, input.button:hover {
     background-color: #343a3d;
 }
 
@@ -319,6 +320,12 @@ a.download:before {
     height:97px;
     padding: 25px;
 }
+
+/* Feedback form */
+.feedback-form form>textarea,input {
+    margin-top:10px;
+}
+
 
 @media all and (min-width: 768px) {
     /* sm */

--- a/docs/_themes/clusterhq/static/js/feedback.js
+++ b/docs/_themes/clusterhq/static/js/feedback.js
@@ -1,0 +1,12 @@
+$("#feedback").submit(function() {
+    event.preventDefault();
+
+    $.ajax({
+        url: "https://www.formstack.com/forms/index.php",
+        method: "POST",
+        data: $("#feedback").serialize(),
+        dataType: "json"
+    });
+
+    $("#feedback").html("<p>Thanks for your feedback, if you gave your email address we'll be in touch with you shortly.</p>");
+});


### PR DESCRIPTION
The form works the same way as the ones on the marketing website do.

When a user submits a form it sends an HTTP request with Javascript to Formstack. We have a formstack form made for documentation feedback and the fields are the IDs defined in the html file.
If the user doesn't have Javascript, the form will just post as normal.

Once the entry is at Formstack, Zapier detects this and creates a new Zendesk ticket.

Fixes FLOC-3391

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2137)
<!-- Reviewable:end -->
