### PR TITLE
[FLOC 3393] remove UserVoice link from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Feature Requests
 ----------------
 
 If you have any feature requests or suggestions, we would love to hear about them.
-Please add your ideas to our `UserVoice`_ forum, or file a `GitHub issue`_.
+Please send us your ideas by filing a `GitHub issue`_.
 
 
 Tests
@@ -58,5 +58,4 @@ Flocker is also tested using `continuous integration`_.
 .. _continuous integration: http://build.clusterhq.com/
 .. _talk to us: http://docs.clusterhq.com/en/latest/gettinginvolved/contributing.html#talk-to-us
 .. _flake8: https://pypi.python.org/pypi/flake8
-.. _UserVoice: https://feedback.clusterhq.com/
 .. _GitHub issue: https://github.com/clusterhq/flocker/issues


### PR DESCRIPTION
Fixes 3393

This issue simply removes the link (and rewords the sentence) relating to feedback via UserVoice, as this will no longer be supported.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2138)
<!-- Reviewable:end -->
