### PR TITLE
[FLOC-3608] Replace ``PRecord`` with ``PClass``.

### DIFF
--- a/admin/build_targets/requirements.txt
+++ b/admin/build_targets/requirements.txt
@@ -9,7 +9,7 @@ requests==2.4.3
 requests-file==1.0
 ipaddr==2.1.11
 eliot==0.6.0
-pyrsistent==0.9.2
+pyrsistent==0.11.9
 python-cinderclient==1.1.1
 python-novaclient==2.24.1
 python-keystoneclient-rackspace==0.1.3

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -31,7 +31,7 @@ from eliot.twisted import DeferredContext
 
 from treq import json_content, content, get, post
 
-from pyrsistent import PRecord, field, CheckedPVector, pmap
+from pyrsistent import PClass, field, CheckedPVector, pmap
 
 from ..control import (
     Application, AttachedVolume, DockerImage, Manifestation, Dataset,
@@ -302,7 +302,7 @@ def get_mongo_client(host, port=27017):
     return d
 
 
-class ControlService(PRecord):
+class ControlService(PClass):
     """
     A record of the cluster's control service.
 
@@ -311,7 +311,7 @@ class ControlService(PRecord):
     public_address = field(type=bytes)
 
 
-class Node(PRecord):
+class Node(PClass):
     """
     A record of a cluster node.
 
@@ -450,7 +450,7 @@ def _ensure_encodeable(value):
     return value
 
 
-class Cluster(PRecord):
+class Cluster(PClass):
     """
     A record of the control service and the nodes in a cluster for acceptance
     testing.

--- a/flocker/ca/_ca.py
+++ b/flocker/ca/_ca.py
@@ -34,7 +34,7 @@ from uuid import uuid4, UUID
 
 from ipaddr import IPAddress
 from OpenSSL import crypto
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 from twisted.internet.ssl import (
     DistinguishedName, KeyPair, Certificate, CertificateOptions,
     PrivateCertificate,
@@ -278,7 +278,7 @@ def load_certificate_from_path(path, key_filename, cert_filename):
     return (keypair, certificate)
 
 
-class FlockerCredential(PRecord):
+class FlockerCredential(PClass):
     """
     Flocker credentials record, comprising a certificate and
     public/private key pair.
@@ -342,7 +342,7 @@ class FlockerCredential(PRecord):
             self.certificate, self.keypair.keypair)
 
 
-class UserCredential(PRecord):
+class UserCredential(PClass):
     """
     A certificate for an API user, signed by a supplied certificate
     authority.
@@ -451,7 +451,7 @@ class UserCredential(PRecord):
         return UUID(hex=self.credential.certificate.getSubject().OU)
 
 
-class NodeCredential(PRecord):
+class NodeCredential(PClass):
     """
     A certificate for a node agent, signed by a supplied certificate
     authority.
@@ -537,7 +537,7 @@ class NodeCredential(PRecord):
         return UUID(hex=self.credential.certificate.getSubject().OU)
 
 
-class ControlCredential(PRecord):
+class ControlCredential(PClass):
     """
     A certificate and key pair for a control service, signed by a supplied
     certificate authority.
@@ -633,7 +633,7 @@ class ControlCredential(PRecord):
             privateKey=key, certificate=certificate, trustRoot=trust_root)
 
 
-class RootCredential(PRecord):
+class RootCredential(PClass):
     """
     A credential representing a self-signed certificate authority.
     :ivar FlockerCredential credential: The certificate and key pair

--- a/flocker/ca/_validation.py
+++ b/flocker/ca/_validation.py
@@ -18,13 +18,13 @@ from twisted.web.client import Agent
 
 from treq.client import HTTPClient
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from ._ca import UserCredential
 
 
 @implementer(IPolicyForHTTPS)
-class ControlServicePolicy(PRecord):
+class ControlServicePolicy(PClass):
     """
     HTTPS TLS policy for validating the control service's identity, and
     providing the HTTP client's identity.

--- a/flocker/ca/testtools.py
+++ b/flocker/ca/testtools.py
@@ -12,7 +12,7 @@ from OpenSSL.crypto import X509Extension
 
 from twisted.python.filepath import FilePath
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from ..ca import (
     RootCredential, ControlCredential, NodeCredential, UserCredential,
@@ -43,7 +43,7 @@ def assert_has_extension(test, credential, name, value):
     test.assertIn(expected.get_data(), values)
 
 
-class CredentialSet(PRecord):
+class CredentialSet(PClass):
     """
     A full set of credentials for a CA.
 

--- a/flocker/common/test/test_thread.py
+++ b/flocker/common/test/test_thread.py
@@ -10,7 +10,7 @@ from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from .. import auto_threaded
 
@@ -62,7 +62,7 @@ class Spy(object):
 
 
 @auto_threaded(IStub, "reactor", "provider", "threadpool")
-class AsyncSpy(PRecord):
+class AsyncSpy(PClass):
     """
     An automatically asynchronous version of ``Spy``.
     """

--- a/flocker/common/test/test_version.py
+++ b/flocker/common/test/test_version.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     PACKAGING_INSTALLED = False
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from ..version import (
     _parse_version, FlockerVersion,
@@ -84,7 +84,7 @@ class InvalidVersionTests(SynchronousTestCase):
         self.assertRaises(UnparseableVersion, _parse_version, 'unparseable')
 
 
-class VersionCase(PRecord):
+class VersionCase(PClass):
     """
     Description of a version and its expected interpretations.
 

--- a/flocker/common/version.py
+++ b/flocker/common/version.py
@@ -5,7 +5,7 @@ import re
 
 from characteristic import attributes, Attribute
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 
 # This regex parses valid version numbers for Flocker. It handles two
@@ -231,7 +231,7 @@ def get_package_key_suffix(version):
         return "-testing"
 
 
-class RPMVersion(PRecord):
+class RPMVersion(PClass):
     """
     An RPM compatible version and a release version.
     See: http://fedoraproject.org/wiki/Packaging:NamingGuidelines#Pre-Release_packages  # noqa

--- a/flocker/control/_clusterstate.py
+++ b/flocker/control/_clusterstate.py
@@ -11,7 +11,7 @@ from twisted.python.deprecate import deprecated
 from twisted.application.service import MultiService
 from twisted.application.internet import TimerService
 
-from pyrsistent import PRecord, field, pmap
+from pyrsistent import PClass, field, pmap
 
 from . import DeploymentState, ChangeSource
 
@@ -21,7 +21,7 @@ EXPIRATION_TIME = timedelta(seconds=120)
 v1_0 = Version("flocker", 1, 0, 0)
 
 
-class _WiperAndSource(PRecord):
+class _WiperAndSource(PClass):
     """
     :ivar IClusterStateWipe wiper: A change wiper.
     :ivar IClusterStateSource source: Where the change wiper came from.

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -19,7 +19,7 @@ from characteristic import attributes
 from twisted.python.filepath import FilePath
 
 from pyrsistent import (
-    pmap, PClass, field, PMap, CheckedPSet, CheckedPMap, discard,
+    pmap, PClass, PRecord, field, PMap, CheckedPSet, CheckedPMap, discard,
     optional as optional_type, CheckedPVector
     )
 
@@ -868,7 +868,7 @@ def ip_to_uuid(ip):
 
 
 @implementer(IClusterStateChange)
-class NodeState(PClass):
+class NodeState(PRecord):
     """
     The current state of a node.
 
@@ -905,13 +905,16 @@ class NodeState(PClass):
         return (True, "")
 
     def __new__(cls, **kwargs):
-        if "uuid" not in kwargs:
-            # See https://clusterhq.atlassian.net/browse/FLOC-1795
-            warn("UUID is required, this is for backwards compat with "
-                 "existing tests. If you see this in production code "
-                 "that's a bug.", DeprecationWarning, stacklevel=2)
-            kwargs["uuid"] = ip_to_uuid(kwargs["hostname"])
-        return PClass.__new__(cls, **kwargs)
+        # PRecord does some crazy stuff, thus _precord_buckets; see
+        # PRecord.__new__.
+        if "_precord_buckets" not in kwargs:
+            if "uuid" not in kwargs:
+                # See https://clusterhq.atlassian.net/browse/FLOC-1795
+                warn("UUID is required, this is for backwards compat with "
+                     "existing tests. If you see this in production code "
+                     "that's a bug.", DeprecationWarning, stacklevel=2)
+                kwargs["uuid"] = ip_to_uuid(kwargs["hostname"])
+        return PRecord.__new__(cls, **kwargs)
 
     uuid = field(type=UUID, mandatory=True)
     hostname = field(type=unicode, factory=unicode, mandatory=True)

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -19,7 +19,7 @@ from characteristic import attributes
 from twisted.python.filepath import FilePath
 
 from pyrsistent import (
-    pmap, PClass, PRecord, field, PMap, CheckedPSet, CheckedPMap, discard,
+    pmap, PClass, field, PMap, CheckedPSet, CheckedPMap, discard,
     optional as optional_type, CheckedPVector
     )
 
@@ -137,7 +137,7 @@ def pmap_field(
                  factory=factory, invariant=invariant)
 
 
-class DockerImage(PRecord):
+class DockerImage(PClass):
     """
     An image that can be used to run an application using Docker.
 
@@ -179,7 +179,7 @@ class DockerImage(PRecord):
         return cls(**kwargs)
 
 
-class Port(PRecord):
+class Port(PClass):
     """
     A record representing the mapping between a port exposed internally by an
     application and the corresponding port exposed to the outside world.
@@ -191,7 +191,7 @@ class Port(PRecord):
     external_port = field(mandatory=True, type=int)
 
 
-class Link(PRecord):
+class Link(PClass):
     """
     A record representing the mapping between a port exposed internally to
     an application, and the corresponding external port of a possibly remote
@@ -227,21 +227,21 @@ class IRestartPolicy(Interface):
 
 
 @implementer(IRestartPolicy)
-class RestartNever(PRecord):
+class RestartNever(PClass):
     """
     A restart policy that never restarts an application.
     """
 
 
 @implementer(IRestartPolicy)
-class RestartAlways(PRecord):
+class RestartAlways(PClass):
     """
     A restart policy that always restarts an application.
     """
 
 
 @implementer(IRestartPolicy)
-class RestartOnFailure(PRecord):
+class RestartOnFailure(PClass):
     """
     A restart policy that restarts an application when it fails.
 
@@ -269,7 +269,7 @@ class RestartOnFailure(PRecord):
         return (True, "")
 
 
-class Application(PRecord):
+class Application(PClass):
     """
     A single `application <http://12factor.net/>`_ to be deployed.
 
@@ -316,7 +316,7 @@ class Application(PRecord):
     command_line = pvector_field(unicode, optional=True, initial=None)
 
 
-class Dataset(PRecord):
+class Dataset(PClass):
     """
     The filesystem data for a particular application.
 
@@ -341,7 +341,7 @@ class Dataset(PRecord):
                      serializer=lambda f, d: dict(d))
 
 
-class Manifestation(PRecord):
+class Manifestation(PClass):
     """
     A dataset that is mounted on a node.
 
@@ -360,7 +360,7 @@ class Manifestation(PRecord):
         return self.dataset.dataset_id
 
 
-class AttachedVolume(PRecord):
+class AttachedVolume(PClass):
     """
     A volume attached to an application to be deployed.
 
@@ -413,7 +413,7 @@ def _keys_match(attribute):
 _keys_match_dataset_id = _keys_match("dataset_id")
 
 
-class Node(PRecord):
+class Node(PClass):
     """
     Configuration for a single node on which applications will be managed
     (deployed, reconfigured, destroyed, etc).
@@ -441,15 +441,13 @@ class Node(PRecord):
         return (True, "")
 
     def __new__(cls, hostname=None, **kwargs):
-        # PRecord does some crazy stuff, thus _precord_buckets; see
-        # PRecord.__new__.
-        if "uuid" not in kwargs and "_precord_buckets" not in kwargs:
+        if "uuid" not in kwargs:
             # To be removed in https://clusterhq.atlassian.net/browse/FLOC-1795
             warn("UUID is required, this is for backwards compat with existing"
                  " tests only. If you see this in production code that's "
                  "a bug.", DeprecationWarning, stacklevel=2)
             kwargs["uuid"] = ip_to_uuid(hostname)
-        return PRecord.__new__(cls, **kwargs)
+        return PClass.__new__(cls, **kwargs)
 
     uuid = field(type=UUID, mandatory=True)
     applications = pset_field(Application)
@@ -607,7 +605,7 @@ class Leases(CheckedPMap):
         return updated
 
 
-class Deployment(PRecord):
+class Deployment(PClass):
     """
     A ``Deployment`` describes the configuration of a number of applications on
     a number of cooperating nodes.
@@ -692,7 +690,7 @@ class Deployment(PRecord):
         return deployment
 
 
-class Configuration(PRecord):
+class Configuration(PClass):
     """
     A ``Configuration`` represents the persisted configured state of a
     cluster.
@@ -870,7 +868,7 @@ def ip_to_uuid(ip):
 
 
 @implementer(IClusterStateChange)
-class NodeState(PRecord):
+class NodeState(PClass):
     """
     The current state of a node.
 
@@ -907,16 +905,13 @@ class NodeState(PRecord):
         return (True, "")
 
     def __new__(cls, **kwargs):
-        # PRecord does some crazy stuff, thus _precord_buckets; see
-        # PRecord.__new__.
-        if "_precord_buckets" not in kwargs:
-            if "uuid" not in kwargs:
-                # See https://clusterhq.atlassian.net/browse/FLOC-1795
-                warn("UUID is required, this is for backwards compat with "
-                     "existing tests. If you see this in production code "
-                     "that's a bug.", DeprecationWarning, stacklevel=2)
-                kwargs["uuid"] = ip_to_uuid(kwargs["hostname"])
-        return PRecord.__new__(cls, **kwargs)
+        if "uuid" not in kwargs:
+            # See https://clusterhq.atlassian.net/browse/FLOC-1795
+            warn("UUID is required, this is for backwards compat with "
+                 "existing tests. If you see this in production code "
+                 "that's a bug.", DeprecationWarning, stacklevel=2)
+            kwargs["uuid"] = ip_to_uuid(kwargs["hostname"])
+        return PClass.__new__(cls, **kwargs)
 
     uuid = field(type=UUID, mandatory=True)
     hostname = field(type=unicode, factory=unicode, mandatory=True)
@@ -981,7 +976,7 @@ class UpdateNodeStateEra(PClass):
 
 
 @implementer(IClusterStateWipe)
-class _WipeNodeState(PRecord):
+class _WipeNodeState(PClass):
     """
     Wipe information about a specific node from a ``DeploymentState``.
 
@@ -1014,7 +1009,7 @@ class _WipeNodeState(PRecord):
         return (self.node_uuid, self.attributes)
 
 
-class DeploymentState(PRecord):
+class DeploymentState(PClass):
     """
     A ``DeploymentState`` describes the state of the nodes in the cluster.
 
@@ -1099,7 +1094,7 @@ class DeploymentState(PRecord):
 
 
 @implementer(IClusterStateChange)
-class NonManifestDatasets(PRecord):
+class NonManifestDatasets(PClass):
     """
     A ``NonManifestDatasets`` represents datasets which are known to exist but
     which have no manifestations anywhere in the cluster.

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -489,7 +489,7 @@ class ConfigurationAPIUserV1(object):
                 response_dataset[u"primary"] = unicode(node.uuid)
                 response_dataset[u"path"] = get_manifestation_path(
                     node.uuid,
-                    dataset[u"dataset_id"]
+                    dataset.dataset_id
                 ).path.decode("utf-8")
 
             if dataset.maximum_size is not None:

--- a/flocker/control/test/test_model.py
+++ b/flocker/control/test/test_model.py
@@ -10,11 +10,14 @@ from uuid import uuid4, UUID
 
 from pyrsistent import (
     InvariantException, pset, PClass, PSet, pmap, PMap, thaw, PVector,
-    pvector
+    pvector, PRecord
 )
 
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
+
+from hypothesis import given, assume
+from hypothesis.strategies import sampled_from
 
 from zope.interface.verify import verifyObject
 
@@ -797,6 +800,9 @@ class AttachedVolumeTests(SynchronousTestCase):
         self.assertIs(volume.dataset, volume.manifestation.dataset)
 
 
+PYRSISTENT_STRUCT = sampled_from({PClass, PRecord})
+
+
 class PSetFieldTests(SynchronousTestCase):
     """
     Tests for ``pset_field``.
@@ -804,94 +810,108 @@ class PSetFieldTests(SynchronousTestCase):
     This will hopefully be contributed upstream to pyrsistent, thus the
     slightly different testing style.
     """
-    def test_initial_value(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_initial_value(self, klass):
         """
         ``pset_field`` results in initial value that is empty.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int)
         assert Record() == Record(value=[])
 
-    def test_custom_initial(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_custom_initial(self, klass):
         """
         A custom initial value can be passed in.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int, initial=(1, 2))
         assert Record() == Record(value=[1, 2])
 
-    def test_factory(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_factory(self, klass):
         """
         ``pset_field`` has a factory that creates a ``PSet``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int)
         record = Record(value=[1, 2])
         assert isinstance(record.value, PSet)
 
-    def test_checked_set(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_checked_set(self, klass):
         """
         ``pset_field`` results in a set that enforces its type.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int)
         record = Record(value=[1, 2])
         self.assertRaises(TypeError, record.value.add, "hello")
 
-    def test_type(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_type(self, klass):
         """
         ``pset_field`` enforces its type.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int)
         record = Record()
         self.assertRaises(TypeError, record.set, "value", None)
 
-    def test_mandatory(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_mandatory(self, klass):
         """
         ``pset_field`` is a mandatory field.
         """
-        class Record(PClass):
+        # PClass sets attributes to the initial value when you try to remove
+        # them.
+        assume(klass is PRecord)
+
+        class Record(klass):
             value = pset_field(int)
         record = Record(value=[1])
         self.assertRaises(InvariantException, record.remove, "value")
 
-    def test_default_non_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_default_non_optional(self, klass):
         """
         By default ``pset_field`` is non-optional, i.e. does not allow
         ``None``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int)
         self.assertRaises(TypeError, Record, value=None)
 
-    def test_explicit_non_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_explicit_non_optional(self, klass):
         """
         If ``optional`` argument is ``False`` then ``pset_field`` is
         non-optional, i.e. does not allow ``None``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int, optional=False)
         self.assertRaises(TypeError, Record, value=None)
 
-    def test_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_optional(self, klass):
         """
         If ``optional`` argument is true, ``None`` is acceptable alternative
         to a set.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(int, optional=True)
         assert ((Record(value=[1, 2]).value, Record(value=None).value) ==
                 (pset([1, 2]), None))
 
-    def test_name(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_name(self, klass):
         """
         The created set class name is based on the type of items in the set.
         """
         class Something(object):
             pass
 
-        class Record(PClass):
+        class Record(klass):
             value = pset_field(Something)
             value2 = pset_field(int)
         assert ((Record().value.__class__.__name__,
@@ -906,94 +926,108 @@ class PVectorFieldTests(SynchronousTestCase):
     This will hopefully be contributed upstream to pyrsistent, thus the
     slightly different testing style.
     """
-    def test_initial_value(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_initial_value(self, klass):
         """
         ``pvector_field`` results in initial value that is empty.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int)
         assert Record() == Record(value=[])
 
-    def test_custom_initial(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_custom_initial(self, klass):
         """
         A custom initial value can be passed in.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int, initial=(1, 2))
         assert Record() == Record(value=[1, 2])
 
-    def test_factory(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_factory(self, klass):
         """
         ``pvector_field`` has a factory that creates a ``PVector``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int)
         record = Record(value=[1, 2])
         assert isinstance(record.value, PVector)
 
-    def test_checked_vector(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_checked_vector(self, klass):
         """
         ``pvector_field`` results in a vector that enforces its type.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int)
         record = Record(value=[1, 2])
         self.assertRaises(TypeError, record.value.append, "hello")
 
-    def test_type(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_type(self, klass):
         """
         ``pvector_field`` enforces its type.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int)
         record = Record()
         self.assertRaises(TypeError, record.set, "value", None)
 
-    def test_mandatory(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_mandatory(self, klass):
         """
         ``pvector_field`` is a mandatory field.
         """
-        class Record(PClass):
+        # PClass sets attributes to the initial value when you try to remove
+        # them.
+        assume(klass is PRecord)
+
+        class Record(klass):
             value = pvector_field(int)
         record = Record(value=[1])
         self.assertRaises(InvariantException, record.remove, "value")
 
-    def test_default_non_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_default_non_optional(self, klass):
         """
         By default ``pvector_field`` is non-optional, i.e. does not allow
         ``None``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int)
         self.assertRaises(TypeError, Record, value=None)
 
-    def test_explicit_non_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_explicit_non_optional(self, klass):
         """
         If ``optional`` argument is ``False`` then ``pvector_field`` is
         non-optional, i.e. does not allow ``None``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int, optional=False)
         self.assertRaises(TypeError, Record, value=None)
 
-    def test_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_optional(self, klass):
         """
         If ``optional`` argument is true, ``None`` is acceptable alternative
         to a sequence.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(int, optional=True)
         assert ((Record(value=[1, 2]).value, Record(value=None).value) ==
                 (pvector([1, 2]), None))
 
-    def test_name(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_name(self, klass):
         """
         The created set class name is based on the type of items in the set.
         """
         class Something(object):
             pass
 
-        class Record(PClass):
+        class Record(klass):
             value = pvector_field(Something)
             value2 = pvector_field(int)
         assert ((Record().value.__class__.__name__,
@@ -1008,104 +1042,119 @@ class PMapFieldTests(SynchronousTestCase):
     This will hopefully be contributed upstream to pyrsistent, thus the
     slightly different testing style.
     """
-    def test_initial_value(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_initial_value(self, klass):
         """
         ``pmap_field`` results in initial value that is empty.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, int)
         assert Record() == Record(value={})
 
-    def test_override_initial_value(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_override_initial_value(self, klass):
         """
         The initial value can be set to a non-empty map by passing the desired
         value to the ``initial`` parameter.
         """
         initial = {1: 2, 3: 4}
 
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, int, initial=initial)
         assert Record() == Record(value=initial)
 
-    def test_none_initial_value(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_none_initial_value(self, klass):
         """
         The initial value for an optional field can be set to ``None`` by
         passing ``None`` to the ``initial`` parameter.
         """
         initial = None
 
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, int, optional=True, initial=initial)
         assert Record() == Record(value=initial)
 
-    def test_factory(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_factory(self, klass):
         """
         ``pmap_field`` has a factory that creates a ``PMap``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, int)
         record = Record(value={1:  1234})
         assert isinstance(record.value, PMap)
 
-    def test_checked_map_key(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_checked_map_key(self, klass):
         """
         ``pmap_field`` results in a map that enforces its key type.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, type(None))
         record = Record(value={1: None})
         self.assertRaises(TypeError, record.value.set, "hello", None)
 
-    def test_checked_map_value(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_checked_map_value(self, klass):
         """
         ``pmap_field`` results in a map that enforces its value type.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, type(None))
         record = Record(value={1: None})
         self.assertRaises(TypeError, record.value.set, 2, 4)
 
-    def test_mandatory(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_mandatory(self, klass):
         """
         ``pmap_field`` is a mandatory field.
         """
-        class Record(PClass):
+        # PClass sets attributes to the initial value when you try to remove
+        # them.
+        assume(klass is PRecord)
+
+        class Record(klass):
             value = pmap_field(int, int)
         record = Record()
         self.assertRaises(InvariantException, record.remove, "value")
 
-    def test_default_non_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_default_non_optional(self, klass):
         """
         By default ``pmap_field`` is non-optional, i.e. does not allow
         ``None``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, int)
         # Ought to be TypeError, but pyrsistent doesn't quite allow that:
         self.assertRaises(AttributeError, Record, value=None)
 
-    def test_explicit_non_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_explicit_non_optional(self, klass):
         """
         If ``optional`` argument is ``False`` then ``pmap_field`` is
         non-optional, i.e. does not allow ``None``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, int, optional=False)
         # Ought to be TypeError, but pyrsistent doesn't quite allow that:
         self.assertRaises(AttributeError, Record, value=None)
 
-    def test_optional(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_optional(self, klass):
         """
         If ``optional`` argument is true, ``None`` is acceptable alternative
         to a set.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(int, int, optional=True)
         self.assertEqual(
             (Record(value={1: 2}).value, Record(value=None).value),
             (pmap({1: 2}), None))
 
-    def test_name(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_name(self, klass):
         """
         The created map class name is based on the types of items in the map.
         """
@@ -1115,18 +1164,19 @@ class PMapFieldTests(SynchronousTestCase):
         class Another(object):
             pass
 
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(Something, Another)
             value2 = pmap_field(int, float)
         assert ((Record().value.__class__.__name__,
                  Record().value2.__class__.__name__) ==
                 ("SomethingAnotherPMap", "IntFloatPMap"))
 
-    def test_invariant(self):
+    @given(PYRSISTENT_STRUCT)
+    def test_invariant(self, klass):
         """
         The ``invariant`` parameter is passed through to ``field``.
         """
-        class Record(PClass):
+        class Record(klass):
             value = pmap_field(
                 int, int,
                 invariant=(

--- a/flocker/control/test/test_model.py
+++ b/flocker/control/test/test_model.py
@@ -9,7 +9,7 @@ import datetime
 from uuid import uuid4, UUID
 
 from pyrsistent import (
-    InvariantException, pset, PRecord, PSet, pmap, PMap, thaw, PVector,
+    InvariantException, pset, PClass, PSet, pmap, PMap, thaw, PVector,
     pvector
 )
 
@@ -808,7 +808,7 @@ class PSetFieldTests(SynchronousTestCase):
         """
         ``pset_field`` results in initial value that is empty.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int)
         assert Record() == Record(value=[])
 
@@ -816,7 +816,7 @@ class PSetFieldTests(SynchronousTestCase):
         """
         A custom initial value can be passed in.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int, initial=(1, 2))
         assert Record() == Record(value=[1, 2])
 
@@ -824,7 +824,7 @@ class PSetFieldTests(SynchronousTestCase):
         """
         ``pset_field`` has a factory that creates a ``PSet``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int)
         record = Record(value=[1, 2])
         assert isinstance(record.value, PSet)
@@ -833,7 +833,7 @@ class PSetFieldTests(SynchronousTestCase):
         """
         ``pset_field`` results in a set that enforces its type.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int)
         record = Record(value=[1, 2])
         self.assertRaises(TypeError, record.value.add, "hello")
@@ -842,7 +842,7 @@ class PSetFieldTests(SynchronousTestCase):
         """
         ``pset_field`` enforces its type.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int)
         record = Record()
         self.assertRaises(TypeError, record.set, "value", None)
@@ -851,7 +851,7 @@ class PSetFieldTests(SynchronousTestCase):
         """
         ``pset_field`` is a mandatory field.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int)
         record = Record(value=[1])
         self.assertRaises(InvariantException, record.remove, "value")
@@ -861,7 +861,7 @@ class PSetFieldTests(SynchronousTestCase):
         By default ``pset_field`` is non-optional, i.e. does not allow
         ``None``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int)
         self.assertRaises(TypeError, Record, value=None)
 
@@ -870,7 +870,7 @@ class PSetFieldTests(SynchronousTestCase):
         If ``optional`` argument is ``False`` then ``pset_field`` is
         non-optional, i.e. does not allow ``None``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int, optional=False)
         self.assertRaises(TypeError, Record, value=None)
 
@@ -879,7 +879,7 @@ class PSetFieldTests(SynchronousTestCase):
         If ``optional`` argument is true, ``None`` is acceptable alternative
         to a set.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(int, optional=True)
         assert ((Record(value=[1, 2]).value, Record(value=None).value) ==
                 (pset([1, 2]), None))
@@ -891,7 +891,7 @@ class PSetFieldTests(SynchronousTestCase):
         class Something(object):
             pass
 
-        class Record(PRecord):
+        class Record(PClass):
             value = pset_field(Something)
             value2 = pset_field(int)
         assert ((Record().value.__class__.__name__,
@@ -910,7 +910,7 @@ class PVectorFieldTests(SynchronousTestCase):
         """
         ``pvector_field`` results in initial value that is empty.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int)
         assert Record() == Record(value=[])
 
@@ -918,7 +918,7 @@ class PVectorFieldTests(SynchronousTestCase):
         """
         A custom initial value can be passed in.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int, initial=(1, 2))
         assert Record() == Record(value=[1, 2])
 
@@ -926,7 +926,7 @@ class PVectorFieldTests(SynchronousTestCase):
         """
         ``pvector_field`` has a factory that creates a ``PVector``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int)
         record = Record(value=[1, 2])
         assert isinstance(record.value, PVector)
@@ -935,7 +935,7 @@ class PVectorFieldTests(SynchronousTestCase):
         """
         ``pvector_field`` results in a vector that enforces its type.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int)
         record = Record(value=[1, 2])
         self.assertRaises(TypeError, record.value.append, "hello")
@@ -944,7 +944,7 @@ class PVectorFieldTests(SynchronousTestCase):
         """
         ``pvector_field`` enforces its type.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int)
         record = Record()
         self.assertRaises(TypeError, record.set, "value", None)
@@ -953,7 +953,7 @@ class PVectorFieldTests(SynchronousTestCase):
         """
         ``pvector_field`` is a mandatory field.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int)
         record = Record(value=[1])
         self.assertRaises(InvariantException, record.remove, "value")
@@ -963,7 +963,7 @@ class PVectorFieldTests(SynchronousTestCase):
         By default ``pvector_field`` is non-optional, i.e. does not allow
         ``None``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int)
         self.assertRaises(TypeError, Record, value=None)
 
@@ -972,7 +972,7 @@ class PVectorFieldTests(SynchronousTestCase):
         If ``optional`` argument is ``False`` then ``pvector_field`` is
         non-optional, i.e. does not allow ``None``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int, optional=False)
         self.assertRaises(TypeError, Record, value=None)
 
@@ -981,7 +981,7 @@ class PVectorFieldTests(SynchronousTestCase):
         If ``optional`` argument is true, ``None`` is acceptable alternative
         to a sequence.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(int, optional=True)
         assert ((Record(value=[1, 2]).value, Record(value=None).value) ==
                 (pvector([1, 2]), None))
@@ -993,7 +993,7 @@ class PVectorFieldTests(SynchronousTestCase):
         class Something(object):
             pass
 
-        class Record(PRecord):
+        class Record(PClass):
             value = pvector_field(Something)
             value2 = pvector_field(int)
         assert ((Record().value.__class__.__name__,
@@ -1012,7 +1012,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         ``pmap_field`` results in initial value that is empty.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int)
         assert Record() == Record(value={})
 
@@ -1023,7 +1023,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         initial = {1: 2, 3: 4}
 
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int, initial=initial)
         assert Record() == Record(value=initial)
 
@@ -1034,7 +1034,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         initial = None
 
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int, optional=True, initial=initial)
         assert Record() == Record(value=initial)
 
@@ -1042,7 +1042,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         ``pmap_field`` has a factory that creates a ``PMap``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int)
         record = Record(value={1:  1234})
         assert isinstance(record.value, PMap)
@@ -1051,7 +1051,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         ``pmap_field`` results in a map that enforces its key type.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, type(None))
         record = Record(value={1: None})
         self.assertRaises(TypeError, record.value.set, "hello", None)
@@ -1060,7 +1060,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         ``pmap_field`` results in a map that enforces its value type.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, type(None))
         record = Record(value={1: None})
         self.assertRaises(TypeError, record.value.set, 2, 4)
@@ -1069,7 +1069,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         ``pmap_field`` is a mandatory field.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int)
         record = Record()
         self.assertRaises(InvariantException, record.remove, "value")
@@ -1079,7 +1079,7 @@ class PMapFieldTests(SynchronousTestCase):
         By default ``pmap_field`` is non-optional, i.e. does not allow
         ``None``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int)
         # Ought to be TypeError, but pyrsistent doesn't quite allow that:
         self.assertRaises(AttributeError, Record, value=None)
@@ -1089,7 +1089,7 @@ class PMapFieldTests(SynchronousTestCase):
         If ``optional`` argument is ``False`` then ``pmap_field`` is
         non-optional, i.e. does not allow ``None``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int, optional=False)
         # Ought to be TypeError, but pyrsistent doesn't quite allow that:
         self.assertRaises(AttributeError, Record, value=None)
@@ -1099,7 +1099,7 @@ class PMapFieldTests(SynchronousTestCase):
         If ``optional`` argument is true, ``None`` is acceptable alternative
         to a set.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(int, int, optional=True)
         self.assertEqual(
             (Record(value={1: 2}).value, Record(value=None).value),
@@ -1115,7 +1115,7 @@ class PMapFieldTests(SynchronousTestCase):
         class Another(object):
             pass
 
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(Something, Another)
             value2 = pmap_field(int, float)
         assert ((Record().value.__class__.__name__,
@@ -1126,7 +1126,7 @@ class PMapFieldTests(SynchronousTestCase):
         """
         The ``invariant`` parameter is passed through to ``field``.
         """
-        class Record(PRecord):
+        class Record(PClass):
             value = pmap_field(
                 int, int,
                 invariant=(

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -117,14 +117,14 @@ def generate_model(root_class=ROOT_CLASS):
     return result
 
 
-class Subtype(PRecord):
+class Subtype(PClass):
     """
     A sub-type used in ``GenerateModelTests``.
     """
 OriginalSubtype = Subtype
 
 
-class Subtype(PRecord):
+class Subtype(PClass):
     """
     A changed variant of ``Subtype``.
     """
@@ -178,11 +178,11 @@ class GenerateModelTests(SynchronousTestCase):
         """
         If a new field is added to a ``PRecord`` the output changes.
         """
-        class Different(PRecord):
+        class Different(PClass):
             pass
         Original = Different
 
-        class Different(PRecord):
+        class Different(PClass):
             x = field()
 
         self.assert_catches_changes(Original, Different)
@@ -192,12 +192,12 @@ class GenerateModelTests(SynchronousTestCase):
         If an existing field is removed from a ``PRecord`` the output
         changes.
         """
-        class Different(PRecord):
+        class Different(PClass):
             x = field()
             y = field()
         Original = Different
 
-        class Different(PRecord):
+        class Different(PClass):
             x = field()
 
         self.assert_catches_changes(Original, Different)
@@ -207,11 +207,11 @@ class GenerateModelTests(SynchronousTestCase):
         If an existing field has its type changed in a ``PRecord`` the output
         changes.
         """
-        class Different(PRecord):
+        class Different(PClass):
             x = field()
         Original = Different
 
-        class Different(PRecord):
+        class Different(PClass):
             x = field(type=int)
 
         self.assert_catches_changes(Original, Different)
@@ -221,11 +221,11 @@ class GenerateModelTests(SynchronousTestCase):
         If the an existing field in a ``PRecord`` has the same type, but the
         type changed somehow, the output changes.
         """
-        class Different(PRecord):
+        class Different(PClass):
             x = field(type=Subtype)
         Original = Different
 
-        class Different(PRecord):
+        class Different(PClass):
             x = field(type=ChangedSubtype)
 
         self.assert_catches_changes(Original, Different)
@@ -234,11 +234,11 @@ class GenerateModelTests(SynchronousTestCase):
         """
         The order of types in a ``PRecord`` doesn't change the output.
         """
-        class Different(PRecord):
+        class Different(PClass):
             x = field(type=(int, str))
         Original = Different
 
-        class Different(PRecord):
+        class Different(PClass):
             x = field(type=(str, int))
 
         self.assertEqual(generate_model(Original),

--- a/flocker/control/test/test_persistence.py
+++ b/flocker/control/test/test_persistence.py
@@ -23,7 +23,7 @@ from twisted.internet.task import Clock
 from twisted.trial.unittest import TestCase, SynchronousTestCase
 from twisted.python.filepath import FilePath
 
-from pyrsistent import PRecord, pset
+from pyrsistent import PClass, pset
 
 from .._persistence import (
     ConfigurationPersistenceService, wire_decode, wire_encode,
@@ -674,7 +674,7 @@ class WireEncodeDecodeTests(SynchronousTestCase):
         ``wire_decode`` will not decode classes that are not in
         ``SERIALIZABLE_CLASSES``.
         """
-        class Temp(PRecord):
+        class Temp(PClass):
             """A class."""
         SERIALIZABLE_CLASSES.append(Temp)
 

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -16,7 +16,7 @@ changes.
 
 from zope.interface import Interface, Attribute, implementer
 
-from pyrsistent import PVector, PRecord, pvector, field, PClass
+from pyrsistent import PVector, pvector, field, PClass
 
 from twisted.internet.defer import maybeDeferred, succeed
 
@@ -87,7 +87,7 @@ LOG_IN_PARALLEL = ActionType("flocker:node:in_parallel", [], [])
 
 
 @implementer(IStateChange)
-class _InParallel(PRecord):
+class _InParallel(PClass):
     changes = field(
         type=PVector,
         # Sort the changes for the benefit of comparison.  Stick with a vector
@@ -129,7 +129,7 @@ def in_parallel(changes):
 
 
 @implementer(IStateChange)
-class _Sequentially(PRecord):
+class _Sequentially(PClass):
     changes = field(type=PVector, factory=pvector, mandatory=True)
 
     @property

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -438,7 +438,7 @@ class SetProxies(PClass):
     def eliot_action(self):
         return start_action(
             _logger, _eliot_system("setproxies"),
-            addresses=list(dict(port) for port in self.ports),
+            addresses=list(port.serialize() for port in self.ports),
         )
 
     def run(self, deployer):

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -15,7 +15,7 @@ from zope.interface import Interface, implementer, Attribute
 
 from characteristic import attributes
 
-from pyrsistent import PRecord, field, PClass
+from pyrsistent import PClass, field
 
 from eliot import Message, write_failure, Logger, start_action
 
@@ -156,7 +156,7 @@ def _eliot_system(part):
 
 
 @implementer(IStateChange)
-class StartApplication(PRecord):
+class StartApplication(PClass):
     """
     Launch the supplied application as a container.
 
@@ -258,7 +258,7 @@ def _link_environment(protocol, alias, local_port, hostname, remote_port):
 
 
 @implementer(IStateChange)
-class StopApplication(PRecord):
+class StopApplication(PClass):
     """
     Stop and disable the given application.
 
@@ -280,7 +280,7 @@ class StopApplication(PRecord):
 
 
 @implementer(IStateChange)
-class CreateDataset(PRecord):
+class CreateDataset(PClass):
     """
     Create a new locally-owned dataset.
 
@@ -389,7 +389,7 @@ class PushDataset(object):
 
 
 @implementer(IStateChange)
-class DeleteDataset(PRecord):
+class DeleteDataset(PClass):
     """
     Delete all local copies of the dataset.
 
@@ -426,7 +426,7 @@ class DeleteDataset(PRecord):
 
 
 @implementer(IStateChange)
-class SetProxies(PRecord):
+class SetProxies(PClass):
     """
     Set the ports which will be forwarded to other nodes.
 
@@ -459,7 +459,7 @@ class SetProxies(PRecord):
 
 
 @implementer(IStateChange)
-class OpenPorts(PRecord):
+class OpenPorts(PClass):
     """
     Set the ports which will have the firewall opened.
 

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -20,7 +20,7 @@ from eliot import Message, MessageType, Field, start_action
 
 from repoze.lru import LRUCache
 
-from pyrsistent import field, PRecord, pset
+from pyrsistent import field, PClass, pset
 from requests import Response
 from characteristic import with_cmp
 
@@ -65,7 +65,7 @@ class AddressInUse(Exception):
         self.apierror = apierror
 
 
-class Environment(PRecord):
+class Environment(PClass):
     """
     A collection of environment variables.
 
@@ -84,7 +84,7 @@ class Environment(PRecord):
         return dict(self.variables)
 
 
-class Volume(PRecord):
+class Volume(PClass):
     """
     A Docker volume.
 
@@ -98,7 +98,7 @@ class Volume(PRecord):
     container_path = field(mandatory=True, type=FilePath)
 
 
-class PortMap(PRecord):
+class PortMap(PClass):
     """
     A record representing the mapping between a port exposed internally by a
     docker container and the corresponding external port on the host.
@@ -110,7 +110,7 @@ class PortMap(PRecord):
     external_port = field(mandatory=True, type=int)
 
 
-class ImageDataCache(PRecord):
+class ImageDataCache(PClass):
     """
     A record representing cached image data. The cache only stores
     the data we care about from an inspected image.
@@ -123,7 +123,7 @@ class ImageDataCache(PRecord):
     environment = field(mandatory=True, type=(list, type(None)))
 
 
-class Unit(PRecord):
+class Unit(PClass):
     """
     Information about a unit managed by Docker.
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -20,7 +20,7 @@ from eliot.serializers import identity
 
 from zope.interface import implementer, Interface
 
-from pyrsistent import PRecord, PClass, field, pmap_field, pset_field
+from pyrsistent import PClass, field, pmap_field, pset_field
 
 import psutil
 
@@ -46,7 +46,7 @@ from ...common.algebraic import TaggedUnionInvariant
 
 
 # Eliot is transitioning away from the "Logger instances all over the place"
-# approach.  And it's hard to put Logger instances on PRecord subclasses which
+# approach.  And it's hard to put Logger instances on PClass subclasses which
 # we have a lot of.  So just use this global logger for now.
 _logger = Logger()
 
@@ -342,11 +342,11 @@ DISCOVERED_RAW_STATE = MessageType(
 
 def _volume_field():
     """
-    Create and return a ``PRecord`` ``field`` to hold a ``BlockDeviceVolume``.
+    Create and return a ``PClass`` ``field`` to hold a ``BlockDeviceVolume``.
     """
     return field(
         type=BlockDeviceVolume, mandatory=True,
-        # Disable the automatic PRecord.create factory.  Callers can just
+        # Disable the automatic PClass.create factory.  Callers can just
         # supply the right type, we don't need the magic coercion behavior
         # supplied by default.
         factory=lambda x: x
@@ -397,7 +397,7 @@ def _blockdevice_volume_from_datasetid(volumes, dataset_id):
 # Get rid of this in favor of calculating each individual operation in
 # BlockDeviceDeployer.calculate_changes.  FLOC-1772
 @implementer(IStateChange)
-class DestroyBlockDeviceDataset(PRecord):
+class DestroyBlockDeviceDataset(PClass):
     """
     Destroy the volume for a dataset with a primary manifestation on the node
     where this state change runs.
@@ -434,7 +434,7 @@ class DestroyBlockDeviceDataset(PRecord):
 
 
 @implementer(IStateChange)
-class CreateFilesystem(PRecord):
+class CreateFilesystem(PClass):
     """
     Create a filesystem on a block device.
 
@@ -522,7 +522,7 @@ def _valid_size(size):
 
 
 @implementer(IStateChange)
-class MountBlockDevice(PRecord):
+class MountBlockDevice(PClass):
     """
     Mount the filesystem mounted from the block device backed by a particular
     volume.
@@ -588,7 +588,7 @@ class MountBlockDevice(PRecord):
 
 
 @implementer(IStateChange)
-class UnmountBlockDevice(PRecord):
+class UnmountBlockDevice(PClass):
     """
     Unmount the filesystem mounted from the block device backed by a particular
     volume.
@@ -626,7 +626,7 @@ class UnmountBlockDevice(PRecord):
 
 
 @implementer(IStateChange)
-class AttachVolume(PRecord):
+class AttachVolume(PClass):
     """
     Attach an unattached volume to this node (the node of the deployer it is
     run with).
@@ -688,7 +688,7 @@ class ActionNeeded(PClass):
 
 
 @implementer(IStateChange)
-class DetachVolume(PRecord):
+class DetachVolume(PClass):
     """
     Detach a volume from the node it is currently attached to.
 
@@ -714,7 +714,7 @@ class DetachVolume(PRecord):
 
 
 @implementer(IStateChange)
-class DestroyVolume(PRecord):
+class DestroyVolume(PClass):
     """
     Destroy the storage (and therefore contents) of a volume.
 
@@ -758,7 +758,7 @@ def allocated_size(allocation_unit, requested_size):
 
 
 @implementer(IStateChange)
-class CreateBlockDeviceDataset(PRecord):
+class CreateBlockDeviceDataset(PClass):
     """
     An operation to create a new dataset on a newly created volume with a newly
     initialized filesystem.
@@ -1084,7 +1084,7 @@ class ProfiledBlockDeviceAPIAdapter(PClass):
 
 @implementer(IBlockDeviceAsyncAPI)
 @auto_threaded(IBlockDeviceAPI, "_reactor", "_sync", "_threadpool")
-class _SyncToThreadedAsyncAPIAdapter(PRecord):
+class _SyncToThreadedAsyncAPIAdapter(PClass):
     """
     Adapt any ``IBlockDeviceAPI`` to ``IBlockDeviceAsyncAPI`` by running its
     methods in threads of a thread pool.
@@ -1252,7 +1252,7 @@ class BlockDeviceDeployerLocalState(PClass):
 
 
 @implementer(IDeployer)
-class BlockDeviceDeployer(PRecord):
+class BlockDeviceDeployer(PClass):
     """
     An ``IDeployer`` that operates on ``IBlockDeviceAPI`` providers.
 
@@ -1303,7 +1303,7 @@ class BlockDeviceDeployer(PRecord):
         During real operation, this is a threadpool-based wrapper around the
         ``IBlockDeviceAPI`` provider.  For testing purposes it can be
         overridden with a different object entirely (and this large amount of
-        support code for this is necessary because this class is a ``PRecord``
+        support code for this is necessary because this class is a ``PClass``
         subclass).
         """
         if self._async_block_device_api is None:

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -12,7 +12,7 @@ from bitmath import Byte, GiB
 
 from eliot import Message
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from keystoneclient.openstack.common.apiclient.exceptions import (
     NotFound as CinderNotFound,
@@ -746,12 +746,12 @@ class _LoggingCinderVolumeManager(object):
 
 
 @auto_openstack_logging(INovaVolumeManager, "_nova_volumes")
-class _LoggingNovaVolumeManager(PRecord):
+class _LoggingNovaVolumeManager(PClass):
     _nova_volumes = field(mandatory=True)
 
 
 @auto_openstack_logging(INovaServerManager, "_nova_servers")
-class _LoggingNovaServerManager(PRecord):
+class _LoggingNovaServerManager(PClass):
     _nova_servers = field(mandatory=True)
 
 

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from bitmath import Byte, GiB
 
 from characteristic import with_cmp
-from pyrsistent import PClass, PRecord, field, pset, pmap, thaw
+from pyrsistent import PClass, field, pset, pmap, thaw
 from zope.interface import implementer
 from boto import ec2
 from boto import config
@@ -180,7 +180,7 @@ class VolumeStates(Values):
     DELETING = ValueConstant(u'deleting')
 
 
-class VolumeStateFlow(PRecord):
+class VolumeStateFlow(PClass):
     """
     Expected EBS volume state flow during ``VolumeOperations``.
     """
@@ -195,7 +195,7 @@ class VolumeStateFlow(PRecord):
     unsets_attach = field(mandatory=True, type=bool)
 
 
-class VolumeStateTable(PRecord):
+class VolumeStateTable(PClass):
     """
     Map of volume operation to expected volume state transitions
     and expected update to volume's ``attach_data``.
@@ -470,9 +470,9 @@ def boto_logger(*args, **kwargs):
 
 
 @boto_logger("connection")
-class _LoggedBotoConnection(PRecord):
+class _LoggedBotoConnection(PClass):
     """
-    Wrapper ``PRecord`` around ``boto.ec2.connection.EC2Connection``
+    Wrapper ``PClass`` around ``boto.ec2.connection.EC2Connection``
     to facilitate logging of exceptions from Boto APIs.
 
     :ivar boto.ec2.connection.EC2Connection connection: Object
@@ -482,7 +482,7 @@ class _LoggedBotoConnection(PRecord):
     connection = field(mandatory=True)
 
 
-class _EC2(PRecord):
+class _EC2(PClass):
     """
     :ivar str zone: The name of the zone for the connection.
     :ivar boto.ec2.connection.EC2Connection connection: Object

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -23,7 +23,7 @@ from zope.interface import implementer
 from zope.interface.verify import verifyObject
 
 from pyrsistent import (
-    PRecord, field, discard, pmap, pvector,
+    PClass, field, discard, pmap, pvector,
 )
 
 from hypothesis import given
@@ -123,7 +123,7 @@ if not platform.isLinux():
     skip = "flocker.node.agents.blockdevice is only supported on Linux"
 
 
-class _SizeInfo(PRecord):
+class _SizeInfo(PClass):
     """
     :ivar int actual: The number of bytes allocated in the filesystem to a
         file, as computed by counting block size.  A sparse file may have less
@@ -3654,7 +3654,7 @@ class MountBlockDeviceInitTests(
     """
 
 
-class _MountScenario(PRecord):
+class _MountScenario(PClass):
     """
     Setup tools for the tests defined on ``MountBlockDeviceTests``.
 

--- a/flocker/node/benchmark.py
+++ b/flocker/node/benchmark.py
@@ -5,7 +5,7 @@ import sys
 from twisted.python.usage import Options, UsageError
 from twisted.internet.defer import succeed
 
-from pyrsistent import PRecord
+from pyrsistent import PClass
 
 from zope.interface import implementer
 
@@ -57,7 +57,7 @@ def hardware_report(options):
 
 
 @implementer(ICommandLineScript)
-class BenchmarkScript(PRecord):
+class BenchmarkScript(PClass):
     """
     Implement top-level logic for the ``flocker-benchmark``.
     """

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -14,7 +14,7 @@ import yaml
 
 from jsonschema import FormatChecker, Draft4Validator
 
-from pyrsistent import PRecord, field, PMap, pmap, pvector
+from pyrsistent import PClass, field, PMap, pmap, pvector
 
 from eliot import ActionType, fields
 
@@ -128,7 +128,7 @@ def _get_external_ip(host, port):
             sleep(0.1)
 
 
-class _TLSContext(PRecord):
+class _TLSContext(PClass):
     """
     Information extracted from the TLS certificates for this node.
 
@@ -257,7 +257,7 @@ class ContainerAgentOptions(_AgentOptions):
 
 
 @implementer(ICommandLineScript)
-class AgentScript(PRecord):
+class AgentScript(PClass):
     """
     Implement top-level logic for the ``flocker-dataset-agent`` and
     ``flocker-container-agent`` scripts.
@@ -276,7 +276,7 @@ class AgentScript(PRecord):
         )
 
 
-class AgentServiceFactory(PRecord):
+class AgentServiceFactory(PClass):
     """
     Implement general agent setup in a way that's usable by
     ``AgentScript`` but also easily testable.
@@ -407,7 +407,7 @@ class DeployerType(Names):
     block = NamedConstant()
 
 
-class BackendDescription(PRecord):
+class BackendDescription(PClass):
     """
     Represent one kind of storage backend we might be able to use.
 
@@ -479,7 +479,7 @@ _DEFAULT_DEPLOYERS = {
 }
 
 
-class AgentService(PRecord):
+class AgentService(PClass):
     """
     :ivar backends: ``BackendDescription`` instances describing how to use each
         available storage backend.
@@ -641,7 +641,7 @@ class AgentService(PRecord):
         )
 
 
-class DatasetServiceFactory(PRecord):
+class DatasetServiceFactory(PClass):
     """
     A helper for creating most of the pieces that go into a dataset convergence
     agent.
@@ -709,7 +709,7 @@ class DiagnosticsOptions(Options):
 
 
 @implementer(ICommandLineScript)
-class DiagnosticsScript(PRecord):
+class DiagnosticsScript(PClass):
     """
     Implement top-level logic for the ``flocker-diagnostics``.
     """

--- a/flocker/node/test/istatechange.py
+++ b/flocker/node/test/istatechange.py
@@ -14,7 +14,7 @@ from zope.interface import implementer
 
 from eliot import Logger, start_action
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 from characteristic import attributes
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -89,7 +89,7 @@ def make_istatechange_tests(klass, kwargs1, kwargs2):
 
 
 @implementer(IStateChange)
-class DummyStateChange(PRecord):
+class DummyStateChange(PClass):
     """
     A do-nothing implementation of ``IStateChange``.
     """

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -8,7 +8,7 @@ from unittest import SkipTest
 
 from zope.interface import implementer
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import FirstError, Deferred, succeed, fail
@@ -81,7 +81,7 @@ def largest(interface, instance):
 
 
 @implementer(IStateChange)
-class BrokenAction(PRecord):
+class BrokenAction(PClass):
     """
     An ``IStateChange`` implementation that synchronously raised an exception
     instead of returning a ``Deferred``.

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -519,7 +519,10 @@ class StartApplicationTests(SynchronousTestCase):
         StartApplication(application=application,
                          node_state=EMPTY_NODESTATE).run(deployer)
 
-        self.assertEqual(policy, RestartNever())
+        [unit] = self.successResultOf(fake_docker.list())
+        self.assertEqual(
+            unit.restart_policy,
+            RestartNever())
 
     def test_command_line(self):
         """
@@ -1026,7 +1029,7 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
 
         manifestation = Manifestation(
             dataset=Dataset(
-                dataset_id=DATASET_ID,
+                dataset_id=self.DATASET_ID,
                 maximum_size=1024 * 1024 * 100),
             primary=True,
         )
@@ -1038,7 +1041,7 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
         )
         d = api.discover_state(self.EMPTY_NODESTATE)
 
-        self.assertItemsEqual(
+        self.assertEqual(
             self.successResultOf(d).node_state.manifestations[
                 self.DATASET_ID],
             manifestation)

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -10,7 +10,7 @@ from unittest import skipUnless
 import yaml
 from ipaddr import IPAddress
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from jsonschema.exceptions import ValidationError
 
@@ -97,7 +97,7 @@ def deployer_factory_stub(**kw):
     return deployer
 
 
-class DummyAgentService(PRecord):
+class DummyAgentService(PClass):
     reactor = field()
     loop_service = field()
     configuration = field()
@@ -242,7 +242,7 @@ class AgentServiceGetAPITests(SynchronousTestCase):
         factory corresponding to the agent's ``backend`` in the agent's
         ``backends`` dictionary, supplying ``api_args``.
         """
-        class API(PRecord):
+        class API(PClass):
             a = field()
             b = field()
 
@@ -280,7 +280,7 @@ class AgentServiceGetAPITests(SynchronousTestCase):
         """
         reactor = MemoryCoreReactor()
 
-        class API(PRecord):
+        class API(PClass):
             reactor = field()
 
         agent_service = self.agent_service.set(
@@ -307,7 +307,7 @@ class AgentServiceGetAPITests(SynchronousTestCase):
         from the node certificate when ``AgentService.get_api`` calls the
         backend factory.
         """
-        class API(PRecord):
+        class API(PClass):
             cluster_id = field()
 
         agent_service = self.agent_service.set(
@@ -424,12 +424,12 @@ class AgentServiceDeployerTests(SynchronousTestCase):
              self.agent_service.control_service_port): ip,
         }
 
-        class Deployer(PRecord):
+        class Deployer(PClass):
             api = field(mandatory=True)
             hostname = field(mandatory=True)
             node_uuid = field(mandatory=True)
 
-        class WrongDeployer(PRecord):
+        class WrongDeployer(PClass):
             pass
 
         def get_external_ip(host, port):

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -1,7 +1,7 @@
 # Copyright Hybrid Logic Ltd.  See LICENSE file for details.
 
 from characteristic import attributes, Attribute
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 from zope.interface import (
     Attribute as InterfaceAttribute, Interface)
 
@@ -56,7 +56,7 @@ class Variants(Values):
     ZFS_TESTING = ValueConstant("zfs-testing")
 
 
-class Cluster(PRecord):
+class Cluster(PClass):
     """
     Description of the components of a cluster.
 

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -15,7 +15,7 @@ import yaml
 from zope.interface import implementer
 
 from characteristic import attributes
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from twisted.internet.error import ProcessTerminated
 
@@ -212,7 +212,7 @@ class DistributionNotSupported(NotImplementedError):
 
 
 @implementer(INode)
-class ManagedNode(PRecord):
+class ManagedNode(PClass):
     """
     A node managed by some other system (eg by hand or by another piece of
     orchestration software).

--- a/flocker/provision/_ssh/_model.py
+++ b/flocker/provision/_ssh/_model.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 from collections import MutableSequence
 from pipes import quote as shell_quote
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 from effect import Effect, sync_performer
 
 from ...common import retry_effect_with_timeout
@@ -16,7 +16,7 @@ def identity(arg):
     return arg
 
 
-class RunRemotely(PRecord):
+class RunRemotely(PClass):
     """
     Run some commands on a remote host.
 
@@ -74,7 +74,7 @@ def _shell_join(seq):
     return ' '.join(result)
 
 
-class Run(PRecord):
+class Run(PClass):
     """
     Run a shell command on a remote host.
 
@@ -92,7 +92,7 @@ class Run(PRecord):
             log_command_filter=log_command_filter)
 
 
-class Sudo(PRecord):
+class Sudo(PClass):
     """
     Run a shell command on a remote host with sudo.
 
@@ -119,7 +119,7 @@ def perform_sudo(dispatcher, intent):
         command='sudo ' + intent.command, log_command_filter=identity))
 
 
-class Put(PRecord):
+class Put(PClass):
     """
     Create a file with the given content on a remote host.
 
@@ -147,7 +147,7 @@ def perform_put(dispatcher, intent):
         ))
 
 
-class Comment(PRecord):
+class Comment(PClass):
     """
     Record a comment to be shown in the documentation corresponding to a task.
 

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -9,7 +9,7 @@ from functools import wraps
 
 from json import loads, dumps
 
-from pyrsistent import PRecord, field, pvector
+from pyrsistent import PClass, field, pvector
 
 from twisted.internet.defer import maybeDeferred
 from twisted.web.http import OK, INTERNAL_SERVER_ERROR
@@ -260,7 +260,7 @@ def structured(inputSchema, outputSchema, schema_store=None,
     return deco
 
 
-class UserDocumentation(PRecord):
+class UserDocumentation(PClass):
     """
     """
     text = field(type=unicode, mandatory=True)

--- a/flocker/route/_model.py
+++ b/flocker/route/_model.py
@@ -5,10 +5,10 @@
 Objects related to the representation of Flocker-controlled network state.
 """
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 
-class Proxy(PRecord):
+class Proxy(PClass):
     """
     :ivar ipaddr.IPv4Address ip: The IPv4 address towards which this proxy
         directs traffic.
@@ -19,7 +19,7 @@ class Proxy(PRecord):
     port = field(type=int, mandatory=True)
 
 
-class OpenPort(PRecord):
+class OpenPort(PClass):
     """
     :ivar int port: The TCP port which is opened.
     """

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -53,7 +53,7 @@ from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 
 from bitmath import GiB, MiB
 
-from pyrsistent import PRecord, field
+from pyrsistent import PClass, field
 
 from docker import Client as DockerClient
 from eliot import ActionType, Message, MessageType, start_action, fields
@@ -594,7 +594,7 @@ class ProtocolPoppingFactory(Factory):
         return self.protocols.pop()
 
 
-class DockerImageBuilder(PRecord):
+class DockerImageBuilder(PClass):
     """
     Build a docker image, tag it, and remove the image later.
 
@@ -845,7 +845,7 @@ PROCESS_ENDED = MessageType(
     u'The process terminated')
 
 
-class _ProcessResult(PRecord):
+class _ProcessResult(PClass):
     """
     The return type for ``run_process`` representing the outcome of the process
     that was run.


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3608

There are a couple of references to `PRecord` left in code that deals explicitly with both (persistence).

Also, `NodeState` was left as a `PRecord`, since `.items()` is called on it.