### PR TITLE
[FLOC-3445] Return something AMP can handle

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -344,8 +344,9 @@ class ControlServiceLocator(CommandLocator):
 
     @SetNodeEraCommand.responder
     def set_node_era(self, era):
-        # Actual work will be done in FLOC-3379, FLOC-3380
-        pass
+        # Version in master actually does something, here just return
+        # nothing so we don't break the connection.
+        return {}
 
 
 class ControlAMP(AMP):


### PR DESCRIPTION
In 1.7.0 this AMP handler was broken, resulting in disconnects immediately after each each new AMP connection.

*Important*: In order to merge this we need to verify not only passing tests, but also that CPU usage on nodes is not 100%!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2167)
<!-- Reviewable:end -->
