### PR TITLE
[FLOC 2390] add favicon to docs

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -65,6 +65,8 @@
             })();
         </script>
     {% endif %}
+	
+    <link rel="shortcut icon" href="https://clusterhq.com/assets/favicon.ico"/>
 </head>
 <body>
     <!-- Menu area -->


### PR DESCRIPTION
Fixes 2390

The docs pages have been missing the favicon that is present for the rest of the website. This adds it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2182)
<!-- Reviewable:end -->
