### PR TITLE
[FLOC-3538] sometimes ec2 instance gets public ip address _after_ becoming running

### DIFF
--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -90,8 +90,9 @@ def _check_if_running(instance):
     Message.new(
         message_type=u"flocker:provision:aws:check_if_running:update",
         instance_state=instance.state,
+        ip_address=instance.ip_address,
     ).write()
-    return instance.state == 'running'
+    return instance.state == 'running' and instance.ip_address is not None
 
 
 def _wait_until_running(instance):


### PR DESCRIPTION
So now we wait until the instance is running and its ip_address attribute
is not None.

https://clusterhq.atlassian.net/browse/FLOC-3538