### PR TITLE
[FLOC-3414] No-op @flaky decorator

### DIFF
--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -10,6 +10,7 @@ from twisted.internet import reactor
 from twisted.trial.unittest import TestCase
 
 from ...common import loop_until
+from ...testtools import flaky
 
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset, DatasetBackend
@@ -20,6 +21,8 @@ class DatasetAPITests(TestCase):
     """
     Tests for the dataset API.
     """
+
+    @flaky('FLOC-3207')
     @require_cluster(1)
     def test_dataset_creation(self, cluster):
         """
@@ -51,6 +54,7 @@ class DatasetAPITests(TestCase):
         waiting_for_create.addCallback(confirm_gold)
         return waiting_for_create
 
+    @flaky('FLOC-3341')
     @require_moving_backend
     @require_cluster(2)
     def test_dataset_move(self, cluster):
@@ -78,6 +82,7 @@ class DatasetAPITests(TestCase):
         waiting_for_create.addCallback(move_dataset)
         return waiting_for_create
 
+    @flaky('FLOC-3196')
     @require_cluster(1)
     def test_dataset_deletion(self, cluster):
         """

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -15,7 +15,7 @@ from ...common import loop_until
 from ...common.runner import run_ssh
 
 from ...testtools import (
-    random_name, find_free_port,
+    random_name, find_free_port, flaky,
 )
 from ..testtools import (
     require_cluster, post_http_server, assert_http_server,
@@ -180,6 +180,7 @@ class DockerPluginTests(TestCase):
             self, node.public_address, host_port, expected_response=data))
         return d
 
+    @flaky('FLOC-3346')
     @require_cluster(1)
     def test_create_container_with_v2_plugin_api(self, cluster):
         """
@@ -354,6 +355,7 @@ class DockerPluginTests(TestCase):
             expected_response=data))
         return d
 
+    @flaky('FLOC-2977')
     @require_cluster(1)
     def test_move_volume_single_node(self, cluster):
         """
@@ -363,6 +365,7 @@ class DockerPluginTests(TestCase):
         """
         return self._test_move(cluster, cluster.nodes[0], cluster.nodes[0])
 
+    @flaky('FLOC-3346')
     @require_cluster(2)
     def test_move_volume_different_node(self, cluster):
         """

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -11,7 +11,7 @@ from twisted.internet.defer import gatherResults
 from twisted.trial.unittest import TestCase
 
 from ...common import loop_until
-from ...testtools import random_name
+from ...testtools import flaky, random_name
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset,
     create_python_container, verify_socket, post_http_server,
@@ -118,6 +118,7 @@ class ContainerAPITests(TestCase):
         )
         return d
 
+    @flaky('FLOC-2488')
     @require_moving_backend
     @require_cluster(2)
     def test_move_container_with_dataset(self, cluster):

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -40,7 +40,7 @@ from ..test.blockdevicefactory import (
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
     get_minimum_allocatable_size, get_openstack_region_for_test,
 )
-from ....testtools import run_process
+from ....testtools import flaky, run_process
 
 from ..cinder import (
     get_keystone_session, get_cinder_v1_client, get_nova_v2_client,
@@ -170,6 +170,11 @@ class CinderBlockDeviceAPIInterfaceTests(
             cinder_client.volumes.get(
                 flocker_volume.blockdevice_id).display_name,
             u"flocker-{}".format(dataset_id))
+
+    @flaky('FLOC-3347')
+    def test_get_device_path_device(self):
+        super(CinderBlockDeviceAPIInterfaceTests,
+              self).test_get_device_path_device()
 
 
 class CinderHttpsTests(SynchronousTestCase):

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -173,8 +173,9 @@ class CinderBlockDeviceAPIInterfaceTests(
 
     @flaky('FLOC-3347')
     def test_get_device_path_device(self):
-        super(CinderBlockDeviceAPIInterfaceTests,
-              self).test_get_device_path_device()
+        return super(
+            CinderBlockDeviceAPIInterfaceTests,
+            self).test_get_device_path_device()
 
 
 class CinderHttpsTests(SynchronousTestCase):

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -274,18 +274,20 @@ class EBSBlockDeviceAPIInterfaceTests(
 
     @flaky('FLOC-2302')
     def test_listed_volume_attributes(self):
-        super(EBSBlockDeviceAPIInterfaceTests,
-              self).test_listed_volume_attributes()
+        return super(
+            EBSBlockDeviceAPIInterfaceTests,
+            self).test_listed_volume_attributes()
 
     @flaky('FLOC-2672')
     def test_multiple_volumes_attached_to_host(self):
-        super(EBSBlockDeviceAPIInterfaceTests,
-              self).test_multiple_volumes_attached_to_host()
+        return super(
+            EBSBlockDeviceAPIInterfaceTests,
+            self).test_multiple_volumes_attached_to_host()
 
     @flaky('FLOC-3236')
     def test_detach_volume(self):
-        super(EBSBlockDeviceAPIInterfaceTests,
-              self).test_detach_volume()
+        return super(
+            EBSBlockDeviceAPIInterfaceTests, self).test_detach_volume()
 
 
 class EBSProfiledBlockDeviceAPIInterfaceTests(

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -26,7 +26,7 @@ from ..ebs import (
     TimeoutException, _should_finish, UnexpectedStateException,
     EBSMandatoryProfileAttributes
 )
-from ...testtools import flaky
+from ....testtools import flaky
 
 from .._logging import (
     AWS_CODE, AWS_MESSAGE, AWS_REQUEST_ID, BOTO_LOG_HEADER,

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -26,6 +26,7 @@ from ..ebs import (
     TimeoutException, _should_finish, UnexpectedStateException,
     EBSMandatoryProfileAttributes
 )
+from ...testtools import flaky
 
 from .._logging import (
     AWS_CODE, AWS_MESSAGE, AWS_REQUEST_ID, BOTO_LOG_HEADER,
@@ -270,6 +271,21 @@ class EBSBlockDeviceAPIInterfaceTests(
         requested_iops = A.requested_iops(ebs_volume.size)
         self.assertEqual(ebs_volume.iops if requested_iops is not None
                          else None, requested_iops)
+
+    @flaky('FLOC-2302')
+    def test_listed_volume_attributes(self):
+        super(EBSBlockDeviceAPIInterfaceTests,
+              self).test_listed_volume_attributes()
+
+    @flaky('FLOC-2672')
+    def test_multiple_volumes_attached_to_host(self):
+        super(EBSBlockDeviceAPIInterfaceTests,
+              self).test_multiple_volumes_attached_to_host()
+
+    @flaky('FLOC-3236')
+    def test_detach_volume(self):
+        super(EBSBlockDeviceAPIInterfaceTests,
+              self).test_detach_volume()
 
 
 class EBSProfiledBlockDeviceAPIInterfaceTests(

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -25,7 +25,7 @@ from ...control._model import (
 from .._docker import DockerClient
 from ..testtools import wait_for_unit_state, if_docker_configured
 from ...testtools import (
-    random_name, DockerImageBuilder, assertContainsAll)
+    random_name, DockerImageBuilder, assertContainsAll, flaky)
 from ...volume.testtools import create_volume_service
 from ...route import make_memory_network
 from .. import run_state_change
@@ -394,6 +394,7 @@ class DeployerTests(TestCase):
         d.addCallback(inspect_application)
         return d
 
+    @flaky('FLOC-3330')
     @if_docker_configured
     def test_cpu_shares(self):
         """

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -1328,4 +1328,4 @@ class NamespacedDockerClientTests(GenericDockerClientTests):
 
     @flaky('FLOC-1657')
     def test_pull_image_if_necessary(self):
-        super(NamespacedDockerClient, self).test_pull_image_if_necessary()
+        super(NamespacedDockerClientTests, self).test_pull_image_if_necessary()

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -32,7 +32,7 @@ from pyrsistent import PClass, pvector, field
 
 from ...common import loop_until, retry_failure
 from ...testtools import (
-    find_free_port, DockerImageBuilder, assertContainsAll,
+    find_free_port, flaky, DockerImageBuilder, assertContainsAll,
     random_name)
 
 from ..test.test_docker import ANY_IMAGE, make_idockerclient_tests
@@ -78,6 +78,11 @@ class IDockerClientNamespacedTests(make_idockerclient_tests(
     @if_docker_configured
     def setUp(self):
         pass
+
+    # XXX: First time we've needed multiple JIRA keys. Is this the right API?
+    @flaky(['FLOC-2628', 'FLOC-2874'])
+    def test_added_is_listed(self):
+        super(IDockerClientNamespacedTests, self).test_added_is_listed()
 
 
 class Registry(PClass):
@@ -524,6 +529,10 @@ class GenericDockerClientTests(TestCase):
         d.addCallback(started)
         return d
 
+    # XXX: This is subclassed, and the subclass decorated with a different
+    # JIRA key. When @flaky actually does something, we should have tests that
+    # cover that case.
+    @flaky('FLOC-3077')
     def test_pull_image_if_necessary(self):
         """
         The Docker image is pulled if it is unavailable locally.
@@ -1073,6 +1082,7 @@ class GenericDockerClientTests(TestCase):
         d.addCallback(self.assertEqual, "1")
         return d
 
+    @flaky('FLOC-2840')
     def test_restart_policy_always(self):
         """
         An container with a restart policy of always is restarted
@@ -1315,3 +1325,7 @@ class NamespacedDockerClientTests(GenericDockerClientTests):
         d.addCallback(lambda _: client2.list())
         d.addCallback(self.assertEqual, set())
         return d
+
+    @flaky('FLOC-1657')
+    def test_pull_image_if_necessary(self):
+        super(NamespacedDockerClient, self).test_pull_image_if_necessary()

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -82,7 +82,7 @@ class IDockerClientNamespacedTests(make_idockerclient_tests(
     # XXX: First time we've needed multiple JIRA keys. Is this the right API?
     @flaky(['FLOC-2628', 'FLOC-2874'])
     def test_added_is_listed(self):
-        super(IDockerClientNamespacedTests, self).test_added_is_listed()
+        return super(IDockerClientNamespacedTests, self).test_added_is_listed()
 
 
 class Registry(PClass):
@@ -1328,4 +1328,5 @@ class NamespacedDockerClientTests(GenericDockerClientTests):
 
     @flaky('FLOC-1657')
     def test_pull_image_if_necessary(self):
-        super(NamespacedDockerClientTests, self).test_pull_image_if_necessary()
+        return super(
+            NamespacedDockerClientTests, self).test_pull_image_if_necessary()

--- a/flocker/test/test_testtools.py
+++ b/flocker/test/test_testtools.py
@@ -1,14 +1,27 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
 
 """
 Tests for ``flocker.testtools``.
 """
 
 from subprocess import CalledProcessError
+import unittest
+
+from eliot.testing import (
+    capture_logging,
+    LoggedAction, LoggedMessage,
+    assertContainsFields,
+)
+
+from hypothesis import given
+from hypothesis.strategies import integers
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from flocker.testtools import run_process
+from flocker.testtools import (
+    flaky,
+    run_process,
+)
 
 
 class RunProcessTests(SynchronousTestCase):
@@ -68,3 +81,47 @@ class RunProcessTests(SynchronousTestCase):
         """
         exception = self._run_fail(self._failing_shell(b"echo hello"))
         self.assertIn("hello", str(exception))
+
+
+class FlakyTests(SynchronousTestCase):
+    """
+    Tests for ``@flaky`` decorator.
+    """
+
+    # XXX: Should I use this branch to introduce testtools as well?
+
+    @given(integers())
+    def test_decorated_function_executed(self, x):
+        """
+        ``@flaky`` decorates the given function sanely.
+        """
+        values = []
+
+        @flaky
+        def f(x):
+            values.append(x)
+            return x
+
+        y = f(x)
+        self.assertEqual(y, x)
+        self.assertEqual([x], values)
+
+    def test_successful_flaky_test(self):
+        """
+        A successful flaky test is considered successful.
+        """
+
+        # We use 'unittest' here to avoid accidentally depending on Twisted
+        # TestCase features, thus increasing complexity.
+        class SomeTest(unittest.TestCase):
+
+            @flaky
+            def test_something(self):
+                pass
+
+        test = SomeTest('test_something')
+        result = unittest.TestResult()
+
+        test.run(result)
+
+        self.assertEqual({}, result.__dict__)

--- a/flocker/test/test_testtools.py
+++ b/flocker/test/test_testtools.py
@@ -5,23 +5,10 @@ Tests for ``flocker.testtools``.
 """
 
 from subprocess import CalledProcessError
-import unittest
-
-from eliot.testing import (
-    capture_logging,
-    LoggedAction, LoggedMessage,
-    assertContainsFields,
-)
-
-from hypothesis import given
-from hypothesis.strategies import integers
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from flocker.testtools import (
-    flaky,
-    run_process,
-)
+from flocker.testtools import run_process
 
 
 class RunProcessTests(SynchronousTestCase):
@@ -81,47 +68,3 @@ class RunProcessTests(SynchronousTestCase):
         """
         exception = self._run_fail(self._failing_shell(b"echo hello"))
         self.assertIn("hello", str(exception))
-
-
-class FlakyTests(SynchronousTestCase):
-    """
-    Tests for ``@flaky`` decorator.
-    """
-
-    # XXX: Should I use this branch to introduce testtools as well?
-
-    @given(integers())
-    def test_decorated_function_executed(self, x):
-        """
-        ``@flaky`` decorates the given function sanely.
-        """
-        values = []
-
-        @flaky
-        def f(x):
-            values.append(x)
-            return x
-
-        y = f(x)
-        self.assertEqual(y, x)
-        self.assertEqual([x], values)
-
-    def test_successful_flaky_test(self):
-        """
-        A successful flaky test is considered successful.
-        """
-
-        # We use 'unittest' here to avoid accidentally depending on Twisted
-        # TestCase features, thus increasing complexity.
-        class SomeTest(unittest.TestCase):
-
-            @flaky
-            def test_something(self):
-                pass
-
-        test = SomeTest('test_something')
-        result = unittest.TestResult()
-
-        test.run(result)
-
-        self.assertEqual({}, result.__dict__)

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -47,10 +47,14 @@ from twisted.python.procutils import which
 from twisted.trial.unittest import TestCase
 from twisted.python.logfile import LogFile
 
+from ._flaky import flaky
 from .. import __version__
 from ..common.script import (
     FlockerScriptRunner, ICommandLineScript)
 
+
+# Export for other places to import. Be still, flake8.
+flaky
 
 # This is currently set to the minimum size for a SATA based Rackspace Cloud
 # Block Storage volume. See:

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -942,3 +942,24 @@ def run_process(command, *args, **kwargs):
                 returncode=status, cmd=command, output=output,
             )
     return result
+
+
+def flaky(test_method):
+    """
+    Mark a test as flaky.
+
+    A 'flaky' test is one that sometimes passes but sometimes fails. Marking a
+    test as flaky means both failures and successes are expected, and that
+    neither will fail the test run.
+
+    :param function test_method: The test method to mark as flaky.
+    :return: A decorated version of ``test_method``.
+    """
+    # TODO
+    # - allow specifying which exceptions are expected
+    # - retry on expected exceptions
+    #   - parametrize on retry options
+    #     - perhaps `loop_until` should take a generator of sleep intervals,
+    #       so we can use same routine for backoff
+    # - provide interesting & parseable logs for flaky tests
+    return test_method

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -6,6 +6,33 @@ Various utilities to help with unit and functional testing.
 
 from __future__ import absolute_import
 
+__all__ = [
+    'CustomException',
+    'DockerImageBuilder',
+    'FakeProcessReactor',
+    'FakeSysModule',
+    'FlockerScriptTestsMixin',
+    'MemoryCoreReactor',
+    'REALISTIC_BLOCKDEVICE_SIZE',
+    'StandardOptionsTestsMixin',
+    'assertContainsAll',
+    'assertNoFDsLeaked',
+    'assert_equal_comparison',
+    'assert_not_equal_comparison',
+    'attempt_effective_uid',
+    'find_free_port',
+    'flaky',
+    'help_problems',
+    'if_root',
+    'logged_run_process',
+    'make_script_tests',
+    'make_with_init_tests',
+    'not_root',
+    'random_name',
+    'run_process',
+    'skip_on_broken_permissions',
+]
+
 import gc
 import io
 import socket
@@ -52,9 +79,6 @@ from .. import __version__
 from ..common.script import (
     FlockerScriptRunner, ICommandLineScript)
 
-
-# Export for other places to import. Be still, flake8.
-flaky
 
 # This is currently set to the minimum size for a SATA based Rackspace Cloud
 # Block Storage volume. See:

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -942,24 +942,3 @@ def run_process(command, *args, **kwargs):
                 returncode=status, cmd=command, output=output,
             )
     return result
-
-
-def flaky(test_method):
-    """
-    Mark a test as flaky.
-
-    A 'flaky' test is one that sometimes passes but sometimes fails. Marking a
-    test as flaky means both failures and successes are expected, and that
-    neither will fail the test run.
-
-    :param function test_method: The test method to mark as flaky.
-    :return: A decorated version of ``test_method``.
-    """
-    # TODO
-    # - allow specifying which exceptions are expected
-    # - retry on expected exceptions
-    #   - parametrize on retry options
-    #     - perhaps `loop_until` should take a generator of sleep intervals,
-    #       so we can use same routine for backoff
-    # - provide interesting & parseable logs for flaky tests
-    return test_method

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -1,0 +1,29 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Logic for handling flaky tests.
+
+XXX: Not all of this code actually belongs here, but while writing it's
+convenient to have one place to put everything.
+"""
+
+
+def flaky(test_method):
+    """
+    Mark a test as flaky.
+
+    A 'flaky' test is one that sometimes passes but sometimes fails. Marking a
+    test as flaky means both failures and successes are expected, and that
+    neither will fail the test run.
+
+    :param function test_method: The test method to mark as flaky.
+    :return: A decorated version of ``test_method``.
+    """
+    # TODO
+    # - allow specifying which exceptions are expected
+    # - retry on expected exceptions
+    #   - parametrize on retry options
+    #     - perhaps `loop_until` should take a generator of sleep intervals,
+    #       so we can use same routine for backoff
+    # - provide interesting & parseable logs for flaky tests
+    return test_method

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -2,13 +2,10 @@
 
 """
 Logic for handling flaky tests.
-
-XXX: Not all of this code actually belongs here, but while writing it's
-convenient to have one place to put everything.
 """
 
 
-def flaky(test_method):
+def flaky(jira_key):
     """
     Mark a test as flaky.
 
@@ -16,14 +13,19 @@ def flaky(test_method):
     test as flaky means both failures and successes are expected, and that
     neither will fail the test run.
 
-    :param function test_method: The test method to mark as flaky.
-    :return: A decorated version of ``test_method``.
+    :param unicode jira_key: The JIRA key of the bug for this flaky test,
+        e.g. 'FLOC-2345'
+    :return: A decorator that can be applied to `TestCase` methods.
     """
-    # TODO
+    # XXX: This raises a crappy error message if you forgot to provide a JIRA
+    # key. Is there a way to provide a good one?
+
+    # TODO (see FLOC-3281):
     # - allow specifying which exceptions are expected
     # - retry on expected exceptions
     #   - parametrize on retry options
-    #     - perhaps `loop_until` should take a generator of sleep intervals,
-    #       so we can use same routine for backoff
     # - provide interesting & parseable logs for flaky tests
-    return test_method
+
+    def wrapper(test_method):
+        return test_method
+    return wrapper

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -1,0 +1,58 @@
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.testtools._flaky``.
+"""
+
+import unittest
+
+from hypothesis import given
+from hypothesis.strategies import integers
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from .._flaky import flaky
+
+
+class FlakyTests(SynchronousTestCase):
+    """
+    Tests for ``@flaky`` decorator.
+    """
+
+    # XXX: Should I use this branch to introduce testtools as well?
+
+    @given(integers())
+    def test_decorated_function_executed(self, x):
+        """
+        ``@flaky`` decorates the given function sanely.
+        """
+        values = []
+
+        @flaky
+        def f(x):
+            values.append(x)
+            return x
+
+        y = f(x)
+        self.assertEqual(y, x)
+        self.assertEqual([x], values)
+
+    def test_successful_flaky_test(self):
+        """
+        A successful flaky test is considered successful.
+        """
+
+        # We use 'unittest' here to avoid accidentally depending on Twisted
+        # TestCase features, thus increasing complexity.
+        class SomeTest(unittest.TestCase):
+
+            @flaky
+            def test_something(self):
+                pass
+
+        test = SomeTest('test_something')
+        result = unittest.TestResult()
+
+        test.run(result)
+
+        self.assertEqual({}, result.__dict__)

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -26,7 +26,7 @@ class FlakyTests(SynchronousTestCase):
         """
         values = []
 
-        @flaky
+        @flaky('FLOC-XXXX')
         def f(x):
             values.append(x)
             return x
@@ -44,7 +44,7 @@ class FlakyTests(SynchronousTestCase):
         # TestCase features, thus increasing complexity.
         class SomeTest(unittest.TestCase):
 
-            @flaky
+            @flaky('FLOC-XXXX')
             def test_something(self):
                 pass
 
@@ -66,7 +66,7 @@ class FlakyTests(SynchronousTestCase):
 
         class SomeTest(unittest.TestCase):
 
-            @flaky
+            @flaky('FLOC-XXXX')
             def test_something(self):
                 1/0
 

--- a/flocker/volume/functional/test_service.py
+++ b/flocker/volume/functional/test_service.py
@@ -8,12 +8,15 @@ from twisted.trial.unittest import TestCase
 
 from ..service import VolumeName
 from ..testtools import create_realistic_servicepair
+from ...testtools import flaky
 
 
 class RealisticTests(TestCase):
     """
     Tests for realistic scenarios, used to catch integration issues.
     """
+
+    @flaky('FLOC-2767')
     def test_handoff(self):
         """
         Handoff of a previously unpushed volume between two ZFS-based volume


### PR DESCRIPTION
Part of the work to add a `@flaky` decorator to flocker.

This patch adds a decorator that does absolutely nothing, and then applies that decorator to all of the tests for which we have bugs saying they are flaky.

It has been a worthwhile exercise in that it has taught me about which tests are actually flaky (I already had a sense of it, but it's surprisingly clear once you look at what actually needs to _import_ `flaky`), and also because it has made the uses for the `@flaky` decorator more clear (see `XXX` notes in the diff).

I think having these markers in the code will help people with debugging (esp. @Azulinho with the Jenkins migration), so even though there's no behavioural change, I think there's enough added value to land.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2154)
<!-- Reviewable:end -->
