### PR TITLE
[FLOC 2236] Add extra info to pre-tag introduction

### DIFF
--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -162,8 +162,10 @@ Preparing For a Release
 Pre-tag Review Process
 ======================
 
-A tag must not be deleted once it has been pushed to GitHub (this is a policy and not a technical limitation).
-So it is important to check that the code in the release branch is working before it is tagged.
+A tag must not be deleted once it has been pushed to GitHub.
+This is a policy and not a technical limitation, as removing tags can cause problems for anyone who has updated a cloned copy of the repo.
+
+It is important to check that the code in the release branch is working before it is tagged.
 
 .. note::
 

--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -163,7 +163,7 @@ Pre-tag Review Process
 ======================
 
 A tag must not be deleted once it has been pushed to GitHub.
-This is a policy and not a technical limitation, as removing tags can cause problems for anyone who has updated a cloned copy of the repo.
+This is a policy and not a technical limitation, as removing tags can cause problems for anyone who has updated a cloned copy of the repository.
 
 It is important to check that the code in the release branch is working before it is tagged.
 


### PR DESCRIPTION
Fixes 2236

The Pre-tag review section of the release docs simply said that not deleting tags pushed to GitHub was a policy. This PR adds an explanation of why we don't do that.