### PR TITLE
[FLOC-3504] Benchmark wait operation

### DIFF
--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -148,7 +148,7 @@ def driver(reactor, config, scenario, operation, metric, result, output):
     def run_benchmark(ignored):
         return benchmark(
             scenario(reactor, control_service),
-            operation(control_service=control_service),
+            operation(clock=reactor, control_service=control_service),
             metric(clock=reactor, control_service=control_service),
         )
 

--- a/benchmark/operations/__init__.py
+++ b/benchmark/operations/__init__.py
@@ -1,2 +1,3 @@
 from .no_op import NoOperation
 from .read_request import ReadRequest
+from .wait import Wait

--- a/benchmark/operations/no_op.py
+++ b/benchmark/operations/no_op.py
@@ -25,6 +25,7 @@ class NoOperation(PClass):
     An nop operation.
     """
 
+    # attributes unused, but required for __init__ signature
     clock = field(mandatory=True)
     control_service = field(mandatory=True)
 

--- a/benchmark/operations/no_op.py
+++ b/benchmark/operations/no_op.py
@@ -25,6 +25,7 @@ class NoOperation(PClass):
     An nop operation.
     """
 
+    clock = field(mandatory=True)
     control_service = field(mandatory=True)
 
     def get_probe(self):

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -29,6 +29,7 @@ class ReadRequest(PClass):
     An operation to perform a read request on the control service.
     """
 
+    # `clock` unused, but required for __init__ signature
     clock = field(mandatory=True)
     control_service = field(mandatory=True)
 

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -29,6 +29,7 @@ class ReadRequest(PClass):
     An operation to perform a read request on the control service.
     """
 
+    clock = field(mandatory=True)
     control_service = field(mandatory=True)
 
     def get_probe(self):

--- a/benchmark/operations/test/test_wait.py
+++ b/benchmark/operations/test/test_wait.py
@@ -1,0 +1,27 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+
+from twisted.internet.task import Clock
+from twisted.trial.unittest import SynchronousTestCase
+
+from benchmark.operations import Wait
+
+
+class WaitOperationTests(SynchronousTestCase):
+    """
+    Test Wait operation
+    """
+
+    def test_wait(self):
+        """
+        Wait operation fires after specified time.
+        """
+        seconds = 10
+        clock = Clock()
+        op = Wait(clock=clock, control_service=None, wait_seconds=seconds)
+        probe = op.get_probe()
+        d = probe.run()
+        d.addCallback(lambda ignored: probe.cleanup)
+        self.assertNoResult(d)
+        # Time passes
+        clock.advance(seconds)
+        self.successResultOf(d)

--- a/benchmark/operations/wait.py
+++ b/benchmark/operations/wait.py
@@ -36,6 +36,7 @@ class Wait(PClass):
     """
 
     clock = field(mandatory=True)
+    # `control_service` attribute unused, but required for __init__ signature
     control_service = field(mandatory=True)
     wait_seconds = field(initial=10)
 

--- a/benchmark/operations/wait.py
+++ b/benchmark/operations/wait.py
@@ -1,0 +1,43 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+"""
+Wait operation for the control service benchmarks.
+"""
+
+from pyrsistent import PClass, field
+from zope.interface import implementer
+
+from twisted.internet.defer import Deferred, succeed
+
+from benchmark._interfaces import IProbe, IOperation
+
+
+@implementer(IProbe)
+class WaitProbe(PClass):
+    """
+    A probe to wait for a specified time period.
+    """
+
+    clock = field(mandatory=True)
+    wait_seconds = field(mandatory=True)
+
+    def run(self):
+        d = Deferred()
+        self.clock.callLater(self.wait_seconds, d.callback, None)
+        return d
+
+    def cleanup(self):
+        return succeed(None)
+
+
+@implementer(IOperation)
+class Wait(PClass):
+    """
+    An operation to wait 10 seconds.
+    """
+
+    clock = field(mandatory=True)
+    control_service = field(mandatory=True)
+    wait_seconds = field(initial=10)
+
+    def get_probe(self):
+        return WaitProbe(clock=self.clock, wait_seconds=self.wait_seconds)

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -35,6 +35,7 @@ _DEFAULT_SCENARIO = 'no-load'
 _OPERATIONS = {
     'no-op': operations.NoOperation,
     'read-request': operations.ReadRequest,
+    'wait-10': operations.Wait,
 }
 
 _DEFAULT_OPERATION = 'read-request'

--- a/benchmark/test/test_operations.py
+++ b/benchmark/test/test_operations.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from zope.interface.verify import verifyObject
 
+from twisted.internet.task import Clock
 from twisted.python.components import proxyForInterface
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -26,7 +27,7 @@ def check_interfaces(factory):
     class OperationTests(SynchronousTestCase):
 
         def test_interfaces(self):
-            operation = factory(control_service=None)
+            operation = factory(clock=Clock(), control_service=None)
             verifyObject(IOperation, operation)
             probe = operation.get_probe()
             verifyObject(IProbe, probe)
@@ -89,7 +90,8 @@ class ReadRequestTests(SynchronousTestCase):
 
         # Get the probe to read the state of the cluster
         def start_read_request(result):
-            request = ReadRequest(control_service=control_service)
+            request = ReadRequest(
+                clock=Clock(), control_service=control_service)
             return request.get_probe()
         d.addCallback(start_read_request)
 

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -47,6 +47,9 @@ The :program:`benchmark` script has several options:
          Read from the control service.
          This is the default.
 
+      ``wait-10``
+         Wait 10 seconds between measurements.
+
 .. option:: --metric <metric>
 
    Specifies the quantity to measure while the operation is performed.


### PR DESCRIPTION
Add an operation to benchmarks to wait for 10 seconds between measurements.

This allows us to take better measurements for idle cluster conditions.  CPU time, for example, has a resolution of 1 second, so we need to run for 10 seconds just to get the nearest 10% of CPU load for each process.

This is probably a precursor to running operations repeatedly for a period of time, in order to ensure measurements are useful in general.

To test with a Flocker cluster, run:
```
$ benchmark/benchmark --control=${FLOCKER_ACCEPTANCE_CONTROL_NODE} --certs=${FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH} --operation wait-10
```

This uses the wallclock time metric and shows that each sample runs for at least (and very close to) 10 seconds.

To test the CPU time metric:
```bash
$ git merge benchmark-cpu-metric-FLOC-3290
$ benchmark/benchmark --control=${FLOCKER_ACCEPTANCE_CONTROL_NODE} --certs=${FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH} --operation wait-10 --metric cputime
```

