### PR TITLE
[FLOC-3514] YAML configuration of benchmark scenarios, operations, and metrics

### DIFF
--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -134,9 +134,12 @@ def driver(
     """
     :param reactor: Reactor to use.
     :param config: Configuration read from options.
-    :param IScenario scenario: A load scenario configuration.
-    :param IOperation operation: An operation configuration.
-    :param IMetric metric: A metric configuration.
+    :param dict scenario_config: A load scenario configuration.  This
+        dictionary may be modified by this function.
+    :param dict operation_config: An operation configuration.  This
+        dictionary may be modified by this function.
+    :param dict metric_config: A metric configuration.  This dictionary
+        may be modified by this function.
     :param result: A dictionary which will be updated with values to
         create a JSON result.
     :param output: A callable to receive the JSON structure, for

--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -1,24 +1,24 @@
 scenarios:
-  default:
+  - name: default
     type: no-load
 
 operations:
-  default:
+  - name: default
     type: read-request
 
-  no-op:
+  - name: no-op
     type: no-op
 
-  wait-10:
+  - name: wait-10
     type: wait
     wait_seconds: 10
 
 metrics:
-  default:
+  - name: default
     type: wallclock
 
-  cputime:
+  - name: cputime
     type: cputime
 
-  wallclock:
+  - name: wallclock
     type: wallclock

--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -1,0 +1,24 @@
+scenarios:
+  default:
+    type: no-load
+
+operations:
+  default:
+    type: read-request
+
+  no-op:
+    type: no-op
+
+  wait-10:
+    type: wait
+    wait_seconds: 10
+
+metrics:
+  default:
+    type: wallclock
+
+  cputime:
+    type: cputime
+
+  wallclock:
+    type: wallclock

--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -13,6 +13,10 @@ operations:
     type: wait
     wait_seconds: 10
 
+  - name: wait-100
+    type: wait
+    wait_seconds: 100
+
 metrics:
   - name: default
     type: wallclock

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -21,7 +21,7 @@ from benchmark.metrics.cputime import (
 # A process name that is expected to always be present on a distribution
 _always_present = {
     'centos': 'systemd',
-    'ubuntu': 'init',
+    'Ubuntu': 'init',
 }
 _distribution = platform.linux_distribution(full_distribution_name=False)[0]
 _standard_process = _always_present.get(_distribution)

--- a/benchmark/metrics/test/test_wallclock.py
+++ b/benchmark/metrics/test/test_wallclock.py
@@ -1,6 +1,6 @@
 # Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
 """
-Measurement tests for the control service benchmarks.
+Wallclock metric tests for the control service benchmarks.
 """
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -18,6 +18,6 @@ class WallClockTests(SynchronousTestCase):
         function.
         """
         clock = Clock()
-        wallclock = WallClock(clock=clock)
+        wallclock = WallClock(clock, None)
         d = wallclock.measure(maybeDeferred, clock.advance, 1.23)
         self.assertEqual(self.successResultOf(d), 1.23)

--- a/benchmark/metrics/wallclock.py
+++ b/benchmark/metrics/wallclock.py
@@ -3,19 +3,20 @@
 Wallclock time metric for the control service benchmarks.
 """
 
-from pyrsistent import PClass, field
 from zope.interface import implementer
 
 from .._interfaces import IMetric
 
 
 @implementer(IMetric)
-class WallClock(PClass):
+class WallClock(object):
     """
     Measure the elapsed wallclock time during an operation.
     """
-    clock = field(mandatory=True)
-    control_service = field()
+
+    def __init__(self, clock, control_service):
+        self.clock = clock
+        self.control_service = control_service
 
     def measure(self, f, *a, **kw):
         def finished(ignored):

--- a/benchmark/operations/no_op.py
+++ b/benchmark/operations/no_op.py
@@ -21,10 +21,9 @@ class NoOpProbe(object):
 @implementer(IOperation)
 class NoOperation(object):
     """
-    An nop operation.
+    A no-op operation.
     """
 
-    # attributes unused, but required for __init__ signature
     def __init__(self, clock, control_service):
         self.clock = clock
         self.control_service = control_service

--- a/benchmark/operations/no_op.py
+++ b/benchmark/operations/no_op.py
@@ -1,4 +1,3 @@
-from pyrsistent import PClass, field
 from zope.interface import implementer
 
 from twisted.internet.defer import succeed
@@ -7,7 +6,7 @@ from .._interfaces import IProbe, IOperation
 
 
 @implementer(IProbe)
-class NoOpProbe(PClass):
+class NoOpProbe(object):
     """
     A probe that performs no operation.
     """
@@ -20,14 +19,15 @@ class NoOpProbe(PClass):
 
 
 @implementer(IOperation)
-class NoOperation(PClass):
+class NoOperation(object):
     """
     An nop operation.
     """
 
     # attributes unused, but required for __init__ signature
-    clock = field(mandatory=True)
-    control_service = field(mandatory=True)
+    def __init__(self, clock, control_service):
+        self.clock = clock
+        self.control_service = control_service
 
     def get_probe(self):
         return NoOpProbe()

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -28,7 +28,6 @@ class ReadRequest(object):
     An operation to perform a read request on the control service.
     """
 
-    # `clock` unused, but required for __init__ signature
     def __init__(self, clock, control_service):
         self.clock = clock
         self.control_service = control_service

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -1,4 +1,3 @@
-from pyrsistent import PClass, field
 from zope.interface import implementer
 
 from twisted.internet.defer import succeed
@@ -7,12 +6,13 @@ from .._interfaces import IProbe, IOperation
 
 
 @implementer(IProbe)
-class ReadRequestProbe(PClass):
+class ReadRequestProbe(object):
     """
     A probe to perform a read request on the control service.
     """
 
-    control_service = field(mandatory=True)
+    def __init__(self, control_service):
+        self.control_service = control_service
 
     def run(self):
         d = self.control_service.list_datasets_state()
@@ -23,14 +23,15 @@ class ReadRequestProbe(PClass):
 
 
 @implementer(IOperation)
-class ReadRequest(PClass):
+class ReadRequest(object):
     """
     An operation to perform a read request on the control service.
     """
 
     # `clock` unused, but required for __init__ signature
-    clock = field(mandatory=True)
-    control_service = field(mandatory=True)
+    def __init__(self, clock, control_service):
+        self.clock = clock
+        self.control_service = control_service
 
     def get_probe(self):
         return ReadRequestProbe(control_service=self.control_service)

--- a/benchmark/operations/test/test_wait.py
+++ b/benchmark/operations/test/test_wait.py
@@ -17,7 +17,7 @@ class WaitOperationTests(SynchronousTestCase):
         """
         seconds = 10
         clock = Clock()
-        op = Wait(clock=clock, control_service=None, wait_seconds=seconds)
+        op = Wait(clock, None, wait_seconds=seconds)
         probe = op.get_probe()
         d = probe.run()
         d.addCallback(lambda ignored: probe.cleanup)

--- a/benchmark/operations/wait.py
+++ b/benchmark/operations/wait.py
@@ -3,7 +3,6 @@
 Wait operation for the control service benchmarks.
 """
 
-from pyrsistent import PClass, field
 from zope.interface import implementer
 
 from twisted.internet.defer import Deferred, succeed
@@ -12,13 +11,14 @@ from benchmark._interfaces import IProbe, IOperation
 
 
 @implementer(IProbe)
-class WaitProbe(PClass):
+class WaitProbe(object):
     """
     A probe to wait for a specified time period.
     """
 
-    clock = field(mandatory=True)
-    wait_seconds = field(mandatory=True)
+    def __init__(self, clock, wait_seconds):
+        self.clock = clock
+        self.wait_seconds = wait_seconds
 
     def run(self):
         d = Deferred()
@@ -30,15 +30,15 @@ class WaitProbe(PClass):
 
 
 @implementer(IOperation)
-class Wait(PClass):
+class Wait(object):
     """
     An operation to wait 10 seconds.
     """
 
-    clock = field(mandatory=True)
-    # `control_service` attribute unused, but required for __init__ signature
-    control_service = field(mandatory=True)
-    wait_seconds = field(initial=10)
+    def __init__(self, clock, control_service, wait_seconds=10):
+        self.clock = clock
+        self.control_service = control_service
+        self.wait_seconds = wait_seconds
 
     def get_probe(self):
         return WaitProbe(clock=self.clock, wait_seconds=self.wait_seconds)

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -70,7 +70,7 @@ metric_name = options['metric']
 scenario_config = scenarios.get(scenario_name) or usage(
     'No such scenario: {!r}'.format(scenario_name))
 operation_config = operations.get(operation_name) or usage(
-    'No such operations: {!r}'.format(operation_name))
+    'No such operation: {!r}'.format(operation_name))
 metric_config = metrics.get(metric_name) or usage(
     'No such metric: {!r}'.format(metric_name))
 

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -20,9 +20,49 @@ from twisted.python.usage import Options, UsageError
 
 from flocker import __version__ as flocker_client_version
 
+from benchmark import metrics, operations, scenarios
 from benchmark._driver import driver
 
+
 to_file(sys.stderr)
+
+# If modifying scenarios, operations, or metrics, please update
+# docs/gettinginvolved/benchmarking.rst
+
+_SCENARIOS = {
+    'no-load': scenarios.NoLoadScenario,
+}
+
+_OPERATIONS = {
+    'no-op': operations.NoOperation,
+    'read-request': operations.ReadRequest,
+    'wait': operations.Wait,
+}
+
+_METRICS = {
+    'cputime': metrics.CPUTime,
+    'wallclock': metrics.WallClock,
+}
+
+
+def create_factory_from_config(table, config):
+    """
+    Create a benchmark parameter factory from a configuration stanza.
+
+    :param table: One of the scenario, operation, or metric tables
+        mapping types to classes.
+    :param config: The configuration stanza for the selected parameter.
+    :return: A callable that just takes a Twisted reactor and cluster
+        control service as  parameters to create the parameter instance.
+    """
+    args = config.copy()
+    del args['name']
+    key = args.pop('type')
+    try:
+        factory = table[key]
+    except KeyError:
+        return None
+    return partial(factory, **args)
 
 
 class BenchmarkOptions(Options):
@@ -118,7 +158,7 @@ def validate_configuration(configuration):
     v.validate(configuration)
 
 
-def get_config(section, name):
+def get_config_by_name(section, name):
     """
     Extract a named section from the configuration file
     """
@@ -142,21 +182,41 @@ def main():
 
     with open(options['config'], 'rt') as f:
         config = yaml.safe_load(f)
-        validate_configuration(config)
-        scenarios = config['scenarios']
-        operations = config['operations']
-        metrics = config['metrics']
+
+    validate_configuration(config)
 
     scenario_name = options['scenario']
-    operation_name = options['operation']
-    metric_name = options['metric']
+    scenario_config = get_config_by_name(config['scenarios'], scenario_name)
+    if scenario_config is None:
+        usage(options, 'Invalid scenario name: {!r}'.format(scenario_name))
+    scenario_factory = create_factory_from_config(_SCENARIOS, scenario_config)
+    if scenario_factory is None:
+        usage(
+            options,
+            'Invalid scenario type: {!r}'.format(scenario_config['type'])
+        )
 
-    scenario_config = get_config(scenarios, scenario_name) or usage(
-        options, 'No such scenario: {!r}'.format(scenario_name))
-    operation_config = get_config(operations, operation_name) or usage(
-        options, 'No such operation: {!r}'.format(operation_name))
-    metric_config = get_config(metrics, metric_name) or usage(
-        options, 'No such metric: {!r}'.format(metric_name))
+    operation_name = options['operation']
+    operation_config = get_config_by_name(config['operations'], operation_name)
+    if operation_config is None:
+        usage(options, 'Invalid operation name: {!r}'.format(operation_name))
+    operation_factory = create_factory_from_config(
+        _OPERATIONS, operation_config)
+    if operation_factory is None:
+        usage(
+            options,
+            'Invalid operation type: {!r}'.format(operation_config['type'])
+        )
+
+    metric_name = options['metric']
+    metric_config = get_config_by_name(config['metrics'], metric_name)
+    if metric_config is None:
+        usage(options, 'Invalid metric name: {!r}'.format(metric_name))
+    metric_factory = create_factory_from_config(_METRICS, metric_config)
+    if metric_factory is None:
+        usage(
+            options, 'Invalid metric type: {!r}'.format(metric_config['type'])
+        )
 
     timestamp = datetime.now().isoformat()
 
@@ -176,9 +236,8 @@ def main():
 
     react(
         driver, (
-            options, scenario_config.copy(), operation_config.copy(),
-            metric_config.copy(), result,
-            partial(json.dump, fp=sys.stdout, indent=2)
+            options, scenario_factory, operation_factory, metric_factory,
+            result, partial(json.dump, fp=sys.stdout, indent=2)
         )
     )
 

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -61,45 +61,54 @@ def validate_configuration(configuration):
         "required": ["scenarios", "operations", "metrics"],
         "properties": {
             "scenarios": {
-                "type": "object",
-                "patternProperties": {
-                    ".*": {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string"
-                            },
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "required": ["name", "type"],
+                    "properties": {
+                        "name": {
+                            "type": "string"
                         },
-                        "additionalProperties": "true",
+                        "type": {
+                            "type": "string"
+                        },
                     },
+                    "additionalProperties": "true",
                 },
             },
             "operations": {
-                "type": "object",
-                "patternProperties": {
-                    ".*": {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string"
-                            },
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "required": ["name", "type"],
+                    "properties": {
+                        "name": {
+                            "type": "string"
                         },
-                        "additionalProperties": "true",
+                        "type": {
+                            "type": "string"
+                        },
                     },
+                    "additionalProperties": "true",
                 },
             },
             "metrics": {
-                "type": "object",
-                "patternProperties": {
-                    ".*": {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string"
-                            },
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "required": ["name", "type"],
+                    "properties": {
+                        "name": {
+                            "type": "string"
                         },
-                        "additionalProperties": "true",
+                        "type": {
+                            "type": "string"
+                        },
                     },
+                    "additionalProperties": "true",
                 },
             }
         }

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -9,6 +9,8 @@ import json
 import os
 from platform import node, platform
 import sys
+
+from jsonschema import FormatChecker, Draft4Validator
 import yaml
 
 from eliot import to_file
@@ -46,6 +48,67 @@ def usage(options, message=None):
     sys.exit(message)
 
 
+def validate_configuration(configuration):
+    """
+    Validate a provided configuration.
+
+    :param dict configuration: A desired configuration.
+    :raises: jsonschema.ValidationError if the configuration is invalid.
+    """
+    schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "required": ["scenarios", "operations", "metrics"],
+        "properties": {
+            "scenarios": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string"
+                            },
+                        },
+                        "additionalProperties": "true",
+                    },
+                },
+            },
+            "operations": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string"
+                            },
+                        },
+                        "additionalProperties": "true",
+                    },
+                },
+            },
+            "metrics": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string"
+                            },
+                        },
+                        "additionalProperties": "true",
+                    },
+                },
+            }
+        }
+    }
+
+    v = Draft4Validator(schema, format_checker=FormatChecker())
+    v.validate(configuration)
+
+
 def main():
     options = BenchmarkOptions()
 
@@ -60,6 +123,7 @@ def main():
 
     with open(options['config'], 'rt') as f:
         config = yaml.safe_load(f)
+        validate_configuration(config)
         scenarios = config['scenarios']
         operations = config['operations']
         metrics = config['metrics']

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -118,6 +118,16 @@ def validate_configuration(configuration):
     v.validate(configuration)
 
 
+def get_config(section, name):
+    """
+    Extract a named section from the configuration file
+    """
+    for config in section:
+        if config['name'] == name:
+            return config
+    return None
+
+
 def main():
     options = BenchmarkOptions()
 
@@ -140,12 +150,6 @@ def main():
     scenario_name = options['scenario']
     operation_name = options['operation']
     metric_name = options['metric']
-
-    def get_config(section, name):
-        for config in section:
-            if config['name'] == name:
-                return config
-        return None
 
     scenario_config = get_config(scenarios, scenario_name) or usage(
         options, 'No such scenario: {!r}'.format(scenario_name))

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -141,11 +141,17 @@ def main():
     operation_name = options['operation']
     metric_name = options['metric']
 
-    scenario_config = scenarios.get(scenario_name) or usage(
+    def get_config(section, name):
+        for config in section:
+            if config['name'] == name:
+                return config
+        return None
+
+    scenario_config = get_config(scenarios, scenario_name) or usage(
         options, 'No such scenario: {!r}'.format(scenario_name))
-    operation_config = operations.get(operation_name) or usage(
+    operation_config = get_config(operations, operation_name) or usage(
         options, 'No such operation: {!r}'.format(operation_name))
-    metric_config = metrics.get(metric_name) or usage(
+    metric_config = get_config(metrics, metric_name) or usage(
         options, 'No such metric: {!r}'.format(metric_name))
 
     timestamp = datetime.now().isoformat()

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -85,14 +85,15 @@ result = dict(
         nodename=node(),
         platform=platform(),
     ),
-    scenario=scenario_config.copy(),
-    operation=operation_config.copy(),
-    metric=metric_config.copy(),
+    scenario=scenario_config,
+    operation=operation_config,
+    metric=metric_config,
 )
 
 react(
     driver, (
-        options, scenario_config, operation_config, metric_config, result,
+        options, scenario_config.copy(), operation_config.copy(),
+        metric_config.copy(), result,
         partial(json.dump, fp=sys.stdout, indent=2)
     )
 )

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -1,0 +1,147 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+
+from jsonschema.exceptions import ValidationError
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from benchmark.script import validate_configuration
+
+
+class ValidationTests(SynchronousTestCase):
+    """
+    Tests for configuration file validation.
+    """
+
+    def setUp(self):
+        self.config = {
+            'scenarios': [
+                {
+                    'name': 'default',
+                    'type': 'no-load',
+                }
+            ],
+            'operations': [
+                {
+                    'name': 'default',
+                    'type': 'no-op',
+                }
+            ],
+            'metrics': [
+                {
+                    'name': 'default',
+                    'type': 'wallclock',
+                }
+            ]
+        }
+
+    def test_valid(self):
+        """
+        Accepts configuration file with valid entries.
+        """
+        validate_configuration(self.config)
+
+    def test_config_extra_attribute(self):
+        """
+        Accepts configuration file with extra attributes.
+        """
+        self.config['extras'] = 3
+        validate_configuration(self.config)
+
+    def test_scenario_extra_attribute(self):
+        """
+        Accepts configuration file with extra attributes on scenario.
+        """
+        self.config['scenarios'][0]['extras'] = 3
+        validate_configuration(self.config)
+
+    def test_operation_extra_attribute(self):
+        """
+        Accepts configuration file with extra attributes on operations.
+        """
+        self.config['operations'][0]['extras'] = 3
+        validate_configuration(self.config)
+
+    def test_metric_extra_attribute(self):
+        """
+        Accepts configuration file with extra attributes on metrics.
+        """
+        self.config['metrics'][0]['extras'] = 3
+        validate_configuration(self.config)
+
+    def test_multiple_scenarios(self):
+        """
+        Accepts configuration file with multiple scenarios.
+        """
+        self.config['scenarios'].append({
+            'name': 'another',
+            'type': 'another'
+        })
+        validate_configuration(self.config)
+
+    def test_multiple_operations(self):
+        """
+        Accepts configuration file with multiple operations.
+        """
+        self.config['operations'].append({
+            'name': 'another',
+            'type': 'another'
+        })
+        validate_configuration(self.config)
+
+    def test_multiple_metrics(self):
+        """
+        Accepts configuration file with multiple metrics.
+        """
+        self.config['metrics'].append({
+            'name': 'another',
+            'type': 'another'
+        })
+        validate_configuration(self.config)
+
+    def test_missing_scenarios(self):
+        """
+        Rejects configuration file with missing scenarios attribute.
+        """
+        del self.config['scenarios']
+        with self.assertRaises(ValidationError):
+            validate_configuration(self.config)
+
+    def test_missing_operations(self):
+        """
+        Rejects configuration file with missing operations attribute.
+        """
+        del self.config['operations']
+        with self.assertRaises(ValidationError):
+            validate_configuration(self.config)
+
+    def test_missing_metrics(self):
+        """
+        Rejects configuration file with missing metrics attribute.
+        """
+        del self.config['metrics']
+        with self.assertRaises(ValidationError):
+            validate_configuration(self.config)
+
+    def test_empty_scenarios(self):
+        """
+        Rejects configuration file with empty scenarios attribute.
+        """
+        self.config['scenarios'] = {}
+        with self.assertRaises(ValidationError):
+            validate_configuration(self.config)
+
+    def test_empty_operations(self):
+        """
+        Rejects configuration file with empty operations attribute.
+        """
+        self.config['operations'] = {}
+        with self.assertRaises(ValidationError):
+            validate_configuration(self.config)
+
+    def test_empty_metrics(self):
+        """
+        Rejects configuration file with empty metrics attribute.
+        """
+        self.config['metrics'] = {}
+        with self.assertRaises(ValidationError):
+            validate_configuration(self.config)

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -4,7 +4,7 @@ from jsonschema.exceptions import ValidationError
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from benchmark.script import validate_configuration
+from benchmark.script import validate_configuration, get_config
 
 
 class ValidationTests(SynchronousTestCase):
@@ -145,3 +145,52 @@ class ValidationTests(SynchronousTestCase):
         self.config['metrics'] = {}
         with self.assertRaises(ValidationError):
             validate_configuration(self.config)
+
+
+class SubConfigurationTests(SynchronousTestCase):
+    """
+    Tests for getting sections from the configuration file.
+    """
+
+    def setUp(self):
+        self.config = {
+            'scenarios': [
+                {
+                    'name': 'default',
+                    'type': 'no-load',
+                }
+            ],
+            'operations': [
+                {
+                    'name': 'default',
+                    'type': 'no-op',
+                }
+            ],
+            'metrics': [
+                {
+                    'name': 'default',
+                    'type': 'wallclock',
+                }
+            ]
+        }
+
+    def test_default_scenario(self):
+        """
+        Extracts default scenario.
+        """
+        config = get_config(self.config['scenarios'], 'default')
+        self.assertEqual(config['name'], 'default')
+
+    def test_default_operation(self):
+        """
+        Extracts default operation.
+        """
+        config = get_config(self.config['operations'], 'default')
+        self.assertEqual(config['name'], 'default')
+
+    def test_default_metric(self):
+        """
+        Extracts default metric.
+        """
+        config = get_config(self.config['metrics'], 'default')
+        self.assertEqual(config['name'], 'default')

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -4,7 +4,7 @@ from jsonschema.exceptions import ValidationError
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from benchmark.script import validate_configuration, get_config
+from benchmark.script import validate_configuration, get_config_by_name
 
 
 class ValidationTests(SynchronousTestCase):
@@ -178,19 +178,19 @@ class SubConfigurationTests(SynchronousTestCase):
         """
         Extracts default scenario.
         """
-        config = get_config(self.config['scenarios'], 'default')
+        config = get_config_by_name(self.config['scenarios'], 'default')
         self.assertEqual(config['name'], 'default')
 
     def test_default_operation(self):
         """
         Extracts default operation.
         """
-        config = get_config(self.config['operations'], 'default')
+        config = get_config_by_name(self.config['operations'], 'default')
         self.assertEqual(config['name'], 'default')
 
     def test_default_metric(self):
         """
         Extracts default metric.
         """
-        config = get_config(self.config['metrics'], 'default')
+        config = get_config_by_name(self.config['metrics'], 'default')
         self.assertEqual(config['name'], 'default')

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -16,8 +16,7 @@ It is called like this:
 
    benchmark/benchmark <options>
 
-
-The :program:`benchmark` script has several options:
+The :program:`benchmark` script has the following command line options:
 
 .. program:: benchmark
 
@@ -31,45 +30,95 @@ The :program:`benchmark` script has several options:
    Specifies the directory containing the user certificates.
    Defaults to the directory ``./certs``.
 
+.. option:: --config <config-file>
+
+   Specifies a file containing configurations for scenarios, operations, and metrics.
+   See below for the format of this file.
+   Defaults to the file ``./benchmark.yml``.
+
 .. option:: --scenario <scenario>
 
    Specifies the scenario to run the benchmark under.
-   Supported values include:
-
-      ``no-load``
-         No additional load on system.
-         This is the default.
+   This is the ``name`` of a scenario in the configuration file.
+   Defaults to the name ``default``.
 
 .. option:: --operation <operation>
 
    Specifies the operation to be benchmarked.
-   This operation is sampled 3 times.
-   Supported values include:
-
-      ``no-op``
-         A no-op operation that performs no action.
-
-      ``read-request``
-         Read from the control service.
-         This is the default.
-
-      ``wait-10``
-         Wait 10 seconds between measurements.
+   This is the ``name`` of an operation in the configuration file.
+   Defaults to the name ``default``.
+   The operation is sampled 3 times.
 
 .. option:: --metric <metric>
 
    Specifies the quantity to measure while the operation is performed.
-   Supported values include:
+   This is the ``name`` of a metric in the configuration file.
+   Defaults to the name ``default``.
 
-      ``cputime``
-         CPU time elapsed.
 
-      ``wallclock``
-         Actual clock time elapsed.
-         This is the default.
+Configuration File
+------------------
 
-To see the supported values for each option, run:
+The :program:`benchmark` script requires a configuration file describing the possible scenarios, operations, and metrics.
+Each of these has a name, a type, and possibly other parameters.
 
-.. prompt:: bash $
+An example file:
 
-   benchmark/benchmark --help
+.. code-block:: yaml
+
+   scenarios:
+     - name: default
+       type: no-load
+
+   operations:
+     - name: default
+       type: read-request
+
+     - name: wait-10
+       type: wait
+       wait_seconds: 10
+
+     - name: wait-100
+       type: wait
+       wait_seconds: 100
+
+   metrics:
+     - name: default
+       type: wallclock
+
+     - name: cputime
+       type: cputime
+
+Scenario Types
+~~~~~~~~~~~~~~
+
+.. option:: no-load
+
+   No additional load on system.
+
+Operation Types
+~~~~~~~~~~~~~~~
+
+.. option:: no-op
+
+   A no-op operation that performs no action.
+
+.. option:: read-request
+
+   Read the current cluster state from the control service.
+
+.. option:: wait
+
+   Wait for a number of seconds between measurements.
+   The number of seconds to wait must be provided as an additional ``wait_seconds`` property.
+
+Metric Types
+~~~~~~~~~~~~
+
+.. option:: cputime
+
+   CPU time elapsed.
+
+.. option:: wallclock
+
+   Actual clock time elapsed.


### PR DESCRIPTION
It is useful to perform the same benchmark for a series of parameters (e.g. measured with 10, 20, 30 request/sec). Command line options for benchmarking make it difficult to parametrize the various options. 

This PR allows the scenarios, operations, and metrics provided to the benchmarking script to be read from a YAML file, allowing each one to contain additional fields for parameterization.

An example YAML file is added, in which the `wait` operation has been parameterized to wait 10 seconds.

This can be tested by running:
```
./benchmark --control ${FLOCKER_ACCEPTANCE_CONTROL_NODE} --certs ${FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH} --operation wait-10 --metric cputime
```

The options to the command now name a scenario, operation, or metric in the YAML file, which maps to a type, which selects the class to use, and a set of keyword parameters to that class.  Classes are also provided with reactor and control service parameters.

The creation of the classes is moved from `script.py` to `_driver.py` to allow creation of the class with the reactor parameter.

The above command returns output as before, but with the operation field containing the parameters:
```
{
  "scenario": {
    "type": "no-load"
  }, 
  "timestamp": "2015-11-30T12:17:11.961664", 
  "metric": {
    "type": "cputime"
  }, 
  "client": {
    "username": "jon", 
    "platform": "Linux-3.13.0-68-generic-x86_64-with-Ubuntu-14.04-trusty", 
    "working_directory": "/home/jon/projects/clusterhq/flocker-alt/benchmark", 
    "nodename": "ecuador", 
    "flocker_version": "1.8.0+84.g9943194"
  }, 
  "samples": [
    {
      "value": {
        "172.99.68.188": {
          "flocker-dataset": 1, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }, 
        "172.99.67.245": {
          "flocker-control": 0, 
          "flocker-dataset": 0, 
          "flocker-docker-": 0, 
          "flocker-contain": 0
        }
      }, 
      "success": true
    }, 
    [...]
  ], 
  "control_service": {
    "flocker_version": "1.8.0+82.g7e996e7", 
    "host": "172.99.67.245", 
    "port": 4523
  }, 
  "operation": {
    "wait_seconds": 10, 
    "type": "wait"
  }
}
```