### PR TITLE
[FLOC 3419] add a margin to the bottom of lists, except if it is part of the toctree

### DIFF
--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -305,6 +305,11 @@ a.download:before {
 .page ul, ol {
     color: #646570;
     font-family: lato;
+    margin-bottom: 10px;
+}
+
+.toctree-l1 ul, .toctree-l1 ol {
+    margin-bottom: 0;
 }
 
 .page>.section {


### PR DESCRIPTION
Fixes 3419

In bulleted lists, nested in a numbered list, the padding at the bottom of the last bullet was missing padding. This PR adds 10px to the bottom of the list, but limits this change so as not to impact the toctree listings used throughout the docs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2183)
<!-- Reviewable:end -->
