### PR TITLE
[FLOC-2963] No more choosing dataset_id via hashing

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -10,6 +10,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+Next release
+============
+
+* The :ref:`Flocker Plugin for Docker<docker-plugin>` now solely relies on the metadata key ``"name"`` to find datasets.
+
 v1.8.0
 ======
 

--- a/flocker/apiclient/__init__.py
+++ b/flocker/apiclient/__init__.py
@@ -9,8 +9,10 @@ This may eventually be a standalone package.
 from ._client import (
     IFlockerAPIV1Client, FakeFlockerClient, Dataset, DatasetState,
     DatasetAlreadyExists, FlockerClient, Lease, LeaseAlreadyHeld,
+    conditional_create, DatasetsConfiguration,
 )
 
 __all__ = ["IFlockerAPIV1Client", "FakeFlockerClient", "Dataset",
            "DatasetState", "DatasetAlreadyExists", "FlockerClient",
-           "Lease", "LeaseAlreadyHeld"]
+           "Lease", "LeaseAlreadyHeld", "conditional_create",
+           "DatasetsConfiguration"]

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -8,7 +8,6 @@ See https://github.com/docker/docker/tree/master/docs/extend for details.
 
 from itertools import repeat
 from functools import wraps
-from uuid import UUID
 
 import yaml
 
@@ -26,8 +25,7 @@ from klein import Klein
 from ..restapi import (
     structured, EndpointResponse, BadRequest, make_bad_request,
 )
-from ..control._config import dataset_id_from_name
-from ..apiclient import DatasetAlreadyExists
+from ..apiclient import DatasetAlreadyExists, conditional_create
 from ..node.agents.blockdevice import PROFILE_METADATA_KEY
 from ..common import loop_until, timeout
 
@@ -220,24 +218,20 @@ class VolumePlugin(object):
 
         :return: Result indicating success.
         """
-        listing = self._flocker_client.list_datasets_configuration()
-
-        def got_configured(configured):
-            for dataset in configured:
-                if dataset.metadata.get(u"name") == Name:
-                    raise DatasetAlreadyExists
-        listing.addCallback(got_configured)
-
         metadata = {u"name": Name}
         opts = Opts or {}
         profile = opts.get(u"profile")
         if profile:
             metadata[PROFILE_METADATA_KEY] = profile
 
-        creating = listing.addCallback(
-            lambda _: self._flocker_client.create_dataset(
-                self._node_id, DEFAULT_SIZE, metadata=metadata,
-                dataset_id=UUID(dataset_id_from_name(Name))))
+        def ensure_unique_name(configured):
+            for dataset in configured:
+                if dataset.metadata.get(u"name") == Name:
+                    raise DatasetAlreadyExists
+
+        creating = conditional_create(
+            self._flocker_client, self._reactor, ensure_unique_name,
+            self._node_id, DEFAULT_SIZE, metadata=metadata)
         creating.addErrback(lambda reason: reason.trap(DatasetAlreadyExists))
         creating.addCallback(lambda _: {u"Err": None})
         return creating


### PR DESCRIPTION
Get rid of a hack that likely caused issues with e.g. deleted datasets.

Builds on #2262 and #2225. 