### PR TITLE
[FLOC-3456] Release Flocker 1.7.2

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,12 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+v1.7.2
+======
+
+* Moved the installation instructions for the Flocker plugin for Docker, to prevent issues when installing and configuring the plugin.
+* Added documentation for :ref:`Dell SC Series <dell-dataset-backend>`, :ref:`Huawei <huawei-backend>` and :ref:`NexentaEdge <nexenta-backend>` drivers 
+
 v1.7.1
 ======
 


### PR DESCRIPTION
Release adds doc changes from `master` that do not have any related changes in code.  In particular, this was done to fix FLOC-3420, which was being reported by users.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clusterhq/flocker/2186)
<!-- Reviewable:end -->
