### PR TITLE
[FLOC-3336] Update commit status on GitHub with Jenkins build result

### DIFF
--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -92,26 +92,26 @@
 
 
 {% macro updateGitHubStatus(status)                                         -%}
-  shell("""
-REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
-echo \$REMOTE_GIT_COMMIT > gitcommit
-  """)
-
 {# Read the commit and github credentials                                    #}
 {# Update github with the build status                                       #}
-  if ("{{status}}" == "pending" ) {
+{% if status == "pending"                                                    %}
     shell("""
-      REMOTE_GIT_COMMIT=\$(cat gitcommit)
-      echo \$REMOTE_GIT_COMMIT
+REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
+echo \$REMOTE_GIT_COMMIT
+echo 'Job started'
     """)
-
-  } else {
+{% endif %}
+{% if status == "complete" %}
     conditionalSteps {
       condition {
         status('FAILURE', 'FAILURE')
       }
       steps {
-        shell("echo 'Job failed'")
+        shell("""
+REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
+echo \$REMOTE_GIT_COMMIT
+echo 'Job failed'
+        """)
       }
     }
     conditionalSteps {
@@ -119,10 +119,14 @@ echo \$REMOTE_GIT_COMMIT > gitcommit
         status('SUCCESS', 'SUCCESS')
       }
       steps {
-        shell("echo 'Job succeeded'")
+        shell("""
+REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
+echo \$REMOTE_GIT_COMMIT
+echo 'Job succeeded'
+        """)
       }
     }
-  }
+{% endif %}
 {%- endmacro                                                                -%}
 
 {% macro folder(folder, display_name)                                       -%}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -109,7 +109,7 @@ curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
-  --data "\$PAYLOAD" 
+  --data "\$PAYLOAD" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
         """)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -94,6 +94,8 @@
                             dashBranchName)                                 -%}
 """
 #!/bin/bash
+{# Jenkins jobs are usually run using 'set -x' however we use 'set +x' here  #}
+{# to avoid leaking credentials into the build logs.                         #}
 set +x
 {# Read the GitHub credentials                                               #}
 . /etc/slave_config/github_status.sh

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -680,7 +680,7 @@ branches.each {
           }
 
 {# Update the commit status on github to the job result                    #}
-          {{ updateGitHubStatus('success') }}
+{#          {{ updateGitHubStatus('success') }}                            #}
 
       }
   }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -102,8 +102,8 @@ echo 'Job started'
     """)
 {% endif %}
 {% if status == "complete" %}
-    configure { node ->
-      node / 'builders' / 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
+    configure { project ->
+      project / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
         spec ''
       }
     }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -98,7 +98,7 @@
     configure {
       it / 'builders' << 'hudson.tasks.Shell' {
         command("""
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 echo \$REMOTE_GIT_COMMIT
 echo 'Job started'
         """)
@@ -124,7 +124,7 @@ echo 'Job started'
         }
         buildStep(class: "hudson.tasks.Shell") {
           command("""
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
           """)
         }
@@ -148,7 +148,7 @@ echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
         }
         buildStep(class: "hudson.tasks.Shell") {
           command("""
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 echo 'Job failed. Updating commit \$REMOTE_GIT_COMMIT with failure status.'
           """)
         }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -104,11 +104,12 @@ set +x
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+PAYLOAD="{\"state\": \"pending\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" 
 curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
-  --data "{\"state\"': \"pending\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" \\
+  --data "\$PAYLOAD" 
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
         """)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -108,6 +108,8 @@ echo 'Job started'
 {% if status == "complete" %}
     configure {
     it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
+      condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition")(plugin: "run-condition@1.0") {
+      }
       }
     }
 {% endif %}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -100,7 +100,7 @@
         command("""
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 echo \$REMOTE_GIT_COMMIT
-echo 'Job started'
+echo "Job started"
         """)
       }
     }
@@ -125,7 +125,7 @@ echo 'Job started'
         buildStep(class: "hudson.tasks.Shell") {
           command("""
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
+echo "Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status."
           """)
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
@@ -149,7 +149,7 @@ echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
         buildStep(class: "hudson.tasks.Shell") {
           command("""
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-echo 'Job failed. Updating commit \$REMOTE_GIT_COMMIT with failure status.'
+echo "Job failed. Updating commit \$REMOTE_GIT_COMMIT with failure status."
           """)
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -108,7 +108,7 @@ echo \$REMOTE_GIT_COMMIT > gitcommit
   } else {
     conditionalSteps {
       condition {
-        status('FAILURE')
+        status('FAILURE', 'FAILURE')
       }
       steps {
         shell("echo 'Job failed'")
@@ -116,7 +116,7 @@ echo \$REMOTE_GIT_COMMIT > gitcommit
     }
     conditionalSteps {
       condition {
-        status('SUCCESS')
+        status('SUCCESS', 'SUCCESS')
       }
       steps {
         shell("echo 'Job succeeded'")

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -107,7 +107,7 @@ echo 'Job started'
 {% endif %}
 {% if status == "complete" %}
     configure {
-      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
+      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.3.3"
       }
     }
 {% endif %}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -526,7 +526,7 @@ branches.each {
     }
       steps {
 {# Set the commit status on github to pending                                #}
-          updateGitHubStatus('pending')
+          {{ updateGitHubStatus('pending') }}
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
 {# build 'parallel_tests' phase that will run all our jobs in parallel       #}
@@ -680,7 +680,7 @@ branches.each {
           }
 
 {# Update the commit status on github to the job result                    #}
-          updateGitHubStatus('success')
+          {{ updateGitHubStatus('success') }}
 
       }
   }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -124,7 +124,7 @@ echo 'Job started'
         }
         buildStep(class: "hudson.tasks.Shell") {
           command("""
-            echo &quot;yay&quot;
+            echo 'yay'
           """)
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -109,7 +109,7 @@ curl \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
   --data "\$PAYLOAD" \\
-  https://api.github.com/repos/{{ cfg.project }}/\$REMOTE_GIT_COMMIT
+  https://api.github.com/repos/{{ cfg.project }}/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
 """
 {%- endmacro -%}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -673,6 +673,13 @@ branches.each {
             failNoReports(false)
           }
 {# Update the commit status on GitHub with the build result                  #}
+{# We use the flexible-publish plugin combined with the the any-buildstep    #}
+{# plugin to allow us to run shell commands as part of a post-build step.    #}
+{# We also use the run-condition plugin to inspect the status of the build   #}
+{# and update the commit with either a 'success' or 'failed' status.         #}
+{# https://wiki.jenkins-ci.org/display/JENKINS/Flexible+Publish+Plugin       #}
+{# https://wiki.jenkins-ci.org/display/JENKINS/Any+Build+Step+Plugin         #}
+{# https://wiki.jenkins-ci.org/display/JENKINS/Run+Condition+Plugin          #}
           flexiblePublish {
             condition {
               status('SUCCESS', 'SUCCESS')

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -594,7 +594,7 @@ branches.each {
           }
     }
 {# Set the commit status on github to pending                                #}
-      {{ updateGitHubStatus('pending', "${branchName}", "${dashProject}", "${dashBranchName}" }}
+      {{ updateGitHubStatus('pending', "${branchName}", "${dashProject}", "${dashBranchName}") }}
       steps {
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
@@ -726,7 +726,7 @@ branches.each {
 {# do an aggregation of all the test results                                 #}
       }
 {# Update the commit status on github to the job result                    #}
-      {{ updateGitHubStatus('complete', "${branchName}", "${dashProject}", "${dashBranchName}" }}
+      {{ updateGitHubStatus('complete', "${branchName}", "${dashProject}", "${dashBranchName}") }}
       publishers {
           archiveJunit('**/results.xml') {
               retainLongStdout(true)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -91,12 +91,12 @@
 {# --------------------------------------------------------------------------#}
 
 
-{% macro updateGitHubStatus(status)                                         -%}
+{% macro updateGitHubStatus(status, branch)                                 -%}
 {# Read the commit and github credentials                                    #}
 {# Update github with the build status                                       #}
 {% if status == "pending"                                                    %}
     shell("""
-REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
 echo \$REMOTE_GIT_COMMIT
 echo 'Job started'
     """)
@@ -108,7 +108,7 @@ echo 'Job started'
       }
       steps {
         shell("""
-REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
 echo \$REMOTE_GIT_COMMIT
 echo 'Job failed'
         """)
@@ -120,7 +120,7 @@ echo 'Job failed'
       }
       steps {
         shell("""
-REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
 echo \$REMOTE_GIT_COMMIT
 echo 'Job succeeded'
         """)
@@ -533,7 +533,7 @@ branches.each {
     }
       steps {
 {# Set the commit status on github to pending                                #}
-          {{ updateGitHubStatus('pending') }}
+          {{ updateGitHubStatus('pending', "${branchName}") }}
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
 {# build 'parallel_tests' phase that will run all our jobs in parallel       #}
@@ -662,7 +662,7 @@ branches.each {
 {%  endfor                                                                   %}
 {% endfor                                                                    %}
 {# Update the commit status on github to the job result                    #}
-        {{ updateGitHubStatus('complete') }}
+        {{ updateGitHubStatus('complete', "${branchName}") }}
 {# do an aggregation of all the test results                                 #}
       }
       publishers {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -108,7 +108,7 @@ curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
-  --data "{'state': 'pending', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \\
+  --data "{\"state\"': \"pending\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
         """)
@@ -144,7 +144,7 @@ curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
-  --data "{'state': 'success', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \\
+  --data "{\"state\"': \"success\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with success status."
           """)
@@ -179,7 +179,7 @@ curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
-  --data "{'state': 'failure', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \\
+  --data "{\"state\"': \"failure\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with failure status."
           """)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -108,7 +108,7 @@ echo 'Job started'
 {% if status == "complete" %}
     configure {
     it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
-      condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition")(plugin: "run-condition@1.0") {
+      condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
       }
       }
     }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -90,6 +90,38 @@
 {# JINJA2 MACROS DEFINED BELOW                                               #}
 {# --------------------------------------------------------------------------#}
 
+
+{% macro updateGitHubStatus(status)                                         -%}
+  shell("""
+    PARENTS=(\$(git log --pretty=%P -1))
+    REMOTE_GIT_COMMIT="\${PARENTS[\${\#PARENTS[@]} - 1]}"
+    echo \$REMOTE_GIT_COMMIT > gitcommit
+  """)
+
+  # Read the commit and github credentials
+  # Update github with the build status
+  if (status == "pending" ) {
+    shell("echo \$REMOTE_GIT_COMMIT")
+  } else {
+    conditionalSteps {
+      condition {
+        status('FAILURE')
+      }
+      steps {
+        shell("echo 'Job failed'")
+      }
+    }
+    conditionalSteps {
+      condition {
+        status('SUCCESS')
+      }
+      steps {
+        shell("echo 'Job succeeded'")
+      }
+    }
+  }
+{%- endmacro                                                                -%}
+
 {% macro folder(folder, display_name)                                       -%}
 {# creates a folder structure to group jobs, these are the Jenkins folder views
    in the Jenkins UI.
@@ -493,6 +525,8 @@ branches.each {
           }
     }
       steps {
+{# Set the commit status on github to pending                                #}
+          updateGitHubStatus('pending')
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
 {# build 'parallel_tests' phase that will run all our jobs in parallel       #}
@@ -644,6 +678,10 @@ branches.each {
             failUnstable(true)
             failNoReports(false)
           }
+
+{# Update the commit status on github to the job result                    #}
+          updateGitHubStatus('success')
+
       }
   }
 }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -110,16 +110,16 @@ echo 'Job started'
       it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
         condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
           worstResult {
-            name('SUCCESS')
-            ordinal('0')
-            color('BLUE')
-            completeBuild('true')
+            name 'SUCCESS'
+            ordinal '0'
+            color 'BLUE'
+            completeBuild 'true'
           }
           bestResult {
-            name('SUCCESS')
-            ordinal('0')
-            color('BLUE')
-            completeBuild('true')
+            name 'SUCCESS'
+            ordinal '0'
+            color 'BLUE'
+            completeBuild 'true'
           }
         }
         buildStep(class: "hudson.tasks.Shell") {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -149,7 +149,7 @@ echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
         buildStep(class: "hudson.tasks.Shell") {
           command("""
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
-echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
+echo 'Job failed. Updating commit \$REMOTE_GIT_COMMIT with failure status.'
           """)
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -517,8 +517,8 @@ branches.each {
 
  {# the multijob runs on the jenkins-master only                             #}
     label("master")
-{# Set the commit status on github to pending                                #}
       steps {
+{# Set the commit status on GitHub to pending                                #}
           shell({{ updateGitHubStatus('pending', 'Build started',
             "${branchName}", "${dashProject}", "${dashBranchName}") }})
 {# make sure we are starting with a clean workspace                          #}
@@ -672,6 +672,7 @@ branches.each {
             failUnstable(true)
             failNoReports(false)
           }
+{# Update the commit status on GitHub with the build result                  #}
           flexiblePublish {
             condition {
               status('SUCCESS', 'SUCCESS')

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -102,28 +102,9 @@ echo 'Job started'
     """)
 {% endif %}
 {% if status == "complete" %}
-    conditionalSteps {
-      condition {
-        status('FAILURE', 'FAILURE')
-      }
-      steps {
-        shell("""
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
-echo \$REMOTE_GIT_COMMIT
-echo 'Job failed'
-        """)
-      }
-    }
-    conditionalSteps {
-      condition {
-        status('SUCCESS', 'SUCCESS')
-      }
-      steps {
-        shell("""
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
-echo \$REMOTE_GIT_COMMIT
-echo 'Job succeeded'
-        """)
+    configure { node ->
+      node / 'builders' / 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
+        spec ''
       }
     }
 {% endif %}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -103,12 +103,12 @@ set +x
 . /tmp/github_status.sh
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-BUILD_URL="$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-curl \
-  -H "Content-Type: application/json" \
-  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN"
-  -X POST
-  --data "{'state': 'pending', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \
+BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+curl \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
+  -X POST \\
+  --data "{'state': 'pending', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
         """)
@@ -139,12 +139,12 @@ set +x
 . /tmp/github_status.sh
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-BUILD_URL="$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-curl \
-  -H "Content-Type: application/json" \
-  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN"
-  -X POST
-  --data "{'state': 'success', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \
+BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+curl \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
+  -X POST \\
+  --data "{'state': 'success', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with success status."
           """)
@@ -174,12 +174,12 @@ set +x
 . /tmp/github_status.sh
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-BUILD_URL="$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-curl \
-  -H "Content-Type: application/json" \
-  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN"
-  -X POST
-  --data "{'state': 'failure', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \
+BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+curl \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
+  -X POST \\
+  --data "{'state': 'failure', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with failure status."
           """)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -657,6 +657,8 @@ branches.each {
 {%    endfor                                                                 %}
 {%  endfor                                                                   %}
 {% endfor                                                                    %}
+{# Update the commit status on github to the job result                    #}
+        {{ updateGitHubStatus('complete') }}
 {# do an aggregation of all the test results                                 #}
       }
       publishers {
@@ -681,10 +683,6 @@ branches.each {
             failUnstable(true)
             failNoReports(false)
           }
-
-{# Update the commit status on github to the job result                    #}
-{#          {{ updateGitHubStatus('success') }}                            #}
-
       }
   }
 }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -91,16 +91,26 @@
 {# --------------------------------------------------------------------------#}
 
 
-{% macro updateGitHubStatus(status, branch)                                 -%}
+{% macro updateGitHubStatus(status, branch, dashProject, dashBranchName)    -%}
 {# Read the commit and github credentials                                    #}
 {# Update github with the build status                                       #}
 {% if status == "pending"                                                    %}
     configure {
       it / 'builders' << 'hudson.tasks.Shell' {
         command("""
+#!/bin/bash
+set +x
+. /tmp/github_status.sh
+
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-echo \$REMOTE_GIT_COMMIT
-echo "Job started"
+BUILD_URL="$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+curl \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN"
+  -X POST
+  --data "{'state': 'pending', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \
+  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
+echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
         """)
       }
     }
@@ -124,8 +134,19 @@ echo "Job started"
         }
         buildStep(class: "hudson.tasks.Shell") {
           command("""
+#!/bin/bash
+set +x
+. /tmp/github_status.sh
+
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-echo "Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status."
+BUILD_URL="$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+curl \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN"
+  -X POST
+  --data "{'state': 'success', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \
+  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
+echo "Updating commit \$REMOTE_GIT_COMMIT with success status."
           """)
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
@@ -148,8 +169,19 @@ echo "Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status."
         }
         buildStep(class: "hudson.tasks.Shell") {
           command("""
+#!/bin/bash
+set +x
+. /tmp/github_status.sh
+
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-echo "Job failed. Updating commit \$REMOTE_GIT_COMMIT with failure status."
+BUILD_URL="$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+curl \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN"
+  -X POST
+  --data "{'state': 'failure', 'target_url': '\$BUILD_URL', 'description': 'Multijob build', 'context': 'Jenkins' }" \
+  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
+echo "Updating commit \$REMOTE_GIT_COMMIT with failure status."
           """)
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
@@ -562,7 +594,7 @@ branches.each {
           }
     }
 {# Set the commit status on github to pending                                #}
-      {{ updateGitHubStatus('pending', "${branchName}") }}
+      {{ updateGitHubStatus('pending', "${branchName}", "${dashProject}", "${dashBranchName}" }}
       steps {
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
@@ -694,7 +726,7 @@ branches.each {
 {# do an aggregation of all the test results                                 #}
       }
 {# Update the commit status on github to the job result                    #}
-      {{ updateGitHubStatus('complete', "${branchName}") }}
+      {{ updateGitHubStatus('complete', "${branchName}", "${dashProject}", "${dashBranchName}" }}
       publishers {
           archiveJunit('**/results.xml') {
               retainLongStdout(true)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -109,17 +109,11 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
 """
 {%- endmacro -%}
 
-{% macro updateGitHubStatus(status, branch, dashProject, dashBranchName)    -%}
+{% macro updateGitHubStatus(buildCompleted, branch, dashProject, dashBranchName) -%}
 {# Read the commit and github credentials                                    #}
 {# Update github with the build status                                       #}
-{% if status == "pending"                                                    %}
-    configure {
-      it / 'builders' << 'hudson.tasks.Shell' {
-        command({{ updateGitHubStatusCommand('pending')}})
-      }
-    }
-{% endif %}
-{% if status == "complete" %}
+
+{% if buildCompleted %}
     configure {
       it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
         condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
@@ -162,6 +156,12 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
         }
+      }
+    }
+{% else                                                    %}
+    configure {
+      it / 'builders' << 'hudson.tasks.Shell' {
+        command({{ updateGitHubStatusCommand('pending')}})
       }
     }
 {% endif %}
@@ -573,7 +573,8 @@ branches.each {
  {# the multijob runs on the jenkins-master only                             #}
     label("master")
 {# Set the commit status on github to pending                                #}
-      {{ updateGitHubStatus('pending', "${branchName}", "${dashProject}", "${dashBranchName}") }}
+{% set buildCompleted = false                                                %}
+      {{ updateGitHubStatus(buildCompleted, "${branchName}", "${dashProject}", "${dashBranchName}") }}
       steps {
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
@@ -704,8 +705,9 @@ branches.each {
 {% endfor                                                                    %}
 {# do an aggregation of all the test results                                 #}
       }
-{# Update the commit status on github to the job result                    #}
-      {{ updateGitHubStatus('complete', "${branchName}", "${dashProject}", "${dashBranchName}") }}
+{# Update the commit status on github to the job result                      #}
+{% set buildCompleted = true                                                 %}
+      {{ updateGitHubStatus(buildCompleted, "${branchName}", "${dashProject}", "${dashBranchName}") }}
       publishers {
           archiveJunit('**/results.xml') {
               retainLongStdout(true)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -90,7 +90,8 @@
 {# JINJA2 MACROS DEFINED BELOW                                               #}
 {# --------------------------------------------------------------------------#}
 
-{% macro updateGitHubStatusCommand(status, branch, dashProject, dashBranchName) -%}
+{% macro updateGitHubStatus(status, description, branch, dashProject,
+                            dashBranchName)                                 -%}
 """
 #!/bin/bash
 set +x
@@ -100,7 +101,7 @@ set +x
 {# Send a request to Github to update the commit with the build status       #}
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-PAYLOAD="{\\"state\\": \\"{{ status }}\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
+PAYLOAD="{\\"state\\": \\"{{ status }}\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"{{ description }}\\", \\"context\\": \\"jenkins-multijob\\" }"
 curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
@@ -518,8 +519,8 @@ branches.each {
     label("master")
 {# Set the commit status on github to pending                                #}
       steps {
-          shell({{ updateGitHubStatusCommand('pending',
-                "${branchName}", "${dashProject}", "${dashBranchName}") }})
+          shell({{ updateGitHubStatus('pending', 'Build started',
+            "${branchName}", "${dashProject}", "${dashBranchName}") }})
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
 {# build 'parallel_tests' phase that will run all our jobs in parallel       #}
@@ -676,7 +677,7 @@ branches.each {
               status('SUCCESS', 'SUCCESS')
             }
             step {
-              shell({{ updateGitHubStatusCommand('success',
+              shell({{ updateGitHubStatus('success', 'Build succeeded',
                 "${branchName}", "${dashProject}", "${dashBranchName}") }})
             }
           }
@@ -685,7 +686,7 @@ branches.each {
               status('FAILURE', 'FAILURE')
             }
             step {
-              shell({{ updateGitHubStatusCommand('failure',
+              shell({{ updateGitHubStatus('failure', 'Build failed',
                 "${branchName}", "${dashProject}", "${dashBranchName}") }})
             }
           }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -100,7 +100,11 @@ echo \$REMOTE_GIT_COMMIT > gitcommit
 {# Read the commit and github credentials                                    #}
 {# Update github with the build status                                       #}
   if ("{{status}}" == "pending" ) {
-    shell("echo \$REMOTE_GIT_COMMIT")
+    shell("""
+      REMOTE_GIT_COMMIT=\$(cat gitcommit)
+      echo \$REMOTE_GIT_COMMIT
+    """)
+
   } else {
     conditionalSteps {
       condition {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -100,7 +100,7 @@
 
 {# Read the commit and github credentials                                    #}
 {# Update github with the build status                                       #}
-  if (status == "pending" ) {
+  if ("{{status}}" == "pending" ) {
     shell("echo \$REMOTE_GIT_COMMIT")
   } else {
     conditionalSteps {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -680,6 +680,15 @@ branches.each {
                 "${branchName}", "${dashProject}", "${dashBranchName}") }})
             }
           }
+          flexiblePublish {
+            condition {
+              status('FAILURE', 'FAILURE')
+            }
+            step {
+              shell({{ updateGitHubStatusCommand('failure',
+                "${branchName}", "${dashProject}", "${dashBranchName}") }})
+            }
+          }
       }
   }
 }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -100,7 +100,7 @@
         command("""
 #!/bin/bash
 set +x
-. /tmp/github_status.sh
+. /etc/slave_config/github_status.sh
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
@@ -137,7 +137,7 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
           command("""
 #!/bin/bash
 set +x
-. /tmp/github_status.sh
+. /etc/slave_config/github_status.sh
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
@@ -173,7 +173,7 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with success status."
           command("""
 #!/bin/bash
 set +x
-. /tmp/github_status.sh
+. /etc/slave_config/github_status.sh
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -90,6 +90,24 @@
 {# JINJA2 MACROS DEFINED BELOW                                               #}
 {# --------------------------------------------------------------------------#}
 
+{% macro updateGitHubStatusCommand(status)                                  -%}
+"""
+#!/bin/bash
+set +x
+. /etc/slave_config/github_status.sh
+
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
+BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+PAYLOAD="{\\"state\\": \\"{{ status }}\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
+curl \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
+  -X POST \\
+  --data "\$PAYLOAD" \\
+  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
+echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
+"""
+{%- endmacro -%}
 
 {% macro updateGitHubStatus(status, branch, dashProject, dashBranchName)    -%}
 {# Read the commit and github credentials                                    #}
@@ -97,22 +115,7 @@
 {% if status == "pending"                                                    %}
     configure {
       it / 'builders' << 'hudson.tasks.Shell' {
-        command("""
-#!/bin/bash
-set +x
-. /etc/slave_config/github_status.sh
-
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-PAYLOAD="{\\"state\\": \\"pending\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
-curl \\
-  -H "Content-Type: application/json" \\
-  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
-  -X POST \\
-  --data "\$PAYLOAD" \\
-  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
-echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
-        """)
+        command({{ updateGitHubStatusCommand('pending')}})
       }
     }
 {% endif %}
@@ -134,22 +137,7 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with pending status."
           }
         }
         buildStep(class: "hudson.tasks.Shell") {
-          command("""
-#!/bin/bash
-set +x
-. /etc/slave_config/github_status.sh
-
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-PAYLOAD="{\\"state\\": \\"success\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
-curl \\
-  -H "Content-Type: application/json" \\
-  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
-  -X POST \\
-  --data "\$PAYLOAD" \\
-  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
-echo "Updating commit \$REMOTE_GIT_COMMIT with success status."
-          """)
+          command({{ updateGitHubStatusCommand('success')}})
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
         }
@@ -170,22 +158,7 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with success status."
           }
         }
         buildStep(class: "hudson.tasks.Shell") {
-          command("""
-#!/bin/bash
-set +x
-. /etc/slave_config/github_status.sh
-
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
-BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-PAYLOAD="{\\"state\\": \\"failure\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
-curl \\
-  -H "Content-Type: application/json" \\
-  -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
-  -X POST \\
-  --data "\$PAYLOAD" \\
-  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
-echo "Updating commit \$REMOTE_GIT_COMMIT with failure status."
-          """)
+          command({{ updateGitHubStatusCommand('failure')}})
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
         }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -107,9 +107,28 @@ echo 'Job started'
 {% endif %}
 {% if status == "complete" %}
     configure {
-    it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
-      condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
-      }
+      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
+        condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
+          worstResult {
+            name('SUCCESS')
+            ordinal('0')
+            color('BLUE')
+            completeBuild('true')
+          }
+          bestResult {
+            name('SUCCESS')
+            ordinal('0')
+            color('BLUE')
+            completeBuild('true')
+          }
+        }
+        buildStep(class: "hudson.tasks.Shell") {
+          command("""
+            echo &quot;yay&quot;
+          """)
+        }
+        runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
+        }
       }
     }
 {% endif %}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -107,7 +107,7 @@ curl \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
   --data "\$PAYLOAD" \\
-  https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
+  https://api.github.com/repos/{{ cfg.project }}/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
 """
 {%- endmacro -%}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -98,8 +98,8 @@
     echo \$REMOTE_GIT_COMMIT > gitcommit
   """)
 
-  # Read the commit and github credentials
-  # Update github with the build status
+{# Read the commit and github credentials                                    #}
+{# Update github with the build status                                       #}
   if (status == "pending" ) {
     shell("echo \$REMOTE_GIT_COMMIT")
   } else {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -596,6 +596,9 @@ branches.each {
           absolute(45)
           }
     }
+
+ {# the multijob runs on the jenkins-master only                             #}
+    label("master")
 {# Set the commit status on github to pending                                #}
       {{ updateGitHubStatus('pending', "${branchName}", "${dashProject}", "${dashBranchName}") }}
       steps {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -104,7 +104,7 @@ set +x
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-PAYLOAD="{\"state\": \"pending\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" 
+PAYLOAD="{\\"state\\": \\"pending\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }" 
 curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -94,8 +94,10 @@
 """
 #!/bin/bash
 set +x
+{# Read the GitHub credentials                                               #}
 . /etc/slave_config/github_status.sh
 
+{# Send a request to Github to update the commit with the build status       #}
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
 PAYLOAD="{\\"state\\": \\"{{ status }}\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
@@ -110,10 +112,7 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
 {%- endmacro -%}
 
 {% macro updateGitHubStatus(buildCompleted, branch, dashProject, dashBranchName) -%}
-{# Read the commit and github credentials                                    #}
-{# Update github with the build status                                       #}
-
-{% if buildCompleted %}
+{% if buildCompleted                                                         %}
     configure {
       it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
         condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
@@ -131,7 +130,7 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
           }
         }
         buildStep(class: "hudson.tasks.Shell") {
-          command({{ updateGitHubStatusCommand('success')}})
+          command({{ updateGitHubStatusCommand('success') }})
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
         }
@@ -152,19 +151,19 @@ echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
           }
         }
         buildStep(class: "hudson.tasks.Shell") {
-          command({{ updateGitHubStatusCommand('failure')}})
+          command({{ updateGitHubStatusCommand('failure') }})
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
         }
       }
     }
-{% else                                                    %}
+{% else                                                                      %}
     configure {
       it / 'builders' << 'hudson.tasks.Shell' {
-        command({{ updateGitHubStatusCommand('pending')}})
+        command({{ updateGitHubStatusCommand('pending') }})
       }
     }
-{% endif %}
+{% endif                                                                     %}
 {%- endmacro                                                                -%}
 
 {% macro folder(folder, display_name)                                       -%}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -110,13 +110,13 @@ echo 'Job started'
       it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
         condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
           worstResult {
-            name 'FAILURE'
+            name 'SUCCESS'
             ordinal '0'
             color 'BLUE'
             completeBuild 'true'
           }
           bestResult {
-            name 'FAILURE'
+            name 'SUCCESS'
             ordinal '0'
             color 'BLUE'
             completeBuild 'true'
@@ -124,7 +124,32 @@ echo 'Job started'
         }
         buildStep(class: "hudson.tasks.Shell") {
           command("""
-            echo 'yay'
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
+echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
+          """)
+        }
+        runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
+        }
+      }
+      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
+        condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
+          worstResult {
+            name 'FAILURE'
+            ordinal '2'
+            color 'RED'
+            completeBuild 'true'
+          }
+          bestResult {
+            name 'FAILURE'
+            ordinal '2'
+            color 'RED'
+            completeBuild 'true'
+          }
+        }
+        buildStep(class: "hudson.tasks.Shell") {
+          command("""
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
+echo 'Job succeeded. Updating commit \$REMOTE_GIT_COMMIT with success status.'
           """)
         }
         runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -90,7 +90,7 @@
 {# JINJA2 MACROS DEFINED BELOW                                               #}
 {# --------------------------------------------------------------------------#}
 
-{% macro updateGitHubStatusCommand(status)                                  -%}
+{% macro updateGitHubStatusCommand(status, branch, dashProject, dashBranchName) -%}
 """
 #!/bin/bash
 set +x
@@ -110,61 +110,6 @@ curl \\
 echo "Updating commit \$REMOTE_GIT_COMMIT with {{ status }} status."
 """
 {%- endmacro -%}
-
-{% macro updateGitHubStatus(buildCompleted, branch, dashProject, dashBranchName) -%}
-{% if buildCompleted                                                         %}
-    configure {
-      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
-        condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
-          worstResult {
-            name 'SUCCESS'
-            ordinal '0'
-            color 'BLUE'
-            completeBuild 'true'
-          }
-          bestResult {
-            name 'SUCCESS'
-            ordinal '0'
-            color 'BLUE'
-            completeBuild 'true'
-          }
-        }
-        buildStep(class: "hudson.tasks.Shell") {
-          command({{ updateGitHubStatusCommand('success') }})
-        }
-        runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
-        }
-      }
-      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
-        condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
-          worstResult {
-            name 'FAILURE'
-            ordinal '2'
-            color 'RED'
-            completeBuild 'true'
-          }
-          bestResult {
-            name 'FAILURE'
-            ordinal '2'
-            color 'RED'
-            completeBuild 'true'
-          }
-        }
-        buildStep(class: "hudson.tasks.Shell") {
-          command({{ updateGitHubStatusCommand('failure') }})
-        }
-        runner(class: "org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail", plugin: "run-condition@1.0") {
-        }
-      }
-    }
-{% else                                                                      %}
-    configure {
-      it / 'builders' << 'hudson.tasks.Shell' {
-        command({{ updateGitHubStatusCommand('pending') }})
-      }
-    }
-{% endif                                                                     %}
-{%- endmacro                                                                -%}
 
 {% macro folder(folder, display_name)                                       -%}
 {# creates a folder structure to group jobs, these are the Jenkins folder views
@@ -572,9 +517,9 @@ branches.each {
  {# the multijob runs on the jenkins-master only                             #}
     label("master")
 {# Set the commit status on github to pending                                #}
-{% set buildCompleted = false                                                %}
-      {{ updateGitHubStatus(buildCompleted, "${branchName}", "${dashProject}", "${dashBranchName}") }}
       steps {
+          shell({{ updateGitHubStatusCommand('pending',
+                "${branchName}", "${dashProject}", "${dashBranchName}") }})
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
 {# build 'parallel_tests' phase that will run all our jobs in parallel       #}
@@ -704,9 +649,6 @@ branches.each {
 {% endfor                                                                    %}
 {# do an aggregation of all the test results                                 #}
       }
-{# Update the commit status on github to the job result                      #}
-{% set buildCompleted = true                                                 %}
-      {{ updateGitHubStatus(buildCompleted, "${branchName}", "${dashProject}", "${dashBranchName}") }}
       publishers {
           archiveJunit('**/results.xml') {
               retainLongStdout(true)
@@ -728,6 +670,15 @@ branches.each {
             failUnhealthy(true)
             failUnstable(true)
             failNoReports(false)
+          }
+          flexiblePublish {
+            condition {
+              status('SUCCESS', 'SUCCESS')
+            }
+            step {
+              shell({{ updateGitHubStatusCommand('success',
+                "${branchName}", "${dashProject}", "${dashBranchName}") }})
+            }
           }
       }
   }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -94,7 +94,7 @@
 {% macro updateGitHubStatus(status)                                         -%}
   shell("""
     PARENTS=(\$(git log --pretty=%P -1))
-    REMOTE_GIT_COMMIT="\${PARENTS[\${\#PARENTS[@]} - 1]}"
+    REMOTE_GIT_COMMIT={{'\${PARENTS[\${#PARENTS[@]} - 1]}'}}
     echo \$REMOTE_GIT_COMMIT > gitcommit
   """)
 

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -107,7 +107,7 @@ echo 'Job started'
 {% endif %}
 {% if status == "complete" %}
     configure {
-      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.3.3"
+    it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
       }
     }
 {% endif %}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -93,9 +93,9 @@
 
 {% macro updateGitHubStatus(status)                                         -%}
   shell("""
-    PARENTS=(\$(git log --pretty=%P -1))
-    REMOTE_GIT_COMMIT={{'\${PARENTS[\${#PARENTS[@]} - 1]}'}}
-    echo \$REMOTE_GIT_COMMIT > gitcommit
+PARENTS=(\$(git log --pretty=%P -1))
+REMOTE_GIT_COMMIT={{'\${PARENTS[\${#PARENTS[@]} - 1]}'}}
+echo \$REMOTE_GIT_COMMIT > gitcommit
   """)
 
 {# Read the commit and github credentials                                    #}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -102,8 +102,8 @@ echo 'Job started'
     """)
 {% endif %}
 {% if status == "complete" %}
-    configure { project ->
-      project / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
+    configure { node ->
+      node / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
         spec ''
       }
     }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -110,13 +110,13 @@ echo 'Job started'
       it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'(plugin: 'conditional-buildstep@1.3.3') {
         condition(class: "org.jenkins_ci.plugins.run_condition.core.StatusCondition", plugin: "run-condition@1.0") {
           worstResult {
-            name 'SUCCESS'
+            name 'FAILURE'
             ordinal '0'
             color 'BLUE'
             completeBuild 'true'
           }
           bestResult {
-            name 'SUCCESS'
+            name 'FAILURE'
             ordinal '0'
             color 'BLUE'
             completeBuild 'true'

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -107,12 +107,7 @@ echo 'Job started'
 {% endif %}
 {% if status == "complete" %}
     configure {
-      it / 'builders' << 'hudson.tasks.Shell' {
-        command("""
-REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
-echo \$REMOTE_GIT_COMMIT
-echo 'Job started'
-        """)
+      it / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
       }
     }
 {% endif %}

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -95,16 +95,24 @@
 {# Read the commit and github credentials                                    #}
 {# Update github with the build status                                       #}
 {% if status == "pending"                                                    %}
-    shell("""
+    configure {
+      it / 'builders' << 'hudson.tasks.Shell' {
+        command("""
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
 echo \$REMOTE_GIT_COMMIT
 echo 'Job started'
-    """)
+        """)
+      }
+    }
 {% endif %}
 {% if status == "complete" %}
-    configure { node ->
-      node / 'builders' << 'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder' {
-        spec ''
+    configure {
+      it / 'builders' << 'hudson.tasks.Shell' {
+        command("""
+REMOTE_GIT_COMMIT=`git rev-list --max-count=1 origin/{{branch}}`
+echo \$REMOTE_GIT_COMMIT
+echo 'Job started'
+        """)
       }
     }
 {% endif %}
@@ -512,9 +520,9 @@ branches.each {
           absolute(45)
           }
     }
-      steps {
 {# Set the commit status on github to pending                                #}
-          {{ updateGitHubStatus('pending', "${branchName}") }}
+      {{ updateGitHubStatus('pending', "${branchName}") }}
+      steps {
 {# make sure we are starting with a clean workspace                          #}
           shell('rm -rf *')
 {# build 'parallel_tests' phase that will run all our jobs in parallel       #}
@@ -642,10 +650,10 @@ branches.each {
 {%    endfor                                                                 %}
 {%  endfor                                                                   %}
 {% endfor                                                                    %}
-{# Update the commit status on github to the job result                    #}
-        {{ updateGitHubStatus('complete', "${branchName}") }}
 {# do an aggregation of all the test results                                 #}
       }
+{# Update the commit status on github to the job result                    #}
+      {{ updateGitHubStatus('complete', "${branchName}") }}
       publishers {
           archiveJunit('**/results.xml') {
               retainLongStdout(true)

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -93,8 +93,7 @@
 
 {% macro updateGitHubStatus(status)                                         -%}
   shell("""
-PARENTS=(\$(git log --pretty=%P -1))
-REMOTE_GIT_COMMIT={{'\${PARENTS[\${#PARENTS[@]} - 1]}'}}
+REMOTE_GIT_COMMIT=`git rev-list --no-merges --max-count=1 HEAD`
 echo \$REMOTE_GIT_COMMIT > gitcommit
   """)
 

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -104,7 +104,7 @@ set +x
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
-PAYLOAD="{\\"state\\": \\"pending\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }" 
+PAYLOAD="{\\"state\\": \\"pending\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
 curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
@@ -141,11 +141,12 @@ set +x
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+PAYLOAD="{\\"state\\": \\"success\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
 curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
-  --data "{\"state\"': \"success\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" \\
+  --data "\$PAYLOAD" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with success status."
           """)
@@ -176,11 +177,12 @@ set +x
 
 REMOTE_GIT_COMMIT=`git rev-list --max-count=1 upstream/{{branch}}`
 BUILD_URL="\$JENKINS_URL/job/{{dashProject}}/job/{{dashBranchName}}/"
+PAYLOAD="{\\"state\\": \\"failure\\", \\"target_url\\": \\"\$BUILD_URL\\", \\"description\\": \\"Multijob build\\", \\"context\\": \\"Jenkins\\" }"
 curl \\
   -H "Content-Type: application/json" \\
   -H "Authorization: token \$GITHUB_STATUS_API_TOKEN" \\
   -X POST \\
-  --data "{\"state\"': \"failure\", \"target_url\": \"\$BUILD_URL\", \"description\": \"Multijob build\", \"context\": \"Jenkins\" }" \\
+  --data "\$PAYLOAD" \\
   https://api.github.com/repos/ClusterHQ/flocker/statuses/\$REMOTE_GIT_COMMIT
 echo "Updating commit \$REMOTE_GIT_COMMIT with failure status."
           """)


### PR DESCRIPTION
This change adds support for updating a commit status with the build result from Jenkins.

After being unable to provide this support using Jenkins plugins, I have chosen to update the commit status using build steps within the configuration for the __main_multijob project. When the __main_multijob project on Jenkins is triggered for a branch, the commit that is being tested will be updated with the status that the build has started. Two conditional post-build steps have been added to update the commit status with the build result of the __main_multijob. This means the status will not be updated until all the builds within this project have been completed.

To update the status on GitHub, we need to obtain the correct SHA for the commit. This is usually available as an environment variable within Jenkins, however, as we are performing a merge with master before the build, this environment variable is set to the SHA of the merge commit instead. To get the correct SHA, we get the latest commit for the branch using `git rev-list`. We then use the [GitHub Status API](https://developer.github.com/v3/repos/statuses/) to update the status for that commit.