### PR TITLE
[FLOC 3546] Explain why the plugin install instructions are optional

### DIFF
--- a/docs/install/install-node.rst
+++ b/docs/install/install-node.rst
@@ -6,6 +6,8 @@ Installing the Flocker Node Services
 
 The following instructions describe how to install the ``clusterhq-flocker node`` package, and the optional ``clusterhq-flocker-docker-plugin`` package on each of the nodes in your cluster.
 
+Installing the :ref:`Flocker plugin for Docker <docker-plugin>` at the same time as the other node services is not essential, but it will save you from revisiting each of the nodes in your cluster again if you were to install it at a later time.
+
 .. _installing-flocker-node-prereq:
 
 Prerequisites

--- a/docs/install/install-node.rst
+++ b/docs/install/install-node.rst
@@ -4,9 +4,10 @@
 Installing the Flocker Node Services
 ====================================
 
-The following instructions describe how to install the ``clusterhq-flocker node`` package, and the optional ``clusterhq-flocker-docker-plugin`` package on each of the nodes in your cluster.
+The following instructions describe how to install the ``clusterhq-flocker node`` package on each of the nodes in your cluster.
 
-Installing the :ref:`Flocker plugin for Docker <docker-plugin>` at the same time as the other node services is not essential, but it will save you from revisiting each of the nodes in your cluster again if you were to install it at a later time.
+If you want Flocker to manage your data volumes while using other tools such as Docker, Docker Swarm, or Mesos to manage your containers, you can also install the ``clusterhq-flocker-docker-plugin`` package on each node in your cluster.
+For more information, see :ref:`docker-plugin`.
 
 .. _installing-flocker-node-prereq:
 


### PR DESCRIPTION
Fixes 3546

Explains why the plugin is an optional install step in the node services install doc, linking back to the introduction document on the plugin.