### PR TITLE
[FLOC 3218] Specify 64-bit Ubuntu platform in CLI install instructions

### DIFF
--- a/docs/install/install-client.rst
+++ b/docs/install/install-client.rst
@@ -13,27 +13,35 @@ The following sections describe how to install the Flocker client on your platfo
 
 .. _installing-flocker-cli-ubuntu-15.04:
 
-Ubuntu 15.04
-============
+Ubuntu 15.04 (64-bit)
+=====================
 
-.. note:: These instructions require that you have ``sudo`` access.
+.. note:: 
+   These instructions require that you have ``sudo`` access.
 
-On Ubuntu 15.04, the Flocker CLI can be installed from the ClusterHQ repository:
+   If you are using a 32-bit Ubuntu platform, see the instructions for  :ref:`installing-flocker-cli-linux`.
+
+On Ubuntu 15.04 (64-bit), the Flocker CLI can be installed from the ClusterHQ repository:
 
 .. task:: cli_pkg_install ubuntu-15.04
    :prompt: alice@mercury:~$
 
 .. _installing-flocker-cli-ubuntu-14.04:
 
-Ubuntu 14.04
-============
+Ubuntu 14.04 (64-bit)
+=====================
 
-.. note:: These instructions require that you have ``sudo`` access.
+.. note:: 
+   These instructions require that you have ``sudo`` access.
 
-On Ubuntu 14.04, the Flocker CLI can be installed from the ClusterHQ repository:
+   If you are using a 32-bit Ubuntu platform, see the instructions for  :ref:`installing-flocker-cli-linux`.
+
+On Ubuntu 14.04 (64-bit), the Flocker CLI can be installed from the ClusterHQ repository:
 
 .. task:: cli_pkg_install ubuntu-14.04
    :prompt: alice@mercury:~$
+
+.. _installing-flocker-cli-linux:
 
 Other Linux Distributions
 =========================


### PR DESCRIPTION
Fixes 3218

Adds details to the CLI install instructions that the Ubuntu supported platforms must be 64-bit.

Users of Ubuntu 32-bit are directed to use our "Other Linux Distributions" instructions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2153)
<!-- Reviewable:end -->
