### PR TITLE
aws may transiently refuse to recognize a new pending instance

### DIFF
--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -4,8 +4,9 @@
 AWS provisioner.
 """
 
+from itertools import repeat
 from textwrap import dedent
-from time import time, sleep
+from time import time
 
 from pyrsistent import PClass, field
 
@@ -19,6 +20,8 @@ from boto.ec2.blockdevicemapping import (
     EBSBlockDeviceType, BlockDeviceMapping,
 )
 from boto.exception import EC2ResponseError
+
+from ..common import poll_until
 
 from ._common import INode, IProvisioner
 
@@ -52,15 +55,43 @@ IMAGE_NAMES = {
 }
 
 BOTO_INSTANCE_NOT_FOUND = u'InvalidInstanceID.NotFound'
+INSTANCE_TIMEOUT = 300
 
 
 def _check_response_error(e, message_type):
+    """
+    Check if an exception is a transient one.
+    If it is, then it is simply logged, otherwise it is raised.
+
+    :param boto.exception import EC2ResponseErro e: The exception to check.
+    :param str message_type: The message type for logging.
+    """
     if e.error_code != BOTO_INSTANCE_NOT_FOUND:
         raise e
     Message.new(
         message_type=message_type,
         reason=e.error_code,
     ).write()
+
+
+def _check_if_running(instance):
+    """
+    Check if an instance is running.
+
+    :param boto.ec2.instance.Instance instance: The instance to check.
+    """
+    try:
+        instance.update()
+    except EC2ResponseError as e:
+        _check_response_error(
+            e,
+            u"flocker:provision:aws:check_if_running:retry"
+        )
+    Message.new(
+        message_type=u"flocker:provision:aws:check_if_running:update",
+        instance_state=instance.state,
+    ).write()
+    return instance.state == 'running'
 
 
 def _wait_until_running(instance):
@@ -73,19 +104,8 @@ def _wait_until_running(instance):
         action_type=u"flocker:provision:aws:wait_until_running",
         instance_id=instance.id,
     ):
-        while instance.state != 'running':
-            with start_action(
-                action_type=u"flocker:provision:aws:wait_until_running:sleep",
-                instance_state=instance.state,
-            ):
-                sleep(1)
-            try:
-                instance.update()
-            except EC2ResponseError as e:
-                _check_response_error(
-                    e,
-                    u"flocker:provision:aws:wait_until_running:retry"
-                )
+        poll_until(lambda: _check_if_running(instance),
+                   repeat(1, INSTANCE_TIMEOUT))
 
 
 @implementer(INode)
@@ -260,17 +280,8 @@ class AWSProvisioner(PClass):
                 instance = reservation.instances[0]
                 context.add_success_fields(instance_id=instance.id)
 
-            while True:
-                try:
-                    self._connection.create_tags([instance.id], metadata)
-                    break
-                except EC2ResponseError as e:
-                    _check_response_error(
-                        e,
-                        u"flocker:provision:aws:create_node:retry"
-                    )
-                    sleep(1)
-
+            poll_until(lambda: self._set_metadata(instance, metadata),
+                       repeat(1, INSTANCE_TIMEOUT))
             _wait_until_running(instance)
 
             return AWSNode(
@@ -279,6 +290,23 @@ class AWSProvisioner(PClass):
                 _instance=instance,
                 distribution=distribution,
             )
+
+    def _set_metadata(self, instance, metadata):
+        """
+        Set metadata for an instance.
+
+        :param boto.ec2.instance.Instance instance: The instance to configure.
+        :param dict metadata: The tag-value metadata.
+        """
+        try:
+            self._connection.create_tags([instance.id], metadata)
+            return True
+        except EC2ResponseError as e:
+            _check_response_error(
+                e,
+                u"flocker:provision:aws:set_metadata:retry"
+            )
+        return False
 
 
 def aws_provisioner(access_key, secret_access_token, keyname,


### PR DESCRIPTION
We are making two calls right after the instance creation,
`boto.ec2.instance.update()` and `boto.ec2.connection.create_tags()`,
so these could be affected by the problem.

Now, if we get `InvalidInstanceID.NotFound` error we simply retry the
affected calls.

https://clusterhq.atlassian.net/browse/FLOC-3537