### PR TITLE
[FLOC-3421] Replace deprecated create_host_config with client method

### DIFF
--- a/flocker/acceptance/endtoend/test_leases.py
+++ b/flocker/acceptance/endtoend/test_leases.py
@@ -10,8 +10,6 @@ from twisted.internet import reactor
 from twisted.internet.task import deferLater
 from twisted.trial.unittest import TestCase
 
-from docker.utils import create_host_config
-
 from ...testtools import (
     random_name, find_free_port, REALISTIC_BLOCKDEVICE_SIZE
 )
@@ -114,7 +112,7 @@ class LeaseAPITests(TestCase):
             script = SCRIPTS.child("datahttp.py")
             script_arguments = [u"/data"]
             docker_arguments = {
-                "host_config": create_host_config(
+                "host_config": client.create_host_config(
                     binds=["{}:/data".format(dataset.path.path)],
                     port_bindings={container_http_port: host_http_port}),
                 "ports": [container_http_port],

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -15,7 +15,6 @@ from zope.interface import Interface, implementer
 
 from docker import Client
 from docker.errors import APIError, NotFound
-from docker.utils import create_host_config
 
 from eliot import Message, MessageType, Field, start_action
 
@@ -626,7 +625,7 @@ class DockerClient(object):
                 p.internal_port: p.external_port
                 for p in ports
             }
-            host_config = create_host_config(
+            host_config = self._client.create_host_config(
                 binds=binds,
                 port_bindings=port_bindings,
                 restart_policy=restart_policy_dict,


### PR DESCRIPTION
Fixes FLOC-3421
https://clusterhq.atlassian.net/browse/FLOC-3421

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2156)
<!-- Reviewable:end -->
