### PR TITLE
[FLOC 3251] add key pair step to AWS instructions

### DIFF
--- a/docs/install/setup-aws.rst
+++ b/docs/install/setup-aws.rst
@@ -47,7 +47,7 @@ Setting Up Nodes Using Amazon Web Services
    * When you are ready to proceed, click Launch.
      This opens a prompt for you to either select an existing key pair, or create and download a new key pair.
 
-   Launch your instances when you are happy to proceed.	 
+   Launch your instances when you are happy to proceed.
 
 #. Add the *Key* to your local key chain (download it from the AWS web interface first if necessary):
 

--- a/docs/install/setup-aws.rst
+++ b/docs/install/setup-aws.rst
@@ -44,8 +44,10 @@ Setting Up Nodes Using Amazon Web Services
      * If you run the MongoDB tutorial using AWS, you will need to open port 27017 to allow your MongoDB client to connect to the database.
 
    * Review to ensure your instances have sufficient storage and your security groups have the required ports.
+   * When you are ready to proceed, click Launch.
+     This opens a prompt for you to either select an existing key pair, or create and download a new key pair.
 
-   Launch when you are ready to proceed.
+   Launch your instances when you are happy to proceed.	 
 
 #. Add the *Key* to your local key chain (download it from the AWS web interface first if necessary):
 


### PR DESCRIPTION
Fixes 3251

Adds a step to our instructions on how to create nodes using AWS. Previously we did not mention there is a step on choosing an existing key pair or create a new one.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2144)
<!-- Reviewable:end -->
