### PR TITLE
fix for FLOC-3436

### DIFF
--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -663,7 +663,7 @@ branches.each {
 {# apply config related to 'cronly_jobs' jobs                                #}
 {%    if job_type == 'cronly_jobs'                                          -%}
 {%        set _job_name = job_name                                          -%}
-  job("${dashProject}/${branchName}/_{{ _job_name }}") {
+  job("${dashProject}/${dashBranchName}/_{{ _job_name }}") {
     parameters {
         textParam("TRIGGERED_BRANCH", "${branchName}", "Branch that triggered this job" )
     }


### PR DESCRIPTION
use release-flocker-1.n instead of release/flocker-1.n in the job name

fixes error:
```
00:00:02.732 Processing DSL script jobs.groovy
00:00:04.213 creating ClusterHQ-flocker...
00:00:04.216 iterating over branch... release/flocker-1.7.0
00:00:04.216 found branch... release/flocker-1.7.0
00:00:04.216 creating ClusterHQ-flocker/release-flocker-1.7.0...
00:00:07.192 ERROR: Could not create item, unknown parent path in "ClusterHQ-flocker/release/flocker-1.7.0/_run_docker_build_ubuntu_vivid_fpm"
00:00:07.195 Finished: FAILURE
```

jenkins jobs:
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/unable_to_build_release_branches_FLOC-3436/
