### PR TITLE
[FLOC-3447] Calculate changes for wakeups

### DIFF
--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -23,7 +23,9 @@ from random import uniform
 
 from zope.interface import implementer
 
-from eliot import ActionType, Field, writeFailure, MessageType
+from eliot import (
+    ActionType, Field, writeFailure, MessageType, write_traceback,
+)
 from eliot.twisted import DeferredContext
 
 from characteristic import attributes
@@ -391,8 +393,16 @@ class ConvergenceLoop(object):
         # still indicates some action should be taken that means we should
         # wake up:
         discovered = self._last_discovered_local_state
-        if self.deployer.calculate_changes(
-                self.configuration, self.cluster_state, discovered) != NoOp():
+        try:
+            changes = self.deployer.calculate_changes(
+                self.configuration, self.cluster_state, discovered)
+        except:
+            # Something went wrong in calculation due to a bug in the
+            # code. We should wake up just in case in order to be more
+            # responsive.
+            write_traceback()
+            changes = None
+        if changes != NoOp():
             self.fsm.receive(ConvergenceLoopInputs.WAKEUP)
 
     def _send_state_to_control_service(self, state_changes):

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -213,7 +213,11 @@ class ControllableDeployer(object):
             (cluster_state.get_node(uuid=self.node_uuid,
                                     hostname=self.hostname),
              desired_configuration, cluster_state))
-        return self.calculated_actions.pop(0)
+        calculated = self.calculated_actions.pop(0)
+        if isinstance(calculated, Exception):
+            raise calculated
+        else:
+            return calculated
 
 
 # A deployment with no information:


### PR DESCRIPTION
calculate_changes() is sometimes called with cached local state to decide if the sleeping converence loop should wake up.

1. If it throws an exception (indicating a bug) then wake up; better to be responsive than to sleep when there is work to be done.
2. Fix a case where it threw an exception due to using cached local state that was missing information

The latter case was happening in acceptance tests and may have been causing timeouts since the loop would not wake up.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2185)
<!-- Reviewable:end -->
