### PR TITLE
[FLOC-3455] Better exception logging

### DIFF
--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -257,7 +257,7 @@ class TimeoutException(Exception):
     """
     def __init__(self, blockdevice_id, operation,
                  start_state, transient_state, end_state, current_state):
-        Exception.__init__(self, blockdevice_id)
+        Exception.__init__(self, blockdevice_id, operation, current_state)
         self.blockdevice_id = blockdevice_id
         self.operation = operation
         self.start_state = start_state
@@ -279,7 +279,7 @@ class UnexpectedStateException(Exception):
     """
     def __init__(self, blockdevice_id, operation,
                  start_state, transient_state, end_state, current_state):
-        Exception.__init__(self, blockdevice_id)
+        Exception.__init__(self, blockdevice_id, operation, current_state)
         self.blockdevice_id = blockdevice_id
         self.operation = operation
         self.start_state = start_state

--- a/flocker/restapi/_error.py
+++ b/flocker/restapi/_error.py
@@ -18,6 +18,8 @@ __all__ = [
 
 from inspect import cleandoc
 
+from eliot import register_exception_extractor
+
 from twisted.web.http import BAD_REQUEST, FORBIDDEN, NOT_FOUND
 
 # HTTP response code indicating the request is syntactically correct but
@@ -46,8 +48,13 @@ class BadRequest(Exception):
         @param result: The value to put into the field of the response
             body as JSON.
         """
+        Exception.__init__(self, code, result)
         self.code = code
         self.result = result
+
+
+# Add response_code field to logged BadRequest:
+register_exception_extractor(BadRequest, lambda e: {u"code": e.code})
 
 
 def makeBadRequest(code=BAD_REQUEST, **result):

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -259,7 +259,10 @@ class StructuredResultHandlingMixin(object):
             application.EXPLICIT_RESPONSE_RESULT)
         return expected.verify(asResponse(request))
 
-    @validateLogging(_assertRequestLogged(b"/foo/badrequest"))
+    @validateLogging(assertHasAction, JSON_REQUEST, False,
+                     {},
+                     {"code":
+                      ResultHandlingApplication.BAD_REQUEST_CODE})
     def test_badRequestRaised(self, logger):
         """
         If the decorated function raises L{BadRequest} then the generated

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cryptography==0.9.1
 debtcollector==0.5.0
 docker-py==1.5.0
 effect==0.10
-eliot==0.9.0
+eliot==0.10.0
 eliot-tree==15.3.0
 enum34==1.0.4
 hypothesis==1.14.0
@@ -37,7 +37,7 @@ pyasn1-modules==0.0.5
 pycparser==2.14
 pycrypto==2.6.1
 pyOpenSSL==0.15.1
-pyrsistent==0.11.7
+pyrsistent==0.11.9
 python-cinderclient==1.1.1
 python-keystoneclient==1.4.0
 python-keystoneclient-rackspace==0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cryptography==0.9.1
 debtcollector==0.5.0
 docker-py==1.5.0
 effect==0.10
-eliot==0.10.0
+eliot==0.10.1
 eliot-tree==15.3.0
 enum34==1.0.4
 hypothesis==1.14.0


### PR DESCRIPTION
1. Upgrade Eliot, and therefore Pyrsistent, so we can get access to new Eliot feature.
2. use the new Eliot feature to make sure all BadRequest exceptions get logged with machine readable response code.
3. Improve default string rendering of a few exceptions so they get logged more informatively by Eliot.