### PR TITLE
[FLOC 3488] Add a note to agent service doc about Docker running

### DIFF
--- a/docs/config/enabling-agent-service.rst
+++ b/docs/config/enabling-agent-service.rst
@@ -9,6 +9,10 @@ The Flocker agents, the ``flocker-dataset-agent`` and the ``flocker-container-ag
 :ref:`docker-plugin` (``flocker-docker-plugin``) is also installed on each node in the cluster.
 The instructions below include enabling and testing the plugin, which allows Flocker to manage your data volumes while using other tools such as Docker, Docker Swarm, or Mesos to manage your containers.
 
+.. note::
+   Flocker's container management features depend on Docker.
+   You will need to make sure `Docker (at least 1.8) is installed`_ and running before you enable ``flocker-container-agent``.
+
 CentOS 7
 ========
 
@@ -62,3 +66,5 @@ Next Steps
 
 The configuration of your Flocker cluster is now complete.
 To learn about controlling and administering Flocker, please move on to :ref:`controlling-flocker`.
+
+.. _Docker (at least 1.8) is installed: https://docs.docker.com/installation/


### PR DESCRIPTION
Fixes 3488

The `flocker-container-agent` service must have Docker running before it is enabled (there is currently a bug on Ubuntu that forces a hang if Docker is not running - see FLOC 3490)

This PR adds a note to the Configuring the Agent Services page so the user is aware that they should have Docker running at this point in configuring Flocker. 