### PR TITLE
[FLOC-3450] Bump testtools to 1.8.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -44,7 +44,7 @@ sphinx-prompt==1.0.0
 sphinx-rtd-theme==0.1.8
 sphinxcontrib-httpdomain==1.3.0
 sphinxcontrib-spelling==2.1.2
-testtools==1.8.0
+testtools==1.8.1
 tox==2.1.1
 versioneer==0.15
 virtualenv==13.1.0

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -59,8 +59,6 @@ class AsyncTestCaseTests(TestCase):
         logs = []
         result = Python27TestResult(logs)
         test.run(result)
-        # testing-cabal/testtools c51fdb854 adds a public API for this. Update
-        # to use new API when we start using a version later than 1.8.0.
         self.assertEqual([
             ('startTest', test),
             ('addSkip', test, reason),

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -56,7 +56,8 @@ class AsyncTestCaseTests(TestCase):
         test = SkippingTest('test_skip')
         # We need a test result double that we can useful results from, and
         # the Python 2.7 TestResult is the lowest common denominator.
-        result = Python27TestResult()
+        logs = []
+        result = Python27TestResult(logs)
         test.run(result)
         # testing-cabal/testtools c51fdb854 adds a public API for this. Update
         # to use new API when we start using a version later than 1.8.0.
@@ -64,7 +65,7 @@ class AsyncTestCaseTests(TestCase):
             ('startTest', test),
             ('addSkip', test, reason),
             ('stopTest', test),
-        ], result._events)
+        ], logs)
 
     def test_mktemp_doesnt_exist(self):
         """


### PR DESCRIPTION
We were using a private API for testtools. Now we're not.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2174)
<!-- Reviewable:end -->
