### PR TITLE
[FLOC-3530] Log the Cinder volume id in some of the Cinder functional tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,6 @@ docutils==0.12
 ecdsa==0.13
 executor==4.4
 Fabric==1.10.2
-fixtures==1.4.0
 flake8==2.4.1
 gitdb==0.6.4
 GitPython==1.0.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,7 @@ docutils==0.12
 ecdsa==0.13
 executor==4.4
 Fabric==1.10.2
+fixtures==1.4.0
 flake8==2.4.1
 gitdb==0.6.4
 GitPython==1.0.1

--- a/flocker/node/agents/functional/logging.py
+++ b/flocker/node/agents/functional/logging.py
@@ -5,7 +5,7 @@ from eliot import Field, MessageType
 CINDER_VOLUME = MessageType(
     u"flocker:functional:cinder:cinder_volume:created",
     [Field.for_types(
-        u"volume_id", [bytes, unicode],
+        u"id", [bytes, unicode],
         u"The Cinder-assigned unique identifier for the volume that was created.",
     )],
 )

--- a/flocker/node/agents/functional/logging.py
+++ b/flocker/node/agents/functional/logging.py
@@ -1,0 +1,11 @@
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
+
+from eliot import Field, MessageType
+
+CINDER_VOLUME = MessageType(
+    u"flocker:functional:cinder:cinder_volume:created",
+    [Field.for_types(
+        u"volume_id", [bytes, unicode],
+        u"The Cinder-assigned unique identifier for the volume that was created.",
+    )],
+)

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -21,6 +21,8 @@ from bitmath import Byte
 import netifaces
 import psutil
 
+from fixtures import Fixture
+
 from keystoneclient.openstack.common.apiclient.exceptions import Unauthorized
 
 from twisted.python.filepath import FilePath
@@ -336,7 +338,7 @@ class VirtIOClient:
                     host_device])
 
 
-class OpenStackFixture(object):
+class OpenStackFixture(Fixture):
     def setUp(self):
         config = get_blockdevice_config(ProviderType.openstack)
         region = get_openstack_region_for_test()
@@ -344,9 +346,6 @@ class OpenStackFixture(object):
         self.cinder = get_cinder_v1_client(session, region)
         self.nova = get_nova_v2_client(session, region)
         self.blockdevice_api = cinderblockdeviceapi_for_test(test_case=self)
-
-    def getDetails(self):
-        return {}
 
     def _detach(self, instance_id, volume):
         self.nova.volumes.delete_server_volume(instance_id, volume.id)

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -20,8 +20,6 @@ from bitmath import Byte
 import netifaces
 import psutil
 
-from eliot import Field, MessageType
-
 from keystoneclient.openstack.common.apiclient.exceptions import Unauthorized
 
 from twisted.python.filepath import FilePath
@@ -50,11 +48,7 @@ from ..cinder import (
     TimeoutException
 )
 
-CINDER_VOLUME = MessageType(
-    u"flocker:functional:cinder:cinder_volume:created",
-    [Field.for_types(u"volume_id", [bytes, unicode])],
-)
-
+from .logging import CINDER_VOLUME
 
 # Tests requiring virtio can currently only be run on a devstack installation
 # that is not within our CI system. This will be addressed with FLOC-2972.

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -370,6 +370,7 @@ class CinderAttachmentTests(testtools.TestCase):
     Cinder volumes can be attached and return correct device path.
     """
     def setUp(self):
+        super(CinderAttachmentTests, self).setUp()
         try:
             self.openstack = OpenStackFixture(self.addCleanup)
         except InvalidConfig as e:
@@ -420,6 +421,7 @@ class CinderAttachmentTests(testtools.TestCase):
 @require_virtio
 class VirtIOCinderAttachmentTests(testtools.TestCase):
     def setUp(self):
+        super(VirtIOCinderAttachmentTests, self).setUp()
         try:
             self.openstack = OpenStackFixture(self.addCleanup)
         except InvalidConfig as e:

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -339,7 +339,7 @@ class VirtIOClient:
 
 
 class OpenStackFixture(Fixture):
-    def setUp(self):
+    def _setUp(self):
         config = get_blockdevice_config(ProviderType.openstack)
         region = get_openstack_region_for_test()
         session = get_keystone_session(**config)

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -473,7 +473,6 @@ class VirtIOCinderAttachmentTests(testtools.TestCase):
 
         self.assertEqual(device_path.realpath(), new_device)
 
-    @require_virtio
     def test_disk_attachment_fails_with_conflicting_disk(self):
         """
         create_server_volume will raise an exception when Cinder attempts to
@@ -512,7 +511,6 @@ class VirtIOCinderAttachmentTests(testtools.TestCase):
             )
         self.assertEqual(e.exception.unexpected_state, u'available')
 
-    @require_virtio
     def test_get_device_path_virtio_blk_error_without_udev(self):
         """
         ``get_device_path`` on systems using the virtio_blk driver raises
@@ -558,7 +556,6 @@ class VirtIOCinderAttachmentTests(testtools.TestCase):
             volume.id,
         )
 
-    @require_virtio
     def test_get_device_path_virtio_blk_symlink(self):
         """
         ``get_device_path`` on systems using the virtio_blk driver

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -13,7 +13,6 @@ Ideally, there'd be some in-memory tests too. Some ideas:
 See https://github.com/rackerlabs/mimic/issues/218
 """
 
-import testtools
 from unittest import skipIf
 from uuid import uuid4
 
@@ -336,13 +335,15 @@ class VirtIOClient:
                     host_device])
 
 
-class OpenStackFixture(object):
-    def __init__(self, addCleanup):
-        self.addCleanup = addCleanup
-        self.setUp()
-
+class CinderAttachmentTests(SynchronousTestCase):
+    """
+    Cinder volumes can be attached and return correct device path.
+    """
     def setUp(self):
-        config = get_blockdevice_config(ProviderType.openstack)
+        try:
+            config = get_blockdevice_config(ProviderType.openstack)
+        except InvalidConfig as e:
+            raise SkipTest(str(e))
         region = get_openstack_region_for_test()
         session = get_keystone_session(**config)
         self.cinder = get_cinder_v1_client(session, region)
@@ -358,27 +359,11 @@ class OpenStackFixture(object):
             transient_states=(u'in-use', u'detaching'),
         )
 
-    def cleanup(self, instance_id, volume):
+    def _cleanup(self, instance_id, volume):
         volume.get()
         if volume.attachments:
             self._detach(instance_id, volume)
         self.cinder.volumes.delete(volume.id)
-
-
-class CinderAttachmentTests(testtools.TestCase):
-    """
-    Cinder volumes can be attached and return correct device path.
-    """
-    def setUp(self):
-        super(CinderAttachmentTests, self).setUp()
-        try:
-            self.openstack = OpenStackFixture(self.addCleanup)
-        except InvalidConfig as e:
-            self.skipTest(str(e))
-        self.cinder = self.openstack.cinder
-        self.nova = self.openstack.nova
-        self.blockdevice_api = self.openstack.blockdevice_api
-        self._cleanup = self.openstack.cleanup
 
     def test_get_device_path_no_attached_disks(self):
         """
@@ -417,20 +402,7 @@ class CinderAttachmentTests(testtools.TestCase):
 
         self.assertEqual(device_path.realpath(), new_device)
 
-
-@require_virtio
-class VirtIOCinderAttachmentTests(testtools.TestCase):
-    def setUp(self):
-        super(VirtIOCinderAttachmentTests, self).setUp()
-        try:
-            self.openstack = OpenStackFixture(self.addCleanup)
-        except InvalidConfig as e:
-            self.skipTest(str(e))
-        self.cinder = self.openstack.cinder
-        self.nova = self.openstack.nova
-        self.blockdevice_api = self.openstack.blockdevice_api
-        self._cleanup = self.openstack.cleanup
-
+    @require_virtio
     def test_get_device_path_correct_with_attached_disk(self):
         """
         get_device_path returns the correct device name even when a non-Cinder
@@ -476,6 +448,7 @@ class VirtIOCinderAttachmentTests(testtools.TestCase):
 
         self.assertEqual(device_path.realpath(), new_device)
 
+    @require_virtio
     def test_disk_attachment_fails_with_conflicting_disk(self):
         """
         create_server_volume will raise an exception when Cinder attempts to
@@ -514,6 +487,7 @@ class VirtIOCinderAttachmentTests(testtools.TestCase):
             )
         self.assertEqual(e.exception.unexpected_state, u'available')
 
+    @require_virtio
     def test_get_device_path_virtio_blk_error_without_udev(self):
         """
         ``get_device_path`` on systems using the virtio_blk driver raises
@@ -559,6 +533,7 @@ class VirtIOCinderAttachmentTests(testtools.TestCase):
             volume.id,
         )
 
+    @require_virtio
     def test_get_device_path_virtio_blk_symlink(self):
         """
         ``get_device_path`` on systems using the virtio_blk driver

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -21,8 +21,6 @@ from bitmath import Byte
 import netifaces
 import psutil
 
-from fixtures import Fixture
-
 from keystoneclient.openstack.common.apiclient.exceptions import Unauthorized
 
 from twisted.python.filepath import FilePath
@@ -338,8 +336,12 @@ class VirtIOClient:
                     host_device])
 
 
-class OpenStackFixture(Fixture):
-    def _setUp(self):
+class OpenStackFixture(object):
+    def __init__(self, addCleanup):
+        self.addCleanup = addCleanup
+        self.setUp()
+
+    def setUp(self):
         config = get_blockdevice_config(ProviderType.openstack)
         region = get_openstack_region_for_test()
         session = get_keystone_session(**config)
@@ -369,7 +371,7 @@ class CinderAttachmentTests(testtools.TestCase):
     """
     def setUp(self):
         try:
-            self.openstack = self.useFixture(OpenStackFixture())
+            self.openstack = OpenStackFixture(self.addCleanup)
         except InvalidConfig as e:
             self.skipTest(str(e))
         self.cinder = self.openstack.cinder
@@ -419,7 +421,7 @@ class CinderAttachmentTests(testtools.TestCase):
 class VirtIOCinderAttachmentTests(testtools.TestCase):
     def setUp(self):
         try:
-            self.openstack = self.useFixture(OpenStackFixture())
+            self.openstack = OpenStackFixture(self.addCleanup)
         except InvalidConfig as e:
             self.skipTest(str(e))
         self.cinder = self.openstack.cinder

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -13,6 +13,7 @@ Ideally, there'd be some in-memory tests too. Some ideas:
 See https://github.com/rackerlabs/mimic/issues/218
 """
 
+import testtools
 from unittest import skipIf
 from uuid import uuid4
 
@@ -335,20 +336,17 @@ class VirtIOClient:
                     host_device])
 
 
-class CinderAttachmentTests(SynchronousTestCase):
-    """
-    Cinder volumes can be attached and return correct device path.
-    """
+class OpenStackFixture(object):
     def setUp(self):
-        try:
-            config = get_blockdevice_config(ProviderType.openstack)
-        except InvalidConfig as e:
-            raise SkipTest(str(e))
+        config = get_blockdevice_config(ProviderType.openstack)
         region = get_openstack_region_for_test()
         session = get_keystone_session(**config)
         self.cinder = get_cinder_v1_client(session, region)
         self.nova = get_nova_v2_client(session, region)
         self.blockdevice_api = cinderblockdeviceapi_for_test(test_case=self)
+
+    def getDetails(self):
+        return {}
 
     def _detach(self, instance_id, volume):
         self.nova.volumes.delete_server_volume(instance_id, volume.id)
@@ -359,11 +357,26 @@ class CinderAttachmentTests(SynchronousTestCase):
             transient_states=(u'in-use', u'detaching'),
         )
 
-    def _cleanup(self, instance_id, volume):
+    def cleanup(self, instance_id, volume):
         volume.get()
         if volume.attachments:
             self._detach(instance_id, volume)
         self.cinder.volumes.delete(volume.id)
+
+
+class CinderAttachmentTests(testtools.TestCase):
+    """
+    Cinder volumes can be attached and return correct device path.
+    """
+    def setUp(self):
+        try:
+            self.openstack = self.useFixture(OpenStackFixture())
+        except InvalidConfig as e:
+            self.skipTest(str(e))
+        self.cinder = self.openstack.cinder
+        self.nova = self.openstack.nova
+        self.blockdevice_api = self.openstack.blockdevice_api
+        self._cleanup = self.openstack.cleanup
 
     def test_get_device_path_no_attached_disks(self):
         """
@@ -402,7 +415,19 @@ class CinderAttachmentTests(SynchronousTestCase):
 
         self.assertEqual(device_path.realpath(), new_device)
 
-    @require_virtio
+
+@require_virtio
+class VirtIOCinderAttachmentTests(testtools.TestCase):
+    def setUp(self):
+        try:
+            self.openstack = self.useFixture(OpenStackFixture())
+        except InvalidConfig as e:
+            self.skipTest(str(e))
+        self.cinder = self.openstack.cinder
+        self.nova = self.openstack.nova
+        self.blockdevice_api = self.openstack.blockdevice_api
+        self._cleanup = self.openstack.cleanup
+
     def test_get_device_path_correct_with_attached_disk(self):
         """
         get_device_path returns the correct device name even when a non-Cinder

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -20,6 +20,8 @@ from bitmath import Byte
 import netifaces
 import psutil
 
+from eliot import Field, MessageType
+
 from keystoneclient.openstack.common.apiclient.exceptions import Unauthorized
 
 from twisted.python.filepath import FilePath
@@ -47,6 +49,12 @@ from ..cinder import (
     wait_for_volume_state, UnexpectedStateException, UnattachedVolume,
     TimeoutException
 )
+
+CINDER_VOLUME = MessageType(
+    u"flocker:functional:cinder:cinder_volume:created",
+    [Field.for_types(u"volume_id", [bytes, unicode])],
+)
+
 
 # Tests requiring virtio can currently only be run on a devstack installation
 # that is not within our CI system. This will be addressed with FLOC-2972.
@@ -130,6 +138,7 @@ class CinderBlockDeviceAPIInterfaceTests(
         requested_volume = cinder_client.volumes.create(
             size=int(Byte(self.minimum_allocatable_size).to_GiB().value)
         )
+        CINDER_VOLUME(id=requested_volume.id).write()
         self.addCleanup(
             cinder_client.volumes.delete,
             requested_volume.id,
@@ -154,6 +163,7 @@ class CinderBlockDeviceAPIInterfaceTests(
             dataset_id=uuid4(),
             size=self.minimum_allocatable_size,
             )
+        CINDER_VOLUME(id=flocker_volume.blockdevice_id).write()
         self.assert_foreign_volume(flocker_volume)
 
     def test_name(self):
@@ -166,6 +176,7 @@ class CinderBlockDeviceAPIInterfaceTests(
             dataset_id=dataset_id,
             size=self.minimum_allocatable_size,
         )
+        CINDER_VOLUME(id=flocker_volume.blockdevice_id).write()
         self.assertEqual(
             cinder_client.volumes.get(
                 flocker_volume.blockdevice_id).display_name,
@@ -369,6 +380,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         cinder_volume = self.cinder.volumes.create(
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
+        CINDER_VOLUME(id=cinder_volume.id).write()
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
@@ -414,6 +426,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         cinder_volume = self.cinder.volumes.create(
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
+        CINDER_VOLUME(id=cinder_volume.id).write()
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
@@ -459,6 +472,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         cinder_volume = self.cinder.volumes.create(
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
+        CINDER_VOLUME(id=cinder_volume.id).write()
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
@@ -490,6 +504,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         cinder_volume = self.cinder.volumes.create(
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
+        CINDER_VOLUME(id=cinder_volume.id).write()
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes, expected_volume=cinder_volume,
@@ -536,6 +551,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         cinder_volume = self.cinder.volumes.create(
             size=int(Byte(get_minimum_allocatable_size()).to_GiB().value)
         )
+        CINDER_VOLUME(id=cinder_volume.id).write()
         self.addCleanup(self._cleanup, instance_id, cinder_volume)
         volume = wait_for_volume_state(
             volume_manager=self.cinder.volumes,
@@ -589,6 +605,7 @@ class BlockDeviceAPIDestroyTests(SynchronousTestCase):
         after waiting some time
         """
         new_volume = self.api.cinder_volume_manager.create(size=100)
+        CINDER_VOLUME(id=new_volume.id).write()
         listed_volume = wait_for_volume_state(
             volume_manager=self.api.cinder_volume_manager,
             expected_volume=new_volume,

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -18,7 +18,7 @@ from ..test.blockdevicefactory import (
 )
 from ....testtools import random_name
 
-from .test_cinder import CINDER_VOLUME
+from .logging import CINDER_VOLUME
 
 
 def cinder_volume_manager():

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -18,6 +18,8 @@ from ..test.blockdevicefactory import (
 )
 from ....testtools import random_name
 
+from .test_cinder import CINDER_VOLUME
+
 
 def cinder_volume_manager():
     """
@@ -56,6 +58,7 @@ class VolumesCreateTests(SynchronousTestCase):
             size=100,
             metadata=expected_metadata
         )
+        CINDER_VOLUME(id=new_volume.id).write()
         self.addCleanup(self.cinder_volumes.delete, new_volume)
         listed_volume = wait_for_volume_state(
             volume_manager=self.cinder_volumes,
@@ -90,6 +93,7 @@ class VolumesSetMetadataTests(SynchronousTestCase):
         expected_metadata = {random_name(self): u"bar"}
 
         new_volume = self.cinder_volumes.create(size=100)
+        CINDER_VOLUME(id=new_volume.id).write()
         self.addCleanup(self.cinder_volumes.delete, new_volume)
 
         listed_volume = wait_for_volume_state(


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3530

This will let us compare logs and volumes that got leaked into the cloud and see how often these tests are the culprit.

http://build.clusterhq.com/boxes-flocker?branch=log-cinder-volume-id-FLOC-3530