### PR TITLE
[FLOC-1576] Repair missing filesystems

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -361,6 +361,11 @@ CREATE_VOLUME_PROFILE_DROPPED = MessageType(
     u"IProfiledBlockDeviceAPI to get profile support."
 )
 
+DISCOVERED_RAW_STATE = MessageType(
+    u"agent:blockdevice:raw_state",
+    [Field(u"raw_state", safe_repr)],
+    u"The discovered raw state of the node's block device volumes.")
+
 
 def _volume_field():
     """
@@ -1376,7 +1381,7 @@ class BlockDeviceDeployer(PRecord):
                     # in the filesystem yet.
                     pass
 
-        return RawState(
+        result = RawState(
             compute_instance_id=compute_instance_id,
             volumes=volumes,
             devices=devices,
@@ -1384,6 +1389,8 @@ class BlockDeviceDeployer(PRecord):
             devices_with_filesystems=[device for device in devices.values()
                                       if _has_filesystem(device)],
         )
+        DISCOVERED_RAW_STATE(raw_state=result).write()
+        return result
 
     def discover_state(self, node_state):
         """

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1235,6 +1235,7 @@ class BlockDeviceDeployerLocalState(PClass):
         paths = {}
         devices = {}
         nonmanifest_datasets = {}
+
         for dataset in self.datasets.values():
             dataset_id = dataset.dataset_id
             if dataset.state == DatasetStates.MOUNTED:
@@ -1248,6 +1249,7 @@ class BlockDeviceDeployerLocalState(PClass):
                 paths[unicode(dataset_id)] = dataset.mount_point
             elif dataset.state in (
                 DatasetStates.NON_MANIFEST, DatasetStates.ATTACHED,
+                DatasetStates.ATTACHED_NO_FILESYSTEM,
             ):
                 nonmanifest_datasets[unicode(dataset_id)] = Dataset(
                     dataset_id=dataset_id,
@@ -1255,6 +1257,7 @@ class BlockDeviceDeployerLocalState(PClass):
                 )
             if dataset.state in (
                 DatasetStates.MOUNTED, DatasetStates.ATTACHED,
+                DatasetStates.ATTACHED_NO_FILESYSTEM,
             ):
                 devices[dataset_id] = dataset.device_path
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -105,7 +105,8 @@ class DiscoveredDataset(PClass):
         that all the attributes required for the state are specified.
         """
         expected_attributes = [
-            ((DatasetStates.ATTACHED, DatasetStates.MOUNTED), "device_path"),
+            ((DatasetStates.ATTACHED, DatasetStates.MOUNTED,
+              DatasetStates.ATTACHED_NO_FILESYSTEM), "device_path"),
             ((DatasetStates.MOUNTED,), "mount_point"),
         ]
         for states, attribute in expected_attributes:
@@ -1421,8 +1422,12 @@ class BlockDeviceDeployer(PRecord):
                         mount_point=mount_point,
                     )
                 else:
+                    if device_path in raw_state.devices_with_filesystems:
+                        state = DatasetStates.ATTACHED
+                    else:
+                        state = DatasetStates.ATTACHED_NO_FILESYSTEM
                     datasets[dataset_id] = DiscoveredDataset(
-                        state=DatasetStates.ATTACHED,
+                        state=state,
                         dataset_id=dataset_id,
                         maximum_size=volume.size,
                         blockdevice_id=volume.blockdevice_id,

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -61,10 +61,17 @@ PROFILE_METADATA_KEY = u"clusterhq:flocker:profile"
 class DatasetStates(Names):
     """
     States that a ``Dataset`` can be in.
+
     """
+    # Exists, but not attached:
     NON_MANIFEST = NamedConstant()
+    # Attached to this node but no filesystem
+    ATTACHED_NO_FILESYSTEM = NamedConstant()
+    # Attached to this node, has filesystem
     ATTACHED = NamedConstant()
+    # Mounted on this node:
     MOUNTED = NamedConstant()
+    # XXX seems pointless might delete at some point
     DELETED = NamedConstant()
 
 
@@ -1179,14 +1186,14 @@ class RawState(PClass):
     """
     The raw state of a node.
 
-    :param unicode compute_instance_id:
-    :param volumes: List of volumes attached to this node or non-manifest.
+    :param unicode compute_instance_id: The identifier for this node.
+    :param volumes: List of all volumes in the cluster.
     :type volumes: ``pvector`` of ``BlockDeviceVolume``
     :param devices: Mapping from dataset UUID to block device path containing
-        filesystem of that dataset.
+        filesystem of that dataset, on this particular node.
     :type devices: ``pmap`` of ``UUID`` to ``FilePath``
     :param system_mounts: Mapping of block device path to mount point of all
-        mounts on the system.
+        mounts on this particular node.
     :type system_mounts: ``pmap`` of ``FilePath`` to ``FilePath``.
     """
     compute_instance_id = field(unicode, mandatory=True)

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -63,15 +63,15 @@ class DatasetStates(Names):
     States that a ``Dataset`` can be in.
 
     """
-    # Exists, but not attached:
+    # Exists, but not attached
     NON_MANIFEST = NamedConstant()
     # Attached to this node but no filesystem
     ATTACHED_NO_FILESYSTEM = NamedConstant()
     # Attached to this node, has filesystem
     ATTACHED = NamedConstant()
-    # Mounted on this node:
+    # Mounted on this node
     MOUNTED = NamedConstant()
-    # XXX seems pointless might delete at some point
+    # Deleted from the driver
     DELETED = NamedConstant()
 
 
@@ -1519,7 +1519,7 @@ class BlockDeviceDeployer(PRecord):
         mounts = list(self._calculate_mounts(
             local_node_state.devices, local_node_state.paths,
             configured_manifestations, local_state.volumes,
-            local_state.discovered_datasets,
+            local_state.datasets,
         ))
         unmounts = list(self._calculate_unmounts(
             local_node_state.paths, configured_manifestations,
@@ -1527,7 +1527,7 @@ class BlockDeviceDeployer(PRecord):
         ))
         filesystem_creates = list(self._calculate_filesystem_creates(
             configured_manifestations,
-            local_state.discovered_datasets,
+            local_state.datasets,
         ))
 
         # XXX prevent the configuration of unsized datasets on blockdevice

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -367,10 +367,13 @@ class BlockDeviceDeployerLocalStateTests(SynchronousTestCase):
             expected_changes,
         )
 
-    def test_attached_dataset(self):
+    def attached_dataset_test(self, state):
         """
-        When there is a a dataset in the ``ATTACHED`` state,
+        When there is a a dataset in the given attached state,
         it is reported as a non-manifest dataset.
+
+        :param state: Either ``DatasetStates.ATTACHED`` or
+            ``DatasetStates.ATTACHED_NO_FILESYSTEM``.
         """
         dataset_id = uuid4()
         local_state = BlockDeviceDeployerLocalState(
@@ -378,7 +381,7 @@ class BlockDeviceDeployerLocalStateTests(SynchronousTestCase):
             hostname=self.hostname,
             datasets={
                 dataset_id: DiscoveredDataset(
-                    state=DatasetStates.ATTACHED,
+                    state=state,
                     dataset_id=dataset_id,
                     blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
                     maximum_size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE,
@@ -410,6 +413,20 @@ class BlockDeviceDeployerLocalStateTests(SynchronousTestCase):
             local_state.shared_state_changes(),
             expected_changes,
         )
+
+    def test_attached_dataset(self):
+        """
+        When there is a a dataset in the ``ATTACHED`` state,
+        it is reported as a non-manifest dataset.
+        """
+        self.attached_dataset_test(DatasetStates.ATTACHED)
+
+    def test_attached_no_filesystem_dataset(self):
+        """
+        When there is a a dataset in the ``ATTACHED_NO_FILESYSTEM`` state,
+        it is reported as a non-manifest dataset.
+        """
+        self.attached_dataset_test(DatasetStates.ATTACHED_NO_FILESYSTEM)
 
     def test_mounted_dataset(self):
         """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -59,6 +59,7 @@ from ..blockdevice import (
     CREATE_BLOCK_DEVICE_DATASET,
     INVALID_DEVICE_PATH,
     CREATE_VOLUME_PROFILE_DROPPED,
+    DISCOVERED_RAW_STATE,
 
     IBlockDeviceAsyncAPI,
     _SyncToThreadedAsyncAPIAdapter,
@@ -627,7 +628,8 @@ class BlockDeviceDeployerDiscoverRawStateTests(SynchronousTestCase):
             unmounted,
         ])
 
-    def test_filesystem_state(self):
+    @capture_logging(assertHasMessage, DISCOVERED_RAW_STATE)
+    def test_filesystem_state(self, logger):
         """
         ``RawState`` includes whether or not a volume has a filesystem.
         """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -990,7 +990,7 @@ def assert_calculated_changes(
         volumes=DiscoverVolumesMethod.INFER_VOLUMES_FROM_STATE,
         compute_instance_id=u"instance-".format(node_state.uuid))
     local_state = local_state.set(
-        discovered_datasets={d.dataset_id: d for d in discovered_datasets})
+        datasets={d.dataset_id: d for d in discovered_datasets})
 
     return assert_calculated_changes_for_deployer(
         case, deployer, node_state, node_config,
@@ -1159,7 +1159,7 @@ class FakeBlockDeviceDeployerLocalState(PClass):
     node_state = field(type=NodeState, mandatory=True)
     nonmanifest_datasets = field(type=NonManifestDatasets, mandatory=True)
     volumes = pvector_field(BlockDeviceVolume)
-    discovered_datasets = pmap_field(UUID, DiscoveredDataset)
+    datasets = pmap_field(UUID, DiscoveredDataset)
 
     def shared_state_changes(self):
         return self.node_state, self.nonmanifest_datasets


### PR DESCRIPTION
As preliminary to breaking up creation into atomic steps, and also to recover from failures mid-way through creation, create a filesystem on an attached block device if it is missing one. Previously we would try to mount it, fail, repeat forever.

http://build.clusterhq.com/boxes-flocker?branch=repair-missing-filesystem-FLOC-1576

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2157)
<!-- Reviewable:end -->
