### PR TITLE
[FLOC-3443] Retry tests marked as flaky 

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,6 @@ ecdsa==0.13
 executor==4.4
 Fabric==1.10.2
 flake8==2.4.1
-flaky==2.4.1
 gitdb==0.6.4
 GitPython==1.0.1
 humanfriendly==1.33

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,6 +13,7 @@ ecdsa==0.13
 executor==4.4
 Fabric==1.10.2
 flake8==2.4.1
+flaky==2.4.1
 gitdb==0.6.4
 GitPython==1.0.1
 humanfriendly==1.33

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -21,7 +21,7 @@ class DatasetAPITests(AsyncTestCase):
     Tests for the dataset API.
     """
 
-    @flaky('FLOC-3207')
+    @flaky(u'FLOC-3207')
     @require_cluster(1)
     def test_dataset_creation(self, cluster):
         """
@@ -53,7 +53,7 @@ class DatasetAPITests(AsyncTestCase):
         waiting_for_create.addCallback(confirm_gold)
         return waiting_for_create
 
-    @flaky('FLOC-3341')
+    @flaky(u'FLOC-3341')
     @require_moving_backend
     @require_cluster(2)
     def test_dataset_move(self, cluster):
@@ -81,7 +81,7 @@ class DatasetAPITests(AsyncTestCase):
         waiting_for_create.addCallback(move_dataset)
         return waiting_for_create
 
-    @flaky('FLOC-3196')
+    @flaky(u'FLOC-3196')
     @require_cluster(1)
     def test_dataset_deletion(self, cluster):
         """

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -180,7 +180,7 @@ class DockerPluginTests(AsyncTestCase):
             self, node.public_address, host_port, expected_response=data))
         return d
 
-    @flaky('FLOC-3346')
+    @flaky(u'FLOC-3346')
     @require_cluster(1)
     def test_create_container_with_v2_plugin_api(self, cluster):
         """
@@ -358,7 +358,7 @@ class DockerPluginTests(AsyncTestCase):
             expected_response=data))
         return d
 
-    @flaky('FLOC-2977')
+    @flaky(u'FLOC-2977')
     @require_cluster(1)
     def test_move_volume_single_node(self, cluster):
         """
@@ -368,7 +368,7 @@ class DockerPluginTests(AsyncTestCase):
         """
         return self._test_move(cluster, cluster.nodes[0], cluster.nodes[0])
 
-    @flaky('FLOC-3346')
+    @flaky(u'FLOC-3346')
     @require_cluster(2)
     def test_move_volume_different_node(self, cluster):
         """

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -118,7 +118,7 @@ class ContainerAPITests(TestCase):
         )
         return d
 
-    @flaky('FLOC-2488')
+    @flaky(u'FLOC-2488')
     @require_moving_backend
     @require_cluster(2)
     def test_move_container_with_dataset(self, cluster):

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -171,7 +171,7 @@ class CinderBlockDeviceAPIInterfaceTests(
                 flocker_volume.blockdevice_id).display_name,
             u"flocker-{}".format(dataset_id))
 
-    @flaky('FLOC-3347')
+    @flaky(u'FLOC-3347')
     def test_get_device_path_device(self):
         return super(
             CinderBlockDeviceAPIInterfaceTests,

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -272,19 +272,19 @@ class EBSBlockDeviceAPIInterfaceTests(
         self.assertEqual(ebs_volume.iops if requested_iops is not None
                          else None, requested_iops)
 
-    @flaky('FLOC-2302')
+    @flaky(u'FLOC-2302')
     def test_listed_volume_attributes(self):
         return super(
             EBSBlockDeviceAPIInterfaceTests,
             self).test_listed_volume_attributes()
 
-    @flaky('FLOC-2672')
+    @flaky(u'FLOC-2672')
     def test_multiple_volumes_attached_to_host(self):
         return super(
             EBSBlockDeviceAPIInterfaceTests,
             self).test_multiple_volumes_attached_to_host()
 
-    @flaky('FLOC-3236')
+    @flaky(u'FLOC-3236')
     def test_detach_volume(self):
         return super(
             EBSBlockDeviceAPIInterfaceTests, self).test_detach_volume()

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -394,7 +394,7 @@ class DeployerTests(TestCase):
         d.addCallback(inspect_application)
         return d
 
-    @flaky('FLOC-3330')
+    @flaky(u'FLOC-3330')
     @if_docker_configured
     def test_cpu_shares(self):
         """

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -79,8 +79,7 @@ class IDockerClientNamespacedTests(make_idockerclient_tests(
     def setUp(self):
         pass
 
-    # XXX: First time we've needed multiple JIRA keys. Is this the right API?
-    @flaky(['FLOC-2628', 'FLOC-2874'])
+    @flaky([u'FLOC-2628', u'FLOC-2874'])
     def test_added_is_listed(self):
         return super(IDockerClientNamespacedTests, self).test_added_is_listed()
 
@@ -532,7 +531,7 @@ class GenericDockerClientTests(TestCase):
     # XXX: This is subclassed, and the subclass decorated with a different
     # JIRA key. When @flaky actually does something, we should have tests that
     # cover that case.
-    @flaky('FLOC-3077')
+    @flaky(u'FLOC-3077')
     def test_pull_image_if_necessary(self):
         """
         The Docker image is pulled if it is unavailable locally.
@@ -1082,7 +1081,7 @@ class GenericDockerClientTests(TestCase):
         d.addCallback(self.assertEqual, "1")
         return d
 
-    @flaky('FLOC-2840')
+    @flaky(u'FLOC-2840')
     def test_restart_policy_always(self):
         """
         An container with a restart policy of always is restarted
@@ -1326,7 +1325,7 @@ class NamespacedDockerClientTests(GenericDockerClientTests):
         d.addCallback(self.assertEqual, set())
         return d
 
-    @flaky('FLOC-1657')
+    @flaky(u'FLOC-1657')
     def test_pull_image_if_necessary(self):
         return super(
             NamespacedDockerClientTests, self).test_pull_image_if_necessary()

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -528,9 +528,6 @@ class GenericDockerClientTests(TestCase):
         d.addCallback(started)
         return d
 
-    # XXX: This is subclassed, and the subclass decorated with a different
-    # JIRA key. When @flaky actually does something, we should have tests that
-    # cover that case.
     @flaky(u'FLOC-3077')
     def test_pull_image_if_necessary(self):
         """

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -14,6 +14,8 @@ from testtools.deferredruntest import (
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
+from ._flaky import retry_flaky
+
 
 class TestCase(unittest.SynchronousTestCase):
     """
@@ -30,10 +32,11 @@ def async_runner(timeout):
     """
     # XXX: Looks like the acceptance tests (which were the first tests that we
     # tried to migrate) aren't cleaning up after themselves even in the
-    # successful case. Use the RunTest that loops the reactor a couple of
-    # times after the test is done.
-    return AsynchronousDeferredRunTestForBrokenTwisted.make_factory(
-        timeout=timeout.total_seconds())
+    # successful case. Use AsynchronousDeferredRunTestForBrokenTwisted, which
+    # loops the reactor a couple of times after the test is done.
+    return retry_flaky(
+        AsynchronousDeferredRunTestForBrokenTwisted.make_factory(
+            timeout=timeout.total_seconds()))
 
 
 # By default, asynchronous tests are timed out after 2 minutes.

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -65,6 +65,7 @@ class AsyncTestCase(testtools.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(AsyncTestCase, self).__init__(*args, **kwargs)
+        # XXX: Work around testing-cabal/unittest-ext#60
         self.exception_handlers.insert(-1, (unittest.SkipTest, _test_skipped))
 
     def mktemp(self):

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 
 import testtools
+from testtools.content import text_content
 from testtools.deferredruntest import (
     AsynchronousDeferredRunTestForBrokenTwisted)
 
@@ -52,7 +53,7 @@ DEFAULT_ASYNC_TIMEOUT = timedelta(minutes=2)
 
 
 def _test_skipped(case, result, exception):
-    result.addSkip(case, str(exception))
+    result.addSkip(case, details={'reason': text_content(unicode(exception))})
 
 
 class AsyncTestCase(testtools.TestCase):

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -123,7 +123,10 @@ class _RetryFlaky(testtools.RunTest):
         else:
             # XXX: Need to actually provide data about the errors.
             # XXX: How are we going to report on tests that sometimes fail,
-            # sometimes error.
+            # sometimes error. Probably "if all failures, failure; otherwise,
+            # error"
+            # XXX: Consider extracting this aggregation into a separate
+            # function.
             result.addError(case, details={})
         result.stopTest(case)
 

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -160,9 +160,12 @@ class _RetryFlaky(testtools.RunTest):
                 successes += 1
             results.append(details)
 
+        flaky_data = flaky.to_dict()
+        flaky_data.update({'runs': len(results), 'passes': successes})
         flaky_details = {
-            'flaky': text_content(pformat(flaky.to_dict())),
+            'flaky': text_content(pformat(flaky_data)),
         }
+
         details = _combine_details([flaky_details] + results)
         result.startTest(case)
         if successes >= flaky.min_passes:

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -244,7 +244,7 @@ class _RetryFlaky(testtools.RunTest):
         if result_type == _ResultType.skip:
             # XXX: Work around a testtools bug where it reports stack traces
             # for skips that aren't passed through its supported
-            # SkipException.
+            # SkipException: https://bugs.launchpad.net/testtools/+bug/1518100
             [reason] = list(tmp_result.skip_reasons.keys())
             details = details.discard('traceback').set(
                 'reason', text_content(reason))

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -14,7 +14,7 @@ from testtools.testcase import gather_details
 _FLAKY_ATTRIBUTE = '_flaky'
 
 
-def flaky(jira_key, max_runs=5, min_passes=2):
+def flaky(jira_keys, max_runs=5, min_passes=2):
     """
     Mark a test as flaky.
 
@@ -22,8 +22,9 @@ def flaky(jira_key, max_runs=5, min_passes=2):
     test as flaky means both failures and successes are expected, and that
     neither will fail the test run.
 
-    :param unicode jira_key: The JIRA key of the bug for this flaky test,
-        e.g. 'FLOC-2345'
+    :param unicode jira_keys: The JIRA key of the bug for this flaky test,
+        e.g. 'FLOC-2345'. Can also be a sequence of keys if the test is flaky
+        fr multiple reasons.
     :param int max_runs: The maximum number of times to run the test.
     :param int min_passes: The minimum number of passes required to treat this
         test as successful.

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -14,6 +14,14 @@ from testtools.testcase import gather_details
 _FLAKY_ATTRIBUTE = '_flaky'
 
 
+# TODO:
+# - actually run a flaky test manually to see what everything looks like
+# - make sure that JIRA data is included in flaky annotations
+#   - do "either text or sequence" UI for jira_keys
+# - attach details to success
+# - handle tests with many different kinds of results
+
+
 def flaky(jira_keys, max_runs=5, min_passes=2):
     """
     Mark a test as flaky.

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -240,14 +240,14 @@ class _RetryFlaky(testtools.RunTest):
         tmp_result = testtools.TestResult()
         self._run_test(case, tmp_result)
         result_type = _get_result_type(tmp_result)
+        details = pmap(case.getDetails())
         if result_type == _ResultType.skip:
             # XXX: Work around a testtools bug where it reports stack traces
             # for skips that aren't passed through its supported
             # SkipException.
             [reason] = list(tmp_result.skip_reasons.keys())
-            details = pmap({'reason': text_content(reason)})
-        else:
-            details = pmap(case.getDetails())
+            details = details.discard('traceback').set(
+                'reason', text_content(reason))
         _reset_case(case)
         return (tmp_result.wasSuccessful(), result_type, details)
 

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -63,18 +63,6 @@ class _RetryFlaky(testtools.RunTest):
         self._args = args
         self._kwargs = kwargs
 
-    def _run_test(self, case, result):
-        """
-        Create an instance of the ``RunTest`` we are wrapping.
-
-        :param testtools.TestCase case: The test to run.
-        :param testtools.TestResult result: The test result to report to.
-            Must conform to testtools extended test result interface.
-        :return: The modified ``result``.
-        """
-        run_test = self._run_test_factory(case, *self._args, **self._kwargs)
-        return run_test._run_prepared_result(result)
-
     def _run_prepared_result(self, result):
         """
         Run the test with a result that conforms to testtools' extended
@@ -90,6 +78,18 @@ class _RetryFlaky(testtools.RunTest):
 
         # No flaky attributes? Then run as normal.
         return self._run_test(self._case, result)
+
+    def _run_test(self, case, result):
+        """
+        Run ``case`` with the ``RunTest`` we are wrapping.
+
+        :param testtools.TestCase case: The test to run.
+        :param testtools.TestResult result: The test result to report to.
+            Must conform to testtools extended test result interface.
+        :return: The modified ``result``.
+        """
+        run_test = self._run_test_factory(case, *self._args, **self._kwargs)
+        return run_test._run_prepared_result(result)
 
     def _run_flaky_test(self, case, result, min_passes, max_runs):
         """

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -271,20 +271,29 @@ def _get_result_type(result):
 
     :param testtools.TestResult result: A TestResult that has had exactly
         one test run on it.
+    :raise ValueError: If ``result`` has run more than one test, or has more
+        than one kind of result.
     :return: A _ResultType for that result.
     """
     if result.testsRun != 1:
         raise ValueError('%r has run %d tests, 1 expected' % (
             result, result.testsRun))
 
+    total = sum(map(len, [
+        result.errors, result.failures, result.unexpectedSuccesses,
+        result.expectedFailures, result.skip_reasons]))
+    if total > 1:
+        raise ValueError(
+            '%r has more than one kind of result: %r found' % (result, total))
+
     if len(result.errors) > 0:
         return _ResultType.error
     elif len(result.failures) > 0:
         return _ResultType.failure
-    elif len(result.expectedFailures) > 0:
-        return _ResultType.expected_failure
     elif len(result.unexpectedSuccesses) > 0:
         return _ResultType.unexpected_success
+    elif len(result.expectedFailures) > 0:
+        return _ResultType.expected_failure
     elif len(result.skip_reasons) > 0:
         return _ResultType.skip
     else:

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -52,7 +52,7 @@ def flaky(jira_keys, max_runs=5, min_passes=2):
     return wrapper
 
 
-def _get_flaky_attrs(case):
+def _get_flaky_annotation(case):
     """
     Get the flaky decoration detail from ``case``.
 
@@ -107,7 +107,7 @@ class _RetryFlaky(testtools.RunTest):
         This overrides a method in base ``RunTest`` which is intended to be
         overwritten.
         """
-        flaky = _get_flaky_attrs(self._case)
+        flaky = _get_flaky_annotation(self._case)
         if flaky is not None:
             return self._run_flaky_test(
                 self._case, result, flaky.min_passes, flaky.max_runs)

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -75,16 +75,6 @@ class _RetryFlaky(testtools.RunTest):
         run_test = self._run_test_factory(case, *self._args, **self._kwargs)
         return run_test._run_prepared_result(result)
 
-    def _reset_case(self, case):
-        """
-        Reset ``case`` so it can be run again.
-        """
-        # Don't want details from last run.
-        case.getDetails().clear()
-        # https://github.com/testing-cabal/testtools/pull/165/ fixes this.
-        case._TestCase__setup_called = False
-        case._TestCase__teardown_called = False
-
     def _run_prepared_result(self, result):
         """
         Run the test with a result that conforms to testtools' extended
@@ -124,7 +114,7 @@ class _RetryFlaky(testtools.RunTest):
             results.append(tmp_result)
             if tmp_result.wasSuccessful():
                 successes += 1
-            self._reset_case(case)
+            _reset_case(case)
 
         if successes >= min_passes:
             result.startTest(case)
@@ -134,6 +124,19 @@ class _RetryFlaky(testtools.RunTest):
 
         # XXX: Obviously we want to report failures!
         return result
+
+
+def _reset_case(case):
+    """
+    Reset ``case`` so it can be run again.
+    """
+    # XXX: Alternative approach is to use clone_test_with_new_id, rather than
+    # resetting the same test case.
+    # Don't want details from last run.
+    case.getDetails().clear()
+    # https://github.com/testing-cabal/testtools/pull/165/ fixes this.
+    case._TestCase__setup_called = False
+    case._TestCase__teardown_called = False
 
 
 def _get_flaky_attrs(case):

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -6,10 +6,11 @@ Logic for handling flaky tests.
 
 from functools import partial
 
+import flaky as _flaky
 import testtools
 
 
-def flaky(jira_key):
+def flaky(jira_key, max_runs=None, min_passes=None):
     """
     Mark a test as flaky.
 
@@ -19,6 +20,9 @@ def flaky(jira_key):
 
     :param unicode jira_key: The JIRA key of the bug for this flaky test,
         e.g. 'FLOC-2345'
+    :param int max_runs: The maximum number of times to run the test.
+    :param int min_passes: The minimum number of passes required to treat this
+        test as successful.
     :return: A decorator that can be applied to `TestCase` methods.
     """
     # XXX: This raises a crappy error message if you forgot to provide a JIRA
@@ -31,7 +35,8 @@ def flaky(jira_key):
     # - provide interesting & parseable logs for flaky tests
 
     def wrapper(test_method):
-        return test_method
+        return _flaky.flaky(max_runs=max_runs, min_passes=min_passes)(
+            test_method)
     return wrapper
 
 

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -16,10 +16,6 @@ from testtools.testcase import gather_details
 _FLAKY_ATTRIBUTE = '_flaky'
 
 
-# TODO:
-# - handle tests with many different kinds of results
-
-
 def flaky(jira_keys, max_runs=5, min_passes=2):
     """
     Mark a test as flaky.
@@ -172,8 +168,7 @@ class _RetryFlaky(testtools.RunTest):
             result.addSuccess(case, details=details)
         else:
             # XXX: How are we going to report on tests that sometimes fail,
-            # sometimes error. Probably "if all failures, failure; otherwise,
-            # error"
+            # sometimes error, sometimes skip? Currently we just error.
             result.addError(case, details=details)
         result.stopTest(case)
         return result

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -15,10 +15,8 @@ _FLAKY_ATTRIBUTE = '_flaky'
 
 
 # TODO:
-# - actually run a flaky test manually to see what everything looks like
 # - make sure that JIRA data is included in flaky annotations
 #   - do "either text or sequence" UI for jira_keys
-# - attach details to success
 # - handle tests with many different kinds of results
 
 
@@ -151,15 +149,15 @@ class _RetryFlaky(testtools.RunTest):
                 successes += 1
             results.append(details)
 
+        details = _combine_details(results)
         result.startTest(case)
         if successes >= min_passes:
-            # XXX: Should attach a whole bunch of information here as details.
-            result.addSuccess(case)
+            result.addSuccess(case, details=details)
         else:
             # XXX: How are we going to report on tests that sometimes fail,
             # sometimes error. Probably "if all failures, failure; otherwise,
             # error"
-            result.addError(case, details=_combine_details(results))
+            result.addError(case, details=details)
         result.stopTest(case)
         return result
 

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -71,6 +71,16 @@ class _FlakyAnnotation(PClass):
                                "Can't pass more than we run")
 
 
+def retry_flaky(run_test_factory=None):
+    """
+    Wrap a ``RunTest`` object so that flaky tests are retried.
+    """
+    if run_test_factory is None:
+        run_test_factory = testtools.RunTest
+
+    return partial(_RetryFlaky, run_test_factory)
+
+
 class _RetryFlaky(testtools.RunTest):
     """
     ``RunTest`` implementation that retries tests that fail.
@@ -199,13 +209,3 @@ def _reset_case(case):
     # https://github.com/testing-cabal/testtools/pull/165/ fixes this.
     case._TestCase__setup_called = False
     case._TestCase__teardown_called = False
-
-
-def retry_flaky(run_test_factory=None):
-    """
-    Wrap a ``RunTest`` object so that flaky tests are retried.
-    """
-    if run_test_factory is None:
-        run_test_factory = testtools.RunTest
-
-    return partial(_RetryFlaky, run_test_factory)

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -35,8 +35,6 @@ def flaky(jira_keys, max_runs=5, min_passes=2):
 
     # TODO (see FLOC-3281):
     # - allow specifying which exceptions are expected
-    # - retry on expected exceptions
-    #   - parametrize on retry options
     # - provide interesting & parseable logs for flaky tests
 
     annotation = _FlakyAnnotation(max_runs=max_runs, min_passes=min_passes)
@@ -86,17 +84,8 @@ class _RetryFlaky(testtools.RunTest):
     """
     ``RunTest`` implementation that retries tests that fail.
     """
-    # XXX: Make this a pyrsistent object
-
     # XXX: This should probably become a part of testtools:
     # https://bugs.launchpad.net/testtools/+bug/1515933
-
-    # TODO: I think the "right" thing to do is to take a RunTest factory and
-    # construct RunTest once per test run, each time giving it a newly-created
-    # TestResult.
-    #
-    # When we're "done", we aggregate all of the results and output that to
-    # the result we were given.
 
     def __init__(self, run_test_factory, case, *args, **kwargs):
         self._run_test_factory = run_test_factory
@@ -148,7 +137,6 @@ class _RetryFlaky(testtools.RunTest):
         successes = 0
         results = []
 
-        # XXX: I am too stupid to figure out whether these should be <=
         while successes < min_passes and len(results) < max_runs:
             was_successful, details = self._attempt_test(case)
             if was_successful:
@@ -160,12 +148,9 @@ class _RetryFlaky(testtools.RunTest):
             # XXX: Should attach a whole bunch of information here as details.
             result.addSuccess(case)
         else:
-            # XXX: Need to actually provide data about the errors.
             # XXX: How are we going to report on tests that sometimes fail,
             # sometimes error. Probably "if all failures, failure; otherwise,
             # error"
-            # XXX: Consider extracting this aggregation into a separate
-            # function.
             result.addError(case, details=_combine_details(results))
         result.stopTest(case)
         return result

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -116,11 +116,16 @@ class _RetryFlaky(testtools.RunTest):
                 successes += 1
             _reset_case(case)
 
+        result.startTest(case)
         if successes >= min_passes:
-            result.startTest(case)
             # XXX: Should attach a whole bunch of information here as details.
             result.addSuccess(case)
-            result.stopTest(case)
+        else:
+            # XXX: Need to actually provide data about the errors.
+            # XXX: How are we going to report on tests that sometimes fail,
+            # sometimes error.
+            result.addError(case, details={})
+        result.stopTest(case)
 
         # XXX: Obviously we want to report failures!
         return result

--- a/flocker/testtools/_testhelpers.py
+++ b/flocker/testtools/_testhelpers.py
@@ -1,0 +1,74 @@
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
+
+"""
+Helpers for testing our test code.
+
+Only put stuff here that is specific to testing code about unit testing.
+"""
+
+import unittest
+
+from testtools.matchers import (
+    AfterPreprocessing,
+    Equals,
+    MatchesStructure,
+)
+
+
+def throw(exception):
+    """
+    Raise 'exception'.
+    """
+    raise exception
+
+
+def only_skips(tests_run, reasons):
+    """
+    Matches results that only had skips, and only for the given reasons.
+    """
+    return has_results(
+        tests_run=Equals(tests_run),
+        skipped=AfterPreprocessing(
+            lambda xs: list(unicode(x[1]) for x in xs),
+            Equals(reasons)),
+    )
+
+
+def has_results(errors=None, failures=None, skipped=None,
+                expected_failures=None, unexpected_successes=None,
+                tests_run=None):
+    """
+    Return a matcher on test results.
+
+    By default, will match a result that has no tests run.
+    """
+    if errors is None:
+        errors = Equals([])
+    if failures is None:
+        failures = Equals([])
+    if skipped is None:
+        skipped = Equals([])
+    if expected_failures is None:
+        expected_failures = Equals([])
+    if unexpected_successes is None:
+        unexpected_successes = Equals([])
+    if tests_run is None:
+        tests_run = Equals(0)
+    return MatchesStructure(
+        errors=errors,
+        failures=failures,
+        skipped=skipped,
+        expectedFailures=expected_failures,
+        unexpectedSuccesses=unexpected_successes,
+        testsRun=tests_run,
+    )
+
+
+def run_test(case):
+    """
+    Run a test and return its results.
+    """
+    # XXX: How many times have I written something like this?
+    result = unittest.TestResult()
+    case.run(result)
+    return result

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -8,7 +8,7 @@ import shutil
 import string
 
 from hypothesis import assume, given
-from hypothesis.strategies import binary, integers, lists, text
+from hypothesis.strategies import integers, lists, text
 from testtools import PlaceHolder, TestCase
 from testtools.matchers import (
     AllMatch,
@@ -42,7 +42,7 @@ class AsyncTestCaseTests(TestCase):
     Tests for `AsyncTestCase`.
     """
 
-    @given(binary(average_size=30))
+    @given(text(average_size=30))
     def test_trial_skip_exception(self, reason):
         """
         If tests raise the ``SkipTest`` exported by Trial, then that's

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -6,6 +6,7 @@ import errno
 import os
 import shutil
 import string
+import unittest
 
 from hypothesis import assume, given
 from hypothesis.strategies import integers, lists, text
@@ -26,14 +27,16 @@ from testtools.matchers import (
     PathExists,
     StartsWith,
 )
-from testtools.testresult.doubles import Python27TestResult
 from twisted.python.filepath import FilePath
-from twisted.trial import unittest
 
 from .._base import (
     AsyncTestCase,
     make_temporary_directory,
     _path_for_test_id,
+)
+from .._testhelpers import (
+    only_skips,
+    run_test,
 )
 
 
@@ -54,16 +57,8 @@ class AsyncTestCaseTests(TestCase):
                 raise unittest.SkipTest(reason)
 
         test = SkippingTest('test_skip')
-        # We need a test result double that we can useful results from, and
-        # the Python 2.7 TestResult is the lowest common denominator.
-        logs = []
-        result = Python27TestResult(logs)
-        test.run(result)
-        self.assertEqual([
-            ('startTest', test),
-            ('addSkip', test, reason),
-            ('stopTest', test),
-        ], logs)
+        result = run_test(test)
+        self.assertThat(result, only_skips(1, [reason]))
 
     def test_mktemp_doesnt_exist(self):
         """
@@ -95,7 +90,7 @@ class AsyncTestCaseTests(TestCase):
                 created_files.append(path)
                 open(path, 'w').write('hello')
 
-        SomeTest('test_create_file').run(Python27TestResult())
+        run_test(SomeTest('test_create_file'))
         [path] = created_files
         self.addCleanup(os.unlink, path)
         self.assertThat(path, FileContains('hello'))

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -11,8 +11,10 @@ from hypothesis import given
 from hypothesis.strategies import integers
 import testtools
 from testtools.matchers import (
+    Contains,
     Equals,
     HasLength,
+    MatchesAll,
     MatchesStructure,
 )
 
@@ -123,10 +125,17 @@ class FlakyTests(testtools.TestCase):
         test = SomeTest('test_something')
         result = unittest.TestResult()
         test.run(result)
-        self.assertThat(result, has_results(
-            errors=HasLength(1),
+        self.expectThat(result, has_results(
             tests_run=Equals(1),
+            errors=HasLength(1),
         ))
+        [(found_test, exception)] = result.errors
+        self.assertThat(
+            exception, MatchesAll(
+                Contains('ValueError'),
+                Contains('RuntimeError'),
+            )
+        )
 
 
 def throw(exception):

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -82,6 +82,38 @@ class FlakyTests(TestCase):
             'testsRun': 1,
         }, get_results(test))
 
+    def test_intermittent_flaky_test(self):
+        """
+        A @flaky test that fails sometimes and succeeds other times counts as a
+        pass.
+        """
+        # XXX: Pass through again and update descriptions and tests for
+        # min_value & max_value.
+        # XXX: Do we have a 'shuffled' strategy?
+        # XXX: We could create an "exceptions" strategy.
+        executions = iter([
+            lambda: throw(ValueError('failure')),
+            lambda: None,
+            lambda: throw(RuntimeError('failure #2')),
+        ])
+
+        class SomeTest(AsyncTestCase):
+
+            @flaky('FLOC-XXXX', max_runs=3, min_passes=1)
+            def test_something(self):
+                next(executions)()
+
+        test = SomeTest('test_something')
+        self.assertEqual({
+            'errors': 0,
+            'failures': 0,
+            'skipped': 0,
+            'expectedFailures': 0,
+            'unexpectedSuccesses': 0,
+            'testsRun': 1,
+        }, get_results(test))
+    test_intermittent_flaky_test.todo = "Acceptance test for flaky retries"
+
 
 def throw(exception):
     """

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -86,10 +86,8 @@ class FlakyTests(TestCase):
     def test_intermittent_flaky_test(self):
         """
         A @flaky test that fails sometimes and succeeds other times counts as a
-        pass.
+        pass, as long as it passes more than the given min_passes threshold.
         """
-        # XXX: Pass through again and update descriptions and tests for
-        # min_value & max_value.
         # XXX: Do we have a 'shuffled' strategy?
         # XXX: We could create an "exceptions" strategy.
         executions = iter([
@@ -99,65 +97,6 @@ class FlakyTests(TestCase):
         ])
 
         class SomeTest(AsyncTestCase):
-
-            @flaky('FLOC-XXXX', max_runs=3, min_passes=1)
-            def test_something(self):
-                next(executions)()
-
-        test = SomeTest('test_something')
-        self.assertEqual({
-            'errors': 0,
-            'failures': 0,
-            'skipped': 0,
-            'expectedFailures': 0,
-            'unexpectedSuccesses': 0,
-            'testsRun': 1,
-        }, get_results(test))
-
-
-class RetryFlakyTests(TestCase):
-    """
-    Tests for our ``RunTest`` implementation that retries flaky tests.
-    """
-
-    def test_executes_test(self):
-        """
-        Tests that the ``retry_flaky`` test runner are still run as normal.
-        """
-
-        values = []
-
-        class NormalTest(testtools.TestCase):
-            run_tests_with = retry_flaky()
-
-            def test_something(self):
-                values.append('foo')
-
-        results = get_results(NormalTest('test_something'))
-        self.assertEqual(['foo'], values)
-        self.assertEqual({
-            'errors': 0,
-            'failures': 0,
-            'skipped': 0,
-            'expectedFailures': 0,
-            'unexpectedSuccesses': 0,
-            'testsRun': 1,
-        }, results)
-
-    def test_flaky_tests_retried_then_successful(self):
-        """
-        Tests marked with 'flaky' are retried if they fail, and marked
-        successful if they reach the minimum number of successes.
-        """
-
-        executions = iter([
-            lambda: throw(ValueError('failure')),
-            lambda: None,
-            lambda: throw(RuntimeError('failure #2')),
-        ])
-
-        class SomeTest(testtools.TestCase):
-            run_tests_with = retry_flaky()
 
             @flaky('FLOC-XXXX', max_runs=3, min_passes=1)
             def test_something(self):

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -113,7 +113,6 @@ class FlakyTests(TestCase):
             'unexpectedSuccesses': 0,
             'testsRun': 1,
         }, get_results(test))
-    test_intermittent_flaky_test.todo = "Acceptance test for flaky retries"
 
 
 class RetryFlakyTests(TestCase):

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -161,12 +161,13 @@ class FlakyTests(testtools.TestCase):
             errors=HasLength(1),
         ))
         [(found_test, exception)] = result.errors
+        flaky_data = _get_flaky_annotation(test).to_dict()
+        flaky_data.update({'runs': 3, 'passes': 1})
         self.assertThat(
             exception, MatchesAll(
                 Contains('ValueError'),
                 Contains('RuntimeError'),
-                Contains('flaky: {{{%s}}}' % pformat(
-                    _get_flaky_annotation(test).to_dict()))
+                Contains(pformat(flaky_data)),
             )
         )
 

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -5,6 +5,7 @@ Tests for ``flocker.testtools._flaky``.
 """
 
 from itertools import repeat
+from pprint import pformat
 import unittest
 
 from hypothesis import assume, given
@@ -19,7 +20,8 @@ from testtools.matchers import (
 )
 
 from .. import AsyncTestCase
-from .._flaky import retry_flaky, flaky, _FLAKY_ATTRIBUTE
+from .._flaky import (
+    retry_flaky, flaky, _FLAKY_ATTRIBUTE, _get_flaky_annotation)
 
 
 class FlakyTests(testtools.TestCase):
@@ -163,6 +165,8 @@ class FlakyTests(testtools.TestCase):
             exception, MatchesAll(
                 Contains('ValueError'),
                 Contains('RuntimeError'),
+                Contains('flaky: {{{%s}}}' % pformat(
+                    _get_flaky_annotation(test).to_dict()))
             )
         )
 

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -11,11 +11,11 @@ from hypothesis import given
 from hypothesis.strategies import integers
 import testtools
 
-from .. import AsyncTestCase, TestCase
+from .. import AsyncTestCase
 from .._flaky import retry_flaky, flaky
 
 
-class FlakyTests(TestCase):
+class FlakyTests(testtools.TestCase):
     """
     Tests for ``@flaky`` decorator.
     """

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -220,9 +220,7 @@ class FlakyTests(testtools.TestCase):
                 next(executions)()
 
         test = SomeTest('test_something')
-        result = unittest.TestResult()
-        test.run(result)
-        self.assertThat(result, has_results(
+        self.assertThat(run_test(test), has_results(
             tests_run=Equals(1),
             errors=HasLength(1),
         ))
@@ -253,9 +251,7 @@ class FlakyTests(testtools.TestCase):
                 super(SubclassTest, self).test_something()
 
         test = SubclassTest('test_something')
-        result = unittest.TestResult()
-        test.run(result)
-        self.assertThat(result, has_results(tests_run=Equals(1)))
+        self.assertThat(run_test(test), has_results(tests_run=Equals(1)))
 
     @given(jira_keys, num_runs, num_runs,
            streaming(text(average_size=10)).map(iter))

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -34,7 +34,7 @@ class FlakyTests(testtools.TestCase):
         """
         values = []
 
-        @flaky('FLOC-XXXX')
+        @flaky(u'FLOC-XXXX')
         def f(x):
             values.append(x)
             return x
@@ -52,7 +52,7 @@ class FlakyTests(testtools.TestCase):
         # TestCase features, thus increasing complexity.
         class SomeTest(AsyncTestCase):
 
-            @flaky('FLOC-XXXX')
+            @flaky(u'FLOC-XXXX')
             def test_something(self):
                 pass
 
@@ -68,7 +68,7 @@ class FlakyTests(testtools.TestCase):
 
         class SomeTest(AsyncTestCase):
 
-            @flaky('FLOC-XXXX')
+            @flaky(u'FLOC-XXXX')
             def test_something(self):
                 next(executions)()
 
@@ -95,7 +95,7 @@ class FlakyTests(testtools.TestCase):
 
         class SomeTest(AsyncTestCase):
 
-            @flaky('FLOC-XXXX', max_runs=3, min_passes=1)
+            @flaky(u'FLOC-XXXX', max_runs=3, min_passes=1)
             def test_something(self):
                 next(executions)()
 
@@ -117,7 +117,7 @@ class FlakyTests(testtools.TestCase):
         class SomeTest(testtools.TestCase):
             run_tests_with = retry_flaky()
 
-            @flaky('FLOC-XXXX', max_runs=3, min_passes=2)
+            @flaky(u'FLOC-XXXX', max_runs=3, min_passes=2)
             def test_something(self):
                 next(executions)()
 

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -59,10 +59,9 @@ class FlakyTests(testtools.TestCase):
         test = SomeTest('test_something')
         self.assertThat(run_test(test), has_results(tests_run=Equals(1)))
 
-    def test_always_failing_flaky_test(self):
+    def test_always_erroring_flaky_test(self):
         """
-        As of FLOC-3414, the @flaky decorator doesn't actually treat failed
-        tests in special in any way - it just acts as a structured comment.
+        A flaky test always errors out is recorded as erroring.
         """
 
         executions = repeat(lambda: throw(ValueError('failure')))

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -4,6 +4,7 @@
 Tests for ``flocker.testtools._flaky``.
 """
 
+from itertools import repeat
 import unittest
 
 from hypothesis import given
@@ -64,11 +65,13 @@ class FlakyTests(SynchronousTestCase):
         tests in special in any way - it just acts as a structured comment.
         """
 
+        executions = repeat(lambda: throw(ValueError('failure')))
+
         class SomeTest(unittest.TestCase):
 
             @flaky('FLOC-XXXX')
             def test_something(self):
-                1/0
+                next(executions)()
 
         test = SomeTest('test_something')
         self.assertEqual({
@@ -79,6 +82,13 @@ class FlakyTests(SynchronousTestCase):
             'unexpectedSuccesses': 0,
             'testsRun': 1,
         }, get_results(test))
+
+
+def throw(exception):
+    """
+    Raise 'exception'.
+    """
+    raise exception
 
 
 def _get_result_stats(result):

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -10,12 +10,11 @@ import unittest
 from hypothesis import given
 from hypothesis.strategies import integers
 
-from twisted.trial.unittest import SynchronousTestCase
-
+from .. import AsyncTestCase, TestCase
 from .._flaky import flaky
 
 
-class FlakyTests(SynchronousTestCase):
+class FlakyTests(TestCase):
     """
     Tests for ``@flaky`` decorator.
     """
@@ -43,7 +42,7 @@ class FlakyTests(SynchronousTestCase):
 
         # We use 'unittest' here to avoid accidentally depending on Twisted
         # TestCase features, thus increasing complexity.
-        class SomeTest(unittest.TestCase):
+        class SomeTest(AsyncTestCase):
 
             @flaky('FLOC-XXXX')
             def test_something(self):
@@ -59,7 +58,7 @@ class FlakyTests(SynchronousTestCase):
             'testsRun': 1,
         }, get_results(test))
 
-    def test_failed_flaky_test(self):
+    def test_always_failing_flaky_test(self):
         """
         As of FLOC-3414, the @flaky decorator doesn't actually treat failed
         tests in special in any way - it just acts as a structured comment.
@@ -67,7 +66,7 @@ class FlakyTests(SynchronousTestCase):
 
         executions = repeat(lambda: throw(ValueError('failure')))
 
-        class SomeTest(unittest.TestCase):
+        class SomeTest(AsyncTestCase):
 
             @flaky('FLOC-XXXX')
             def test_something(self):

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -37,7 +37,8 @@ jira_keys = text(average_size=5)
 num_runs = integers(min_value=1, max_value=5)
 
 # Used to run tests without emitting to stdout.
-silent_async_runner = async_runner(timedelta(seconds=1), flaky_output=StringIO())
+silent_async_runner = async_runner(
+    timedelta(seconds=1), flaky_output=StringIO())
 
 
 class FlakyTests(testtools.TestCase):

--- a/flocker/volume/functional/test_service.py
+++ b/flocker/volume/functional/test_service.py
@@ -16,7 +16,7 @@ class RealisticTests(TestCase):
     Tests for realistic scenarios, used to catch integration issues.
     """
 
-    @flaky('FLOC-2767')
+    @flaky(u'FLOC-2767')
     def test_handoff(self):
         """
         Handoff of a previously unpushed volume between two ZFS-based volume


### PR DESCRIPTION
This branch adds support for retrying flaky tests.

It adds thing that wraps an arbitrary `RunTest` object with something that retries tests until they pass a minimum number of times, and updates our `async_runner` to use that, which means that any test case which inherits from `AsyncTestCase` and has a `@flaky` decorator will automatically retry.

The implementation approach means that it should also work for synchronous test cases, once we switch those over to testtools.

An earlier version of this branch used the [flaky](https://github.com/box/flaky) library. Unfortunately, there is very little that it provides which is useful to us.

You might notice the `_run_prepared_result` call. This is an infelicity in testtools, which uses underscore prefixes for both private and "protected" methods. 

Slight diff bloat due to changing all existing `@flaky` markers to use unicode literals. Tradeoffs called out w/ `XXX` comments.