### PR TITLE
[FLOC 3577] Temporarily remove the TrueAbility links from the documentation

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -6,7 +6,9 @@ Installing Flocker
 
 There are several installation options with which you can get up and running with Flocker.
 
-You can also try Flocker without installation, either in our live hosted environment or on virtual machines using our Vagrant image. For more information, see :ref:`get-started`.
+.. XXX The following sentence has been suppressed (FLOC 3577). TrueAbility has temporarily been taken offline to be updated.
+   You can also try Flocker without installation, either in our live hosted environment or on virtual machines using our Vagrant image.
+   For more information, see :ref:`get-started`.
 
 .. _quick-start-installer:
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -6,10 +6,7 @@ Installing Flocker
 
 There are several installation options with which you can get up and running with Flocker.
 
-.. XXX The following sentence has been suppressed (FLOC 3577). TrueAbility has temporarily been taken offline to be updated.
-
-.. You can also try Flocker without installation, either in our live hosted environment or on virtual machines using our Vagrant image.
-.. For more information, see :ref:`get-started`.
+.. XXX The content relating to our live hosted environment or virtual machines using our Vagrant image has been removed (See FLOC 3577 and https://github.com/ClusterHQ/flocker/pull/2260).
 
 .. _quick-start-installer:
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -7,8 +7,9 @@ Installing Flocker
 There are several installation options with which you can get up and running with Flocker.
 
 .. XXX The following sentence has been suppressed (FLOC 3577). TrueAbility has temporarily been taken offline to be updated.
-   You can also try Flocker without installation, either in our live hosted environment or on virtual machines using our Vagrant image.
-   For more information, see :ref:`get-started`.
+
+.. You can also try Flocker without installation, either in our live hosted environment or on virtual machines using our Vagrant image.
+.. For more information, see :ref:`get-started`.
 
 .. _quick-start-installer:
 

--- a/docs/introduction/get-started.rst
+++ b/docs/introduction/get-started.rst
@@ -4,22 +4,7 @@
 Get Started with Flocker
 ========================
 
-.. XXX The following sentence has been suppressed (FLOC 3577). TrueAbility has temporarily been taken offline to be updated.
-
-.. Before you begin to install Flocker, there are a couple of ways in which you can try out Flocker without having to go through the full installation steps:
-
-.. Flocker in a Live Hosted Environment
-.. ------------------------------------
-
-.. You can take Flocker for a spin using a free, live hosted environment. 
-.. No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
-.. * The live demo environment is hosted by ClusterHQ.
-.. * The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
-.. * You will have root access to this environment, so you can test Flocker however you want.
-.. * Follow a step-by-step tutorial.
-.. * To give you time to play, you’ll have access to the environment for 3 hours.
-
-.. For more information, see the `Try Flocker`_ page.
+.. XXX The content relating to our live hosted environment or virtual machines using our Vagrant image has been removed (See FLOC 3577 and https://github.com/ClusterHQ/flocker/pull/2260).
 
 .. _vagrant-install:
 

--- a/docs/introduction/get-started.rst
+++ b/docs/introduction/get-started.rst
@@ -4,21 +4,22 @@
 Get Started with Flocker
 ========================
 
-Before you begin to install Flocker, there are a couple of ways in which you can try out Flocker without having to go through the full installation steps:
+.. XXX The following sentence has been suppressed (FLOC 3577). TrueAbility has temporarily been taken offline to be updated.
 
-Flocker in a Live Hosted Environment
-------------------------------------
+.. Before you begin to install Flocker, there are a couple of ways in which you can try out Flocker without having to go through the full installation steps:
 
-You can take Flocker for a spin using a free, live hosted environment. 
-No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
+.. Flocker in a Live Hosted Environment
+.. ------------------------------------
 
-* The live demo environment is hosted by ClusterHQ.
-* The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
-* You will have root access to this environment, so you can test Flocker however you want.
-* Follow a step-by-step tutorial.
-* To give you time to play, you’ll have access to the environment for 3 hours.
+.. You can take Flocker for a spin using a free, live hosted environment. 
+.. No installation is required, and it’s great for getting a hands-on introduction to what Flocker is all about.
+.. * The live demo environment is hosted by ClusterHQ.
+.. * The demo environment will include a fully-installed and configured 2-node Flocker cluster and CLI.
+.. * You will have root access to this environment, so you can test Flocker however you want.
+.. * Follow a step-by-step tutorial.
+.. * To give you time to play, you’ll have access to the environment for 3 hours.
 
-For more information, see the `Try Flocker`_ page.
+.. For more information, see the `Try Flocker`_ page.
 
 .. _vagrant-install:
 


### PR DESCRIPTION
Fixes 3577

Due to TA not working, it has been taken offline to be updated. While this is down, this PR suppresses 2 locations in the documentation which referenced it.