### PR TITLE
[FLOC-3618] Fix another incompatibility between UNIX sockets and Twisted's HTTP implementation

### DIFF
--- a/flocker/dockerplugin/__init__.py
+++ b/flocker/dockerplugin/__init__.py
@@ -5,3 +5,12 @@ Docker plugin allowing use of Flocker to manage Docker volumes.
 
 This may eventually be a standalone package.
 """
+
+from twisted.internet.address import UNIXAddress
+
+# Many places in both twisted.web and Klein are unhappy with listening on
+# Unix socket, e.g.  https://twistedmatrix.com/trac/ticket/5406.  The
+# Docker plugin needs to listen using a Unix socket, so "fix" that by
+# pretending we have a port number. Yes, I feel guilty.
+UNIXAddress.port = 0
+del UNIXAddress

--- a/flocker/dockerplugin/__init__.py
+++ b/flocker/dockerplugin/__init__.py
@@ -11,6 +11,7 @@ from twisted.internet.address import UNIXAddress
 # Many places in both twisted.web and Klein are unhappy with listening on
 # Unix socket, e.g.  https://twistedmatrix.com/trac/ticket/5406.  The
 # Docker plugin needs to listen using a Unix socket, so "fix" that by
-# pretending we have a port number. Yes, I feel guilty.
+# pretending we have a port number and host. Yes, I feel guilty.
 UNIXAddress.port = 0
+UNIXAddress.host = b"127.0.0.1"
 del UNIXAddress

--- a/flocker/dockerplugin/_script.py
+++ b/flocker/dockerplugin/_script.py
@@ -12,7 +12,6 @@ from twisted.internet.endpoints import serverFromString
 from twisted.application.internet import StreamServerEndpointService
 from twisted.web.server import Site
 from twisted.python.filepath import FilePath
-from twisted.internet.address import UNIXAddress
 
 from ..common.script import (
     flocker_standard_options, FlockerScriptRunner, main_for_service)
@@ -59,12 +58,6 @@ class DockerPluginScript(object):
             umask(original_umask)
 
     def main(self, reactor, options):
-        # Many places in both twisted.web and Klein are unhappy with
-        # listening on Unix socket, e.g.
-        # https://twistedmatrix.com/trac/ticket/5406 "fix" that by
-        # pretending we have a port number. Yes, I feel guilty.
-        UNIXAddress.port = 0
-
         # We can use /etc/flocker/agent.yml and /etc/flocker/node.crt to load
         # some information we need:
         agent_config = get_configuration(options)

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -442,15 +442,15 @@ class APITestsMixin(APIAssertionsMixin):
 
     def test_unsupported_method(self):
         """
-        If an unsupported method is requested the appropriate response code is
-        returned.
+        If an unsupported method is requested the 405 Not Allowed response
+        code is returned.
         """
         return self.assertResponseCode(
             b"BAD_METHOD", b"/VolumeDriver.Path", None, NOT_ALLOWED)
 
     def test_unknown_uri(self):
         """
-        If an unknown URI path is requested the appropriate response code is
+        If an unknown URI path is requested the 404 Not Found response code is
         returned.
         """
         return self.assertResponseCode(
@@ -459,7 +459,8 @@ class APITestsMixin(APIAssertionsMixin):
     def test_empty_host(self):
         """
         If an empty host header is sent to the Docker plugin it does not blow
-        up.
+        up, instead operating normally. E.g. for ``Plugin.Activate`` call
+        returns the ``Implements`` response.
         """
         return self.assertResult(b"POST", b"/Plugin.Activate", 12345, OK,
                                  {u"Implements": [u"VolumeDriver"]},

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -6,7 +6,7 @@ Tests for the Volumes Plugin API provided by the plugin.
 
 from uuid import uuid4
 
-from twisted.web.http import OK
+from twisted.web.http import OK, NOT_ALLOWED, NOT_FOUND
 from twisted.internet.task import Clock, LoopingCall
 
 from pyrsistent import pmap
@@ -439,6 +439,22 @@ class APITestsMixin(APIAssertionsMixin):
             b"POST", b"/VolumeDriver.Path",
             {u"Name": u"whatever"}, 423,
             {u"Err": "no good"})
+
+    def test_unsupported_method(self):
+        """
+        If an unsupported method is requested the appropriate response code is
+        returned.
+        """
+        return self.assertResponseCode(
+            b"BAD_METHOD", b"/VolumeDriver.Path", None, NOT_ALLOWED)
+
+    def test_unknown_uri(self):
+        """
+        If an unknown URI path is requested the appropriate response code is
+        returned.
+        """
+        return self.assertResponseCode(
+            b"BAD_METHOD", b"/xxxnotthere", None, NOT_FOUND)
 
 
 def _build_app(test):

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -18,7 +18,9 @@ from ...apiclient import FakeFlockerClient, Dataset, DatasetsConfiguration
 from ...testtools import CustomException
 
 from ...restapi import make_bad_request
-from ...restapi.testtools import buildIntegrationTests, APIAssertionsMixin
+from ...restapi.testtools import (
+    buildUNIXIntegrationTests, APIAssertionsMixin,
+)
 
 
 class SimpleCountingProxy(object):
@@ -443,5 +445,4 @@ def _build_app(test):
     test.initialize()
     return VolumePlugin(
         test.volume_plugin_reactor, test.flocker_client, test.NODE_A).app
-RealTestsAPI, MemoryTestsAPI = buildIntegrationTests(
-    APITestsMixin, "API", _build_app)
+RealTestsAPI = buildUNIXIntegrationTests(APITestsMixin, "API", _build_app)

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -19,7 +19,7 @@ from ...testtools import CustomException
 
 from ...restapi import make_bad_request
 from ...restapi.testtools import (
-    buildUNIXIntegrationTests, APIAssertionsMixin,
+    build_UNIX_integration_tests, APIAssertionsMixin,
 )
 
 
@@ -471,4 +471,4 @@ def _build_app(test):
     test.initialize()
     return VolumePlugin(
         test.volume_plugin_reactor, test.flocker_client, test.NODE_A).app
-RealTestsAPI = buildUNIXIntegrationTests(APITestsMixin, "API", _build_app)
+RealTestsAPI = build_UNIX_integration_tests(APITestsMixin, "API", _build_app)

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -456,6 +456,15 @@ class APITestsMixin(APIAssertionsMixin):
         return self.assertResponseCode(
             b"BAD_METHOD", b"/xxxnotthere", None, NOT_FOUND)
 
+    def test_empty_host(self):
+        """
+        If an empty host header is sent to the Docker plugin it does not blow
+        up.
+        """
+        return self.assertResult(b"POST", b"/Plugin.Activate", 12345, OK,
+                                 {u"Implements": [u"VolumeDriver"]},
+                                 additional_headers={b"Host": [""]})
+
 
 def _build_app(test):
     test.initialize()

--- a/flocker/restapi/testtools.py
+++ b/flocker/restapi/testtools.py
@@ -14,7 +14,7 @@ from zope.interface import implementer
 
 from twisted.python.log import err
 from twisted.web.iweb import IAgent, IResponse
-from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.endpoints import TCP4ClientEndpoint, UNIXClientEndpoint
 from twisted.internet import defer
 from twisted.web.client import ProxyAgent, readBody, FileBodyProducer
 from twisted.web.server import NOT_DONE_YET, Site
@@ -210,6 +210,42 @@ def buildIntegrationTests(mixinClass, name, fixture):
     RealTests.__module__ = mixinClass.__module__
     MemoryTests.__module__ = mixinClass.__module__
     return RealTests, MemoryTests
+
+
+def buildUNIXIntegrationTests(mixinClass, name, fixture):
+    """
+    Build L{TestCase} class that runs the tests in the mixin class with
+    real queries over a UNIX socket.
+
+    @param mixinClass: A mixin class for L{TestCase} that relies on having a
+        C{self.scenario}.
+
+    @param name: A C{str}, the name of the test category.
+
+    :param fixture: A callable that takes a ``TestCase`` and returns a
+        ``klein.Klein`` object.
+
+    @return: A L{TestCase} class.
+    """
+    class RealTests(mixinClass, TestCase):
+        """
+        Tests that endpoints are available over the network interfaces that
+        real API users will be connecting from.
+        """
+        def setUp(self):
+            path = self.mktemp()
+            self.app = fixture(self)
+            self.port = reactor.listenUNIX(
+                path, Site(self.app.resource()),
+            )
+            self.addCleanup(self.port.stopListening)
+            self.agent = ProxyAgent(UNIXClientEndpoint(reactor, path), reactor)
+            super(RealTests, self).setUp()
+
+    RealTests.__name__ += name
+    RealTests.__module__ = mixinClass.__module__
+    return RealTests
+
 
 # Fakes for testing Twisted Web servers.  Unverified.  Belongs in Twisted.
 # https://twistedmatrix.com/trac/ticket/3274

--- a/flocker/restapi/testtools.py
+++ b/flocker/restapi/testtools.py
@@ -212,22 +212,22 @@ def buildIntegrationTests(mixinClass, name, fixture):
     return RealTests, MemoryTests
 
 
-def buildUNIXIntegrationTests(mixinClass, name, fixture):
+def build_UNIX_integration_tests(mixin_class, name, fixture):
     """
-    Build L{TestCase} class that runs the tests in the mixin class with
+    Build ``TestCase`` class that runs the tests in the mixin class with
     real queries over a UNIX socket.
 
-    @param mixinClass: A mixin class for L{TestCase} that relies on having a
-        C{self.scenario}.
+    :param mixin_class: A mixin class for ``TestCase`` that relies on having a
+        ``self.scenario``.
 
-    @param name: A C{str}, the name of the test category.
+    :param name: A ``str``, the name of the test category.
 
     :param fixture: A callable that takes a ``TestCase`` and returns a
         ``klein.Klein`` object.
 
-    @return: A L{TestCase} class.
+    :return: A L``TestCase`` class.
     """
-    class RealTests(mixinClass, TestCase):
+    class RealTests(mixin_class, TestCase):
         """
         Tests that endpoints are available over the network interfaces that
         real API users will be connecting from.
@@ -243,7 +243,7 @@ def buildUNIXIntegrationTests(mixinClass, name, fixture):
             super(RealTests, self).setUp()
 
     RealTests.__name__ += name
-    RealTests.__module__ = mixinClass.__module__
+    RealTests.__module__ = mixin_class.__module__
     return RealTests
 
 


### PR DESCRIPTION
When the `Host` header was empty or missing the the address is used to calculate the host ... and `UNIXAddress` has no `host` attribute. Apparently Docker 1.10 (dev release) stops sending the `Host` header in HTTP requests, or maybe sends it as empty string, triggering this bug; haven't actually looked at Docker source code.

This addresses user-reported issue #2284.