### PR TITLE
[FLOC-3544] Skip virsh-requiring cinder functional tests faster

### DIFF
--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -13,7 +13,6 @@ Ideally, there'd be some in-memory tests too. Some ideas:
 See https://github.com/rackerlabs/mimic/issues/218
 """
 
-import testtools
 from unittest import skipIf
 from uuid import uuid4
 
@@ -360,7 +359,7 @@ class OpenStackFixture(object):
         self.cinder.volumes.delete(volume.id)
 
 
-class CinderAttachmentTests(testtools.TestCase):
+class CinderAttachmentTests(SynchronousTestCase):
     """
     Cinder volumes can be attached and return correct device path.
     """
@@ -412,8 +411,8 @@ class CinderAttachmentTests(testtools.TestCase):
         self.assertEqual(device_path.realpath(), new_device)
 
 
-@require_virtio
-class VirtIOCinderAttachmentTests(testtools.TestCase):
+class VirtIOCinderAttachmentTests(SynchronousTestCase):
+    @require_virtio
     def setUp(self):
         super(VirtIOCinderAttachmentTests, self).setUp()
         try:


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3544

Skips the tests that depend on virsh before they make a bunch of OpenStack API calls.

http://build.clusterhq.com/boxes-flocker?branch=skip-cinder-functional-tests-faster-FLOC-3544
