### PR TITLE
Update timeout logic to work with new flaky retries FLOC-3531

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -772,7 +772,9 @@ run_trial_modules: &run_trial_modules
   - flocker.dockerplugin
   - flocker.node.agents
   - flocker.node.test
-  - flocker.node.functional.test_docker
+  - flocker.node.functional.test_docker.GenericDockerClientTests
+  - flocker.node.functional.test_docker.IDockerClientNamespacedTests
+  - flocker.node.functional.test_docker.NamespacedDockerClientTests
   - flocker.node.functional.test_script
   - flocker.node.functional.test_deploy
   - flocker.provision

--- a/build.yaml
+++ b/build.yaml
@@ -894,7 +894,7 @@ job_type:
       archive_artifacts: *flocker_artifacts
       coverage_report: true
       clean_repo: true
-      timeout: 30
+      timeout: 45
 
     run_trial_for_ebs_storage_driver_on_Ubuntu_trusty:
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
@@ -912,7 +912,7 @@ job_type:
       archive_artifacts: *flocker_artifacts
       coverage_report: true
       clean_repo: true
-      timeout: 30
+      timeout: 45
 
 
     run_trial_for_cinder_storage_driver_on_CentOS_7:
@@ -931,7 +931,7 @@ job_type:
       archive_artifacts: *flocker_artifacts
       coverage_report: true
       clean_repo: true
-      timeout: 30
+      timeout: 45
 
     run_trial_for_cinder_storage_driver_on_Ubuntu_trusty:
       on_nodes_with_labels: 'rackspace-jenkins-slave-ubuntu14-standard-4-dfw'
@@ -949,7 +949,7 @@ job_type:
       archive_artifacts: *flocker_artifacts
       coverage_report: true
       clean_repo: true
-      timeout: 30
+      timeout: 45
 
 
   # http://build.clusterhq.com/builders/flocker-docs
@@ -987,7 +987,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
-      timeout: 30
+      timeout: 45
     run_acceptance_on_AWS_Ubuntu_Trusty_for:
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_modules: *run_acceptance_modules
@@ -1006,7 +1006,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
-      timeout: 30
+      timeout: 45
     run_acceptance_on_Rackspace_CentOS_7_for:
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS
@@ -1027,7 +1027,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
-      timeout: 30
+      timeout: 45
     run_acceptance_on_Rackspace_Ubuntu_Trusty_for:
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS
@@ -1048,7 +1048,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
-      timeout: 30
+      timeout: 45
 
 
   run_client:

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -486,10 +486,10 @@ branches.each {
     wrappers {
       timestamps()
       colorizeOutput()
-      {# lock down the multijob to 45 minutes so that 'stuck' jobs won't
+      {# lock down the multijob to 60 minutes so that 'stuck' jobs won't
           block future runs                                                  #}
       timeout {
-          absolute(45)
+          absolute(60)
           }
     }
       steps {


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3531

The changes introduced by the flaky decorator increased the overal time of the acceptance tests as they retry failed steps.
Jenkins was configured to abort any jobs that took longer than 30minutes, as we assumed those jobs to be stuck.
Now as the jobs take longer due to @flaky, normal running tests were being aborted by jenkins as they exceeded the 30 minutes window.

The initial goal of FLOC-3531 was to introduce an elastic timeout, where Jenkins would abort builds based on the average time taken over the last 'n' builds. 
This data is however related to a single job, and we configure different jobs for each branch. 
This means that any new PR branch being tested doesn't contain any valid data from previous builds.
We could still configure an elastic timeout with a default timeout for new jobs, but that would provide limited value for this particular usage case.

Instead I am taking the shortcut (too much stuff on my hands) to simply address the long running jobs with an increased timeout, leaving all the short lived jobs with the same timeout settings.

We want to timeout a job as soon as possible in the event of that job being stuck, so that we can repurpose the jenkins slave builders back into the pool.
Backlog trends from the jobs addressed show that these are good values to use at this moment.

Jenkins status here:
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/update_timeout_logic_to_work_with_new_flaky_retries_FLOC-3531/

note that the 'admin' job has been failling for 11 days or so on master:
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/master/job/run_trial_on_AWS_Ubuntu_Trusty_admin/buildTimeTrend

since:
 http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/master/job/run_trial_on_AWS_Ubuntu_Trusty_admin/102/
