### PR TITLE
[FLOC-3556] split jobs into tabs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -738,7 +738,6 @@ common_cli:
     # flake8 is used by lint tests on Flocker source code
     \${PARSE_LOGS} pip install flake8 \${PIP_ADDITIONAL_OPTIONS}
 
-
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point
 #-----------------------------------------------------------------------------#
@@ -1204,3 +1203,69 @@ job_type:
                    *package_jenkins_osx_yosemite_box ]
           }
       timeout: 120
+
+#-----------------------------------------------------------------------------#
+# View definitions below this point
+#-----------------------------------------------------------------------------#
+
+# Use the section below to define multiple 'views/tabs' that appear at the top
+# of the jenkins build page for every branch.
+# These views allow for filtering of particular jobs according to its type,
+# cloud, operating system, ...
+#
+#
+# The views are built from :
+# * the dictionary 'key', which is the view name.
+# * description, containing a description of the jobs in this view
+# * regex, containing a regular expression that is applied to build the view.
+#
+# the site below can help with regular expressions:
+# http://pythex.org/
+
+views:
+  trial:
+    description: 'All jobs that are executed directly using trial'
+    regex: 'run_(?i)trial_.*.*'
+  acceptance:
+    description: 'All Acceptance jobs'
+    regex: 'run_(?i)acceptance_.*.*'
+  client:
+    description: 'All client installation jobs'
+    regex: 'run_(?i)client_.*.*'
+  code_quality:
+    description: 'All code quality jobs'
+    regex: 'run_(?i)lint.*.*'
+  docs:
+    description: 'Documentation jobs'
+    regex: 'run_(?i)sphinx.*.*'
+  cinder:
+    description: 'cinder jobs'
+    regex: '.*_(?i)cinder_.*.*'
+  ebs:
+    description: 'ebs jobs'
+    regex: '.*_(?i)ebs_.*.*'
+  storage_drivers:
+    description: 'All Storage Driver Jobs'
+    regex: '.*_(?i)storage_(?i)driver_.*.*'
+  on_AWS:
+    description: 'All AWS Jobs'
+    regex: '(.*_(?i)ebs_.*.*|.*_(?i)aws_.*.*)'
+  on_Rackspace:
+    description: 'All Rackspace Jobs'
+    regex: '(.*_(?i)cinder_.*.*|.*_(?i)rackspace_.*.*)'
+  CentOS_7:
+    description: 'All CentOS jobs'
+    regex: '.*_(?i)centos_.*.*'
+  Ubuntu_Trusty_14_04_LTS:
+    description: 'All Ubuntu Trusty LTS (14.04) jobs'
+    regex: '.*_(?i)trusty_.*.*'
+  Ubuntu_Vivid_15_04:
+    description: 'All Ubuntu Vivid (15.04) jobs'
+    regex: '.*_(?i)vivid_.*.*'
+  Ubuntu_Wily_15_10:
+    description: 'All Ubuntu Wily (15.10) jobs'
+    regex: '.*_(?i)wily_.*.*'
+  cron:
+    description: 'All Nightly Cron jobs'
+    regex: '^_[^_](?i)[a-z]*.*'
+

--- a/build.yaml
+++ b/build.yaml
@@ -760,6 +760,7 @@ common_cli:
 # through trial.
 run_trial_modules: &run_trial_modules
   - admin
+  - benchmark
   - flocker.acceptance
   - flocker.apiclient
   - flocker.ca.functional

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -101,6 +101,31 @@ println("creating {{folder}}...")
 folder("{{folder}}") { displayName("{{display_name}}") }
 {%- endmacro                                                                -%}
 
+{% macro view(name, regex, description)                                     -%}
+{# creates a tab view structure to group jobs inside a branch folder         %}
+
+   param name:  '/clusterhq-flocker/branchname/myView1'
+   param regex: '.*ubuntu.*r'                                                #}
+
+println("creating tab {{name}}...")
+listView("${dashProject}/${dashBranchName}/{{name}}") {
+  description("{{description}}")
+  filterBuildQueue()
+  filterExecutors()
+  jobs {
+    regex("{{regex}}")
+  }
+  columns {
+    status()
+    weather()
+    name()
+    lastSuccess()
+    lastFailure()
+    lastDuration()
+    buildButton()
+  }
+}
+{%- endmacro                                                                -%}
 
 {% macro wrappers(v, directory_to_delete)                                   -%}
 {# adds a list of common wrappers to the build jobs.
@@ -324,6 +349,10 @@ branches.each {
 {# create a folder for every branch: /git-username/git-repo/branch           #}
   {{ folder("${dashProject}/${dashBranchName}","${branchName}") }}
 
+{# create tabs inside the branch folder                                      #}
+{% for name, v  in cfg.views.iteritems()                                    -%}
+  {{ view(name, v.regex, v.description) }}
+{% endfor                                                                    %}
 
 {# ------------------------------------------------------------------------- #}
 {# JOB DEFINITIONS BELOW - THESE WILL BE ADDED TO A MULTIJOB PHASE           #}


### PR DESCRIPTION
This adds multiple tabs at the top of the job list to help with the large number of jobs in the branch.

It filters jobs based on:
Cloud Provider
Client
Acceptance
Trial
OperatingSystem
other bits and pieces


view with the added tabs:
http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/split-jobs-into-different-tabs-FLOC-3556/