### PR TITLE
[FLOC-3395] Release flocker 1.7.0

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.7.0
+======
+
+* Added support for :ref:`storage profiles<storage-profiles>`.
+
 v1.6.1
 ======
 


### PR DESCRIPTION
Release flocker 1.7.0 with profiles support.

The test run at http://build.clusterhq.com/boxes-flocker?branch=release%2Fflocker-1.7.0 was not originally all green, specifically `flocker/unit-test/centos-7/zfs-head` was red for a few runs. See https://clusterhq.atlassian.net/browse/FLOC-3395 for discussions on why proceeding anyway, the summary is that the flakes occurred in test code and docker and thus are thought to not be indicative of any failures with core flocker code.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2159)
<!-- Reviewable:end -->
