### PR TITLE
[FLOC 1877] add the Ubuntu log directory

### DIFF
--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -7,7 +7,7 @@ Debugging
 .. _flocker-logging:
 
 Logging
--------
+=======
 
 Flocker processes use the `Eliot`_ framework for logging.
 Eliot structures logs as a tree of actions, which means given an error you can see what Flocker actions caused the errors by finding the other messages in the tree.
@@ -20,7 +20,7 @@ Logs from the Docker containers can be viewed using `the Docker CLI <https://doc
 Ubuntu
 ^^^^^^
 
-XXX This should be documented, see :issue:`1877`.
+Logs from the Flocker processes running on the nodes can be found in the :file:`var/log/flocker` directory.
 
 CentOS 7
 ^^^^^^^^
@@ -86,7 +86,7 @@ We can then find the full set of actions leading up to this decision, as well as
 .. _flocker-bug-reporting:
 
 Bug Reporting
--------------
+=============
 
 When reporting issues with Flocker please include:
 
@@ -166,7 +166,7 @@ Alternatively, the information can be gathered manually using the following comm
 * Flocker log files (see :ref:`Flocker logging <flocker-logging>` above)
 
 Profiling
----------
+=========
 
 .. warning::
 
@@ -207,5 +207,5 @@ For example:
 
 
 .. _`systemd's journal`: http://www.freedesktop.org/software/systemd/man/journalctl.html
-.. _`Eliot`: https://eliot.readthedocs.org
+.. _`Eliot`: https://eliot.readthedocs.org≈
 .. _`eliot-tree`: https://github.com/jonathanj/eliottree

--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -21,30 +21,38 @@ Ubuntu
 ^^^^^^
 
 Logs from the Flocker processes running on the nodes can be found in the :file:`/var/log/flocker` directory.
+They have unit names that begin with a ``flocker-`` prefix.
+
+For example, to find all logged errors for ``flocker-dataset-agent``, run:
+
+.. prompt:: bash [root@ubuntu]#
+
+   cat /var/log/flocker/flocker-dataset-agent.log
 
 CentOS 7
 ^^^^^^^^
 
 Logs from the Flocker processes running on the nodes are written to `systemd's journal`_.
-They have unit names starting constructed with a ``flocker-`` prefix, e.g. ``flocker-dataset-agent``.
+They have unit names that begin with a ``flocker-`` prefix.
+For example, ``flocker-dataset-agent``.
 
 It is possible to see the available unit names, and then view the logs with ``journalctl``:
 
-.. prompt:: bash [root@node1]# auto
+.. prompt:: bash [root@centos]# auto
 
-   [root@node1]# ls /etc/systemd/system/multi-user.target.wants/flocker-*.service | xargs -n 1 -I {} sh -c 'basename {} .service'
+   [root@centos]# ls /etc/systemd/system/multi-user.target.wants/flocker-*.service | xargs -n 1 -I {} sh -c 'basename {} .service'
    flocker-dataset-agent
    flocker-container-agent
    flocker-control
-   [root@node1]# journalctl -u flocker-dataset-agent
+   [root@centos]# journalctl -u flocker-dataset-agent
 
 When outputting logs to ``eliot-prettyprint`` or ``eliot-tree`` you will want to call ``journalctl`` with additional options ``--all --output cat`` to ensure the output can be read correctly by these tools.
 
 Using ``journalctl`` we can find all logged errors:
 
-.. prompt:: bash [root@node1]# auto
+.. prompt:: bash [root@centos]# auto
 
-   [root@node1]# journalctl --all --output cat -u flocker-dataset-agent --priority=err | eliot-prettyprint
+   [root@centos]# journalctl --all --output cat -u flocker-dataset-agent --priority=err | eliot-prettyprint
    ce64eb77-bb7f-4e69-83f8-07d7cdaffaca -> /2
    2015-09-23 21:26:37.972945Z
       action_type: flocker:dataset:resize
@@ -55,9 +63,9 @@ Using ``journalctl`` we can find all logged errors:
 The first part of the first line of each message, in this case ``ce64eb77-bb7f-4e69-83f8-07d7cdaffaca``, is an identifier shared by all actions in the particular tree (or "task") that led up to this error.
 We can use it to find all messages related to this particular error in an effort to figure out what caused it; we'll output to ``eliot-tree`` so we can see the structure of messages:
 
-.. prompt:: bash [root@node1]# auto
+.. prompt:: bash [root@centos]# auto
 
-   [root@node1]# journalctl --all --output cat -u flocker-dataset-agent ELIOT_TASK=ce64eb77-bb7f-4e69-83f8-07d7cdaffaca | eliot-tree
+   [root@centos]# journalctl --all --output cat -u flocker-dataset-agent ELIOT_TASK=ce64eb77-bb7f-4e69-83f8-07d7cdaffaca | eliot-tree
 
 We can also find all messages of a particular type.
 Some useful messages types for agents include:
@@ -68,9 +76,9 @@ Some useful messages types for agents include:
 
 In the following example we find what actions the dataset agent decided it needed to run most recently:
 
-.. prompt:: bash [root@node1]# auto
+.. prompt:: bash [root@centos]# auto
 
-   [root@node1]# journalctl --all --output cat -u flocker-dataset-agent ELIOT_TYPE=flocker:agent:converge:actions | tail -1 | eliot-prettyprint
+   [root@centos]# journalctl --all --output cat -u flocker-dataset-agent ELIOT_TYPE=flocker:agent:converge:actions | tail -1 | eliot-prettyprint
    32e5b4e9-0a8c-4b5c-9895-d2a88315a8d7 -> /2/4
    2015-09-02 13:42:28.943926Z
      message_type: flocker:agent:converge:actions
@@ -78,9 +86,9 @@ In the following example we find what actions the dataset agent decided it neede
 
 We can then find the full set of actions leading up to this decision, as well as the results of the block device creation, by searching for the task UUID:
 
-.. prompt:: bash [root@node1]# auto
+.. prompt:: bash [root@centos]# auto
 
-   [root@node1]# journalctl --all --output cat -u flocker-dataset-agent ELIOT_TASK=32e5b4e9-0a8c-4b5c-9895-d2a88315a8d7 | eliot-tree
+   [root@centos]# journalctl --all --output cat -u flocker-dataset-agent ELIOT_TASK=32e5b4e9-0a8c-4b5c-9895-d2a88315a8d7 | eliot-tree
 
  
 .. _flocker-bug-reporting:

--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -207,5 +207,5 @@ For example:
 
 
 .. _`systemd's journal`: http://www.freedesktop.org/software/systemd/man/journalctl.html
-.. _`Eliot`: https://eliot.readthedocs.org≈
+.. _`Eliot`: https://eliot.readthedocs.org
 .. _`eliot-tree`: https://github.com/jonathanj/eliottree

--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -20,7 +20,7 @@ Logs from the Docker containers can be viewed using `the Docker CLI <https://doc
 Ubuntu
 ^^^^^^
 
-Logs from the Flocker processes running on the nodes can be found in the :file:`var/log/flocker` directory.
+Logs from the Flocker processes running on the nodes can be found in the :file:`/var/log/flocker` directory.
 
 CentOS 7
 ^^^^^^^^


### PR DESCRIPTION
Fixes 1877

Ubuntu logs are in the var/log/flocker directory. This PR adds this location to the debugging page.

There was some inconsistent titles, so this was cleaned up also.

FLOC-1936 will add more information about requiring the user to be root in order to view logs, so this PR simply adds the location.