### PR TITLE
[FLOC 2280] add zone to AWS provider in Appendix

### DIFF
--- a/docs/gettinginvolved/example-acceptance.yml
+++ b/docs/gettinginvolved/example-acceptance.yml
@@ -6,6 +6,7 @@ aws:
   secret_access_token: "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
   keyname: your.ec2.ssh.key.identifier
   region: us-east-1
+  zone: us-east-1d
   security_groups: ['acceptance']
 
 rackspace:


### PR DESCRIPTION
Fixes 2280

Adds the zone item to the AWS provider section in the gettinginvolved/appendix document.