### PR TITLE
Move system interactions with block devices to an Interface

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -454,7 +454,8 @@ class CreateFilesystem(PRecord):
     def run(self, deployer):
         try:
             _ensure_no_filesystem(self.device, deployer.block_device_manager)
-            deployer.block_device_manager.mkfs(self.device, self.filesystem)
+            deployer.block_device_manager.make_filesystem(self.device,
+                                                          self.filesystem)
         except:
             return fail()
         return succeed(None)

--- a/flocker/node/agents/blockdevice_manager.py
+++ b/flocker/node/agents/blockdevice_manager.py
@@ -54,6 +54,8 @@ class IBlockDeviceManager(Interface):
 
         :param FilePath blockdevice: The path to the block device to mount.
         :param FilePath mountpoint: The path to mount the block device at.
+
+        :raises: ``UnformattedException`` if the block device is not formatted.
         """
 
     def unmount(blockdevice):

--- a/flocker/node/agents/blockdevice_manager.py
+++ b/flocker/node/agents/blockdevice_manager.py
@@ -32,7 +32,7 @@ class IBlockDeviceManager(Interface):
     An interface for interactions with the OS pertaining to block devices.
     """
 
-    def mkfs(self, blockdevice, filesystem):
+    def make_filesystem(blockdevice, filesystem):
         """
         Format the blockdevice at blockdevice.path with the given filesystem.
 
@@ -40,7 +40,7 @@ class IBlockDeviceManager(Interface):
         :param unicode filesystem: The filesystem type to use.
         """
 
-    def has_filesystem(self, blockdevice):
+    def has_filesystem(blockdevice):
         """
         Returns whether the blockdevice at blockdevice.path has a filesystem.
 
@@ -48,7 +48,7 @@ class IBlockDeviceManager(Interface):
         :returns: True if the blockdevice has a filesystem.
         """
 
-    def mount(self, blockdevice, mountpoint):
+    def mount(blockdevice, mountpoint):
         """
         Mounts the blockdevice at blockdevice.path at mountpoint.path.
 
@@ -56,14 +56,14 @@ class IBlockDeviceManager(Interface):
         :param FilePath mountpoint: The path to mount the block device at.
         """
 
-    def unmount(self, blockdevice):
+    def unmount(blockdevice):
         """
         Unmounts the blockdevice at blockdevice.path
 
         :param FilePath blockdevice: The path to the block device to unmount.
         """
 
-    def get_mounts(self):
+    def get_mounts():
         """
         Returns all known mounts on the system.
 
@@ -77,7 +77,7 @@ class BlockDeviceManager(PClass):
     Real implementation of IBlockDeviceManager.
     """
 
-    def mkfs(self, blockdevice, filesystem):
+    def make_filesystem(self, blockdevice, filesystem):
         check_output([
             b"mkfs", b"-t", filesystem.encode("ascii"),
             # This is ext4 specific, and ensures mke2fs doesn't ask
@@ -122,5 +122,3 @@ class BlockDeviceManager(PClass):
         return (MountInfo(blockdevice=FilePath(mount.device),
                           mountpoint=FilePath(mount.mountpoint))
                 for mount in mounts)
-
-

--- a/flocker/node/agents/blockdevice_manager.py
+++ b/flocker/node/agents/blockdevice_manager.py
@@ -1,0 +1,126 @@
+# -*- test-case-name: flocker.node.agents.test.test_blockdevice_manager -*-
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+This module implements interactions between the OS pertaining to block devices.
+This controls actions such as formatting and mounting a blockdevice.
+"""
+
+import psutil
+from subprocess import CalledProcessError, check_output, STDOUT
+
+from zope.interface import Interface, implementer
+
+from pyrsistent import PClass, field
+
+from twisted.python.filepath import FilePath
+
+
+class MountInfo(PClass):
+    """
+    Information about an existing mount on the system.
+
+    :ivar FilePath blockdevice: The device path to the mounted blockdevice.
+    :ivar FilePath mounpoint: The file path to the mount point.
+    """
+    blockdevice = field(type=FilePath, mandatory=True)
+    mountpoint = field(type=FilePath, mandatory=True)
+
+
+class IBlockDeviceManager(Interface):
+    """
+    An interface for interactions with the OS pertaining to block devices.
+    """
+
+    def mkfs(self, blockdevice, filesystem):
+        """
+        Format the blockdevice at blockdevice.path with the given filesystem.
+
+        :param FilePath blockdevice: The blockdevice to make the filesystem on.
+        :param unicode filesystem: The filesystem type to use.
+        """
+
+    def has_filesystem(self, blockdevice):
+        """
+        Returns whether the blockdevice at blockdevice.path has a filesystem.
+
+        :param FilePath blockdevice: The bockdevice to query for a filesystem.
+        :returns: True if the blockdevice has a filesystem.
+        """
+
+    def mount(self, blockdevice, mountpoint):
+        """
+        Mounts the blockdevice at blockdevice.path at mountpoint.path.
+
+        :param FilePath blockdevice: The path to the block device to mount.
+        :param FilePath mountpoint: The path to mount the block device at.
+        """
+
+    def unmount(self, blockdevice):
+        """
+        Unmounts the blockdevice at blockdevice.path
+
+        :param FilePath blockdevice: The path to the block device to unmount.
+        """
+
+    def get_mounts(self):
+        """
+        Returns all known mounts on the system.
+
+        :returns: An iterable of ``MountInfo``s of all known mounts.
+        """
+
+
+@implementer(IBlockDeviceManager)
+class BlockDeviceManager(PClass):
+    """
+    Real implementation of IBlockDeviceManager.
+    """
+
+    def mkfs(self, blockdevice, filesystem):
+        check_output([
+            b"mkfs", b"-t", filesystem.encode("ascii"),
+            # This is ext4 specific, and ensures mke2fs doesn't ask
+            # user interactively about whether they really meant to
+            # format whole device rather than partition. It will be
+            # removed once upstream bug is fixed. See FLOC-2085.
+            b"-F",
+            blockdevice.path
+        ])
+
+    def has_filesystem(self, blockdevice):
+        try:
+            check_output(
+                [b"blkid", b"-p", b"-u", b"filesystem", blockdevice.path],
+                stderr=STDOUT,
+            )
+        except CalledProcessError as e:
+            # According to the man page:
+            #   the specified token was not found, or no (specified) devices
+            #   could be identified
+            #
+            # Experimentation shows that there is no output in the case of the
+            # former, and an error printed to stderr in the case of the
+            # latter.
+            #
+            # FLOC-2388: We're assuming an interface. We should test this
+            # assumption.
+            if e.returncode == 2 and not e.output:
+                # There is no filesystem on this device.
+                return False
+            raise
+        return True
+
+    def mount(self, blockdevice, mountpoint):
+        check_output([b"mount", blockdevice.path, mountpoint.path])
+
+    def unmount(self, blockdevice):
+        check_output([b"umount", blockdevice.path])
+
+    def get_mounts(self):
+        mounts = psutil.disk_partitions()
+        return (MountInfo(blockdevice=FilePath(mount.device),
+                          mountpoint=FilePath(mount.mountpoint))
+                for mount in mounts)
+
+

--- a/flocker/node/agents/blockdevice_manager.py
+++ b/flocker/node/agents/blockdevice_manager.py
@@ -2,7 +2,7 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 """
-This module implements interactions between the OS pertaining to block devices.
+Interactions between the OS pertaining to block devices.
 This controls actions such as formatting and mounting a blockdevice.
 """
 
@@ -20,7 +20,14 @@ from characteristic import attributes
 
 @attributes(["blockdevice", "mountpoint", "source_message"])
 class MountError(Exception):
-    """Exception class for errors in attempts to mount."""
+    """Raised from errors while mounting a blockdevice.
+
+    :ivar FilePath blockdevice: The path to the blockdevice that was
+        being mounted when the error occurred.
+    :ivar FilePath mountpoint: The path that the blockdevice was going to be
+        mounted at when the error occurred.
+    :ivar unicode source_message: The error message describing the error.
+    """
 
     def __str__(self):
         return self.__repr__()
@@ -28,7 +35,12 @@ class MountError(Exception):
 
 @attributes(["blockdevice", "source_message"])
 class MakeFilesystemError(Exception):
-    """Exception class for errors in attempts to make a filesystem."""
+    """Raised from errors while making a filesystem on a blockdevice.
+
+    :ivar FilePath blockdevice: The path to the blockdevice that was
+        being formatted when the error occurred.
+    :ivar unicode source_message: The error message describing the error.
+    """
 
     def __str__(self):
         return self.__repr__()
@@ -36,7 +48,12 @@ class MakeFilesystemError(Exception):
 
 @attributes(["blockdevice", "source_message"])
 class UnmountError(Exception):
-    """Exception class for errors in attempts to unmount."""
+    """Raised from errors while unmounting a blockdevice.
+
+    :ivar FilePath blockdevice: The path to the blockdevice that was
+        being unmounted when the error occurred.
+    :ivar unicode source_message: The error message describing the error.
+    """
 
     def __str__(self):
         return self.__repr__()

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -70,7 +70,6 @@ from ..blockdevice import (
     UnknownInstanceID,
     get_blockdevice_volume,
 )
-from ..blockdevice_manager import BlockDeviceManager
 
 from ..loopback import (
     check_allocatable_size,
@@ -1403,11 +1402,8 @@ class BlockDeviceDeployerIgnorantCalculateChangesTests(
         assert_calculated_changes(
             self, local_state, local_config, set(),
             in_parallel(changes=[
-                DestroyBlockDeviceDataset(
-                    dataset_id=self.DATASET_ID,
-                    blockdevice_id=self.BLOCKDEVICE_ID,
-                    block_device_manager=BlockDeviceManager(),
-                )
+                DestroyBlockDeviceDataset(dataset_id=self.DATASET_ID,
+                                          blockdevice_id=self.BLOCKDEVICE_ID)
             ]),
             # Another node which is ignorant about its state:
             set([NodeState(hostname=u"1.2.3.4", uuid=uuid4())])
@@ -1436,11 +1432,8 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
         assert_calculated_changes(
             self, local_state, local_config, set(),
             in_parallel(changes=[
-                DestroyBlockDeviceDataset(
-                    dataset_id=self.DATASET_ID,
-                    blockdevice_id=self.BLOCKDEVICE_ID,
-                    block_device_manager=BlockDeviceManager(),
-                )
+                DestroyBlockDeviceDataset(dataset_id=self.DATASET_ID,
+                                          blockdevice_id=self.BLOCKDEVICE_ID)
             ]),
             discovered_datasets=[
                 DiscoveredDataset(
@@ -1578,8 +1571,7 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
                             unicode(self.DATASET_ID)
                         ),
                         blockdevice_id=self.BLOCKDEVICE_ID,
-                        dataset_id=self.DATASET_ID,
-                        block_device_manager=BlockDeviceManager(),
+                        dataset_id=self.DATASET_ID
                     )
                 ]
             ),
@@ -1640,7 +1632,6 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
                     CreateFilesystem(
                         device=device,
                         filesystem=u"ext4",
-                        block_device_manager=BlockDeviceManager(),
                     )
                 ]
             ),
@@ -1798,8 +1789,7 @@ class BlockDeviceDeployerMountCalculateChangesTests(
                     blockdevice_id=self.BLOCKDEVICE_ID,
                     mountpoint=FilePath(b"/flocker/").child(
                         bytes(self.DATASET_ID)
-                    ),
-                    block_device_manager=BlockDeviceManager(),
+                    )
                 ),
             ]),
             discovered_datasets=[
@@ -1846,8 +1836,7 @@ class BlockDeviceDeployerCreateFilesystemCalculateChangesTests(
             self, node_state, node_config,
             {Dataset(dataset_id=unicode(self.DATASET_ID))},
             in_parallel(changes=[
-                CreateFilesystem(device=device, filesystem=u"ext4",
-                                 block_device_manager=BlockDeviceManager())
+                CreateFilesystem(device=device, filesystem=u"ext4")
             ]),
             discovered_datasets=[
                 DiscoveredDataset(
@@ -1889,8 +1878,7 @@ class BlockDeviceDeployerUnmountCalculateChangesTests(
             self, node_state, node_config, set(),
             in_parallel(changes=[
                 UnmountBlockDevice(dataset_id=self.DATASET_ID,
-                                   blockdevice_id=self.BLOCKDEVICE_ID,
-                                   block_device_manager=BlockDeviceManager())
+                                   blockdevice_id=self.BLOCKDEVICE_ID)
             ])
         )
 
@@ -1957,8 +1945,7 @@ class BlockDeviceDeployerUnmountCalculateChangesTests(
             self, node_state, node_config, set(),
             in_parallel(changes=[
                 UnmountBlockDevice(dataset_id=self.DATASET_ID,
-                                   blockdevice_id=self.BLOCKDEVICE_ID,
-                                   block_device_manager=BlockDeviceManager())
+                                   blockdevice_id=self.BLOCKDEVICE_ID)
             ]), leases=leases,
         )
 
@@ -3471,8 +3458,7 @@ def _make_destroy_dataset():
     """
     return DestroyBlockDeviceDataset(
         dataset_id=_ARBITRARY_VOLUME.dataset_id,
-        blockdevice_id=_ARBITRARY_VOLUME.blockdevice_id,
-        block_device_manager=BlockDeviceManager(),
+        blockdevice_id=_ARBITRARY_VOLUME.blockdevice_id
     )
 
 
@@ -3502,8 +3488,7 @@ def multistep_change_log(parent, children):
 class DestroyBlockDeviceDatasetInitTests(
     make_with_init_tests(
         DestroyBlockDeviceDataset,
-        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
-             block_device_manager=BlockDeviceManager()),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
         dict(),
     )
 ):
@@ -3517,11 +3502,9 @@ class DestroyBlockDeviceDatasetTests(
         DestroyBlockDeviceDataset,
         # Avoid using the same instance, just provide the same value.
         lambda _uuid=uuid4(): dict(dataset_id=_uuid,
-                                   blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
-                                   block_device_manager=BlockDeviceManager()),
+                                   blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
         lambda _uuid=uuid4(): dict(dataset_id=_uuid,
-                                   blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2,
-                                   block_device_manager=BlockDeviceManager()),
+                                   blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2),
     )
 ):
     """
@@ -3567,8 +3550,7 @@ class DestroyBlockDeviceDatasetTests(
         mount(device, mountpoint)
 
         change = DestroyBlockDeviceDataset(
-            dataset_id=dataset_id, blockdevice_id=volume.blockdevice_id,
-            block_device_manager=BlockDeviceManager())
+            dataset_id=dataset_id, blockdevice_id=volume.blockdevice_id)
         self.successResultOf(run_state_change(change, deployer))
 
         # It's only possible to destroy a volume that's been detached.  It's
@@ -3581,8 +3563,7 @@ class DestroyBlockDeviceDatasetTests(
 class CreateFilesystemInitTests(
     make_with_init_tests(
         CreateFilesystem,
-        dict(device=FilePath(b"/dev/null"), filesystem=u"ext4",
-             block_device_manager=BlockDeviceManager()),
+        dict(device=FilePath(b"/dev/null"), filesystem=u"ext4"),
         dict(),
     )
 ):
@@ -3594,10 +3575,8 @@ class CreateFilesystemInitTests(
 class CreateFilesystemTests(
     make_istatechange_tests(
         CreateFilesystem,
-        dict(device=FilePath(b"/dev/null"), filesystem=u"ext4",
-             block_device_manager=BlockDeviceManager()),
-        dict(device=FilePath(b"/dev/null"), filesystem=u"btrfs",
-             block_device_manager=BlockDeviceManager())
+        dict(device=FilePath(b"/dev/null"), filesystem=u"ext4"),
+        dict(device=FilePath(b"/dev/null"), filesystem=u"btrfs"),
     )
 ):
     """
@@ -3611,8 +3590,7 @@ class MountBlockDeviceInitTests(
     make_with_init_tests(
         MountBlockDevice,
         dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
-             mountpoint=FilePath(b"/foo"),
-             block_device_manager=BlockDeviceManager()),
+             mountpoint=FilePath(b"/foo")),
         dict(),
     )
 ):
@@ -3703,8 +3681,7 @@ class _MountScenario(PRecord):
         return run_state_change(
             CreateFilesystem(
                 device=self.api.get_device_path(self.volume.blockdevice_id),
-                filesystem=self.filesystem_type,
-                block_device_manager=BlockDeviceManager(),
+                filesystem=self.filesystem_type
             ),
             self.deployer,
         )
@@ -3714,11 +3691,9 @@ class MountBlockDeviceTests(
     make_istatechange_tests(
         MountBlockDevice,
         dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
-             mountpoint=FilePath(b"/foo"),
-             block_device_manager=BlockDeviceManager()),
+             mountpoint=FilePath(b"/foo")),
         dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2,
-             mountpoint=FilePath(b"/bar"),
-             block_device_manager=BlockDeviceManager()),
+             mountpoint=FilePath(b"/bar")),
     )
 ):
     """
@@ -3736,8 +3711,7 @@ class MountBlockDeviceTests(
         change = MountBlockDevice(
             dataset_id=scenario.dataset_id,
             blockdevice_id=scenario.volume.blockdevice_id,
-            mountpoint=scenario.mountpoint,
-            block_device_manager=BlockDeviceManager(),
+            mountpoint=scenario.mountpoint
         )
         return scenario, run_state_change(change, scenario.deployer)
 
@@ -3766,8 +3740,7 @@ class MountBlockDeviceTests(
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
                              blockdevice_id=scenario.volume.blockdevice_id,
-                             mountpoint=mountpoint,
-                             block_device_manager=BlockDeviceManager()),
+                             mountpoint=mountpoint),
             scenario.deployer))
 
     def test_run(self):
@@ -3877,8 +3850,7 @@ class MountBlockDeviceTests(
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
                              blockdevice_id=scenario.volume.blockdevice_id,
-                             mountpoint=scenario.mountpoint,
-                             block_device_manager=BlockDeviceManager()),
+                             mountpoint=scenario.mountpoint),
             scenario.deployer))
 
     def test_lost_found_deleted_remount(self):
@@ -3892,8 +3864,7 @@ class MountBlockDeviceTests(
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
                              blockdevice_id=scenario.volume.blockdevice_id,
-                             mountpoint=scenario.mountpoint,
-                             block_device_manager=BlockDeviceManager()),
+                             mountpoint=scenario.mountpoint),
             scenario.deployer))
         self.assertEqual(mountpoint.children(), [])
 
@@ -3910,8 +3881,7 @@ class MountBlockDeviceTests(
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
                              blockdevice_id=scenario.volume.blockdevice_id,
-                             mountpoint=scenario.mountpoint,
-                             block_device_manager=BlockDeviceManager()),
+                             mountpoint=scenario.mountpoint),
             scenario.deployer))
         self.assertItemsEqual(mountpoint.children(),
                               [mountpoint.child(b"file"),
@@ -3931,8 +3901,7 @@ class MountBlockDeviceTests(
         self.successResultOf(run_state_change(
             MountBlockDevice(dataset_id=scenario.dataset_id,
                              blockdevice_id=scenario.volume.blockdevice_id,
-                             mountpoint=scenario.mountpoint,
-                             block_device_manager=BlockDeviceManager()),
+                             mountpoint=scenario.mountpoint),
             scenario.deployer))
         self.assertEqual(mountpoint.getPermissions().shorthand(),
                          'rwx------')
@@ -3942,8 +3911,7 @@ class UnmountBlockDeviceInitTests(
     make_with_init_tests(
         record_type=UnmountBlockDevice,
         kwargs=dict(dataset_id=uuid4(),
-                    blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
-                    block_device_manager=BlockDeviceManager()),
+                    blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
         expected_defaults=dict(),
     )
 ):
@@ -3955,10 +3923,8 @@ class UnmountBlockDeviceInitTests(
 class UnmountBlockDeviceTests(
     make_istatechange_tests(
         UnmountBlockDevice,
-        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID,
-             block_device_manager=BlockDeviceManager()),
-        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2,
-             block_device_manager=BlockDeviceManager()),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID),
+        dict(dataset_id=uuid4(), blockdevice_id=ARBITRARY_BLOCKDEVICE_ID_2),
     )
 ):
     """
@@ -3997,8 +3963,7 @@ class UnmountBlockDeviceTests(
         check_output([b"mount", device.path, mountpoint.path])
 
         change = UnmountBlockDevice(dataset_id=dataset_id,
-                                    blockdevice_id=volume.blockdevice_id,
-                                    block_device_manager=BlockDeviceManager())
+                                    blockdevice_id=volume.blockdevice_id)
         self.successResultOf(run_state_change(change, deployer))
         self.assertNotIn(
             device,

--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -6,7 +6,7 @@ Tests for ``flocker.node.agents.blockdevice_manager``.
 
 from uuid import uuid4
 
-from twisted.trial.unittest import SynchronousTestCase
+from twisted.trial.unittest import TestCase
 from zope.interface.verify import verifyObject
 
 from ..blockdevice_manager import (
@@ -25,7 +25,7 @@ from .test_blockdevice import (
 )
 
 
-class BlockDeviceManagerTests(SynchronousTestCase):
+class BlockDeviceManagerTests(TestCase):
     """Tests for flocker.node.agents.blockdevice_manager.BlockDeviceManager."""
 
     def setUp(self):

--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -6,8 +6,8 @@ Tests for ``flocker.node.agents.blockdevice_manager``.
 
 from uuid import uuid4
 
-from twisted.trial.unittest import TestCase
 from zope.interface.verify import verifyObject
+from ....testtools import AsyncTestCase
 
 from ..blockdevice_manager import (
     IBlockDeviceManager,
@@ -25,7 +25,7 @@ from .test_blockdevice import (
 )
 
 
-class BlockDeviceManagerTests(TestCase):
+class BlockDeviceManagerTests(AsyncTestCase):
     """
     Tests for flocker.node.agents.blockdevice_manager.BlockDeviceManager.
     """
@@ -80,7 +80,7 @@ class BlockDeviceManagerTests(TestCase):
         """
         Mounting a device to n different locations requires n unmounts.
 
-        Also verify they are unmounted in FIFO order.
+        Also verify they are unmounted in LIFO order.
         """
         blockdevice = self._get_free_blockdevice()
         self.manager_under_test.make_filesystem(blockdevice, 'ext4')

--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -26,22 +26,30 @@ from .test_blockdevice import (
 
 
 class BlockDeviceManagerTests(TestCase):
-    """Tests for flocker.node.agents.blockdevice_manager.BlockDeviceManager."""
+    """
+    Tests for flocker.node.agents.blockdevice_manager.BlockDeviceManager.
+    """
 
     def setUp(self):
-        """Establishes testing infrastructure for test cases."""
+        """
+        Establish testing infrastructure for test cases.
+        """
         self.loopback_api = loopbackblockdeviceapi_for_test(self)
         self.manager_under_test = BlockDeviceManager()
         self.mountroot = mountroot_for_test(self)
 
     def _get_directory_for_mount(self):
-        """Constructs a temporary directory to be used as a mountpoint."""
+        """
+        Construct a temporary directory to be used as a mountpoint.
+        """
         directory = self.mountroot.child(str(uuid4()))
         directory.makedirs()
         return directory
 
     def _get_free_blockdevice(self):
-        """Constructs a new blockdevice for testing purposes."""
+        """
+        Construct a new blockdevice for testing purposes.
+        """
         volume = self.loopback_api.create_volume(
             dataset_id=uuid4(), size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE)
         self.loopback_api.attach_volume(
@@ -49,12 +57,16 @@ class BlockDeviceManagerTests(TestCase):
         return self.loopback_api.get_device_path(volume.blockdevice_id)
 
     def test_implements_interface(self):
-        """``BlockDeviceManager`` implementes ``IBlockDeviceManager``."""
+        """
+        ``BlockDeviceManager`` implements ``IBlockDeviceManager``.
+        """
         self.assertTrue(verifyObject(IBlockDeviceManager,
                                      self.manager_under_test))
 
     def test_get_mounts_shows_only_mounted(self):
-        """Only mounted blockdevices should appear in get_mounts."""
+        """
+        Only mounted blockdevices appear in get_mounts.
+        """
         blockdevice = self._get_free_blockdevice()
         mountpoint = self._get_directory_for_mount()
         self.manager_under_test.make_filesystem(blockdevice, 'ext4')
@@ -65,7 +77,8 @@ class BlockDeviceManagerTests(TestCase):
         self.assertNotIn(mount_info, self.manager_under_test.get_mounts())
 
     def test_mount_multiple_times(self):
-        """Mounting a device to n different locations requires n unmounts.
+        """
+        Mounting a device to n different locations requires n unmounts.
 
         Also verify they are unmounted in FIFO order.
         """
@@ -89,7 +102,8 @@ class BlockDeviceManagerTests(TestCase):
                              for m in self.manager_under_test.get_mounts()))
 
     def test_mount_multiple_blockdevices(self):
-        """Mounting multiple devices to the same mountpoint.
+        """
+        Mounting multiple devices to the same mountpoint.
 
         Note that the blockdevices must be unmounted in reverse order,
         otherwise the unmount operations will fail.
@@ -119,20 +133,26 @@ class BlockDeviceManagerTests(TestCase):
                        if m.mountpoint == mountpoint))
 
     def test_unmount_unmounted(self):
-        """Errors in unmounting raise an ``UnmountError``"""
+        """
+        Errors in unmounting raise an ``UnmountError``.
+        """
         blockdevice = self._get_free_blockdevice()
         with self.assertRaisesRegexp(UnmountError, blockdevice.path):
             self.manager_under_test.unmount(blockdevice)
 
     def test_mount_unformatted(self):
-        """Errors in mounting raise a ``MountError``."""
+        """
+        Errors in mounting raise a ``MountError``.
+        """
         blockdevice = self._get_free_blockdevice()
         mountpoint = self._get_directory_for_mount()
         with self.assertRaisesRegexp(MountError, blockdevice.path):
             self.manager_under_test.mount(blockdevice, mountpoint)
 
     def test_formatted_bad_type(self):
-        """Errors in formatting raise a ``MakeFilesystemError``."""
+        """
+        Errors in formatting raise a ``MakeFilesystemError``.
+        """
         blockdevice = self._get_free_blockdevice()
         with self.assertRaisesRegexp(MakeFilesystemError, blockdevice.path):
             self.manager_under_test.make_filesystem(blockdevice, 'myfakeyfs')

--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -1,0 +1,55 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.node.agents.blockdevice_manager``.
+"""
+
+from uuid import uuid4
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from ..blockdevice_manager import BlockDeviceManager, MountInfo
+from .test_blockdevice import (
+    loopbackblockdeviceapi_for_test,
+    LOOPBACK_MINIMUM_ALLOCATABLE_SIZE,
+    mountroot_for_test,
+)
+
+
+class BlockDeviceManagerTests(SynchronousTestCase):
+    """Tests for flocker.node.agents.blockdevice_manager.BlockDeviceManager
+
+    XXX: Turn this into a test generator once we have a verified fake.
+    """
+
+    def setUp(self):
+        """Creates a loopback BlockDeviceAPI for creating blockdevices."""
+        self.loopback_api = loopbackblockdeviceapi_for_test(self)
+        self.manager_under_test = BlockDeviceManager()
+        self.mountroot = mountroot_for_test(self)
+
+    def _get_directory_for_mount(self):
+        directory = self.mountroot.child(str(uuid4()))
+        # This is unneeded for testing fakes.
+        directory.makedirs()
+        return directory
+
+    def _get_free_blockdevice(self):
+        # This is unneeded for testing fakes.
+        volume = self.loopback_api.create_volume(
+            dataset_id=uuid4(), size=LOOPBACK_MINIMUM_ALLOCATABLE_SIZE)
+        self.loopback_api.attach_volume(
+            volume.blockdevice_id, self.loopback_api.compute_instance_id())
+        return self.loopback_api.get_device_path(volume.blockdevice_id)
+
+    def test_happy_case(self):
+        """Mounted blockdevices should appear in get_mounts."""
+        blockdevice = self._get_free_blockdevice()
+        mountpoint = self._get_directory_for_mount()
+        self.manager_under_test.mkfs(blockdevice, 'ext4')
+        self.manager_under_test.mount(blockdevice, mountpoint)
+        mount_info = MountInfo(blockdevice=blockdevice, mountpoint=mountpoint)
+        self.assertIn(mount_info, self.manager_under_test.get_mounts())
+        self.manager_under_test.unmount(blockdevice)
+        self.assertNotIn(mount_info, self.manager_under_test.get_mounts())
+

--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -29,7 +29,7 @@ class BlockDeviceManagerTests(SynchronousTestCase):
     """Tests for flocker.node.agents.blockdevice_manager.BlockDeviceManager."""
 
     def setUp(self):
-        """Creates a loopback BlockDeviceAPI for creating blockdevices."""
+        """Establishes testing infrastructure for test cases."""
         self.loopback_api = loopbackblockdeviceapi_for_test(self)
         self.manager_under_test = BlockDeviceManager()
         self.mountroot = mountroot_for_test(self)

--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -7,8 +7,10 @@ Tests for ``flocker.node.agents.blockdevice_manager``.
 from uuid import uuid4
 
 from twisted.trial.unittest import SynchronousTestCase
+from zope.interface.verify import verifyObject
 
 from ..blockdevice_manager import (
+    IBlockDeviceManager,
     BlockDeviceManager,
     MountInfo,
     MakeFilesystemError,
@@ -45,6 +47,11 @@ class BlockDeviceManagerTests(SynchronousTestCase):
         self.loopback_api.attach_volume(
             volume.blockdevice_id, self.loopback_api.compute_instance_id())
         return self.loopback_api.get_device_path(volume.blockdevice_id)
+
+    def test_implements_interface(self):
+        """``BlockDeviceManager`` implementes ``IBlockDeviceManager``."""
+        self.assertTrue(verifyObject(IBlockDeviceManager,
+                                     self.manager_under_test))
 
     def test_get_mounts_shows_only_mounted(self):
         """Only mounted blockdevices should appear in get_mounts."""

--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -46,7 +46,7 @@ class BlockDeviceManagerTests(SynchronousTestCase):
         """Mounted blockdevices should appear in get_mounts."""
         blockdevice = self._get_free_blockdevice()
         mountpoint = self._get_directory_for_mount()
-        self.manager_under_test.mkfs(blockdevice, 'ext4')
+        self.manager_under_test.make_filesystem(blockdevice, 'ext4')
         self.manager_under_test.mount(blockdevice, mountpoint)
         mount_info = MountInfo(blockdevice=blockdevice, mountpoint=mountpoint)
         self.assertIn(mount_info, self.manager_under_test.get_mounts())


### PR DESCRIPTION
Make an explicit interface out of the existing system calls surrounding mounting and formatting disks. This will be useful to have a smaller interface to test and verify as we move to doing fancier mount tricks in the interest of protecting dataset paths in FLOC-3254.

It might also provide a nice abstraction layer to inject mount failures for testing.

The goal is not for this to be a particularly pretty interface at this point, merely just a no-op change that re-slices our code to explicitly call out the interface with the system. Tests are added to help define the interface a little better.