### PR TITLE
[FLOC-3602] Design sketch: make the container agent optional.

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -12,7 +12,8 @@ You can learn more about where we might be going with future releases by:
 Next Release
 ============
 
-No significant changes since last release.
+* The container agent is now optional and can be safely disabled if you don't expect to be using Flocker's deprecated container API or ``flocker-deploy``.
+  The :ref:`Flocker plugin for Docker<plugin>` allows you to use Flocker from Docker without using Flocker's container API.
 
 Previous Releases
 =================

--- a/flocker/acceptance/endtoend/test_diagnostics.py
+++ b/flocker/acceptance/endtoend/test_diagnostics.py
@@ -20,7 +20,7 @@ class DiagnosticsTests(AsyncTestCase):
     Tests for ``flocker-diagnostics``.
     """
     # This only requires the container agent to check
-    # that it's log is collected. We still care about
+    # that its log is collected. We still care about
     # that working, so we run it. We should stop
     # running it for this test when we get closer
     # to never running it in production.

--- a/flocker/acceptance/endtoend/test_diagnostics.py
+++ b/flocker/acceptance/endtoend/test_diagnostics.py
@@ -19,7 +19,12 @@ class DiagnosticsTests(AsyncTestCase):
     """
     Tests for ``flocker-diagnostics``.
     """
-    @require_cluster(1)
+    # This only requires the container agent to check
+    # that it's log is collected. We still care about
+    # that working, so we run it. We should stop
+    # running it for this test when we get closer
+    # to never running it in production.
+    @require_cluster(1, require_container_agent=True)
     def test_export(self, cluster):
         """
         ``flocker-diagnostics`` creates an archive of all Flocker service logs

--- a/flocker/acceptance/integration/testtools.py
+++ b/flocker/acceptance/integration/testtools.py
@@ -62,7 +62,9 @@ def make_dataset_integration_testcase(image_name, volume_path, internal_port,
                     cluster.remove_container, name))
             return created
 
-        @require_cluster(1)
+        # TODO: this test don't actually require the container agent, it just
+        # uses it do to the setup. It should be ported to the docker API.
+        @require_cluster(1, require_container_agent=True)
         def test_start(self, cluster):
             """
             The specified application can be started with a Docker dataset
@@ -86,7 +88,9 @@ def make_dataset_integration_testcase(image_name, volume_path, internal_port,
                 lambda _: assert_inserted(self, host, port))
             return creating_dataset
 
-        @require_cluster(1)
+        # TODO: this test don't actually require the container agent, it just
+        # uses it do to the setup. It should be ported to the docker API.
+        @require_cluster(1, require_container_agent=True)
         def test_restart(self, cluster):
             """
             The specified application can be started with a Docker dataset

--- a/flocker/acceptance/integration/testtools.py
+++ b/flocker/acceptance/integration/testtools.py
@@ -62,7 +62,7 @@ def make_dataset_integration_testcase(image_name, volume_path, internal_port,
                     cluster.remove_container, name))
             return created
 
-        # TODO: this test don't actually require the container agent, it just
+        # TODO: this test doesn't actually require the container agent, it just
         # uses it do to the setup. It should be ported to the docker API.
         @require_cluster(1, require_container_agent=True)
         def test_start(self, cluster):

--- a/flocker/acceptance/node_scripts/disable_service.py
+++ b/flocker/acceptance/node_scripts/disable_service.py
@@ -4,7 +4,7 @@ Stop a service and disable across reboots.
 
 import os
 import sys
-from subprocess import check_call
+from subprocess import check_call, check_output
 
 service = sys.argv[1]
 
@@ -17,4 +17,5 @@ else:
     override = "/etc/init/%s.override" % (service,)
     with file(override, "w") as f:
         f.write("manual\n")
-    check_call(["service", service, "stop"])
+    if 'stop/waiting' not in check_output(["service", service, "status"]):
+        check_call(["service", service, "stop"])

--- a/flocker/acceptance/node_scripts/service_running.py
+++ b/flocker/acceptance/node_scripts/service_running.py
@@ -1,0 +1,20 @@
+"""
+Check if a service is running
+"""
+
+# TODO: maybe check if it is enabled as well.
+
+import os
+import sys
+from subprocess import check_output
+
+service = sys.argv[1]
+
+if os.path.exists("/etc/redhat-release"):
+    # Redhat-based system:
+    if "active (running)" not in \
+       check_output(["systemctl", "status", service]):
+        sys.exit(1)
+else:
+    if 'start/running' not in check_output(["service", service, "status"]):
+        sys.exit(1)

--- a/flocker/acceptance/obsolete/test_cli.py
+++ b/flocker/acceptance/obsolete/test_cli.py
@@ -105,7 +105,7 @@ class FlockerDeployTests(AsyncTestCase):
 
     @flaky([u'FLOC-3528'])
     @require_flocker_cli
-    @require_cluster(1)
+    @require_cluster(1, require_container_agent=True)
     def test_deploy(self, cluster):
         """
         Deploying an application to one node and not another puts the

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -437,3 +437,16 @@ class ContainerAPITests(AsyncTestCase):
 
         creating_dataset.addCallback(got_initial_result)
         return creating_dataset
+
+    # Unfortunately this test is very very slow.
+    @run_test_with(async_runner(timeout=timedelta(minutes=6)))
+    @require_cluster(2)
+    def test_container_agent_optional(self, cluster):
+        """
+        The container agent is not necessary for the dataset agent to
+        function.
+        """
+        # 1. Disable container agent
+        # 2. Either wait for control service cache to clear (120 seconds) or reboot the node
+        # 3. Create a dataset in config, wait for it to be added to state
+        # 4. Re-enable container agent

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -12,7 +12,6 @@ from testtools import run_test_with
 
 from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
-from twisted.internet.error import ProcessTerminated
 
 from ...common import loop_until
 from ...testtools import AsyncTestCase, async_runner, flaky, random_name

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -49,14 +49,14 @@ class ContainerAPITests(AsyncTestCase):
         d.addCallback(check_result)
         return d
 
-    @require_cluster(1)
+    @require_cluster(1, require_container_agent=True)
     def test_create_container_with_ports(self, cluster):
         """
         Create a container including port mappings on a single-node cluster.
         """
         return self._create_container(cluster, SCRIPTS.child(b"hellohttp.py"))
 
-    @require_cluster(1)
+    @require_cluster(1, require_container_agent=True)
     def test_create_container_restart_stopped(self, cluster):
         """
         A container is restarted if it is stopped.
@@ -94,7 +94,7 @@ class ContainerAPITests(AsyncTestCase):
 
         return created
 
-    @require_cluster(1)
+    @require_cluster(1, require_container_agent=True)
     def test_create_container_with_environment(self, cluster):
         """
         If environment variables are specified when creating a container,
@@ -124,7 +124,7 @@ class ContainerAPITests(AsyncTestCase):
 
     @flaky(u'FLOC-2488')
     @require_moving_backend
-    @require_cluster(2)
+    @require_cluster(2, require_container_agent=True)
     def test_move_container_with_dataset(self, cluster):
         """
         Create a container with an attached dataset, issue API call
@@ -169,7 +169,7 @@ class ContainerAPITests(AsyncTestCase):
 
         return creating_dataset
 
-    @require_cluster(1)
+    @require_cluster(1, require_container_agent=True)
     def test_create_container_with_dataset(self, cluster):
         """
         Create a container with an attached dataset, write some data,
@@ -229,7 +229,7 @@ class ContainerAPITests(AsyncTestCase):
         )
         return creating_dataset
 
-    @require_cluster(1)
+    @require_cluster(1, require_container_agent=True)
     def test_current(self, cluster):
         """
         The current container endpoint includes a currently running container.
@@ -249,7 +249,7 @@ class ContainerAPITests(AsyncTestCase):
         creating.addCallback(created)
         return creating
 
-    @require_cluster(1)
+    @require_cluster(1, require_container_agent=True)
     def test_non_root_container_can_access_dataset(self, cluster):
         """
         A container running as a user that is not root can write to a
@@ -273,7 +273,7 @@ class ContainerAPITests(AsyncTestCase):
             lambda _: assert_http_server(self, node.public_address, 8080))
         return creating_dataset
 
-    @require_cluster(2)
+    @require_cluster(2, require_container_agent=True)
     def test_linking(self, cluster):
         """
         A link from an origin container to a destination container allows the
@@ -314,7 +314,7 @@ class ContainerAPITests(AsyncTestCase):
         return running
 
     @flaky([u"FLOC-3485"])
-    @require_cluster(2)
+    @require_cluster(2, require_container_agent=True)
     def test_traffic_routed(self, cluster):
         """
         An application can be accessed even from a connection to a node
@@ -342,8 +342,8 @@ class ContainerAPITests(AsyncTestCase):
         return running
 
     # Unfortunately this test is very very slow.
-    @run_test_with(async_runner(timeout=timedelta(minutes=6)))
-    @require_cluster(2)
+    @run_test_with(async_runner(timeout=timedelta(minutes=5)))
+    @require_cluster(2, require_container_agent=True)
     def test_reboot(self, cluster):
         """
         After a reboot the containers are only started once all datasets are
@@ -437,16 +437,3 @@ class ContainerAPITests(AsyncTestCase):
 
         creating_dataset.addCallback(got_initial_result)
         return creating_dataset
-
-    # Unfortunately this test is very very slow.
-    @run_test_with(async_runner(timeout=timedelta(minutes=6)))
-    @require_cluster(2)
-    def test_container_agent_optional(self, cluster):
-        """
-        The container agent is not necessary for the dataset agent to
-        function.
-        """
-        # 1. Disable container agent
-        # 2. Either wait for control service cache to clear (120 seconds) or reboot the node
-        # 3. Create a dataset in config, wait for it to be added to state
-        # 4. Re-enable container agent

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -18,12 +18,14 @@ import ssl
 
 from docker.tls import TLSConfig
 
+from twisted.internet import defer
 from twisted.web.http import OK, CREATED
 from twisted.python.filepath import FilePath
 from twisted.python.constants import Names, NamedConstant
 from twisted.python.procutils import which
 from twisted.internet import reactor
 from twisted.internet.error import ProcessTerminated
+from twisted.internet.task import deferLater
 
 from eliot import start_action, Message, write_failure
 from eliot.twisted import DeferredContext
@@ -1029,7 +1031,8 @@ def _get_test_cluster(reactor):
     )
 
 
-def require_cluster(num_nodes, required_backend=None):
+def require_cluster(num_nodes, required_backend=None,
+                    require_container_agent=False):
     """
     A decorator which will call the supplied test_method when a cluster with
     the required number of nodes is available.
@@ -1085,6 +1088,20 @@ def require_cluster(num_nodes, required_backend=None):
                         ["nodes"], lambda nodes: nodes[:num_nodes]))
 
             waiting_for_cluster.addCallback(clean)
+
+            def enable_container_agent(cluster):
+                # This should ideally be some sort of fixture/testresources
+                # thing, but the APIs aren't quite right today.
+                def configure_container_agent(node):
+                    return ensure_container_agent_enabled(
+                        node, require_container_agent)
+                d = defer.gatherResults(
+                    map(configure_container_agent, cluster.nodes),
+                    consumeErrors=True)
+                d.addCallback(lambda _: cluster)
+                return d
+
+            waiting_for_cluster.addCallback(enable_container_agent)
             calling_test_method = waiting_for_cluster.addCallback(
                 call_test_method_with_cluster,
                 test_case, args, kwargs
@@ -1092,6 +1109,100 @@ def require_cluster(num_nodes, required_backend=None):
             return calling_test_method
         return wrapper
     return decorator
+
+
+def is_container_agent_running(node):
+    """
+    Check if the container agent is running on the specified node.
+
+    :param Node node: the node to check.
+    :return Deferred[bool]: a Deferred that will fire when
+        with whether the container agent is runnning.
+    """
+    d = node.run_script("service_running", "flocker-container-agent")
+
+    def not_existing(failure):
+        failure.trap(ProcessTerminated)
+        return False
+    d.addCallbacks(lambda result: True, not_existing)
+    return d
+
+
+def set_container_agent_enabled_on_node(node, enabled):
+    """
+    Ensure the container agent is enabled/disabled as specified.
+
+    :param Node node: the node on which to ensure the container
+        agent's state
+    :param bool enabled: True to ensure the container agent
+        is enabled and running, false to ensure the opposite.
+    :return Deferred[None]: a Deferred that will fire when
+        the container agent is in the desired state.
+    """
+    if enabled:
+        d = node.run_script("enable_service", "flocker-container-agent")
+    else:
+        d = node.run_script("disable_service", "flocker-container-agent")
+    # If the agent was disabled We have to reboot to clear the control cache.
+    # If we want to avoid the reboot we could add an API to do this.
+    # XXX: does this need to reboot the control node? the node that
+    # changed?
+    if not enabled:
+        d.addCallback(lambda _: node.reboot())
+        # Wait for reboot to be far enough along that everything
+        # should be shutdown:
+        d.addCallback(lambda _: deferLater(reactor, 20, lambda: None))
+        # Wait until server is back up:
+        d = d.addCallback(lambda _:
+                          verify_socket(node.public_address, 22))
+
+        def dataset_agent_running():
+            # pidof will return the pid if flocker-container-agent is
+            # running else exit with status 1 which triggers the
+            # errback chain.
+            command = [b'pidof', b'-x', b'flocker-dataset-agent']
+            d = node.run_as_root(command)
+
+            def not_existing(failure):
+                failure.trap(ProcessTerminated)
+                return False
+            d.addCallbacks(lambda result: True, not_existing)
+            return d
+        d.addCallback(lambda _: loop_until(reactor, dataset_agent_running))
+    # Hide the value in the callback as it could come from
+    # different places and shouldn't be used.
+    d.addCallback(lambda _: None)
+    return d
+
+
+def ensure_container_agent_enabled(node, to_enable):
+    """
+    Ensure the container agent is enabled/disabled as specified.
+
+    Doesn't make any changes if the agent is already in the
+    desired state.
+
+    :param Node node: the node on which to ensure the container
+        agent's state
+    :param bool to_enable: True to ensure the container agent
+        is enabled and running, false to ensure the opposite.
+    :return Deferred[None]: a Deferred that will fire when
+        the container agent is in the desired state.
+    """
+    # If the agent is enabled but stopped, and the test
+    # requests no container agent, then if the test rebooted
+    # the node it would get a running container agent after
+    # that point. This means that a test that fails in a
+    # particular way could cause incorrect results in later
+    # tests that rely on reboots. This function could change
+    # to check the enabled status as well.
+    d = is_container_agent_running(node)
+
+    def change_if_needed(enabled):
+        if enabled != to_enable:
+            return set_container_agent_enabled_on_node(node, to_enable)
+    d.addCallback(change_if_needed)
+    return d
 
 
 def create_python_container(test_case, cluster, parameters, script,
@@ -1318,7 +1429,6 @@ def query_http_server(host, port, path=b""):
 
 def assert_http_server(test, host, port,
                        path=b"", expected_response=b"hi"):
-
     """
     Assert that a HTTP serving a response with body ``b"hi"`` is running
     at given host and port.

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -1145,8 +1145,6 @@ def set_container_agent_enabled_on_node(node, enabled):
         d = node.run_script("disable_service", "flocker-container-agent")
     # If the agent was disabled We have to reboot to clear the control cache.
     # If we want to avoid the reboot we could add an API to do this.
-    # XXX: does this need to reboot the control node? the node that
-    # changed?
     if not enabled:
         d.addCallback(lambda _: node.reboot())
         # Wait for reboot to be far enough along that everything

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -1197,7 +1197,7 @@ def ensure_container_agent_enabled(node, to_enable):
     :param Node node: the node on which to ensure the container
         agent's state
     :param bool to_enable: True to ensure the container agent
-        is enabled and running, false to ensure the opposite.
+        is enabled and running, False to ensure the opposite.
     :return Deferred[None]: a Deferred that will fire when
         the container agent is in the desired state.
     """

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -122,12 +122,6 @@ class NotInUseDatasets(object):
     """
     Filter out datasets that are in use by applications on the current
     node.
-
-    For now we delay things like deletion until we know applications
-    aren't using the dataset, and also until there are no leases. Later on
-    we'll switch the container agent to rely solely on leases, at which
-    point we can rip out the logic related to Application objects. See
-    https://clusterhq.atlassian.net/browse/FLOC-2732.
     """
     def __init__(self, node_uuid, local_applications, leases):
         """
@@ -135,6 +129,8 @@ class NotInUseDatasets(object):
         :param applications: Applications running on the node.
         :param Leases leases: The current leases on datasets.
         """
+        if local_applications is None:
+            local_applications = []
         self._node_id = node_uuid
         self._in_use_datasets = {app.volume.manifestation.dataset_id
                                  for app in local_applications

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1864,12 +1864,6 @@ class BlockDeviceDeployer(PClass):
         local_node_state = cluster_state.get_node(self.node_uuid,
                                                   hostname=self.hostname)
 
-        # We need to know applications (for now) to see if we should delay
-        # deletion or handoffs. Eventually this will rely on leases instead.
-        # https://clusterhq.atlassian.net/browse/FLOC-1425.
-        if local_node_state.applications is None:
-            return NOTHING_TO_DO
-
         desired_datasets = self._calculate_desired_state(
             configuration=configuration,
             local_applications=local_node_state.applications,

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1814,7 +1814,7 @@ class ScenarioMixin(object):
         devices={
             DATASET_ID: FilePath(b"/dev/sda"),
         },
-        applications=[],
+        applications=None,
     )
 
     MOUNT_ROOT = FilePath('/flocker')
@@ -2139,15 +2139,17 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
         )
         api.attach_volume(volume.blockdevice_id, self.NODE)
 
+        other_node_uuid = uuid4()
         deployer = BlockDeviceDeployer(
             # This deployer is responsible for *other_node*, not node.
             hostname=other_node,
-            node_uuid=uuid4(),
+            node_uuid=other_node_uuid,
             block_device_api=api,
         )
 
         local_state = local_state_from_shared_state(
-            node_state=node_state,
+            node_state=cluster_state.get_node(
+                other_node_uuid, hostname=other_node),
             nonmanifest_datasets={},
         )
         changes = deployer.calculate_changes(
@@ -2155,7 +2157,10 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
 
         self.assertEqual(
             in_parallel(changes=[]),
-            changes
+            changes,
+            "Wrong changes for node {} when "
+            "dataset {} attached to node {}".format(
+                other_node_uuid, self.DATASET_ID, self.NODE_UUID)
         )
 
     def test_no_delete_if_in_use(self):
@@ -2657,7 +2662,7 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
             }
         )
         state = DeploymentState(nodes=[NodeState(
-            uuid=uuid, hostname=node, applications=[], manifestations={},
+            uuid=uuid, hostname=node, applications=None, manifestations={},
             devices={}, paths={})])
         deployer = create_blockdevicedeployer(
             self, hostname=node, node_uuid=uuid,
@@ -2701,7 +2706,7 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
             }
         )
         state = DeploymentState(nodes=[NodeState(
-            uuid=uuid, hostname=node, applications=[], manifestations={},
+            uuid=uuid, hostname=node, applications=None, manifestations={},
             devices={}, paths={})])
         deployer = create_blockdevicedeployer(
             self, hostname=node, node_uuid=uuid,
@@ -2710,9 +2715,6 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
             node_state=state.get_node(uuid),
             nonmanifest_datasets={}
         )
-        # Override the local_state to applications=None, as if the
-        # container agent is missing.
-        local_state = local_state.set(applications=None)
         changes = deployer.calculate_changes(configuration, state, local_state)
         self.assertEqual(
             in_parallel(
@@ -2751,7 +2753,7 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
             }
         )
         node_state = NodeState(
-            uuid=uuid, hostname=node, applications=[], manifestations={},
+            uuid=uuid, hostname=node, applications=None, manifestations={},
             devices={}, paths={})
         state = DeploymentState(nodes={node_state})
         deployer = create_blockdevicedeployer(
@@ -2893,7 +2895,7 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
         node_state = NodeState(
             uuid=node_id,
             hostname=node_address,
-            applications=[],
+            applications=None,
             manifestations={},
             devices={},
             paths={},
@@ -2943,7 +2945,7 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
         node_state = NodeState(
             uuid=node_id,
             hostname=node_address,
-            applications=[],
+            applications=None,
             manifestations={},
             devices={},
             paths={},
@@ -3009,7 +3011,7 @@ class BlockDeviceDeployerDetachCalculateChangesTests(
         # some attached volumes.
         node_state = NodeState(
             uuid=self.NODE_UUID, hostname=self.NODE,
-            applications={},
+            applications=None,
             manifestations={},
             devices={self.DATASET_ID: FilePath(b"/dev/xda")},
             paths={},
@@ -3039,7 +3041,7 @@ class BlockDeviceDeployerDetachCalculateChangesTests(
         # some attached volumes.
         node_state = NodeState(
             uuid=self.NODE_UUID, hostname=self.NODE,
-            applications={},
+            applications=None,
             manifestations={},
             devices={self.DATASET_ID: FilePath(b"/dev/xda")},
             paths={},
@@ -3079,7 +3081,7 @@ class BlockDeviceDeployerDetachCalculateChangesTests(
         # Local node has no manifestations:
         node_state = NodeState(
             uuid=self.NODE_UUID, hostname=self.NODE,
-            applications={},
+            applications=None,
             manifestations={},
             devices={},
             paths={},
@@ -3116,7 +3118,7 @@ class BlockDeviceDeployerDetachCalculateChangesTests(
         # Local node has no manifestations:
         node_state = NodeState(
             uuid=self.NODE_UUID, hostname=self.NODE,
-            applications={},
+            applications=None,
             manifestations={},
             devices={},
             paths={},
@@ -3212,7 +3214,7 @@ class BlockDeviceDeployerCalculateChangesTests(
         node_state = NodeState(
             hostname=ScenarioMixin.NODE,
             uuid=ScenarioMixin.NODE_UUID,
-            applications=[],
+            applications=None,
         )
         node_config = to_node(node_state)
 
@@ -3265,7 +3267,7 @@ class BlockDeviceDeployerCalculateChangesTests(
         node_state = NodeState(
             hostname=ScenarioMixin.NODE,
             uuid=ScenarioMixin.NODE_UUID,
-            applications=[],
+            applications=None,
         )
         node_config = to_node(node_state)
 

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -537,6 +537,8 @@ def aws_provisioner(
         aws_secret_access_key=secret_access_token,
         security_token=session_token,
     )
+    if conn is None:
+        raise ValueError("Invalid region: {}".format(region))
     return AWSProvisioner(
         _connection=conn,
         _keyname=keyname,


### PR DESCRIPTION


Currently the container agent is required, even if one is not using Flocker's container API. This uses resources (CPU, disk, RAM) without offering any benefit. In the medium term we want to remove the agent completely, but for now it would be good to simply allow people to disable it.

The way to do that is to make sure the dataset agent no longer requires the container agent be running in order to operate. This means that if the container agent becomes unresponsive somehow for more than two minutes and a container is still using a dataset we might end up moving a dataset that is still in use. In practice this is unlikely to happen due to fact one can't unmount a filesystem that is in use, so allowing this edge case seems reasonable.

This issue does not cover documentation changes to make it clear that the container agent is optional, except perhaps a release notes comment; the relevant docs are already quite complex. This will however allow us to improve the docs in a separate issue as part of planned docs changes in this area.
