### PR TITLE
[FLOC-3590] Remove the unit test module from the list of acceptance test modules.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -791,7 +791,6 @@ run_acceptance_modules: &run_acceptance_modules
   - flocker.acceptance.integration.test_postgres
   - flocker.acceptance.obsolete.test_cli
   - flocker.acceptance.obsolete.test_containers
-  - flocker.acceptance.test.test_testtools
 
 # flocker.node.functional is hanging, so we don't run it
 job_type:


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3590

Note only the removal is needed because `flocker.acceptance` is already listed as a unit test module elsewhere and is so is already run by one of the regular "trial" jobs.