### PR TITLE
[FLOC-3445] Prevent 100% CPU from disconnect/reconnect AMP clients cycle

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -344,8 +344,9 @@ class ControlServiceLocator(CommandLocator):
 
     @SetNodeEraCommand.responder
     def set_node_era(self, era):
-        # Actual work will be done in FLOC-3379, FLOC-3380
-        pass
+        # Version in master actually does something, here just return
+        # nothing so we don't break the connection.
+        return {}
 
 
 class ControlAMP(AMP):


### PR DESCRIPTION
Fix issue that caused AMP connections to disconnect immediately upon connecting.

IMPORTANT: To verify the fix we need to check lack of error and logs and CPU usage that is not 100%; green tests do not indicate this is fixed.

`master` does not have this issue since the stub code has been filled in.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2168)
<!-- Reviewable:end -->
