### PR TITLE
[FLOC 2824] Correct irregular title fonts in Acceptance/Functional test docs

### DIFF
--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -1,5 +1,6 @@
 .. _acceptance-testing:
 
+==================
 Acceptance Testing
 ==================
 
@@ -70,7 +71,7 @@ To see the supported values for each option, run:
    admin/run-acceptance-tests --help
 
 Configuration File
-------------------
+==================
 
 .. This is pretty messy.
    FLOC-2090
@@ -101,7 +102,7 @@ These are used to provide required parameters to the cluster runner selected by 
 Configuration is loaded from the item in the top-level mapping with a key matching the value given to ``--provider``.
 
 Vagrant
-~~~~~~~
+=======
 
 The Vagrant cluster runner does not require any configuration and so does not require an item in the configuration file.
 
@@ -132,7 +133,7 @@ Ensure that they all pass, with no skips:
 .. _acceptance-testing-rackspace-config:
 
 Rackspace
-~~~~~~~~~
+=========
 
 To run the acceptance tests on Rackspace, you need:
 
@@ -165,7 +166,7 @@ Rackspace can use these dataset backends:
 .. _acceptance-testing-aws-config:
 
 AWS
-~~~
+===
 
 To run the acceptance tests on AWS, you need:
 
@@ -200,7 +201,7 @@ If you're using the AWS dataset backend make sure the regions and zones are the 
 .. _acceptance-testing-managed-config:
 
 Managed
-~~~~~~~
+=======
 
 You can also run acceptance tests on existing "managed" nodes.
 
@@ -290,64 +291,3 @@ And then run the acceptance tests on those nodes using the following command:
      --branch=master \
      --flocker-version='' \
      flocker.acceptance.obsolete.test_containers.ContainerAPITests.test_create_container_with_ports
-
-
-Functional Testing
-==================
-
-The tests for the various cloud block device backends depend on access to credentials supplied from the environment.
-
-The tests look for two environment variables:
-  ..
-     # FLOC-2090 This is yet another configuration file.
-     # Make it just be the same as the acceptance testing configuration file.
-
-- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This points at a YAML file with the credentials.
-- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This is the name of a top-level key in the configuration file.
-
-The credentials are read from the stanza specified by the ``CLOUD_PROVIDER`` environment variable.
-The supported block-device backend is specified by a ``provider`` key in the stanza,
-or the name of the stanza, if the ``provider`` key is missing.
-
-If the environment variables aren't present, the tests will be skipped.
-The tests that do not correspond to the configured provider will also be skipped.
-
-AWS
----
-
-The configuration stanza for the EBS backend looks as follows:
-
-.. code:: yaml
-
-   aws:
-     access_key: <aws access key>
-     secret_access_token: <aws secret access token>
-
-The AWS backend also requires that the availability zone the test are running in be specified in the  ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` environment variable.
-This is specified separately from the credential file, so that the file can be reused in different regions.
-
-Rackspace
----------
-
-The configuration stanza for the OpenStack backend running on Rackspace looks as follows:
-
-.. code:: yaml
-
-   rackspace:
-     region: <rackspace region, e.g. "iad">
-     username: <rackspace username>
-     key: <access key>
-
-OpenStack
----------
-
-The configuration stanza for an private OpenStack deployment looks as follows:
-
-.. code:: yaml
-
-   private-cloud:
-     provider: openstack
-     auth_plugin: plugin_name
-     plugin_option: value
-
-``auth_plugin`` refers to an authentication plugin provided by ``python-keystoneclient``.

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -1,0 +1,60 @@
+==================
+Functional Testing
+==================
+
+The tests for the various cloud block device backends depend on access to credentials supplied from the environment.
+
+The tests look for two environment variables:
+  ..
+     # FLOC-2090 This is yet another configuration file.
+     # Make it just be the same as the acceptance testing configuration file.
+
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This points at a YAML file with the credentials.
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This is the name of a top-level key in the configuration file.
+
+The credentials are read from the stanza specified by the ``CLOUD_PROVIDER`` environment variable.
+The supported block-device backend is specified by a ``provider`` key in the stanza,
+or the name of the stanza, if the ``provider`` key is missing.
+
+If the environment variables aren't present, the tests will be skipped.
+The tests that do not correspond to the configured provider will also be skipped.
+
+AWS
+===
+
+The configuration stanza for the EBS backend looks as follows:
+
+.. code:: yaml
+
+   aws:
+     access_key: <aws access key>
+     secret_access_token: <aws secret access token>
+
+The AWS backend also requires that the availability zone the test are running in be specified in the  ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` environment variable.
+This is specified separately from the credential file, so that the file can be reused in different regions.
+
+Rackspace
+=========
+
+The configuration stanza for the OpenStack backend running on Rackspace looks as follows:
+
+.. code:: yaml
+
+   rackspace:
+     region: <rackspace region, e.g. "iad">
+     username: <rackspace username>
+     key: <access key>
+
+OpenStack
+=========
+
+The configuration stanza for an private OpenStack deployment looks as follows:
+
+.. code:: yaml
+
+   private-cloud:
+     provider: openstack
+     auth_plugin: plugin_name
+     plugin_option: value
+
+``auth_plugin`` refers to an authentication plugin provided by ``python-keystoneclient``.

--- a/docs/gettinginvolved/index.rst
+++ b/docs/gettinginvolved/index.rst
@@ -10,6 +10,7 @@ Getting Involved
    contributing
    plugins/index
    acceptance-testing
+   functional-testing
    benchmarking
    client-testing
    infrastructure/index


### PR DESCRIPTION
Fixes 2824

We had some strange header tags being used in Acceptance testing doc - This has been corrected, and the Functional Testing content has been moved to its own page (it previously was embedded in the Acceptance test page, but the use of headers was inconsistent)