### PR TITLE
[FLOC-3290] Add CPU time metric to benchmark

### DIFF
--- a/benchmark/metrics/__init__.py
+++ b/benchmark/metrics/__init__.py
@@ -1,1 +1,2 @@
+from .cputime import CPUTime
 from .wallclock import WallClock

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -1,0 +1,151 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+"""
+CPU time metric for the control service benchmarks.
+"""
+
+from characteristic import Attribute, attributes
+from pyrsistent import PClass, field, pset
+from zope.interface import implementer
+
+from twisted.protocols.basic import LineOnlyReceiver
+
+from flocker.common import gather_deferreds
+from flocker.common.runner import run_ssh
+
+from .._interfaces import IMetric
+
+_FLOCKER_PROCESSES = _JOURNAL_UNITS = pset({
+    u'flocker-control',
+    u'flocker-dataset-agent',
+    u'flocker-container-agent',
+})
+
+
+_GET_CPUTIME_COMMAND = [
+    # Use system ps to collect the information
+    b'ps',
+    # Output the command name (truncated) and the cputime of the process.
+    # `=` provides a header.  Making all the headers blank prevents the header
+    # line from being written.
+    b'-o',
+    b'comm=,cputime=',
+    # Output lines for processes with names matching the following (values
+    # supplied by invoker)
+    b'-C',
+]
+
+
+class _CPUParser(LineOnlyReceiver):
+
+    def __init__(self):
+        self.result = {}
+
+    def lineReceived(self, line):
+        # Lines are like:
+        #
+        # flocker-control 1-00:03:41
+        # flocker-dataset 00:18:14
+        # flocker-contain 01:47:02
+        if not line.strip():
+            # ignore blank lines
+            return
+        try:
+            name, formatted_cputime = line.split()
+            parts = formatted_cputime.split(b'-', 1)
+            # The last item is always HH:MM:SS. Split it and convert to
+            # integers.
+            h, m, s = [int(t) for t in parts.pop().split(b':')]
+            # Anything left is the number of days
+            days = int(parts[0]) if parts else 0
+            cputime = ((days * 24 + h) * 60 + m) * 60 + s
+        except ValueError as e:
+            e.args = e.args + (line,)
+            raise e
+
+        self.result[name] = self.result.get(name, 0) + cputime
+
+
+class SSHRunner:
+
+    def __init__(self, reactor, node, user=b'root'):
+        self.reactor = reactor
+        self.node = node
+        self.user = user
+
+    def run(self, command_args, handle_stdout):
+        d = run_ssh(
+            self.reactor,
+            self.user,
+            self.node.public_address.exploded,
+            command_args,
+            handle_stdout=handle_stdout,
+        )
+        return d
+
+
+def get_node_cpu_times(runner, processes):
+    parser = _CPUParser()
+    d = runner.run(
+        _GET_CPUTIME_COMMAND + [b",".join(processes)],
+        handle_stdout=parser.lineReceived,
+    )
+    d.addCallback(lambda ignored: parser.result)
+    return d
+
+
+def _get_cluster_cpu_times(clock, nodes, processes):
+    return gather_deferreds(list(
+        get_node_cpu_times(SSHRunner(clock, node), processes)
+        for node in nodes
+    ))
+
+
+def _compute_change(labels, before, after):
+    result = {}
+    for (label, before, after) in zip(labels, before, after):
+        matched_keys = set(before) & set(after)
+        value = {key: after[key] - before[key] for key in matched_keys}
+        result[label] = value
+    return result
+
+
+@implementer(IMetric)
+class CPUTime(PClass):
+    """
+    Measure the elapsed CPU time during an operation.
+    """
+    clock = field(mandatory=True)
+    control_service = field(mandatory=True)
+
+    def measure(self, f, *a, **kw):
+        nodes = []
+        before_cpu = []
+        after_cpu = []
+
+        # Retrieve the cluster nodes
+        d = self.control_service.list_nodes().addCallback(nodes.extend)
+
+        # Obtain elapsed CPU time before test
+        d.addCallback(
+            lambda _ignored: _get_cluster_cpu_times(
+                self.clock, nodes, _FLOCKER_PROCESSES)
+        ).addCallback(before_cpu.extend)
+
+        # Perform the test function
+        d.addCallback(lambda _ignored: f(*a, **kw))
+
+        # Obtain elapsed CPU time after test
+        d.addCallback(
+            lambda _ignored: _get_cluster_cpu_times(
+                self.clock, nodes, _FLOCKER_PROCESSES)
+        ).addCallback(after_cpu.extend)
+
+        # Create the result from before and after times
+        d.addCallback(
+            lambda _ignored: _compute_change(
+                (node.public_address.exploded for node in nodes),
+                before_cpu, after_cpu
+            )
+        )
+
+        return d

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -18,6 +18,7 @@ _FLOCKER_PROCESSES = {
     u'flocker-control',
     u'flocker-dataset-agent',
     u'flocker-container-agent',
+    u'flocker-docker-plugin',
 }
 
 

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -22,7 +22,7 @@ _FLOCKER_PROCESSES = {
 
 _GET_CPUTIME_COMMAND = [
     # Use system ps to collect the information
-    b'ps',
+    b'psdd',
     # Output the command name (truncated) and the cputime of the process.
     # `=` provides a header.  Making all the headers blank prevents the header
     # line from being written.

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -178,11 +178,8 @@ def compute_change(labels, before, after):
     """
     result = {}
     for (label, before, after) in zip(labels, before, after):
-        if before is None or after is None:
-            value = None
-        else:
-            matched_keys = set(before) & set(after)
-            value = {key: after[key] - before[key] for key in matched_keys}
+        matched_keys = set(before) & set(after)
+        value = {key: after[key] - before[key] for key in matched_keys}
         result[label] = value
     return result
 

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -22,7 +22,7 @@ _FLOCKER_PROCESSES = {
 
 _GET_CPUTIME_COMMAND = [
     # Use system ps to collect the information
-    b'psdd',
+    b'ps',
     # Output the command name (truncated) and the cputime of the process.
     # `=` provides a header.  Making all the headers blank prevents the header
     # line from being written.

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -145,7 +145,7 @@ def get_cluster_cpu_times(clock, runner, nodes, processes):
 
 def compute_change(labels, before, after):
     """
-    Compute the difference between times retrieved ast different times.
+     Compute the difference between CPU times from consecutive measurements.
 
     :param [str] labels: Label for each result.
     :param before: Times collected per process name for time 0.

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -1,0 +1,89 @@
+import subprocess
+
+from twisted.internet.threads import deferToThread
+from twisted.trial.unittest import SynchronousTestCase, TestCase
+
+from benchmark.metrics.cputime import _CPUParser, get_node_cpu_times
+
+
+class CPUParseTests(SynchronousTestCase):
+
+    def test_blank_line(self):
+        """
+        Blank lines ignored.
+        """
+        parser = _CPUParser()
+        parser.lineReceived('')
+        self.assertEqual(parser.result, {})
+
+    def test_nodays(self):
+        """
+        CPU time line with no days parses correctly.
+        """
+        parser = _CPUParser()
+        parser.lineReceived('proc  12:34:56')
+        expected_cputime = (12 * 60 + 34) * 60 + 56
+        self.assertEqual(parser.result, {'proc': expected_cputime})
+
+    def test_days(self):
+        """
+        CPU time line with days parses correctly.
+        """
+        parser = _CPUParser()
+        parser.lineReceived('proc  5-12:34:56')
+        expected_cputime = ((5 * 24 + 12) * 60 + 34) * 60 + 56
+        self.assertEqual(parser.result, {'proc': expected_cputime})
+
+    def test_unexpected_line(self):
+        """
+        Line that doesn't fit expected pattern raises exception.
+        """
+        parser = _CPUParser()
+        with self.assertRaises(ValueError) as e:
+            parser.lineReceived('Unexpected Error Message')
+        self.assertEqual(e.exception.args[-1], 'Unexpected Error Message')
+
+    def test_unexpected_parse(self):
+        """
+        Line that has incorrect time raises exception.
+        """
+        parser = _CPUParser()
+        with self.assertRaises(ValueError) as e:
+            parser.lineReceived('proc 20:34')
+        self.assertEqual(e.exception.args[-1], 'proc 20:34')
+
+
+class _LocalRunner:
+
+    def _run(self, command_args, handle_stdout):
+        output = subprocess.check_output(command_args)
+        for line in output.split('\n'):
+            handle_stdout(line)
+
+    def run(self, command_args, handle_stdout):
+        return deferToThread(self._run, command_args, handle_stdout)
+
+
+class GetNodeCPUTimeTests(TestCase):
+
+    def test_get_node_cpu_times(self):
+        d = get_node_cpu_times(_LocalRunner(), ['init'])
+
+        def check(result):
+            self.assertEqual(result.keys(), ['init'])
+
+        d.addCallback(check)
+
+        return d
+
+
+class ComputeChangesTests(SynchronousTestCase):
+
+    # XXX
+    pass
+
+
+class CPUTimeTests(TestCase):
+
+    # XXX
+    pass

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -163,26 +163,6 @@ class ComputeChangesTests(SynchronousTestCase):
         result = compute_change(labels, before, after)
         self.assertNotIn('bar', result['node1'])
 
-    def test_compute_change_error_before(self):
-        """
-        Error in ``before`` measurement provides ``None`` result.
-        """
-        labels = ['node1']
-        before = [None]
-        after = [{'foo': 555, 'bar': 5}]
-        result = compute_change(labels, before, after)
-        self.assertEqual(result, {'node1': None})
-
-    def test_compute_change_error_after(self):
-        """
-        Error in ``after`` measurement provides ``None`` result.
-        """
-        labels = ['node1']
-        before = [{'foo': 555, 'bar': 5}]
-        after = [None]
-        result = compute_change(labels, before, after)
-        self.assertEqual(result, {'node1': None})
-
 
 class CPUTimeTests(TestCase):
     """

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -2,42 +2,47 @@ import subprocess
 from uuid import uuid4
 
 from ipaddr import IPAddress
+from zope.interface.verify import verifyClass
 
 from twisted.internet.task import Clock
 from twisted.internet.threads import deferToThread
 from twisted.trial.unittest import SynchronousTestCase, TestCase
 
-from benchmark.metrics.cputime import (
-    CPUTime, _CPUParser, get_node_cpu_times, _compute_change, SSHRunner,
-)
-
 from flocker.apiclient._client import FakeFlockerClient, Node
+
+from benchmark._interfaces import IMetric
+from benchmark.metrics.cputime import (
+    CPUTime, CPUParser, get_node_cpu_times, compute_change,
+)
 
 
 class CPUParseTests(SynchronousTestCase):
+    """
+    Test parsing of CPU time command.
+    """
 
     def test_blank_line(self):
         """
-        Blank lines ignored.
+        Blank lines are ignored.
         """
-        parser = _CPUParser()
+        parser = CPUParser()
         parser.lineReceived('')
         self.assertEqual(parser.result, {})
 
     def test_nodays(self):
         """
-        CPU time line with no days parses correctly.
+        CPU time line with no days part parses correctly.
         """
-        parser = _CPUParser()
+        parser = CPUParser()
         parser.lineReceived('proc  12:34:56')
         expected_cputime = (12 * 60 + 34) * 60 + 56
         self.assertEqual(parser.result, {'proc': expected_cputime})
 
     def test_days(self):
         """
-        CPU time line with days parses correctly.
+        CPU time line with a days part parses correctly.
         """
-        parser = _CPUParser()
+        parser = CPUParser()
         parser.lineReceived('proc  5-12:34:56')
         expected_cputime = ((5 * 24 + 12) * 60 + 34) * 60 + 56
         self.assertEqual(parser.result, {'proc': expected_cputime})
@@ -46,22 +51,25 @@ class CPUParseTests(SynchronousTestCase):
         """
         Line that doesn't fit expected pattern raises exception.
         """
-        parser = _CPUParser()
+        parser = CPUParser()
         with self.assertRaises(ValueError) as e:
             parser.lineReceived('Unexpected Error Message')
         self.assertEqual(e.exception.args[-1], 'Unexpected Error Message')
 
     def test_unexpected_parse(self):
         """
-        Line that has incorrect time raises exception.
+        Line that has incorrectly formatted time raises exception.
         """
-        parser = _CPUParser()
+        parser = CPUParser()
         with self.assertRaises(ValueError) as e:
             parser.lineReceived('proc 20:34')
         self.assertEqual(e.exception.args[-1], 'proc 20:34')
 
 
 class _LocalRunner:
+    """
+    Like SSHRunner, but runs command locally.
+    """
 
     def _run(self, command_args, handle_stdout):
         output = subprocess.check_output(command_args)
@@ -74,8 +82,14 @@ class _LocalRunner:
 
 
 class GetNodeCPUTimeTests(TestCase):
+    """
+    Test ``get_node_cpu_times`` command.
+    """
 
     def test_get_node_cpu_times(self):
+        """
+        Success results in output of dictionary containing process names.
+        """
         d = get_node_cpu_times(
             _LocalRunner(),
             Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1')),
@@ -91,7 +105,7 @@ class GetNodeCPUTimeTests(TestCase):
 
     def test_no_such_process(self):
         """
-        Errors result in output of None
+        Errors result in output of ``None``.
         """
         d = get_node_cpu_times(
             _LocalRunner(),
@@ -108,6 +122,9 @@ class GetNodeCPUTimeTests(TestCase):
 
 
 class ComputeChangesTests(SynchronousTestCase):
+    """
+    Test computation of CPU time change between two measurements.
+    """
 
     def test_compute_change(self):
         """
@@ -116,7 +133,7 @@ class ComputeChangesTests(SynchronousTestCase):
         labels = ['node1', 'node2']
         before = [{'foo': 3, 'bar': 5}, {'foo': 10, 'bar': 2}]
         after = [{'foo': 4, 'bar': 5}, {'foo': 12, 'bar': 5}]
-        result = _compute_change(labels, before, after)
+        result = compute_change(labels, before, after)
         self.assertEqual(result, {
             'node1': {'foo': 1, 'bar': 0},
             'node2': {'foo': 2, 'bar': 3},
@@ -129,7 +146,7 @@ class ComputeChangesTests(SynchronousTestCase):
         labels = ['node1']
         before = [{'foo': 500}]
         after = [{'foo': 555, 'bar': 5}]
-        result = _compute_change(labels, before, after)
+        result = compute_change(labels, before, after)
         self.assertEqual(result, {'node1': {'foo': 55}})
 
     def test_compute_change_lost_proc(self):
@@ -139,33 +156,45 @@ class ComputeChangesTests(SynchronousTestCase):
         labels = ['node1']
         before = [{'foo': 555, 'bar': 5}]
         after = [{'foo': 600}]
-        result = _compute_change(labels, before, after)
+        result = compute_change(labels, before, after)
         self.assertEqual(result, {'node1': {'foo': 45}})
 
     def test_compute_change_error_before(self):
         """
-        Error in before results in None result.
+        Error in ``before`` measurement provides ``None`` result.
         """
         labels = ['node1']
         before = [None]
         after = [{'foo': 555, 'bar': 5}]
-        result = _compute_change(labels, before, after)
+        result = compute_change(labels, before, after)
         self.assertEqual(result, {'node1': None})
 
     def test_compute_change_error_after(self):
         """
-        Error in after results in None result.
+        Error in ``after`` measurement provides ``None`` result.
         """
         labels = ['node1']
         before = [{'foo': 555, 'bar': 5}]
         after = [None]
-        result = _compute_change(labels, before, after)
+        result = compute_change(labels, before, after)
         self.assertEqual(result, {'node1': None})
 
 
 class CPUTimeTests(TestCase):
+    """
+    Test top-level CPU time metric.
+    """
+
+    def implements_IMetric(self):
+        """
+        CPUTime provides the IMetric interface.
+        """
+        verifyClass(IMetric, CPUTime)
 
     def test_cpu_time(self):
+        """
+        Fake Flocker cluster gives expected results.
+        """
         node1 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1'))
         node2 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.2'))
         metric = CPUTime(

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -1,4 +1,6 @@
+import platform
 import subprocess
+from unittest import skipIf
 from uuid import uuid4
 
 from ipaddr import IPAddress
@@ -14,6 +16,9 @@ from benchmark._interfaces import IMetric
 from benchmark.metrics.cputime import (
     CPUTime, CPUParser, get_node_cpu_times, compute_change,
 )
+
+
+on_linux = skipIf(platform.system() != 'Linux', 'Requires Linux')
 
 
 class CPUParseTests(SynchronousTestCase):
@@ -86,6 +91,7 @@ class GetNodeCPUTimeTests(TestCase):
     Test ``get_node_cpu_times`` command.
     """
 
+    @on_linux
     def test_get_node_cpu_times(self):
         """
         Success results in output of dictionary containing process names.
@@ -103,6 +109,7 @@ class GetNodeCPUTimeTests(TestCase):
 
         return d
 
+    @on_linux
     def test_no_such_process(self):
         """
         If processes do not exist, empty directory is returned.
@@ -188,6 +195,7 @@ class CPUTimeTests(TestCase):
         """
         verifyClass(IMetric, CPUTime)
 
+    @on_linux
     def test_cpu_time(self):
         """
         Fake Flocker cluster gives expected results.

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -205,7 +205,7 @@ class CPUTimeTests(TestCase):
         metric = CPUTime(
             Clock(), FakeFlockerClient([node1, node2]),
             _LocalRunner(), processes=['init'])
-        d = metric.measure(lambda: 1)
+        d = metric.measure(lambda: None)  # measure a fast no-op command
 
         # Although it is unlikely, it's possible that we could get a CPU
         # time != 0, so filter values out.

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -151,7 +151,7 @@ class ComputeChangesTests(SynchronousTestCase):
         before = [{'foo': 500}]
         after = [{'foo': 555, 'bar': 5}]
         result = compute_change(labels, before, after)
-        self.assertEqual(result, {'node1': {'foo': 55}})
+        self.assertNotIn('bar', result['node1'])
 
     def test_compute_change_lost_proc(self):
         """
@@ -161,7 +161,7 @@ class ComputeChangesTests(SynchronousTestCase):
         before = [{'foo': 555, 'bar': 5}]
         after = [{'foo': 600}]
         result = compute_change(labels, before, after)
-        self.assertEqual(result, {'node1': {'foo': 45}})
+        self.assertNotIn('bar', result['node1'])
 
     def test_compute_change_error_before(self):
         """

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -105,7 +105,7 @@ class GetNodeCPUTimeTests(TestCase):
 
     def test_no_such_process(self):
         """
-        Errors result in output of ``None``.
+        If processes do not exist, empty directory is returned.
         """
         d = get_node_cpu_times(
             _LocalRunner(),
@@ -113,10 +113,7 @@ class GetNodeCPUTimeTests(TestCase):
             ['n0n-exist'],
         )
 
-        def check(result):
-            self.assertIs(result, None)
-
-        d.addCallback(check)
+        d.addCallback(self.assertEqual, {})
 
         return d
 

--- a/benchmark/metrics/wallclock.py
+++ b/benchmark/metrics/wallclock.py
@@ -1,6 +1,6 @@
 # Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
 """
-Metrics for the control service benchmarks.
+Wallclock time metric for the control service benchmarks.
 """
 
 from pyrsistent import PClass, field

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -2,7 +2,6 @@ from pyrsistent import PClass, field
 from zope.interface import implementer
 
 from twisted.internet.defer import succeed
-from twisted.web.client import ResponseFailed
 
 from .._interfaces import IProbe, IOperation
 

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -40,6 +40,7 @@ _OPERATIONS = {
 _DEFAULT_OPERATION = 'read-request'
 
 _METRICS = {
+    'cputime': metrics.CPUTime,
     'wallclock': metrics.WallClock,
 }
 

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -3,6 +3,12 @@
 Benchmarking
 ============
 
+.. note::
+
+   For the ``benchmark`` command described on this page, if the cluster uses private addresses for communication (e.g. AWS nodes), set the environment variable ``FLOCKER_ACCEPTANCE_HOSTNAME_TO_PUBLIC_ADDRESS`` to a serialized JSON object mapping cluster internal IP addresses to public IP addresses.
+   This environment variable is provided if the cluster is started using the ``run-acceptance-tests`` command.
+   This is intended to be a temporary requirement, until other mechanisms are available [:issue:`2137`, :issue:`3514`, :issue:`3521`].
+
 Flocker includes a tool for benchmarking operations.
 It is called like this:
 

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -52,6 +52,9 @@ The :program:`benchmark` script has several options:
    Specifies the quantity to measure while the operation is performed.
    Supported values include:
 
+      ``cputime``
+         CPU time elapsed.
+
       ``wallclock``
          Actual clock time elapsed.
          This is the default.


### PR DESCRIPTION
Add CPU time as a metric for benchmarking.

SSH to each node in the cluster, and run a `ps` command to see the elapsed cpu time of named processes (the Flocker services). Perform some operation, and then repeat the `ps` command to see how much the elapsed CPU time has increased for each service.

If you have Flocker cluster available, this allows you to run
```
benchmark/benchmark --control=${FLOCKER_ACCEPTANCE_CONTROL_NODE} --certs=${FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH} --metric cputime
```
to get output like:
```
{
  "scenario": "no-load", 
  "timestamp": "2015-11-20T15:52:15.126751", 
  "metric": "cputime", 
  "client": {
    "username": "jon", 
    "platform": "Linux-3.13.0-68-generic-x86_64-with-Ubuntu-14.04-trusty", 
    "working_directory": "/home/jon/projects/clusterhq/flocker", 
    "nodename": "ecuador", 
    "flocker_version": "1.7.2+342.g6feb850"
  }, 
  "samples": [
    {
      "value": {
        "104.130.239.240": {
          "flocker-control": 0, 
          "flocker-dataset": 1, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }, 
        "104.130.239.127": {
          "flocker-dataset": 1, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }
      }, 
      "success": true
    }, 
    {
      "value": {
        "104.130.239.240": {
          "flocker-control": 0, 
          "flocker-dataset": 0, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }, 
        "104.130.239.127": {
          "flocker-dataset": 0, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }
      }, 
      "success": true
    }, 
    {
      "value": {
        "104.130.239.240": {
          "flocker-control": 0, 
          "flocker-dataset": 0, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }, 
        "104.130.239.127": {
          "flocker-dataset": 0, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }
      }, 
      "success": true
    }
  ], 
  "control_service": {
    "flocker_version": "1.7.1+175.g031bfed", 
    "host": "104.130.239.240", 
    "port": 4523
  }, 
  "operation": "read-request"
```

Only 1-second resolution, so the results won't be very interesting until we implement a long-wait operation, to put a significant gap between the two readings.