### PR TITLE
[FLOC-3552] make sure we collect the logs from the acceptance nodes

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -349,6 +349,18 @@ common_cli:
     - _trial_temp/test.log
     - coverage.xml
 
+  # acceptance-test-artifacts contains the list of files we want to collect
+  # from our _main_multijob.
+  # These are the remote logs from the acceptance tests.
+  acceptance_tests_artifacts: &acceptance_tests_artifacts
+    - run-acceptance-tests.log
+    - remote_logs.log
+
+  # Ubuntu acceptance tests do not collect the logs from the remote nodes
+  # https://clusterhq.atlassian.net/browse/FLOC-2560
+  acceptance_tests_artifacts_ubuntu_special_case: &acceptance_tests_artifacts_ubuntu_special_case
+    - run-acceptance-tests.log
+
   run_trial_with_coverage: &run_trial_with_coverage |
     # The jobs.groovy.j2 file produces jobs that contain a parameterized job
     # type. These type of jobs always require a parameter to be passed on in
@@ -839,6 +851,7 @@ job_type:
       with_steps:
         - { type: 'shell', cli: *run_trial_cli }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 30
@@ -850,6 +863,7 @@ job_type:
       with_steps:
         - { type: 'shell', cli: *run_trial_cli_as_root }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 30
@@ -862,6 +876,7 @@ job_type:
       with_steps:
         - { type: 'shell', cli: *run_trial_cli }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 30
@@ -873,6 +888,7 @@ job_type:
       with_steps:
         - { type: 'shell', cli: *run_trial_cli_as_root }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 30
@@ -911,6 +927,7 @@ job_type:
                    *convert_results_to_junit ]
           }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 45
@@ -930,6 +947,7 @@ job_type:
                    *convert_results_to_junit ]
           }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 45
@@ -948,6 +966,7 @@ job_type:
                    *convert_results_to_junit ]
           }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 45
@@ -988,6 +1007,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts
       timeout: 45
     run_acceptance_on_AWS_Ubuntu_Trusty_for:
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
@@ -1007,6 +1027,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
       timeout: 45
     run_acceptance_on_Rackspace_CentOS_7_for:
       # flocker.provision is responsible for creating the test nodes on
@@ -1028,6 +1049,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts
       timeout: 45
     run_acceptance_on_Rackspace_Ubuntu_Trusty_for:
       # flocker.provision is responsible for creating the test nodes on
@@ -1049,6 +1071,7 @@ job_type:
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
       timeout: 45
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -760,6 +760,7 @@ common_cli:
 # through trial.
 run_trial_modules: &run_trial_modules
   - admin
+  - benchmark
   - flocker.acceptance
   - flocker.apiclient
   - flocker.ca.functional

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -229,6 +229,9 @@ folder("{{folder}}") { displayName("{{display_name}}") }
    'results.xml', 'coverage.xml', '_trial_temp/trial.log'                    #}
       archiveArtifacts("{{artifact}}")
 {%        endfor                                                             %}
+{%      endif                                                               -%}
+
+{% if v.publish_test_results                                                -%}
 {# archives the junit results and publish the test results                   #}
       archiveJunit('results.xml') {
         retainLongStdout(true)


### PR DESCRIPTION
Jenkins wasn't retrieving the remote acceptance node logs from the jenkins slaves when the acceptance tests were executed.
This PR sets jenkins to grab those artifacts so that they are available after the Slave is deleted.

build here:
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/ADD_REMOTE_LOGS_FLOC-3552/
