### PR TITLE
[FLOC-3381] Allow looking up node identity by era

### DIFF
--- a/docs/reference/api_examples.yml
+++ b/docs/reference/api_examples.yml
@@ -644,6 +644,22 @@
     ]
 
 -
+  id: "get node by era"
+
+  doc: |
+    Lookup a node by its era, in this case "56780f44-0499-4153-9352-92344b180021".
+
+  request: |
+    GET /v1/state/nodes/by_era/56780f44-0499-4153-9352-92344b180021
+
+  response: |
+    HTTP/1.1 200 OK
+
+    {
+      "uuid": "%(NODE_0)s",
+    }
+
+-
   id:
     "release a lease"
 

--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -572,4 +572,3 @@ class FlockerClient(object):
         request = getting_era.addCallback(got_era)
         request.addCallback(lambda result: UUID(result["uuid"]))
         return request
-

--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -4,7 +4,9 @@
 Tests for the Flocker REST API client.
 """
 
-from uuid import uuid4
+from uuid import uuid4, UUID
+from unittest import skipUnless
+from subprocess import check_output
 
 from bitmath import GiB
 
@@ -24,6 +26,8 @@ from twisted.internet import reactor
 from twisted.internet.endpoints import TCP4ServerEndpoint
 from twisted.web.http import BAD_REQUEST
 from twisted.internet.defer import gatherResults
+from twisted.python.runtime import platform
+from twisted.python.procutils import which
 
 from .._client import (
     IFlockerAPIV1Client, FakeFlockerClient, Dataset, DatasetAlreadyExists,
@@ -38,6 +42,7 @@ from ...control._clusterstate import ClusterStateService
 from ...control.httpapi import create_api_service
 from ...control import (
     NodeState, NonManifestDatasets, Dataset as ModelDataset, ChangeSource,
+    UpdateNodeStateEra,
 )
 from ...restapi._logging import JSON_REQUEST
 from ...restapi import _infrastructure as rest_api
@@ -374,6 +379,15 @@ def make_clientv1_tests():
             )
             return d
 
+        def test_this_node_uuid(self):
+            """
+            ``this_node_uuid`` returns ``Deferred`` firing the UUID of the
+            current node.
+            """
+            d = self.client.this_node_uuid()
+            d.addCallback(self.assertEqual, self.node_1.uuid)
+            return d
+
     return InterfaceTests
 
 
@@ -383,7 +397,8 @@ class FakeFlockerClientTests(make_clientv1_tests()):
     """
     def create_client(self):
         return FakeFlockerClient(
-            nodes=[self.node_1, self.node_2]
+            nodes=[self.node_1, self.node_2],
+            this_node_uuid=self.node_1.uuid,
         )
 
     def synchronize_state(self):
@@ -394,6 +409,10 @@ class FlockerClientTests(make_clientv1_tests()):
     """
     Interface tests for ``FlockerClient``.
     """
+    @skipUnless(platform.isLinux(),
+                "flocker-node-era currently requires Linux.")
+    @skipUnless(which("flocker-node-era"),
+                "flocker-node-era needs to be in $PATH.")
     def create_client(self):
         """
         Create a new ``FlockerClient`` instance pointing at a running control
@@ -411,9 +430,10 @@ class FlockerClientTests(make_clientv1_tests()):
         source = ChangeSource()
         # Prevent nodes being deleted by the state wiper.
         source.set_last_activity(reactor.seconds())
+        era = UUID(check_output(["flocker-node-era"]))
         self.cluster_state_service.apply_changes_from_source(
             source=source,
-            changes=[
+            changes=[UpdateNodeStateEra(era=era, uuid=self.node_1.uuid)] + [
                 NodeState(uuid=node.uuid, hostname=node.public_address)
                 for node in [self.node_1, self.node_2]
             ],
@@ -534,3 +554,4 @@ class FlockerClientTests(make_clientv1_tests()):
                                         path=None)],
                           states))
         return d
+

--- a/flocker/control/__init__.py
+++ b/flocker/control/__init__.py
@@ -20,12 +20,13 @@ from ._model import (
     Link, AttachedVolume, NodeState, Manifestation, Dataset, RestartNever,
     RestartOnFailure, RestartAlways, DeploymentState, NonManifestDatasets,
     same_node, IClusterStateWipe, Leases, Lease, LeaseError, pmap_field,
-    ChangeSource,
+    ChangeSource, UpdateNodeStateEra, NoWipe,
 )
 from ._protocol import (
     IConvergenceAgent,
     NodeStateCommand,
     AgentAMP,
+    SetNodeEraCommand,
 )
 
 __all__ = [
@@ -54,10 +55,13 @@ __all__ = [
 
     'IConvergenceAgent',
     'NodeStateCommand',
+    'SetNodeEraCommand',
     'AgentAMP',
     'pmap_field',
     'Lease',
     'Leases',
     'LeaseError',
     'ChangeSource',
+    'UpdateNodeStateEra',
+    'NoWipe',
 ]

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -13,8 +13,7 @@ from twisted.application.internet import TimerService
 
 from pyrsistent import PRecord, field, pmap
 
-from ._model import DeploymentState, ChangeSource
-
+from . import DeploymentState, ChangeSource
 
 # Allowed inactivity period before updates are expired
 EXPIRATION_TIME = timedelta(seconds=120)

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -758,7 +758,7 @@ class IClusterStateChange(Interface):
         this change.
 
         For example, if this update adds information to a particular node,
-        the returned ``IClusterStateChange`` will wipe out that
+        the returned ``IClusterStateWipe`` will wipe out that
         information indicating ignorance about that information. We need
         this ability in order to expire out-of-date state information.
 
@@ -796,6 +796,25 @@ class IClusterStateWipe(Interface):
         cover different information, so there is no need for the key to
         express that differentation.
         """
+
+
+@implementer(IClusterStateWipe)
+class NoWipe(object):
+    """
+    Wipe object that does nothing.
+    """
+    def key(self):
+        """
+        We always have the same key, so we end up with just one instance of
+        ``NoWipe`` remembered by ``ClusterStateService``.
+        """
+        return None
+
+    def update_cluster_state(self, cluster_state):
+        """
+        Do nothing.
+        """
+        return cluster_state
 
 
 class IClusterStateSource(Interface):
@@ -890,12 +909,13 @@ class NodeState(PRecord):
     def __new__(cls, **kwargs):
         # PRecord does some crazy stuff, thus _precord_buckets; see
         # PRecord.__new__.
-        if "uuid" not in kwargs and "_precord_buckets" not in kwargs:
-            # To be removed in https://clusterhq.atlassian.net/browse/FLOC-1795
-            warn("UUID is required, this is for backwards compat with existing"
-                 " tests only. If you see this in production code that's "
-                 "a bug.", DeprecationWarning, stacklevel=2)
-            kwargs["uuid"] = ip_to_uuid(kwargs["hostname"])
+        if "_precord_buckets" not in kwargs:
+            if "uuid" not in kwargs:
+                # See https://clusterhq.atlassian.net/browse/FLOC-1795
+                warn("UUID is required, this is for backwards compat with "
+                     "existing tests. If you see this in production code "
+                     "that's a bug.", DeprecationWarning, stacklevel=2)
+                kwargs["uuid"] = ip_to_uuid(kwargs["hostname"])
         return PRecord.__new__(cls, **kwargs)
 
     uuid = field(type=UUID, mandatory=True)
@@ -928,6 +948,38 @@ class NodeState(PRecord):
                       self._POTENTIALLY_IGNORANT_ATTRIBUTES
                       if getattr(self, attr) is not None]
         return _WipeNodeState(node_uuid=self.uuid, attributes=attributes)
+
+
+@implementer(IClusterStateChange)
+class UpdateNodeStateEra(PClass):
+    """
+    Update a node's era.
+
+    :ivar UUID uuid: The node's UUID.
+    :ivar UUID era: The node's era.
+    """
+    uuid = field(type=UUID, mandatory=True)
+    era = field(type=UUID, mandatory=True)
+
+    def update_cluster_state(self, cluster_state):
+        """
+        Record the node's era and discard the ``NodeState`` if it doesn't
+        match the era.
+        """
+        if cluster_state.node_uuid_to_era.get(self.uuid) != self.era:
+            # Discard the NodeState:
+            cluster_state = cluster_state.set(
+                nodes={n for n in cluster_state.nodes
+                       if n.uuid != self.uuid})
+        cluster_state = cluster_state.transform(
+            ["node_uuid_to_era", self.uuid], self.era)
+        return cluster_state
+
+    def get_information_wipe(self):
+        """
+        Since we just deleted some information, there's nothing to wipe.
+        """
+        return NoWipe()
 
 
 @implementer(IClusterStateWipe)
@@ -970,6 +1022,7 @@ class DeploymentState(PRecord):
 
     :ivar PSet nodes: A set containing ``NodeState`` instances describing the
         state of each cooperating node.
+    :ivar PMap node_uuid_to_era: Mapping between a node's UUID and its era.
     :ivar PMap nonmanifest_datasets: A mapping from dataset identifiers (as
         ``unicode``) to corresponding ``Dataset`` instances.  This mapping
         describes every ``Dataset`` which is known to exist as part of the
@@ -985,12 +1038,12 @@ class DeploymentState(PRecord):
         https://clusterhq.atlassian.net/browse/FLOC-1247).
     """
     nodes = pset_field(NodeState)
-
-    get_node = _get_node(NodeState)
-
+    node_uuid_to_era = pmap_field(UUID, UUID)
     nonmanifest_datasets = pmap_field(
         unicode, Dataset, invariant=_keys_match_dataset_id
     )
+
+    get_node = _get_node(NodeState)
 
     def update_node(self, node_state):
         """
@@ -1049,25 +1102,11 @@ class NonManifestDatasets(PRecord):
 
     def get_information_wipe(self):
         """
-        Result will wipe all information about non-manifest datasets.
+        There's no point in wiping this update. Even if no relevant agents are
+        connected the datasets probably still continue to exist unchanged,
+        since they're not node-specific.
         """
-        return _NonManifestDatasetsWipe()
-
-
-@implementer(IClusterStateWipe)
-class _NonManifestDatasetsWipe(object):
-    """
-    Wipe object that does nothing.
-
-    There's no point in wiping this information. Even if no relevant
-    agents are connected the datasets probably still continue to exist
-    unchanged, since they're not node-specific.
-    """
-    def key(self):
-        return None
-
-    def update_cluster_state(self, cluster_state):
-        return cluster_state
+        return NoWipe()
 
 
 # Classes that can be serialized to disk or sent over the network:

--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 """
 Communication protocol between control service and convergence agent.
@@ -36,9 +36,10 @@ from io import BytesIO
 from itertools import count
 from contextlib import contextmanager
 from twisted.internet.defer import maybeDeferred
+from uuid import UUID
 
 from eliot import (
-    Logger, ActionType, Action, Field, MessageType, writeFailure,
+    Logger, ActionType, Action, Field, MessageType,
 )
 from eliot.twisted import DeferredContext
 
@@ -58,10 +59,9 @@ from twisted.internet.protocol import ServerFactory
 from twisted.application.internet import StreamServerEndpointService
 from twisted.protocols.tls import TLSMemoryBIOFactory
 
-from ..common._era import get_era
 from ._persistence import wire_encode, wire_decode
 from ._model import (
-    Deployment, DeploymentState, ChangeSource,
+    Deployment, DeploymentState, ChangeSource, UpdateNodeStateEra,
 )
 
 PING_INTERVAL = timedelta(seconds=30)
@@ -252,7 +252,8 @@ class SetNodeEraCommand(Command):
     ensure it doesn't get stale pre-reboot information (i.e. NodeState
     with wrong era).
     """
-    arguments = [('era', Unicode())]
+    arguments = [('era', Unicode()),
+                 ('node_uuid', Unicode())]
     response = []
 
 
@@ -343,9 +344,15 @@ class ControlServiceLocator(CommandLocator):
             return {}
 
     @SetNodeEraCommand.responder
-    def set_node_era(self, era):
-        # Actual work will be done in FLOC-3379, FLOC-3380
-        pass
+    def set_node_era(self, era, node_uuid):
+        # Further work will be done in FLOC-3380
+        self.control_amp_service.cluster_state.apply_changes_from_source(
+            self._source, [UpdateNodeStateEra(era=UUID(era),
+                                              uuid=UUID(node_uuid))])
+        # We don't bother sending an update to other nodes because this
+        # command will immediately be followed by a ``NodeStateCommand``
+        # with more interesting information.
+        return {}
 
 
 class ControlAMP(AMP):
@@ -755,8 +762,6 @@ class AgentAMP(AMP):
         AMP.connectionMade(self)
         self.agent.connected(self)
         self._pinger.start(self, PING_INTERVAL)
-        d = self.callRemote(SetNodeEraCommand, era=unicode(get_era()))
-        d.addErrback(writeFailure)
 
     def connectionLost(self, reason):
         AMP.connectionLost(self, reason)

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -91,7 +91,8 @@ LEASE_NOT_FOUND = make_bad_request(
     code=NOT_FOUND, description=u"Lease not found.")
 LEASE_HELD = make_bad_request(
     code=CONFLICT, description=u"Lease already held.")
-
+NODE_BY_ERA_NOT_FOUND = make_bad_request(
+    code=NOT_FOUND, description=u"No node found with given era.")
 _UNDEFINED_MAXIMUM_SIZE = object()
 
 
@@ -835,6 +836,45 @@ class ConfigurationAPIUserV1(object):
         return [{u"host": node.hostname, u"uuid": unicode(node.uuid)}
                 for node in
                 self.cluster_state_service.as_deployment().nodes]
+
+    @app.route("/state/nodes/by_era/<era>", methods=['GET'])
+    @user_documentation(
+        u"""
+        If you are talking to the API from a process on a node then this
+        is the recommended way of figuring out the node UUID. Since eras
+        are reset on reboot, looking up by era means you will never get
+        stale pre-reboot state.
+
+        You can discover a node's era by running the ``flocker-node-era``
+        command-line tool on the relevant node. Make sure you don't cache
+        this information across reboots!
+
+        If the era is unknown you will get a 404 HTTP response. In this
+        case retry until the node UUID is returned.
+        """,
+        header=u"Lookup a node by its era",
+        examples=[
+            u"get node by era",
+        ],
+        section=u"common",
+    )
+    @structured(
+        inputSchema={},
+        outputSchema={"$ref":
+                      '/v1/endpoints.json#/definitions/node'},
+        schema_store=SCHEMAS
+    )
+    def get_node_by_era(self, era):
+        era = UUID(era)
+        cluster_state = self.cluster_state_service.as_deployment()
+        era_to_node_uuid = dict(
+            (era, node_uuid) for (node_uuid, era) in
+            cluster_state.node_uuid_to_era.items())
+        try:
+            node_uuid = era_to_node_uuid[era]
+        except KeyError:
+            raise NODE_BY_ERA_NOT_FOUND
+        return {u"uuid": unicode(node_uuid)}
 
     @app.route("/configuration/_compose", methods=['POST'])
     @private_api

--- a/flocker/control/schema/endpoints.yml
+++ b/flocker/control/schema/endpoints.yml
@@ -67,6 +67,16 @@ definitions:
       - node_uuid
     additionalProperties: false
 
+  node:
+    description: "A known node in the cluster."
+    type: object
+    properties:
+      uuid:
+        '$ref': 'types.json#/definitions/node_uuid'
+    required:
+      - uuid
+    additionalProperties: false
+
   nodes_array:
     decription: "An array of known nodes in the cluster."
     type: array

--- a/flocker/control/test/test_model.py
+++ b/flocker/control/test/test_model.py
@@ -26,7 +26,7 @@ from .. import (
     Application, DockerImage, Node, Deployment, AttachedVolume, Dataset,
     RestartOnFailure, RestartAlways, RestartNever, Manifestation,
     NodeState, DeploymentState, NonManifestDatasets, same_node,
-    Link, Lease, Leases, LeaseError
+    Link, Lease, Leases, LeaseError, UpdateNodeStateEra, NoWipe,
 )
 
 
@@ -1418,40 +1418,49 @@ class NodeStateWipingTests(SynchronousTestCase):
             DeploymentState(nodes={node_2}))
 
 
-class NonManifestDatasetsWipingTests(SynchronousTestCase):
+class NoWipeTests(SynchronousTestCase):
     """
-    Tests for ``NonManifestDatasets.get_information_wipe()``.
+    Tests for ``NoWipe``.
     """
-    NON_MANIFEST = NonManifestDatasets(datasets={MANIFESTATION.dataset_id:
-                                                 MANIFESTATION.dataset})
-    WIPE = NON_MANIFEST.get_information_wipe()
-
     def test_interface(self):
         """
-        The object returned from ``NodeStateWipe`` implements
-        ``IClusterStateWipe``.
+        ``NoWipe`` instances provide ``IClusterStateWipe``.
         """
-        self.assertTrue(verifyObject(IClusterStateWipe, self.WIPE))
+        self.assertTrue(verifyObject(IClusterStateWipe, NoWipe()))
 
     def test_key_always_the_same(self):
         """
-        The ``IClusterStateWipe`` always has the same key.
+        A ``NoWipe`` always has the same key.
         """
-        self.assertEqual(
-            NonManifestDatasets().get_information_wipe().key(),
-            self.WIPE.key())
+        self.assertEqual(NoWipe().key(), NoWipe().key())
 
     def test_applying_does_nothing(self):
         """
-        Applying the ``IClusterStateWipe`` does nothing to the cluster state.
+        Applying the ``NoWipe`` does nothing to the cluster state.
         """
-        # Cluster has some non-manifested datasets:
-        cluster_state = self.NON_MANIFEST.update_cluster_state(
-            DeploymentState())
+        non_manifest = NonManifestDatasets(datasets={MANIFESTATION.dataset_id:
+                                                     MANIFESTATION.dataset})
+        cluster_state = non_manifest.update_cluster_state(DeploymentState())
 
         # "Wiping" this information has no effect:
-        updated = self.WIPE.update_cluster_state(cluster_state)
+        updated = NoWipe().update_cluster_state(cluster_state)
         self.assertEqual(updated, cluster_state)
+
+
+class NonManifestDatasetsWipingTests(SynchronousTestCase):
+    """
+    Tests for ``NonManifestDatasets.get_information_wipe()``.
+
+    See above for demonstration ``NoWipe`` has no side-effects.
+    """
+    def test_no_wipe(self):
+        """
+        Applying the ``IClusterStateWipe`` does nothing to the cluster state.
+        """
+        non_manifest = NonManifestDatasets(datasets={MANIFESTATION.dataset_id:
+                                                     MANIFESTATION.dataset})
+        wipe = non_manifest.get_information_wipe()
+        self.assertIsInstance(wipe, NoWipe)
 
 
 class LinkTests(SynchronousTestCase):
@@ -1638,3 +1647,76 @@ class LeaseTests(SynchronousTestCase):
             InvariantException,
             self.leases.set, uuid4(), lease
         )
+
+
+class UpdateNodeStateEraTests(SynchronousTestCase):
+    """
+    Tests for ``UpdateNodeStateEraTests``.
+    """
+    KNOWN_STATE = NodeState(hostname=u"1.1.1.1", uuid=uuid4())
+    INITIAL_CLUSTER = DeploymentState(
+        nodes=[KNOWN_STATE],
+        node_uuid_to_era={KNOWN_STATE.uuid: uuid4()})
+    NODE_STATE = NodeState(hostname=u"1.2.3.4",
+                           uuid=uuid4(),
+                           applications=None,
+                           manifestations={},
+                           devices={}, paths={})
+    UPDATE_ERA_1 = UpdateNodeStateEra(uuid=NODE_STATE.uuid, era=uuid4())
+    UPDATE_ERA_2 = UpdateNodeStateEra(uuid=NODE_STATE.uuid, era=uuid4())
+
+    def test_iclusterstatechange(self):
+        """
+        ``UpdateNodeStateEra`` instances provide ``IClusterStateChange``.
+        """
+        self.assertTrue(verifyObject(IClusterStateChange, self.UPDATE_ERA_1))
+
+    def test_get_information_wipe(self):
+        """
+        ``UpdateNodeStateEra`` has no side-effects from wiping.
+        """
+        self.assertIsInstance(self.UPDATE_ERA_1.get_information_wipe(), NoWipe)
+
+    def test_no_era(self):
+        """
+        If era information was not known, ``UpdateNodeStateEra`` adds it.
+        """
+        state = self.UPDATE_ERA_1.update_cluster_state(self.INITIAL_CLUSTER)
+        self.assertEqual(
+            state,
+            self.INITIAL_CLUSTER.transform(
+                ["node_uuid_to_era", self.UPDATE_ERA_1.uuid],
+                self.UPDATE_ERA_1.era))
+
+    def test_same_era(self):
+        """
+        If the known era matches, ``UpdateNodeStateEra`` does nothing.
+        """
+        state = self.UPDATE_ERA_1.update_cluster_state(self.INITIAL_CLUSTER)
+        state = self.NODE_STATE.update_cluster_state(state)
+
+        updated_state = self.UPDATE_ERA_1.update_cluster_state(state)
+        self.assertEqual(state, updated_state)
+
+    def test_different_era(self):
+        """
+        If the era differs, it is updated.
+        """
+        state = self.UPDATE_ERA_1.update_cluster_state(self.INITIAL_CLUSTER)
+
+        updated_state = self.UPDATE_ERA_2.update_cluster_state(state)
+        self.assertEqual(
+            updated_state,
+            self.UPDATE_ERA_2.update_cluster_state(self.INITIAL_CLUSTER))
+
+    def test_different_era_discards_state(self):
+        """
+        If the era differs the corresponding ``NodeState`` is removed.
+        """
+        state = self.UPDATE_ERA_1.update_cluster_state(self.INITIAL_CLUSTER)
+        state = self.NODE_STATE.update_cluster_state(state)
+
+        updated_state = self.UPDATE_ERA_2.update_cluster_state(state)
+        self.assertEqual(
+            updated_state,
+            self.UPDATE_ERA_2.update_cluster_state(self.INITIAL_CLUSTER))

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 """
 Tests for ``flocker.control._protocol``.
@@ -6,7 +6,6 @@ Tests for ``flocker.control._protocol``.
 
 from uuid import uuid4
 from json import loads
-from unittest import skipUnless
 
 from zope.interface import implementer
 from zope.interface.verify import verifyObject
@@ -18,7 +17,6 @@ from eliot.testing import (
     capture_logging, validate_logging, assertHasAction,
 )
 
-from twisted.python.runtime import platform
 from twisted.internet.error import ConnectionDone
 from twisted.test.iosim import connectedServerAndClient
 from twisted.trial.unittest import SynchronousTestCase
@@ -36,7 +34,7 @@ from twisted.application.internet import StreamServerEndpointService
 from twisted.internet.ssl import ClientContextFactory
 from twisted.internet.task import Clock
 
-from ...testtools.amp import DelayedAMPClient
+from ...testtools.amp import DelayedAMPClient, connected_amp_protocol
 
 from .._protocol import (
     PING_INTERVAL, Big, SerializableArgument,
@@ -52,7 +50,6 @@ from .. import (
     Dataset, DeploymentState, NonManifestDatasets,
 )
 from .._persistence import ConfigurationPersistenceService, wire_encode
-from ...common._era import get_era
 from .clusterstatetools import advance_some, advance_rest
 
 
@@ -654,6 +651,22 @@ class ControlAMPTests(ControlTestCase):
             self.control_amp_service.cluster_state.as_deployment(),
         )
 
+    def test_set_node_era(self):
+        """
+        A ``SetNodeEraCommand`` results in the node's era being
+        updated.
+        """
+        node_uuid = uuid4()
+        era = uuid4()
+        d = self.client.callRemote(SetNodeEraCommand,
+                                   node_uuid=unicode(node_uuid),
+                                   era=unicode(era))
+        self.successResultOf(d)
+        self.assertEqual(
+            DeploymentState(node_uuid_to_era={node_uuid: era}),
+            self.control_amp_service.cluster_state.as_deployment(),
+        )
+
 
 class ControlAMPServiceTests(ControlTestCase):
     """
@@ -951,18 +964,6 @@ class AgentClientTests(SynchronousTestCase):
         self.assertEqual(self.agent, FakeAgent(is_connected=True,
                                                client=self.client))
 
-    @skipUnless(platform.isLinux(), "get_era() is only supported on Linux.")
-    def test_send_era_on_connect(self):
-        """
-        Upon connecting a ``SetNodeEra`` is sent with the current node's era.
-        """
-        locator = _NoOpCounter()
-        peer = AMP(locator=locator)
-        pump = connectedServerAndClient(lambda: self.client,
-                                        lambda: peer)[2]
-        pump.flush()
-        self.assertEqual(locator.era, unicode(get_era()))
-
     def test_connection_lost(self):
         """
         Connection lost events are passed on to the agent.
@@ -1043,7 +1044,7 @@ def iconvergence_agent_tests_factory(fixture):
             ``IConvergenceAgent.connected()`` takes an AMP instance.
             """
             agent = fixture(self)
-            agent.connected(AMP())
+            agent.connected(connected_amp_protocol())
 
         def test_disconnected(self):
             """
@@ -1051,7 +1052,7 @@ def iconvergence_agent_tests_factory(fixture):
             ``IConvergenceAgent.connected()``.
             """
             agent = fixture(self)
-            agent.connected(AMP())
+            agent.connected(connected_amp_protocol())
             agent.disconnected()
 
         def test_reconnected(self):
@@ -1060,9 +1061,9 @@ def iconvergence_agent_tests_factory(fixture):
             ``IConvergenceAgent.disconnected()``.
             """
             agent = fixture(self)
-            agent.connected(AMP())
+            agent.connected(connected_amp_protocol())
             agent.disconnected()
-            agent.connected(AMP())
+            agent.connected(connected_amp_protocol())
 
         def test_cluster_updated(self):
             """
@@ -1070,7 +1071,7 @@ def iconvergence_agent_tests_factory(fixture):
             instances.
             """
             agent = fixture(self)
-            agent.connected(AMP())
+            agent.connected(connected_amp_protocol())
             agent.cluster_updated(
                 Deployment(nodes=frozenset()), Deployment(nodes=frozenset()))
 
@@ -1198,12 +1199,6 @@ class SendStateToConnectionsTests(SynchronousTestCase):
 
 class _NoOpCounter(CommandLocator):
     noops = 0
-    era = None
-
-    @SetNodeEraCommand.responder
-    def set_node_era(self, era):
-        self.era = era
-        return {}
 
     @NoOp.responder
     def noop(self):

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -810,6 +810,25 @@ NodesTests = build_schema_test(
     ],
 )
 
+NodeTests = build_schema_test(
+    name="NodeTests",
+    schema={'$ref': '/v1/endpoints.json#/definitions/node'},
+    schema_store=SCHEMAS,
+    failing_instances=[
+        # Wrong type
+        [], 1, None,
+        # Missing uuid
+        {},
+        # Wrong uuid type
+        {'uuid': 123},
+        # Extra key
+        {'uuid': unicode(uuid4()), 'x': 'y'},
+    ],
+    passing_instances=[
+        {'uuid': unicode(uuid4())},
+    ],
+)
+
 
 LEASE_WITH_EXPIRATION = {'dataset_id': unicode(uuid4()),
                          'node_uuid': unicode(uuid4()),

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -48,7 +48,7 @@ from .agents.loopback import (
     LoopbackBlockDeviceAPI,
 )
 from ..ca import ControlServicePolicy, NodeCredential
-
+from ..common._era import get_era
 
 __all__ = [
     "flocker_dataset_agent_main",
@@ -327,6 +327,7 @@ class AgentServiceFactory(PRecord):
                 cluster_uuid=tls_info.node_credential.cluster_uuid),
             host=host, port=port,
             context_factory=tls_info.context_factory,
+            era=get_era(),
         )
 
 
@@ -636,6 +637,7 @@ class AgentService(PRecord):
             deployer=deployer,
             host=self.control_service_host, port=self.control_service_port,
             context_factory=self.get_tls_context().context_factory,
+            era=get_era(),
         )
 
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -5,6 +5,7 @@ Tests for :module:`flocker.node.script`.
 """
 
 import socket
+from unittest import skipUnless
 
 import yaml
 from ipaddr import IPAddress
@@ -21,9 +22,11 @@ from twisted.internet.defer import Deferred
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.application.service import Service
+from twisted.python.runtime import platform
 
 from ...common.script import ICommandLineScript
 from ...common import get_all_ips
+from ...common._era import get_era
 
 from ..script import (
     AgentScript, ContainerAgentOptions,
@@ -467,6 +470,7 @@ class AgentServiceLoopTests(SynchronousTestCase):
     """
     setUp = agent_service_setup
 
+    @skipUnless(platform.isLinux(), "get_era() only supports Linux.")
     def test_agentloopservice(self):
         """
         ```AgentService.get_loop_service`` returns an ``AgentLoopService``
@@ -483,6 +487,7 @@ class AgentServiceLoopTests(SynchronousTestCase):
                 host=self.host,
                 port=self.port,
                 context_factory=context_factory,
+                era=get_era()
             ),
             loop_service,
         )
@@ -527,6 +532,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
              self.ca_set.node.cluster_uuid),
             result[0])
 
+    @skipUnless(platform.isLinux(), "get_era() only supports Linux.")
     def test_get_service(self):
         """
         ``AgentServiceFactory.get_service`` creates an ``AgentLoopService``
@@ -547,10 +553,12 @@ class AgentServiceFactoryTests(SynchronousTestCase):
                 port=1234,
                 context_factory=_context_factory_and_credential(
                     self.config.parent(), b"10.0.0.1", 1234).context_factory,
+                era=get_era(),
             ),
             service_factory.get_service(reactor, options)
         )
 
+    @skipUnless(platform.isLinux(), "get_era() only supports Linux.")
     def test_default_port(self):
         """
         ``AgentServiceFactory.get_service`` creates an ``AgentLoopService``
@@ -581,6 +589,7 @@ class AgentServiceFactoryTests(SynchronousTestCase):
                 port=4524,
                 context_factory=_context_factory_and_credential(
                     self.config.parent(), b"10.0.0.2", 4524).context_factory,
+                era=get_era(),
             ),
             service_factory.get_service(reactor, options)
         )

--- a/flocker/testtools/amp.py
+++ b/flocker/testtools/amp.py
@@ -117,3 +117,12 @@ class DelayedAMPClient(object):
         """
         d, response = self._calls.pop(0)
         response.chainDeferred(d)
+
+
+def connected_amp_protocol():
+    """
+    :return: ``AMP`` hooked up to transport.
+    """
+    p = AMP()
+    p.makeConnection(StringTransport())
+    return p


### PR DESCRIPTION
This builds on #2141 which will hopefully be merged soon.

This adds a REST API for looking up nodes by era. The idea is that this is the new mechanism for figuring out "which node is this", and since eras are reboot-specific it's a mechanism that ensures clients of the REST API don't get stale node state.

For example, in the next stacked branch the Docker plugin will be changed to use this new API to discover its node identity, instead of extracting it from the node TLS certificate. This will mean the Docker plugin won't ever get stale pre-reboot state, since it won't be able to lookup node identity until an agent has updated the control service post-reboot.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2150)
<!-- Reviewable:end -->
