### PR TITLE
[FLOC-3379] Control service learns about eras

### DIFF
--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -20,7 +20,7 @@ from ._model import (
     Link, AttachedVolume, NodeState, Manifestation, Dataset, RestartNever,
     RestartOnFailure, RestartAlways, DeploymentState, NonManifestDatasets,
     same_node, IClusterStateWipe, Leases, Lease, LeaseError, pmap_field,
-    ChangeSource, NO_WIPE, UpdateNodeStateEra,
+    ChangeSource, UpdateNodeStateEra, NoWipe,
 )
 from ._protocol import (
     IConvergenceAgent,
@@ -62,6 +62,6 @@ __all__ = [
     'Leases',
     'LeaseError',
     'ChangeSource',
-    'NO_WIPE',
     'UpdateNodeStateEra',
+    'NoWipe',
 ]

--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -20,7 +20,7 @@ from ._model import (
     Link, AttachedVolume, NodeState, Manifestation, Dataset, RestartNever,
     RestartOnFailure, RestartAlways, DeploymentState, NonManifestDatasets,
     same_node, IClusterStateWipe, Leases, Lease, LeaseError, pmap_field,
-    ChangeSource,
+    ChangeSource, NO_WIPE,
 )
 from ._protocol import (
     IConvergenceAgent,
@@ -60,4 +60,5 @@ __all__ = [
     'Leases',
     'LeaseError',
     'ChangeSource',
+    'NO_WIPE',
 ]

--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -20,7 +20,7 @@ from ._model import (
     Link, AttachedVolume, NodeState, Manifestation, Dataset, RestartNever,
     RestartOnFailure, RestartAlways, DeploymentState, NonManifestDatasets,
     same_node, IClusterStateWipe, Leases, Lease, LeaseError, pmap_field,
-    ChangeSource, NO_WIPE,
+    ChangeSource, NO_WIPE, UpdateNodeStateEra,
 )
 from ._protocol import (
     IConvergenceAgent,
@@ -61,4 +61,5 @@ __all__ = [
     'LeaseError',
     'ChangeSource',
     'NO_WIPE',
+    'UpdateNodeStateEra',
 ]

--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -26,6 +26,7 @@ from ._protocol import (
     IConvergenceAgent,
     NodeStateCommand,
     AgentAMP,
+    SetNodeEraCommand,
 )
 
 __all__ = [
@@ -54,6 +55,7 @@ __all__ = [
 
     'IConvergenceAgent',
     'NodeStateCommand',
+    'SetNodeEraCommand',
     'AgentAMP',
     'pmap_field',
     'Lease',

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -13,7 +13,7 @@ from twisted.application.internet import TimerService
 
 from pyrsistent import PRecord, field, pmap
 
-from . import DeploymentState, ChangeSource, NO_WIPE
+from . import DeploymentState, ChangeSource
 
 # Allowed inactivity period before updates are expired
 EXPIRATION_TIME = timedelta(seconds=120)
@@ -119,8 +119,6 @@ class ClusterStateService(MultiService):
             )
         for change in changes:
             wiper = change.get_information_wipe()
-            if wiper is NO_WIPE:
-                continue
             key = (wiper.__class__, wiper.key())
             self._information_wipers = self._information_wipers.set(
                 key, _WiperAndSource(wiper=wiper, source=source)

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -13,8 +13,7 @@ from twisted.application.internet import TimerService
 
 from pyrsistent import PRecord, field, pmap
 
-from ._model import DeploymentState, ChangeSource
-
+from . import DeploymentState, ChangeSource, NO_WIPE
 
 # Allowed inactivity period before updates are expired
 EXPIRATION_TIME = timedelta(seconds=120)
@@ -120,6 +119,8 @@ class ClusterStateService(MultiService):
             )
         for change in changes:
             wiper = change.get_information_wipe()
+            if wiper is NO_WIPE:
+                continue
             key = (wiper.__class__, wiper.key())
             self._information_wipers = self._information_wipers.set(
                 key, _WiperAndSource(wiper=wiper, source=source)

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -765,7 +765,7 @@ class IClusterStateChange(Interface):
         this change.
 
         For example, if this update adds information to a particular node,
-        the returned ``IClusterStateChange`` will wipe out that
+        the returned ``IClusterStateWipe`` will wipe out that
         information indicating ignorance about that information. We need
         this ability in order to expire out-of-date state information.
 

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -738,6 +738,13 @@ class DatasetChanges(object):
     """
 
 
+class _NoWipe(object):
+    """
+    Indicate no wipe is necessary.
+    """
+NO_WIPE = _NoWipe()
+
+
 class IClusterStateChange(Interface):
     """
     An ``IClusterStateChange`` can update a ``DeploymentState`` with new
@@ -762,7 +769,8 @@ class IClusterStateChange(Interface):
         information indicating ignorance about that information. We need
         this ability in order to expire out-of-date state information.
 
-        :return: A ``IClusterStateWipe`` that undoes this update.
+        :return: A ``IClusterStateWipe`` that undoes this update, or
+            ``NO_WIPE`` if no undo is necessary or possible.
         """
 
 

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -977,11 +977,7 @@ class UpdateNodeStateEra(PClass):
 
     def get_information_wipe(self):
         """
-        Do nothing: no followup wipes are necessary.
-
-        If we did discard the node state we'll be leaving its wiper hanging,
-        but it won't actually do anything if it can't find the node so
-        that's OK.
+        Since we just deleted some information, there's nothing to wipe.
         """
         return NoWipe()
 

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -349,9 +349,9 @@ class ControlServiceLocator(CommandLocator):
         self.control_amp_service.cluster_state.apply_changes_from_source(
             self._source, [UpdateNodeStateEra(era=UUID(era),
                                               uuid=UUID(node_uuid))])
-        # We don't bother sending update to other nodes because this
-        # command will almost immediatey be following by a
-        # ``NodeStateCommand`` with more interesting information.
+        # We don't bother sending an update to other nodes because this
+        # command will immediately be followed by a ``NodeStateCommand``
+        # with more interesting information.
         return {}
 
 

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -38,7 +38,7 @@ from contextlib import contextmanager
 from twisted.internet.defer import maybeDeferred
 
 from eliot import (
-    Logger, ActionType, Action, Field, MessageType, writeFailure,
+    Logger, ActionType, Action, Field, MessageType,
 )
 from eliot.twisted import DeferredContext
 
@@ -252,7 +252,8 @@ class SetNodeEraCommand(Command):
     ensure it doesn't get stale pre-reboot information (i.e. NodeState
     with wrong era).
     """
-    arguments = [('era', Unicode())]
+    arguments = [('era', Unicode()),
+                 ('node_uuid', Unicode())]
     response = []
 
 
@@ -343,7 +344,7 @@ class ControlServiceLocator(CommandLocator):
             return {}
 
     @SetNodeEraCommand.responder
-    def set_node_era(self, era):
+    def set_node_era(self, era, node_uuid):
         # Actual work will be done in FLOC-3379, FLOC-3380
         pass
 
@@ -755,8 +756,6 @@ class AgentAMP(AMP):
         AMP.connectionMade(self)
         self.agent.connected(self)
         self._pinger.start(self, PING_INTERVAL)
-        d = self.callRemote(SetNodeEraCommand, era=unicode(get_era()))
-        d.addErrback(writeFailure)
 
     def connectionLost(self, reason):
         AMP.connectionLost(self, reason)

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 """
 Communication protocol between control service and convergence agent.

--- a/flocker/control/test/test_clusterstate.py
+++ b/flocker/control/test/test_clusterstate.py
@@ -6,8 +6,6 @@ Tests for ``flocker.control._clusterstate``.
 
 from uuid import uuid4
 
-from zope.interface import implementer
-
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 from twisted.internet.task import Clock
@@ -16,7 +14,7 @@ from .._model import ChangeSource
 from .._clusterstate import ClusterStateService
 from .. import (
     Application, DockerImage, NodeState, DeploymentState, Manifestation,
-    Dataset, IClusterStateChange,
+    Dataset,
 )
 from .clusterstatetools import advance_some, advance_rest
 

--- a/flocker/control/test/test_clusterstate.py
+++ b/flocker/control/test/test_clusterstate.py
@@ -16,7 +16,7 @@ from .._model import ChangeSource
 from .._clusterstate import ClusterStateService
 from .. import (
     Application, DockerImage, NodeState, DeploymentState, Manifestation,
-    Dataset, NO_WIPE, IClusterStateChange,
+    Dataset, IClusterStateChange,
 )
 from .clusterstatetools import advance_some, advance_rest
 
@@ -253,26 +253,4 @@ class ClusterStateServiceTests(SynchronousTestCase):
         self.assertEqual(
             service.as_deployment(),
             DeploymentState(nodes=[self.WITH_APPS]),
-        )
-
-    def test_no_wipe(self):
-        """
-        An update can indicate no wiping is necessary by returning
-        ``NO_WIPE``. Other changes will still expire as usual.
-        """
-        @implementer(IClusterStateChange)
-        class NoChange(object):
-            def update_cluster_state(self, cluster_state):
-                return cluster_state
-
-            def get_information_wipe(self):
-                return NO_WIPE
-
-        service = self.service()
-        service.apply_changes([NoChange(), self.WITH_APPS])
-        advance_some(self.clock)
-        advance_rest(self.clock)
-        # At this point both changes should have expired.
-        self.assertEqual(
-            service.as_deployment(), DeploymentState(nodes=[])
         )

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -34,7 +34,7 @@ from twisted.application.internet import StreamServerEndpointService
 from twisted.internet.ssl import ClientContextFactory
 from twisted.internet.task import Clock
 
-from ...testtools.amp import DelayedAMPClient
+from ...testtools.amp import DelayedAMPClient, connected_amp_protocol
 
 from .._protocol import (
     PING_INTERVAL, Big, SerializableArgument,
@@ -1039,20 +1039,12 @@ def iconvergence_agent_tests_factory(fixture):
         """
         Tests for ``IConvergenceAgent``.
         """
-        def protocol(self):
-            """
-            Return an ``AMP`` instance with a transport.
-            """
-            protocol = AMP()
-            protocol.makeConnection(StringTransport())
-            return protocol
-
         def test_connected(self):
             """
             ``IConvergenceAgent.connected()`` takes an AMP instance.
             """
             agent = fixture(self)
-            agent.connected(self.protocol())
+            agent.connected(connected_amp_protocol())
 
         def test_disconnected(self):
             """
@@ -1060,7 +1052,7 @@ def iconvergence_agent_tests_factory(fixture):
             ``IConvergenceAgent.connected()``.
             """
             agent = fixture(self)
-            agent.connected(self.protocol())
+            agent.connected(connected_amp_protocol())
             agent.disconnected()
 
         def test_reconnected(self):
@@ -1069,9 +1061,9 @@ def iconvergence_agent_tests_factory(fixture):
             ``IConvergenceAgent.disconnected()``.
             """
             agent = fixture(self)
-            agent.connected(self.protocol())
+            agent.connected(connected_amp_protocol())
             agent.disconnected()
-            agent.connected(self.protocol())
+            agent.connected(connected_amp_protocol())
 
         def test_cluster_updated(self):
             """
@@ -1079,7 +1071,7 @@ def iconvergence_agent_tests_factory(fixture):
             instances.
             """
             agent = fixture(self)
-            agent.connected(self.protocol())
+            agent.connected(connected_amp_protocol())
             agent.cluster_updated(
                 Deployment(nodes=frozenset()), Deployment(nodes=frozenset()))
 

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 """
 Tests for ``flocker.control._protocol``.

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -651,6 +651,22 @@ class ControlAMPTests(ControlTestCase):
             self.control_amp_service.cluster_state.as_deployment(),
         )
 
+    def test_set_node_era(self):
+        """
+        A ``SetNodeEraCommand`` results in the node's era being
+        updated.
+        """
+        node_uuid = uuid4()
+        era = uuid4()
+        d = self.client.callRemote(SetNodeEraCommand,
+                                   node_uuid=unicode(node_uuid),
+                                   era=unicode(era))
+        self.successResultOf(d)
+        self.assertEqual(
+            DeploymentState(node_uuid_to_era={node_uuid: era}),
+            self.control_amp_service.cluster_state.as_deployment(),
+        )
+
 
 class ControlAMPServiceTests(ControlTestCase):
     """

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -48,7 +48,7 @@ from .agents.loopback import (
     LoopbackBlockDeviceAPI,
 )
 from ..ca import ControlServicePolicy, NodeCredential
-
+from ..common._era import get_era
 
 __all__ = [
     "flocker_dataset_agent_main",
@@ -327,6 +327,7 @@ class AgentServiceFactory(PRecord):
                 cluster_uuid=tls_info.node_credential.cluster_uuid),
             host=host, port=port,
             context_factory=tls_info.context_factory,
+            era=get_era(),
         )
 
 
@@ -635,6 +636,7 @@ class AgentService(PRecord):
             deployer=deployer,
             host=self.control_service_host, port=self.control_service_port,
             context_factory=self.get_tls_context().context_factory,
+            era=get_era(),
         )
 
 

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -15,7 +15,7 @@ from pyrsistent import pset
 
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.test.proto_helpers import StringTransport, MemoryReactorClock
-from twisted.internet.protocol import Protocol, ReconnectingClientFactory
+from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.internet.defer import succeed, Deferred, fail
 from twisted.internet.ssl import ClientContextFactory
 from twisted.internet.task import Clock

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -1087,6 +1087,9 @@ class ConvergenceLoopFSMTests(SynchronousTestCase):
 
 
 class UpdateNodeEraLocator(CommandLocator):
+    """
+    An AMP locator that can handle the ``SetNodeEraCommand`` AMP command.
+    """
     uuid = None
     era = None
 
@@ -1158,13 +1161,16 @@ class AgentLoopServiceTests(SynchronousTestCase):
         Upon connecting a ``SetNodeEraCommand`` is sent with the current
         node's era and UUID.
         """
-        protocol = AgentAMP(self.reactor, self.service)
-        locator = UpdateNodeEraLocator()
-        peer = AMP(locator=locator)
-        pump = connectedServerAndClient(lambda: protocol, lambda: peer)[2]
+        client = AgentAMP(self.reactor, self.service)
+        # The object that processes incoming AMP commands:
+        server_locator = UpdateNodeEraLocator()
+        server = AMP(locator=server_locator)
+        pump = connectedServerAndClient(lambda: client, lambda: server)[2]
         pump.flush()
         self.assertEqual(
-            dict(era=locator.era, uuid=locator.uuid),
+            # Actual result of handling AMP commands, if any:
+            dict(era=server_locator.era, uuid=server_locator.uuid),
+            # Expected result:
             dict(era=unicode(self.service.era),
                  uuid=unicode(self.deployer.node_uuid)))
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -5,6 +5,7 @@ Tests for :module:`flocker.node.script`.
 """
 
 import socket
+from unittest import skipUnless
 
 import yaml
 from ipaddr import IPAddress
@@ -21,9 +22,11 @@ from twisted.internet.defer import Deferred
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.application.service import Service
+from twisted.python.runtime import platform
 
 from ...common.script import ICommandLineScript
 from ...common import get_all_ips
+from ...common._era import get_era
 
 from ..script import (
     AgentScript, ContainerAgentOptions,
@@ -467,6 +470,7 @@ class AgentServiceLoopTests(SynchronousTestCase):
     """
     setUp = agent_service_setup
 
+    @skipUnless(platform.isLinux(), "get_era() only supports Linux.")
     def test_agentloopservice(self):
         """
         ```AgentService.get_loop_service`` returns an ``AgentLoopService``
@@ -483,6 +487,7 @@ class AgentServiceLoopTests(SynchronousTestCase):
                 host=self.host,
                 port=self.port,
                 context_factory=context_factory,
+                era=get_era()
             ),
             loop_service,
         )
@@ -527,6 +532,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
              self.ca_set.node.cluster_uuid),
             result[0])
 
+    @skipUnless(platform.isLinux(), "get_era() only supports Linux.")
     def test_get_service(self):
         """
         ``AgentServiceFactory.get_service`` creates an ``AgentLoopService``
@@ -547,10 +553,12 @@ class AgentServiceFactoryTests(SynchronousTestCase):
                 port=1234,
                 context_factory=_context_factory_and_credential(
                     self.config.parent(), b"10.0.0.1", 1234).context_factory,
+                era=get_era(),
             ),
             service_factory.get_service(reactor, options)
         )
 
+    @skipUnless(platform.isLinux(), "get_era() only supports Linux.")
     def test_default_port(self):
         """
         ``AgentServiceFactory.get_service`` creates an ``AgentLoopService``
@@ -581,6 +589,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
                 port=4524,
                 context_factory=_context_factory_and_credential(
                     self.config.parent(), b"10.0.0.2", 4524).context_factory,
+                era=get_era(),
             ),
             service_factory.get_service(reactor, options)
         )

--- a/flocker/testtools/amp.py
+++ b/flocker/testtools/amp.py
@@ -117,3 +117,12 @@ class DelayedAMPClient(object):
         """
         d, response = self._calls.pop(0)
         response.chainDeferred(d)
+
+
+def connected_amp_protocol():
+    """
+    :return: ``AMP`` hooked up to transport.
+    """
+    p = AMP()
+    p.makeConnection(StringTransport())
+    return p


### PR DESCRIPTION
1. The control service now handles node era update.
2. Sending of node era updates was moved elsewhere so we can easily get at the node UUID.

For full plan see https://clusterhq.atlassian.net/browse/FLOC-3261

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2141)
<!-- Reviewable:end -->
