### PR TITLE
[FLOC 3545] Add missing content from Functional Test doc

### DIFF
--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -10,15 +10,17 @@ The tests look for the following environment variables:
      # FLOC-2090 This is yet another configuration file.
      # Make it just be the same as the acceptance testing configuration file.
 
-- ``FLOCKER_FUNCTIONAL_TEST``: This variable must be set to ``TRUE``.
+- ``FLOCKER_FUNCTIONAL_TEST``: This variable must be set.
 - ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This variable points at a YAML file with the credentials.
 - ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This variable must be the name of a top-level key in the configuration file.
+- ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` (AWS only): The AWS backend also requires that the availability zone that the test is running in to be specified.
+  This is specified separately from the credential file, so that the file can be reused in different regions.
 
-The credentials are read from the stanza specified by the ``CLOUD_PROVIDER`` environment variable.
+The credentials are read from the stanza specified by the ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER`` environment variable.
 The supported block-device backend is specified by a ``provider`` key in the stanza, 
 or the name of the stanza, if the ``provider`` key is missing.
 
-If the environment variables aren't present, the tests will be skipped.
+If the environment variables are not present, the tests will be skipped.
 The tests that do not correspond to the configured provider will also be skipped.
 
 AWS
@@ -32,8 +34,6 @@ The configuration stanza for the EBS backend looks as follows:
      access_key: <aws access key>
      secret_access_token: <aws secret access token>
 
-The AWS backend also requires that the availability zone the test are running in be specified in the  ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` environment variable.
-This is specified separately from the credential file, so that the file can be reused in different regions.
 
 Rackspace
 =========
@@ -60,3 +60,6 @@ The configuration stanza for an private OpenStack deployment looks as follows:
      plugin_option: value
 
 ``auth_plugin`` refers to an authentication plugin provided by ``python-keystoneclient``.
+
+If required, you may need to add additional fields.
+For more information, see :ref:`openstack-dataset-backend`.

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -77,22 +77,7 @@ To run the functional tests, run the following command:
 OpenStack
 =========
 
-The configuration stanza for an private OpenStack deployment looks as follows:
-
-.. code:: yaml
-
-   private-cloud:
-     provider: openstack
-     auth_plugin: plugin_name
-     plugin_option: value
-
-``auth_plugin`` refers to an authentication plugin provided by ``python-keystoneclient``.
+The configuration stanza for an private OpenStack deployment is the same as Rackspace above, but ``auth_plugin`` should be included, which refers to an authentication plugin provided by ``python-keystoneclient``.
 
 If required, you may need to add additional fields.
 For more information, see :ref:`openstack-dataset-backend`.
-
-To run the functional tests, run the following command:
-
-.. prompt:: bash #
-
-   trial --testmodule flocker/node/agents/cinder.py

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -55,7 +55,6 @@ The configuration stanza for the OpenStack backend running on Rackspace looks as
 .. code:: yaml
 
    rackspace:
-     region: <rackspace region, e.g. "iad">
      username: <rackspace username>
      key: <access key>
 

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -17,7 +17,7 @@ The tests look for the following environment variables:
   This is specified separately from the credential file, so that the file can be reused in different regions.
 
 The credentials are read from the stanza specified by the ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER`` environment variable.
-The supported block-device backend is specified by a ``provider`` key in the stanza, 
+The supported block-device backend is specified by a ``provider`` key in the stanza,
 or the name of the stanza, if the ``provider`` key is missing.
 
 If the environment variables are not present, the tests will be skipped.

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -10,11 +10,12 @@ The tests look for two environment variables:
      # FLOC-2090 This is yet another configuration file.
      # Make it just be the same as the acceptance testing configuration file.
 
+- ``FLOCKER_FUNCTIONAL_TEST``: This variable must be set to ``TRUE``.
 - ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This points at a YAML file with the credentials.
 - ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This is the name of a top-level key in the configuration file.
 
 The credentials are read from the stanza specified by the ``CLOUD_PROVIDER`` environment variable.
-The supported block-device backend is specified by a ``provider`` key in the stanza,
+The supported block-device backend is specified by a ``provider`` key in the stanza, 
 or the name of the stanza, if the ``provider`` key is missing.
 
 If the environment variables aren't present, the tests will be skipped.

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -4,15 +4,15 @@ Functional Testing
 
 The tests for the various cloud block device backends depend on access to credentials supplied from the environment.
 
-The tests look for two environment variables:
+The tests look for the following environment variables:
 
 .. XXX
      # FLOC-2090 This is yet another configuration file.
      # Make it just be the same as the acceptance testing configuration file.
 
 - ``FLOCKER_FUNCTIONAL_TEST``: This variable must be set to ``TRUE``.
-- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This points at a YAML file with the credentials.
-- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This is the name of a top-level key in the configuration file.
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This variable points at a YAML file with the credentials.
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This variable must be the name of a top-level key in the configuration file.
 
 The credentials are read from the stanza specified by the ``CLOUD_PROVIDER`` environment variable.
 The supported block-device backend is specified by a ``provider`` key in the stanza, 

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -45,6 +45,10 @@ To run the functional tests, run the following command:
 
 .. prompt:: bash #
 
+   FLOCKER_FUNCTIONAL_TEST=TRUE \
+   FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE=$HOME/acceptance.yml \
+   FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=aws \
+   FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE=<aws region> \
    trial --testmodule flocker/node/agents/ebs.py
 
 Rackspace
@@ -54,14 +58,20 @@ The configuration stanza for the OpenStack backend running on Rackspace looks as
 
 .. code:: yaml
 
-   rackspace:
-     username: <rackspace username>
-     key: <access key>
+   openstack:
+     username: "<rackspace username>"
+     api_key: "<access key>"
+     auth_plugin: "rackspace"
+     auth_url: "https://identity.api.rackspacecloud.com/v2.0"
 
 To run the functional tests, run the following command:
 
 .. prompt:: bash #
 
+   FLOCKER_FUNCTIONAL_TEST=TRUE \
+   FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE=$HOME/acceptance.yml \
+   FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=openstack \
+   FLOCKER_FUNCTIONAL_TEST_OPENSTACK_REGION=<rackspace region> \
    trial --testmodule flocker/node/agents/cinder.py
 
 OpenStack

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -10,10 +10,17 @@ The tests look for the following environment variables:
      # FLOC-2090 This is yet another configuration file.
      # Make it just be the same as the acceptance testing configuration file.
 
-- ``FLOCKER_FUNCTIONAL_TEST``: This variable must be set.
-- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``: This variable points at a YAML file with the credentials.
-- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``: This variable must be the name of a top-level key in the configuration file.
-- ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` (AWS only): The AWS backend also requires that the availability zone that the test is running in to be specified.
+- ``FLOCKER_FUNCTIONAL_TEST``:
+  This variable must be set.
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE``:
+  This variable points at a YAML file with the credentials.
+- ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER``:
+  This variable must be the name of a top-level key in the configuration file.
+- ``FLOCKER_FUNCTIONAL_TEST_AWS_AVAILABILITY_ZONE`` (AWS only):
+  The AWS backend requires that the availability zone that the test is running in to be specified.
+  This is specified separately from the credential file, so that the file can be reused in different regions.
+- ``FLOCKER_FUNCTIONAL_TEST_OPENSTACK_REGION`` (Rackspace and OpenStack only):
+  The Rackspace and OpenStack backends require that the region that the test is running in to be specified.
   This is specified separately from the credential file, so that the file can be reused in different regions.
 
 The credentials are read from the stanza specified by the ``FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER`` environment variable.

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -5,7 +5,8 @@ Functional Testing
 The tests for the various cloud block device backends depend on access to credentials supplied from the environment.
 
 The tests look for two environment variables:
-  ..
+
+.. XXX
      # FLOC-2090 This is yet another configuration file.
      # Make it just be the same as the acceptance testing configuration file.
 

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -34,6 +34,11 @@ The configuration stanza for the EBS backend looks as follows:
      access_key: <aws access key>
      secret_access_token: <aws secret access token>
 
+To run the functional tests, run the following command:
+
+.. prompt:: bash #
+
+   trial --testmodule flocker/node/agents/ebs.py
 
 Rackspace
 =========
@@ -46,6 +51,12 @@ The configuration stanza for the OpenStack backend running on Rackspace looks as
      region: <rackspace region, e.g. "iad">
      username: <rackspace username>
      key: <access key>
+
+To run the functional tests, run the following command:
+
+.. prompt:: bash #
+
+   trial --testmodule flocker/node/agents/cinder.py
 
 OpenStack
 =========
@@ -63,3 +74,9 @@ The configuration stanza for an private OpenStack deployment looks as follows:
 
 If required, you may need to add additional fields.
 For more information, see :ref:`openstack-dataset-backend`.
+
+To run the functional tests, run the following command:
+
+.. prompt:: bash #
+
+   trial --testmodule flocker/node/agents/cinder.py


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3545

The instructions for setting up functional tests was missing key environment variables, and then the instructions for each backend were thin.

Working with @jongiddy, we've added the extra environment variables, and provided the commands necessary to run the tests on each backend.