### PR TITLE
[FLOC-2997] Log structured information rather than strings for configuration and state

### DIFF
--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -213,7 +213,18 @@ def wire_decode(data):
     return loads(data, object_hook=decode)
 
 
-_DEPLOYMENT_FIELD = Field(u"configuration", repr)
+def to_unserialized_json(obj):
+    """
+    Convert a wire encodeable object into structured Python objects that
+    are JSON serializable.
+
+    :param obj: An object that can be passed to ``wire_encode``.
+    :return: Python object that can be JSON serialized.
+    """
+    # Worst implementation everrrr:
+    return loads(wire_encode(obj))
+
+_DEPLOYMENT_FIELD = Field(u"configuration", to_unserialized_json)
 _LOG_STARTUP = MessageType(u"flocker-control:persistence:startup",
                            [_DEPLOYMENT_FIELD])
 _LOG_SAVE = ActionType(u"flocker-control:persistence:save",

--- a/flocker/control/test/test_persistence.py
+++ b/flocker/control/test/test_persistence.py
@@ -30,7 +30,7 @@ from .._persistence import (
     _LOG_SAVE, _LOG_STARTUP, migrate_configuration,
     _CONFIG_VERSION, ConfigurationMigration, ConfigurationMigrationError,
     _LOG_UPGRADE, MissingMigrationError, update_leases, _LOG_EXPIRE,
-    _LOG_UNCHANGED_DEPLOYMENT_NOT_SAVED,
+    _LOG_UNCHANGED_DEPLOYMENT_NOT_SAVED, to_unserialized_json,
     )
 from .._model import (
     Deployment, Application, DockerImage, Node, Dataset, Manifestation,
@@ -651,7 +651,7 @@ SUPPORTED_VERSIONS = st.integers(1, _CONFIG_VERSION)
 
 class WireEncodeDecodeTests(SynchronousTestCase):
     """
-    Tests for ``wire_encode`` and ``wire_decode``.
+    Tests for ``to_unserialized_json``, ``wire_encode`` and ``wire_decode``.
     """
     def test_encode_to_bytes(self):
         """
@@ -668,6 +668,15 @@ class WireEncodeDecodeTests(SynchronousTestCase):
         source_json = wire_encode(deployment)
         decoded_deployment = wire_decode(source_json)
         self.assertEqual(decoded_deployment, deployment)
+
+    @given(DEPLOYMENTS)
+    def test_to_unserialized_json(self, deployment):
+        """
+        ``to_unserialized_json`` is same output as ``wire_encode`` except
+        without doing JSON byte encoding.
+        """
+        unserialized = to_unserialized_json(deployment)
+        self.assertEquals(wire_decode(json.dumps(unserialized)), deployment)
 
     def test_no_arbitrary_decoding(self):
         """

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -20,7 +20,6 @@ control service, and sends inputs to the ConvergenceLoop state machine.
 """
 
 from random import uniform
-from json import loads
 
 from zope.interface import implementer
 
@@ -48,7 +47,7 @@ from ..common import gather_deferreds
 from ..control import (
     NodeStateCommand, IConvergenceAgent, AgentAMP, SetNodeEraCommand,
 )
-from ..control._persistence import wire_encode
+from ..control._persistence import to_unserialized_json
 
 
 class ClusterStatusInputs(Names):
@@ -302,25 +301,13 @@ class ConvergenceLoopOutputs(Names):
     UPDATE_MAYBE_WAKEUP = NamedConstant()
 
 
-def _to_unserialized_json(obj):
-    """
-    Convert a wire encodeable object into structured Python objects that
-    are JSON serializable.
-
-    :param obj: An object that can be passed to ``wire_encode``.
-    :return: Python object that can be JSON serialized.
-    """
-    # Worst implementation everrrr:
-    return loads(wire_encode(obj))
-
-
 _FIELD_CONNECTION = Field(
     u"connection",
     repr,
     "The AMP connection to control service")
 
 _FIELD_LOCAL_CHANGES = Field(
-    u"local_changes", _to_unserialized_json,
+    u"local_changes", to_unserialized_json,
     "Changes discovered in local state.")
 
 LOG_SEND_TO_CONTROL_SERVICE = ActionType(
@@ -329,11 +316,11 @@ LOG_SEND_TO_CONTROL_SERVICE = ActionType(
     "Send the local state to the control service.")
 
 _FIELD_CLUSTERSTATE = Field(
-    u"cluster_state", _to_unserialized_json,
+    u"cluster_state", to_unserialized_json,
     "The state of the cluster, according to control service.")
 
 _FIELD_CONFIGURATION = Field(
-    u"desired_configuration", _to_unserialized_json,
+    u"desired_configuration", to_unserialized_json,
     "The configuration of the cluster according to the control service.")
 
 _FIELD_ACTIONS = Field(

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -20,6 +20,7 @@ control service, and sends inputs to the ConvergenceLoop state machine.
 """
 
 from random import uniform
+from json import loads
 
 from zope.interface import implementer
 
@@ -47,6 +48,7 @@ from ..common import gather_deferreds
 from ..control import (
     NodeStateCommand, IConvergenceAgent, AgentAMP, SetNodeEraCommand,
 )
+from ..control._persistence import wire_encode
 
 
 class ClusterStatusInputs(Names):
@@ -300,13 +302,25 @@ class ConvergenceLoopOutputs(Names):
     UPDATE_MAYBE_WAKEUP = NamedConstant()
 
 
+def _to_unserialized_json(obj):
+    """
+    Convert a wire encodeable object into structured Python objects that
+    are JSON serializable.
+
+    :param obj: An object that can be passed to ``wire_encode``.
+    :return: Python object that can be JSON serialized.
+    """
+    # Worst implementation everrrr:
+    return loads(wire_encode(obj))
+
+
 _FIELD_CONNECTION = Field(
     u"connection",
-    lambda client: repr(client),
+    repr,
     "The AMP connection to control service")
 
 _FIELD_LOCAL_CHANGES = Field(
-    u"local_changes", repr,
+    u"local_changes", _to_unserialized_json,
     "Changes discovered in local state.")
 
 LOG_SEND_TO_CONTROL_SERVICE = ActionType(
@@ -315,11 +329,11 @@ LOG_SEND_TO_CONTROL_SERVICE = ActionType(
     "Send the local state to the control service.")
 
 _FIELD_CLUSTERSTATE = Field(
-    u"cluster_state", repr,
+    u"cluster_state", _to_unserialized_json,
     "The state of the cluster, according to control service.")
 
 _FIELD_CONFIGURATION = Field(
-    u"desired_configuration", repr,
+    u"desired_configuration", _to_unserialized_json,
     "The configuration of the cluster according to the control service.")
 
 _FIELD_ACTIONS = Field(


### PR DESCRIPTION
Structured information is easier to pretty print, e.g. with json formatting tools or `eliot-prettyprint` (the latter requires some follow up coding though).