### PR TITLE
[FLOC-3496] Hacky solution to re-enable `trial -u` for acceptance tests

### DIFF
--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -87,7 +87,8 @@ class AsyncTestCase(testtools.TestCase):
         """
         Run ``AsyncTestCase``
         """
-        # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879
+        # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879.
+        # Constructed tests are called more than once when run with `trial -u`.
         _reset_case(self)
         super(AsyncTestCase, self).run(*args, **kwargs)
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -16,7 +16,7 @@ from testtools.deferredruntest import (
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
-from ._flaky import retry_flaky
+from ._flaky import retry_flaky, _reset_case
 
 
 class TestCase(unittest.SynchronousTestCase):
@@ -87,18 +87,9 @@ class AsyncTestCase(testtools.TestCase):
         """
         Run ``AsyncTestCase``
         """
-        self._reset()
+        # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879
+        _reset_case(self)
         super(AsyncTestCase, self).run(*args, **kwargs)
-
-    def _reset(self):
-        """
-        Reset test case so it can be run again.
-        """
-        # https://github.com/testing-cabal/testtools/pull/165/ fixes this.
-        # Don't want details from last run.
-        self.getDetails().clear()
-        self._TestCase__setup_called = False
-        self._TestCase__teardown_called = False
 
 
 def _path_for_test_id(test_id, max_segment_length=32):

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -83,6 +83,23 @@ class AsyncTestCase(testtools.TestCase):
         # to async.
         return make_temporary_directory(self).child('temp').path
 
+    def run(self, *args, **kwargs):
+        """
+        Run ``AsyncTestCase``
+        """
+        self._reset()
+        super(AsyncTestCase, self).run(*args, **kwargs)
+
+    def _reset(self):
+        """
+        Reset test case so it can be run again.
+        """
+        # https://github.com/testing-cabal/testtools/pull/165/ fixes this.
+        # Don't want details from last run.
+        self.getDetails().clear()
+        self._TestCase__setup_called = False
+        self._TestCase__teardown_called = False
+
 
 def _path_for_test_id(test_id, max_segment_length=32):
     """

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -238,6 +238,8 @@ class _RetryFlaky(testtools.RunTest):
             result was and ``details`` is a dictionary of testtools details.
         """
         tmp_result = testtools.TestResult()
+        # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879
+        _reset_case(case)
         self._run_test(case, tmp_result)
         result_type = _get_result_type(tmp_result)
         details = pmap(case.getDetails())
@@ -248,7 +250,6 @@ class _RetryFlaky(testtools.RunTest):
             [reason] = list(tmp_result.skip_reasons.keys())
             details = details.discard('traceback').set(
                 'reason', text_content(reason))
-        _reset_case(case)
         return (tmp_result.wasSuccessful(), result_type, details)
 
 
@@ -316,10 +317,8 @@ def _reset_case(case):
     """
     Reset ``case`` so it can be run again.
     """
-    # XXX: Alternative approach is to use clone_test_with_new_id, rather than
-    # resetting the same test case.
+    # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879
     # Don't want details from last run.
     case.getDetails().clear()
-    # https://github.com/testing-cabal/testtools/pull/165/ fixes this.
     case._TestCase__setup_called = False
     case._TestCase__teardown_called = False


### PR DESCRIPTION
testing-cabal/testtools#165 is the real solution, but it's going to take longer because it's being held to higher testing standards, and because we'd have to wait for a release before we could use it.

In the meantime, this patch re-enables `trial -u` support.