### PR TITLE
[FLOC-3512] Add reactor to benchmark operations constructor

### DIFF
--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -148,7 +148,7 @@ def driver(reactor, config, scenario, operation, metric, result, output):
     def run_benchmark(ignored):
         return benchmark(
             scenario(reactor, control_service),
-            operation(control_service=control_service),
+            operation(clock=reactor, control_service=control_service),
             metric(clock=reactor, control_service=control_service),
         )
 

--- a/benchmark/operations/no_op.py
+++ b/benchmark/operations/no_op.py
@@ -25,6 +25,7 @@ class NoOperation(PClass):
     An nop operation.
     """
 
+    clock = field(mandatory=True)
     control_service = field(mandatory=True)
 
     def get_probe(self):

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -29,6 +29,7 @@ class ReadRequest(PClass):
     An operation to perform a read request on the control service.
     """
 
+    clock = field(mandatory=True)
     control_service = field(mandatory=True)
 
     def get_probe(self):

--- a/benchmark/test/test_operations.py
+++ b/benchmark/test/test_operations.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from zope.interface.verify import verifyObject
 
+from twisted.internet.task import Clock
 from twisted.python.components import proxyForInterface
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -26,7 +27,7 @@ def check_interfaces(factory):
     class OperationTests(SynchronousTestCase):
 
         def test_interfaces(self):
-            operation = factory(control_service=None)
+            operation = factory(clock=Clock(), control_service=None)
             verifyObject(IOperation, operation)
             probe = operation.get_probe()
             verifyObject(IProbe, probe)
@@ -89,7 +90,8 @@ class ReadRequestTests(SynchronousTestCase):
 
         # Get the probe to read the state of the cluster
         def start_read_request(result):
-            request = ReadRequest(control_service=control_service)
+            request = ReadRequest(
+                clock=Clock(), control_service=control_service)
             return request.get_probe()
         d.addCallback(start_read_request)
 


### PR DESCRIPTION
To add an operation that waits 10 seconds, we need to access a Twisted `IReactorTime`. Pass the reactor as an explicit parameter to operations.

This copies the situation for benchmark scenarios and metrics, which get both the clock and the Flocker client.
