### PR TITLE
[FLOC-2984] Retry many package management operations

### DIFF
--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -422,7 +422,7 @@ def install_commands_ubuntu(package_name, distribution, package_source,
             'mv', '/tmp/apt-pref', '/etc/apt/preferences.d/clusterhq-900']))
 
     # Install package and all dependencies
-    # XXX Dunno why we --force-yes here
+    # We use --force-yes here because our packages aren't signed.
     commands.append(apt_get_install(["--force-yes", package_name]))
 
     return sequence(commands)

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -69,10 +69,8 @@ def _from_args(sudo):
         return run_network_interacting_from_args
 
 
-def yum_install(args, package_manager="yum"):
-    return run_network_interacting_from_args(
-        [package_manager, "install", "-y"] + args
-    )
+def yum_install(args, package_manager="yum", sudo=False):
+    return _from_args(sudo)([package_manager, "install", "-y"] + args)
 
 
 def apt_get_install(args, sudo=False):

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -30,6 +30,8 @@ from ._ssh import (
 )
 from ._effect import sequence
 
+from ..common import retry_effect_with_timeout
+
 from flocker import __version__ as version
 from flocker.cli import configure_ssh
 from flocker.common.version import (

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -68,7 +68,7 @@ def yum_install(args, package_manager="yum"):
     )
 
 
-def apt_get_install(*args):
+def apt_get_install(args):
     return run_network_interacting_from_args(
         ["apt-get", "-y", "install", ] + args
     )

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -65,6 +65,16 @@ def is_centos(distribution):
 
 
 def _from_args(sudo):
+    """
+    Select a function for running a command, either using ``sudo(8)`` or not.
+
+    :param bool sudo: Whether or not the returned function should apply sudo to
+        the command.
+
+    :return: If ``sudo`` is ``True``, return a function that runs a command
+        using sudo.  If ``sudo`` is ``False``, return a function that runs a
+        command as-is, without sudo.
+    """
     if sudo:
         return sudo_network_interacting_from_args
     else:
@@ -72,16 +82,25 @@ def _from_args(sudo):
 
 
 def yum_install(args, package_manager="yum", sudo=False):
+    """
+    Install a package with ``yum`` or a ``yum``-like package manager.
+    """
     return _from_args(sudo)([package_manager, "install", "-y"] + args)
 
 
 def apt_get_install(args, sudo=False):
+    """
+    Install a package with ``apt-get``.
+    """
     return _from_args(sudo)(
         ["apt-get", "-y", "install", ] + args
     )
 
 
 def apt_get_update(sudo=False):
+    """
+    Update apt's package metadata cache.
+    """
     return _from_args(sudo)(["apt-get", "update"])
 
 

--- a/flocker/provision/_ssh/__init__.py
+++ b/flocker/provision/_ssh/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Hybrid Logic Ltd.  See LICENSE file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 from ._model import (
     run_network_interacting_from_args, sudo_network_interacting_from_args,

--- a/flocker/provision/_ssh/__init__.py
+++ b/flocker/provision/_ssh/__init__.py
@@ -1,6 +1,7 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
 from ._model import (
+    run_network_interacting_from_args, sudo_network_interacting_from_args,
     Run, run, run_from_args,
     Sudo, sudo, sudo_from_args,
     Put, put,
@@ -10,6 +11,7 @@ from ._model import (
 )
 
 __all__ = [
+    "run_network_interacting_from_args", "sudo_network_interacting_from_args",
     "Run", "run", "run_from_args",
     "Sudo", "sudo", "sudo_from_args",
     "Put", "put",

--- a/flocker/provision/_ssh/_model.py
+++ b/flocker/provision/_ssh/_model.py
@@ -228,6 +228,8 @@ def run_from_args(command, log_command_filter=identity):
         Run.from_args(command, log_command_filter=log_command_filter))
 
 
+# TODO: Create an effect that can compose with any other effect to apply sudo,
+# then replace use of this function with `sudo(run_from_args(...))`.
 def sudo_from_args(command, log_command_filter=identity):
     """
     Run a command on a remote host with sudo. This quotes the provided
@@ -244,13 +246,24 @@ def sudo_from_args(command, log_command_filter=identity):
 
 
 def run_network_interacting_from_args(*a, **kw):
+    """
+    Run a command that interacts with an unreliable network.
+
+    :see: ``run_from_args``
+    """
     return retry_effect_with_timeout(
         run_from_args(*a, **kw),
         timeout=_TIMEOUT.total_seconds(),
     )
 
 
+# TODO: See sudo_from_args.  We should be able to get rid of this function too.
 def sudo_network_interacting_from_args(*a, **kw):
+    """
+    Run a command that interacts with an unreliable network using ``sudo``.
+
+    :see: ``sudo_from_args``
+    """
     return retry_effect_with_timeout(
         sudo_from_args(*a, **kw),
         timeout=_TIMEOUT.total_seconds(),

--- a/flocker/provision/_ssh/_model.py
+++ b/flocker/provision/_ssh/_model.py
@@ -1,7 +1,14 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+from datetime import timedelta
 from collections import MutableSequence
 from pipes import quote as shell_quote
 from pyrsistent import PRecord, field
 from effect import Effect, sync_performer
+
+from ...common import retry_effect_with_timeout
+
+_TIMEOUT = timedelta(minutes=5)
 
 
 def identity(arg):
@@ -234,3 +241,17 @@ def sudo_from_args(command, log_command_filter=identity):
     """
     return Effect(
         Sudo.from_args(command, log_command_filter=log_command_filter))
+
+
+def run_network_interacting_from_args(*a, **kw):
+    return retry_effect_with_timeout(
+        run_from_args(*a, **kw),
+        timeout=_TIMEOUT.total_seconds(),
+    )
+
+
+def sudo_network_interacting_from_args(*a, **kw):
+    return retry_effect_with_timeout(
+        sudo_from_args(*a, **kw),
+        timeout=_TIMEOUT.total_seconds(),
+    )


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-2984

This adds retry-on-failure to most package interactions in the installation code used by the acceptance test runner.  This should fix the failure case described in the issue as well as various other hypothetical cases which could arise from other network-dependency package manager interactions.

There are still some non-retrying package manager uses but they follow a different pattern so require a slightly different change.

http://build.clusterhq.com/boxes-flocker?branch=retry-apt-get-update-FLOC-2984