### PR TITLE
[FLOC-3606] Cleanup volume created by test_destroy_timesout

### DIFF
--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -40,7 +40,7 @@ from ..test.blockdevicefactory import (
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
     get_minimum_allocatable_size, get_openstack_region_for_test,
 )
-from ....testtools import flaky, run_process
+from ....testtools import REALISTIC_BLOCKDEVICE_SIZE, flaky, run_process
 
 from ..cinder import (
     get_keystone_session, get_cinder_v1_client, get_nova_v2_client,
@@ -622,14 +622,11 @@ class BlockDeviceAPIDestroyTests(SynchronousTestCase):
         If the cinder cannot delete the volume, we should timeout
         after waiting some time
         """
-        new_volume = self.api.cinder_volume_manager.create(size=100)
-        CINDER_VOLUME(id=new_volume.id).write()
-        listed_volume = wait_for_volume_state(
-            volume_manager=self.api.cinder_volume_manager,
-            expected_volume=new_volume,
-            desired_state=u'available',
-            transient_states=(u'creating',),
+        new_volume = self.api.create_volume(
+            dataset_id=uuid4(),
+            size=REALISTIC_BLOCKDEVICE_SIZE,
         )
+
         expected_timeout = 8
         # Using a fake no-op delete so it doesn't actually delete anything
         # (we don't need any actual volumes here, as we only need to verify
@@ -639,6 +636,7 @@ class BlockDeviceAPIDestroyTests(SynchronousTestCase):
             "delete",
             lambda *args, **kwargs: None
         )
+
         # Now try to delete it
         time_module = FakeTime(initial_time=0)
         self.patch(self.api, "_time", time_module)
@@ -647,7 +645,7 @@ class BlockDeviceAPIDestroyTests(SynchronousTestCase):
         exception = self.assertRaises(
             TimeoutException,
             self.api.destroy_volume,
-            blockdevice_id=listed_volume.id
+            blockdevice_id=new_volume.blockdevice_id,
         )
 
         self.assertEqual(

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -619,8 +619,8 @@ class BlockDeviceAPIDestroyTests(SynchronousTestCase):
 
     def test_destroy_timesout(self):
         """
-        If the cinder cannot delete the volume, we should timeout
-        after waiting some time
+        If Cinder does not delete the volume within a specified amount of time,
+        the destroy attempt fails by raising ``TimeoutException``.
         """
         new_volume = self.api.create_volume(
             dataset_id=uuid4(),


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3606

The reason it didn't work before is that the directly-created volume didn't appear to belong to the `IBlockDeviceAPI` implementation being used for cleanup and so it wasn't cleaned up.

You can verify this is fixed by running the test and then looking for the created blockdevice_id in the test log and then using the Rackspace Storage web UI to search for it.  On master, you'll always find it.  With the branch, you never should.

Downside is that the test takes twice as long now because it actually has to destroy the volume. :wink: 

Perhaps also noteworthy is that this change should also cause the periodic batch cleanup to be capable of cleaning up this volume should the test runner itself somehow fail to clean it up (because the destroy operation hits a network hiccup or because the test suite crashes before cleanup can be run or whatever).  Since the `IBlockDeviceAPI` implementation is now creating the volume, it has metadata associating it with a cluster that can be recognized as belonging to a test suite run.  That should be sufficient to cause the batch cleanup job to recognize it.