### PR TITLE
Add documentation for Dell SC backend driver

### DIFF
--- a/docs/config/configuring-nodes-storage.rst
+++ b/docs/config/configuring-nodes-storage.rst
@@ -55,14 +55,15 @@ The following pages describe how to configure the backends currently supported b
    
    openstack-configuration
    aws-configuration
-   emc-configuration
-   vmware-configuration
-   netapp-configuration
-   hedvig-configuration
-   convergeio-configuration
-   saratogaspeed-configuration
    zfs-configuration
    loopback-configuration
+   convergeio-configuration
+   hedvig-configuration
+   dell-configuration
+   emc-configuration
+   netapp-configuration
+   saratogaspeed-configuration
+   vmware-configuration
    
 Flocker supports pluggable storage backends. 
 Any storage system that is able to present itself as a network-based block device can serve as the underlying storage for a Docker data volume managed by Flocker.

--- a/docs/config/dell-configuration.rst
+++ b/docs/config/dell-configuration.rst
@@ -1,0 +1,14 @@
+.. _dell-dataset-backend:
+
+=================================================
+Dell SC Series Block Device Backend Configuration
+=================================================
+
+Dell provides a plugin for Flocker integration with `SC Series`_ storage arrays.
+
+For more information and installation instructions, visit the following GitHub repository:
+
+* `Dell Storage Center Flocker driver on GitHub`_
+
+.. _SC Series: http://www.dell.com/us/business/p/dell-compellent
+.. _Dell Storage Center Flocker driver on GitHub: https://github.com/dellstorage/storagecenter-flocker-driver


### PR DESCRIPTION
Added info page for Dell SC series storage block
device driver. Added link in main backend reference
page and restructured the list of backends to be:

* Flocker supplied
* Vendor supplied

Also resorted within categories for a little more
logical of an order.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2158)
<!-- Reviewable:end -->
