### PR TITLE
[FLOC-3503] Test benchmark directory on Jenkins

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -760,6 +760,7 @@ common_cli:
 # through trial.
 run_trial_modules: &run_trial_modules
   - admin
+  - benchmark
   - flocker.acceptance
   - flocker.apiclient
   - flocker.ca.functional


### PR DESCRIPTION
This changes adds support for testing the `benchmark` module on Jenkins. This change results in two `run_trial_*` jobs which can now be seen on Jenkins: [CentOS 7](http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/test-benchmark-on-jenkins-FLOC-3503/job/run_trial_on_AWS_CentOS_7_benchmark/) and [Ubuntu Trusty](http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/test-benchmark-on-jenkins-FLOC-3503/job/run_trial_on_AWS_Ubuntu_Trusty_benchmark/).