### PR TITLE
[FLOC-3448] Release Flocker 1.7.1

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.7.1
+======
+
+* Prevent disconnect/reconnect cycles causing high CPU load.
+
 v1.7.0
 ======
 


### PR DESCRIPTION
Single patch on top of 1.7.0 to prevent breakage of AMP protocol.

Apart from the usual change to the release notes, this PR also provides a quick fix to the AMP protocol.  This fix conflicts with the real fix in `master`. When this PR is merged, the conflict will be resolved in favour of the `master` code.

I expect to do this by tagging the release, then creating a new branch `1.7.1-merge` from `1.7.1` to be merged into `master`. Before merging into `master`, this new branch will have `master` merged in and the conflict resolved. [EDIT - latest release notes actually describe what to do in this case]

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2169)
<!-- Reviewable:end -->
