### PR TITLE
[FLOC-3448] Merge release 1.7.1 back into master

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.7.1
+======
+
+* Prevent disconnect/reconnect cycles causing high CPU load.
+
 v1.7.0
 ======
 

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.7.0
+======
+
+* Added support for :ref:`storage profiles<storage-profiles>`.
+
 v1.6.1
 ======
 


### PR DESCRIPTION
Merge to get the release notes and the tag back into master. Merge resolved in favor of master so the release branch only patch is effectively removed from this merge.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2170)
<!-- Reviewable:end -->
