### PR TITLE
[FLOC-3557] Read cluster description from YAML file

### DIFF
--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -123,7 +123,7 @@ def driver(
 
     def add_control_service(version, result):
         result['control_service'] = dict(
-            host=cluster.control_node_address(),
+            host=cluster.control_node_address().compressed,
             flocker_version=version[u"flocker"],
         )
 

--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -6,11 +6,8 @@ Driver for the control service benchmarks.
 from eliot import start_action
 from eliot.twisted import DeferredContext
 
-from twisted.python.filepath import FilePath
 from twisted.internet.task import cooperate
-from twisted.internet.defer import Deferred, logError, maybeDeferred, succeed
-
-from flocker.apiclient import FlockerClient
+from twisted.internet.defer import Deferred, logError, maybeDeferred
 
 
 def bypass(result, func, *args, **kw):
@@ -107,12 +104,12 @@ def benchmark(scenario, operation, metric, num_samples=3):
 
 
 def driver(
-    reactor, config, scenario_factory, operation_factory, metric_factory,
+    reactor, cluster, scenario_factory, operation_factory, metric_factory,
     result, output
 ):
     """
     :param reactor: Reactor to use.
-    :param config: Configuration read from options.
+    :param cluster: Benchmark cluster.
     :param callable scenario_factory: A load scenario factory.
     :param callable operation_factory: An operation factory.
     :param callable metric_factory: A metric factory.
@@ -122,27 +119,11 @@ def driver(
         printing or storage.
     """
 
-    if config['control']:
-        cert_directory = FilePath(config['certs'])
-        control_service = FlockerClient(
-            reactor,
-            host=config['control'],
-            port=4523,
-            ca_cluster_path=cert_directory.child(b"cluster.crt"),
-            cert_path=cert_directory.child(b"user.crt"),
-            key_path=cert_directory.child(b"user.key"),
-        )
-
-        d = control_service.version()
-    else:
-        # Only valid for operation 'no-op'
-        control_service = None
-        d = succeed({u'flocker': None})
+    d = cluster.control_service(reactor).version()
 
     def add_control_service(version, result):
         result['control_service'] = dict(
-            host=config['control'],
-            port=4523,
+            host=cluster.control_node_address(),
             flocker_version=version[u"flocker"],
         )
 
@@ -150,9 +131,9 @@ def driver(
 
     def run_benchmark(ignored):
         return benchmark(
-            scenario_factory(reactor, control_service),
-            operation_factory(reactor, control_service),
-            metric_factory(reactor, control_service),
+            scenario_factory(reactor, cluster),
+            operation_factory(reactor, cluster),
+            metric_factory(reactor, cluster),
         )
 
     d.addCallback(run_benchmark)

--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -119,7 +119,7 @@ def driver(
         printing or storage.
     """
 
-    d = cluster.control_service(reactor).version()
+    d = cluster.get_control_service(reactor).version()
 
     def add_control_service(version, result):
         result['control_service'] = dict(

--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -109,7 +109,7 @@ def driver(
 ):
     """
     :param reactor: Reactor to use.
-    :param cluster: Benchmark cluster.
+    :param BenchmarkCluster cluster: Benchmark cluster.
     :param callable scenario_factory: A load scenario factory.
     :param callable operation_factory: An operation factory.
     :param callable metric_factory: A metric factory.

--- a/benchmark/cluster.py
+++ b/benchmark/cluster.py
@@ -1,0 +1,112 @@
+from ipaddr import IPAddress
+import json
+
+import yaml
+
+from twisted.python.filepath import FilePath
+
+from flocker.apiclient import FlockerClient
+
+
+class BenchmarkCluster:
+
+    def __init__(
+        self, control_node_address, ca_cert_path, cert_path,
+        key_path, public_addresses
+    ):
+        self._control_node_address = control_node_address
+        self.ca_cert_path = ca_cert_path
+        self.cert_path = cert_path
+        self.key_path = key_path
+        self._public_addresses = public_addresses
+
+        self._control_service = None
+
+    @classmethod
+    def from_acceptance_test_env(cls, env):
+        certs = FilePath(env['FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH'])
+        ca_cluster_path = certs.child(b"cluster.crt")
+        cert_path = certs.child(b"user.crt")
+        key_path = certs.child(b"user.key")
+        host_to_public = json.loads(
+            env['FLOCKER_ACCEPTANCE_HOSTNAME_TO_PUBLIC_ADDRESS']
+        )
+        public_addresses = {
+            IPAddress(k): IPAddress(v) for k, v in host_to_public.items()
+        }
+        return cls(
+            env['FLOCKER_ACCEPTANCE_CONTROL_NODE'], ca_cluster_path, cert_path,
+            key_path, public_addresses
+        )
+
+    @classmethod
+    def from_uft_setup(cls, uft):
+        ca_cluster_path = uft.child(b"cluster.crt")
+        cert_path = uft.child(b"user.crt")
+        key_path = uft.child(b"user.key")
+        with open(uft.child('cluster.yml'), 'rt') as f:
+            cluster = yaml.safe_load(f)
+        host_to_public = {
+            node['private']: node['public'] for node in cluster['agent_nodes']
+        }
+        public_addresses = {
+            IPAddress(k): IPAddress(v) for k, v in host_to_public.items()
+        }
+        return cls(
+            cluster['control-node'], ca_cluster_path, cert_path,
+            key_path, public_addresses
+        )
+
+    def control_node_address(self):
+        return self._control_node_address
+
+    def control_service(self, reactor):
+        control_service = self._control_service
+        if control_service is None:
+            control_service = self._control_service = FlockerClient(
+                reactor,
+                host=self._control_node_address,
+                port=4523,
+                ca_cluster_path=self.ca_cert_path,
+                cert_path=self.cert_path,
+                key_path=self.key_path,
+            )
+        return control_service
+
+    def public_address(self, hostname):
+        """
+        Convert a node's internal hostname to a public address.  If the
+        hostname does not exist in ``_public_addresses``, just return the
+        hostname, and hope it is public.
+
+        :param IPAddress hostname: Hostname for Flocker node.
+        :return IPAddress: Public IP address for node.
+        """
+        return self._public_addresses.get(hostname, hostname)
+
+
+class FakeBenchmarkCluster:
+
+    def __init__(
+        self, control_node_address, control_service, public_addresses={}
+    ):
+        self._control_node_address = control_node_address
+        self._control_service = control_service
+        self._public_addresses = public_addresses
+
+    def control_node_address(self):
+        return self._control_node_address
+
+    def control_service(self, reactor):
+        return self._control_service
+
+    def public_address(self, hostname):
+        """
+        Convert a node's internal hostname to a public address.  If the
+        hostname does not exist in ``_public_addresses``, just return the
+        hostname, and hope it is public.
+
+        :param IPAddress hostname: Hostname for Flocker node.
+        :return IPAddress: Public IP address for node.
+        """
+        return self._public_addresses.get(hostname, hostname)

--- a/benchmark/cluster.py
+++ b/benchmark/cluster.py
@@ -54,9 +54,11 @@ class BenchmarkCluster:
     """
     Cluster for benchmark performance.
 
-    :ivar str control_node_address: IP address for control service.
+    :ivar IPAddress control_node_address: IP address for control service.
     :ivar control_service_factory: Callable taking a reactor parameter,
         and returning a IFlockerAPIV1Client.
+    :ivar dict[IPAddress: IPAddress] public_addresses: mapping of
+        internal cluster IP addresses to public IP addresses.
     """
 
     def __init__(
@@ -93,7 +95,8 @@ class BenchmarkCluster:
             cert_path=certs.child('user.crt'),
             key_path=certs.child('user.key')
         )
-        return cls(control_node_address, control_service, public_addresses)
+        return cls(
+            IPAddress(control_node_address), control_service, public_addresses)
 
     @classmethod
     def from_cluster_yaml(cls, path):
@@ -120,12 +123,19 @@ class BenchmarkCluster:
             cert_path=path.child('user.crt'),
             key_path=path.child('user.key')
         )
-        return cls(control_node_address, control_service, public_addresses)
+        return cls(
+            IPAddress(control_node_address), control_service, public_addresses)
 
     def control_node_address(self):
+        """
+        Return the control node IP address.
+        """
         return self._control_node_address
 
     def control_service(self, reactor):
+        """
+        Return a provider of the ``IFlockerAPIV1Client`` interface.
+        """
         control_service = self._control_service
         if control_service is None:
             control_service = self._control_service_factory(reactor)

--- a/benchmark/cluster.py
+++ b/benchmark/cluster.py
@@ -1,3 +1,5 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+
 from functools import partial
 from ipaddr import IPAddress
 import json
@@ -49,6 +51,13 @@ def validate_cluster_configuration(cluster_config):
 
 
 class BenchmarkCluster:
+    """
+    Cluster for benchmark performance.
+
+    :ivar str control_node_address: IP address for control service.
+    :ivar control_service_factory: Callable taking a reactor parameter,
+        and returning a IFlockerAPIV1Client.
+    """
 
     def __init__(
         self, control_node_address, control_service_factory, public_addresses

--- a/benchmark/cluster.py
+++ b/benchmark/cluster.py
@@ -168,7 +168,7 @@ class BenchmarkCluster(object):
         """
         return self._control_node_address
 
-    def control_service(self, reactor):
+    def get_control_service(self, reactor):
         """
         Return a provider of the ``IFlockerAPIV1Client`` interface.
         """

--- a/benchmark/cluster.py
+++ b/benchmark/cluster.py
@@ -50,7 +50,7 @@ def validate_cluster_configuration(cluster_config):
     v.validate(cluster_config)
 
 
-class BenchmarkCluster:
+class BenchmarkCluster(object):
     """
     Cluster for benchmark performance.
 

--- a/benchmark/cluster.py
+++ b/benchmark/cluster.py
@@ -89,22 +89,22 @@ class BenchmarkCluster:
             FlockerClient,
             host=control_node_address,
             port=4523,
-            ca_cluster_path=certs.child(b"cluster.crt"),
-            cert_path=certs.child(b"user.crt"),
-            key_path=certs.child(b"user.key")
+            ca_cluster_path=certs.child('cluster.crt'),
+            cert_path=certs.child('user.crt'),
+            key_path=certs.child('user.key')
         )
         return cls(control_node_address, control_service, public_addresses)
 
     @classmethod
-    def from_uft_setup(cls, uft):
+    def from_cluster_yaml(cls, path):
         """
-        Create a cluster from UFT installer files.
+        Create a cluster from Quick Start Installer files.
 
-        :param FilePath uft: directory containing UFT ``cluster.yml`` and
-            certificate files.
+        :param FilePath path: directory containing Quick Start Installer
+            ``cluster.yml`` and certificate files.
         :return: A ``BenchmarkCluster`` instance.
         """
-        with uft.child('cluster.yml').open() as f:
+        with path.child('cluster.yml').open() as f:
             cluster = yaml.safe_load(f)
         validate_cluster_configuration(cluster)
         control_node_address = cluster['control_node']
@@ -116,9 +116,9 @@ class BenchmarkCluster:
             FlockerClient,
             host=control_node_address,
             port=4523,
-            ca_cluster_path=uft.child(b"cluster.crt"),
-            cert_path=uft.child(b"user.crt"),
-            key_path=uft.child(b"user.key")
+            ca_cluster_path=path.child('cluster.crt'),
+            cert_path=path.child('user.crt'),
+            key_path=path.child('user.key')
         )
         return cls(control_node_address, control_service, public_addresses)
 

--- a/benchmark/cluster.py
+++ b/benchmark/cluster.py
@@ -67,7 +67,6 @@ class BenchmarkCluster(object):
         self._control_node_address = control_node_address
         self._control_service_factory = control_service_factory
         self._public_addresses = public_addresses
-
         self._control_service = None
 
     @classmethod

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -3,9 +3,6 @@
 CPU time metric for the control service benchmarks.
 """
 
-import os
-
-import yaml
 from zope.interface import implementer
 
 from twisted.protocols.basic import LineOnlyReceiver
@@ -84,13 +81,13 @@ class SSHRunner:
     Run a command using ssh.
 
     :ivar reactor: Twisted Reactor.
-    :ivar node_mapping: Dictionary mapping hostname to public IP address.
+    :ivar cluster: Benchmark cluster.
     :ivar user: Remote user name.
     """
 
-    def __init__(self, reactor, node_mapping, user=b'root'):
+    def __init__(self, reactor, cluster, user=b'root'):
         self.reactor = reactor
-        self.node_mapping = node_mapping
+        self.cluster = cluster
         self.user = user
 
     def run(self, node, command_args, handle_stdout):
@@ -102,13 +99,10 @@ class SSHRunner:
         :param callable handle_stdout: Function to handle each line of output.
         :return: Deferred, firing when complete.
         """
-        hostname = node.public_address.exploded
-        # Map hostname to public IP address. If not in mapping, use hostname.
-        public_ip = self.node_mapping.get(hostname, hostname)
         d = run_ssh(
             self.reactor,
             self.user,
-            public_ip,
+            self.cluster.public_address(node.public_address).exploded,
             command_args,
             handle_stdout=handle_stdout,
         )
@@ -147,11 +141,11 @@ def get_node_cpu_times(runner, node, processes):
     return d
 
 
-def get_cluster_cpu_times(clock, runner, nodes, processes):
+def get_cluster_cpu_times(reactor, runner, nodes, processes):
     """
     Get the CPU times for processes running on a cluster.
 
-    :param clock: Twisted Reactor.
+    :param reactor: Twisted Reactor.
     :param runner: A method of running a command on a node.
     :param node: Node to run the command on.
     :param processes: An iterator of process names to monitor. The process
@@ -191,19 +185,12 @@ class CPUTime(object):
     """
 
     def __init__(
-        self, clock, cluster, runner=None, processes=_FLOCKER_PROCESSES
+        self, reactor, cluster, runner=None, processes=_FLOCKER_PROCESSES
     ):
-        self.clock = clock
+        self.reactor = reactor
         self.cluster = cluster
         if runner is None:
-            # Use the acceptance test environment variable to work out the
-            # public addresses of the cluster nodes.  This is intended to be a
-            # quick fix until a better solution is provided by one of
-            # FLOC-2137, FLOC-3514, or FLOC-3521.
-            node_mapping = yaml.safe_load(
-                os.environ.get(
-                    'FLOCKER_ACCEPTANCE_HOSTNAME_TO_PUBLIC_ADDRESS', '{}'))
-            self.runner = SSHRunner(clock, node_mapping)
+            self.runner = SSHRunner(reactor, cluster)
         else:
             self.runner = runner
         self.processes = processes
@@ -213,7 +200,7 @@ class CPUTime(object):
         before_cpu = []
         after_cpu = []
 
-        control_service = self.cluster.control_service(self.clock)
+        control_service = self.cluster.control_service(self.reactor)
 
         # Retrieve the cluster nodes
         d = control_service.list_nodes().addCallback(nodes.extend)
@@ -221,7 +208,7 @@ class CPUTime(object):
         # Obtain elapsed CPU time before test
         d.addCallback(
             lambda _ignored: get_cluster_cpu_times(
-                self.clock, self.runner, nodes, self.processes)
+                self.reactor, self.runner, nodes, self.processes)
         ).addCallback(before_cpu.extend)
 
         # Perform the test function
@@ -230,7 +217,7 @@ class CPUTime(object):
         # Obtain elapsed CPU time after test
         d.addCallback(
             lambda _ignored: get_cluster_cpu_times(
-                self.clock, self.runner, nodes, self.processes)
+                self.reactor, self.runner, nodes, self.processes)
         ).addCallback(after_cpu.extend)
 
         # Create the result from before and after times

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -191,11 +191,10 @@ class CPUTime(object):
     """
 
     def __init__(
-        self, clock, control_service, runner=None,
-        processes=_FLOCKER_PROCESSES
+        self, clock, cluster, runner=None, processes=_FLOCKER_PROCESSES
     ):
         self.clock = clock
-        self.control_service = control_service
+        self.cluster = cluster
         if runner is None:
             # Use the acceptance test environment variable to work out the
             # public addresses of the cluster nodes.  This is intended to be a
@@ -214,8 +213,10 @@ class CPUTime(object):
         before_cpu = []
         after_cpu = []
 
+        control_service = self.cluster.control_service(self.clock)
+
         # Retrieve the cluster nodes
-        d = self.control_service.list_nodes().addCallback(nodes.extend)
+        d = control_service.list_nodes().addCallback(nodes.extend)
 
         # Obtain elapsed CPU time before test
         d.addCallback(

--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -200,7 +200,7 @@ class CPUTime(object):
         before_cpu = []
         after_cpu = []
 
-        control_service = self.cluster.control_service(self.reactor)
+        control_service = self.cluster.get_control_service(self.reactor)
 
         # Retrieve the cluster nodes
         d = control_service.list_nodes().addCallback(nodes.extend)

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -12,7 +12,7 @@ from twisted.trial.unittest import SynchronousTestCase, TestCase
 
 from flocker.apiclient._client import FakeFlockerClient, Node
 
-from benchmark.cluster import FakeBenchmarkCluster
+from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IMetric
 from benchmark.metrics.cputime import (
     CPUTime, CPUParser, get_node_cpu_times, compute_change,
@@ -195,8 +195,9 @@ class CPUTimeTests(TestCase):
         node1 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1'))
         node2 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.2'))
         metric = CPUTime(
-            Clock(), FakeBenchmarkCluster(
-                IPAddress('10.0.0.1'), FakeFlockerClient([node1, node2])
+            Clock(), BenchmarkCluster(
+                IPAddress('10.0.0.1'),
+                lambda reactor: FakeFlockerClient([node1, node2]), {}
             ),
             _LocalRunner(), processes=[_standard_process])
         d = metric.measure(lambda: None)  # measure a fast no-op command

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -12,6 +12,7 @@ from twisted.trial.unittest import SynchronousTestCase, TestCase
 
 from flocker.apiclient._client import FakeFlockerClient, Node
 
+from benchmark.cluster import FakeBenchmarkCluster
 from benchmark._interfaces import IMetric
 from benchmark.metrics.cputime import (
     CPUTime, CPUParser, get_node_cpu_times, compute_change,
@@ -180,7 +181,7 @@ class CPUTimeTests(TestCase):
     Test top-level CPU time metric.
     """
 
-    def implements_IMetric(self):
+    def test_implements_IMetric(self):
         """
         CPUTime provides the IMetric interface.
         """
@@ -194,7 +195,9 @@ class CPUTimeTests(TestCase):
         node1 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1'))
         node2 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.2'))
         metric = CPUTime(
-            Clock(), FakeFlockerClient([node1, node2]),
+            Clock(), FakeBenchmarkCluster(
+                IPAddress('10.0.0.1'), FakeFlockerClient([node1, node2])
+            ),
             _LocalRunner(), processes=[_standard_process])
         d = metric.measure(lambda: None)  # measure a fast no-op command
 

--- a/benchmark/metrics/wallclock.py
+++ b/benchmark/metrics/wallclock.py
@@ -14,16 +14,16 @@ class WallClock(object):
     Measure the elapsed wallclock time during an operation.
     """
 
-    def __init__(self, clock, cluster):
-        self.clock = clock
+    def __init__(self, reactor, cluster):
+        self.reactor = reactor
 
     def measure(self, f, *a, **kw):
         def finished(ignored):
-            end = self.clock.seconds()
+            end = self.reactor.seconds()
             elapsed = end - start
             return elapsed
 
-        start = self.clock.seconds()
+        start = self.reactor.seconds()
         d = f(*a, **kw)
         d.addCallback(finished)
         return d

--- a/benchmark/metrics/wallclock.py
+++ b/benchmark/metrics/wallclock.py
@@ -14,9 +14,8 @@ class WallClock(object):
     Measure the elapsed wallclock time during an operation.
     """
 
-    def __init__(self, clock, control_service):
+    def __init__(self, clock, cluster):
         self.clock = clock
-        self.control_service = control_service
 
     def measure(self, f, *a, **kw):
         def finished(ignored):

--- a/benchmark/operations/no_op.py
+++ b/benchmark/operations/no_op.py
@@ -24,9 +24,8 @@ class NoOperation(object):
     A no-op operation.
     """
 
-    def __init__(self, clock, control_service):
-        self.clock = clock
-        self.control_service = control_service
+    def __init__(self, clock, cluster):
+        pass
 
     def get_probe(self):
         return NoOpProbe()

--- a/benchmark/operations/no_op.py
+++ b/benchmark/operations/no_op.py
@@ -24,7 +24,7 @@ class NoOperation(object):
     A no-op operation.
     """
 
-    def __init__(self, clock, cluster):
+    def __init__(self, reactor, cluster):
         pass
 
     def get_probe(self):

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -28,9 +28,8 @@ class ReadRequest(object):
     An operation to perform a read request on the control service.
     """
 
-    def __init__(self, clock, control_service):
-        self.clock = clock
-        self.control_service = control_service
+    def __init__(self, clock, cluster):
+        self.control_service = cluster.control_service(clock)
 
     def get_probe(self):
         return ReadRequestProbe(control_service=self.control_service)

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -28,8 +28,8 @@ class ReadRequest(object):
     An operation to perform a read request on the control service.
     """
 
-    def __init__(self, clock, cluster):
-        self.control_service = cluster.control_service(clock)
+    def __init__(self, reactor, cluster):
+        self.control_service = cluster.control_service(reactor)
 
     def get_probe(self):
         return ReadRequestProbe(control_service=self.control_service)

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -29,7 +29,7 @@ class ReadRequest(object):
     """
 
     def __init__(self, reactor, cluster):
-        self.control_service = cluster.control_service(reactor)
+        self.control_service = cluster.get_control_service(reactor)
 
     def get_probe(self):
         return ReadRequestProbe(control_service=self.control_service)

--- a/benchmark/operations/test/test_no_op.py
+++ b/benchmark/operations/test/test_no_op.py
@@ -1,0 +1,19 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+"""
+Operations tests for the control service benchmarks.
+"""
+from zope.interface.verify import verifyClass
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from benchmark._interfaces import IOperation
+from benchmark.operations import NoOperation
+
+
+class NoOpTests(SynchronousTestCase):
+
+    def test_implements_IOperation(self):
+        """
+        NoOp provides the IOperation interface.
+        """
+        verifyClass(IOperation, NoOperation)

--- a/benchmark/operations/test/test_read_request.py
+++ b/benchmark/operations/test/test_read_request.py
@@ -3,8 +3,9 @@
 Operations tests for the control service benchmarks.
 """
 from uuid import uuid4
+from ipaddr import IPAddress
 
-from zope.interface.verify import verifyObject
+from zope.interface.verify import verifyClass
 
 from twisted.internet.task import Clock
 from twisted.python.components import proxyForInterface
@@ -12,32 +13,9 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from flocker.apiclient import IFlockerAPIV1Client, FakeFlockerClient
 
-from benchmark.operations import NoOperation, ReadRequest
-from benchmark._interfaces import IProbe, IOperation
-
-
-def check_interfaces(factory):
-    """
-    Check interfaces for IOperation/IProbe pairs.
-
-    Check that an IOperation factory produces an IOperation, whose
-    ``get_probe`` method creates an IProbe.
-    """
-
-    class OperationTests(SynchronousTestCase):
-
-        def test_interfaces(self):
-            operation = factory(clock=Clock(), control_service=None)
-            verifyObject(IOperation, operation)
-            probe = operation.get_probe()
-            verifyObject(IProbe, probe)
-
-    testname = '{}InterfaceTests'.format(factory.__name__)
-    OperationTests.__name__ = testname
-    globals()[testname] = OperationTests
-
-for factory in (NoOperation, ReadRequest):
-    check_interfaces(factory)
+from benchmark.cluster import FakeBenchmarkCluster
+from benchmark._interfaces import IOperation
+from benchmark.operations import ReadRequest
 
 
 class FastConvergingFakeFlockerClient(
@@ -78,6 +56,12 @@ class ReadRequestTests(SynchronousTestCase):
     ReadRequest operation tests.
     """
 
+    def test_implements_IOperation(self):
+        """
+        ReadRequest provides the IOperation interface.
+        """
+        verifyClass(IOperation, ReadRequest)
+
     def test_read_request(self):
         """
         ReadRequest probe returns the cluster state.
@@ -90,8 +74,10 @@ class ReadRequestTests(SynchronousTestCase):
 
         # Get the probe to read the state of the cluster
         def start_read_request(result):
-            request = ReadRequest(
-                clock=Clock(), control_service=control_service)
+            cluster = FakeBenchmarkCluster(
+                IPAddress('10.0.0.1'), control_service
+            )
+            request = ReadRequest(Clock(), cluster)
             return request.get_probe()
         d.addCallback(start_read_request)
 

--- a/benchmark/operations/test/test_read_request.py
+++ b/benchmark/operations/test/test_read_request.py
@@ -13,7 +13,7 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from flocker.apiclient import IFlockerAPIV1Client, FakeFlockerClient
 
-from benchmark.cluster import FakeBenchmarkCluster
+from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IOperation
 from benchmark.operations import ReadRequest
 
@@ -74,8 +74,8 @@ class ReadRequestTests(SynchronousTestCase):
 
         # Get the probe to read the state of the cluster
         def start_read_request(result):
-            cluster = FakeBenchmarkCluster(
-                IPAddress('10.0.0.1'), control_service
+            cluster = BenchmarkCluster(
+                IPAddress('10.0.0.1'), lambda reactor: control_service, {}
             )
             request = ReadRequest(Clock(), cluster)
             return request.get_probe()

--- a/benchmark/operations/wait.py
+++ b/benchmark/operations/wait.py
@@ -37,7 +37,6 @@ class Wait(object):
 
     def __init__(self, clock, control_service, wait_seconds=10):
         self.clock = clock
-        self.control_service = control_service
         self.wait_seconds = wait_seconds
 
     def get_probe(self):

--- a/benchmark/operations/wait.py
+++ b/benchmark/operations/wait.py
@@ -16,13 +16,13 @@ class WaitProbe(object):
     A probe to wait for a specified time period.
     """
 
-    def __init__(self, clock, wait_seconds):
-        self.clock = clock
+    def __init__(self, reactor, wait_seconds):
+        self.reactor = reactor
         self.wait_seconds = wait_seconds
 
     def run(self):
         d = Deferred()
-        self.clock.callLater(self.wait_seconds, d.callback, None)
+        self.reactor.callLater(self.wait_seconds, d.callback, None)
         return d
 
     def cleanup(self):
@@ -35,9 +35,9 @@ class Wait(object):
     An operation to wait for a number of seconds.
     """
 
-    def __init__(self, clock, cluster, wait_seconds=10):
-        self.clock = clock
+    def __init__(self, reactor, cluster, wait_seconds=10):
+        self.reactor = reactor
         self.wait_seconds = wait_seconds
 
     def get_probe(self):
-        return WaitProbe(clock=self.clock, wait_seconds=self.wait_seconds)
+        return WaitProbe(self.reactor, self.wait_seconds)

--- a/benchmark/operations/wait.py
+++ b/benchmark/operations/wait.py
@@ -32,10 +32,10 @@ class WaitProbe(object):
 @implementer(IOperation)
 class Wait(object):
     """
-    An operation to wait 10 seconds.
+    An operation to wait for a number of seconds.
     """
 
-    def __init__(self, clock, control_service, wait_seconds=10):
+    def __init__(self, clock, cluster, wait_seconds=10):
         self.clock = clock
         self.wait_seconds = wait_seconds
 

--- a/benchmark/scenarios/no_load.py
+++ b/benchmark/scenarios/no_load.py
@@ -16,7 +16,7 @@ class NoLoadScenario(object):
     A scenario that places no additional load on the cluster.
     """
 
-    def __init__(self, clock, control_service):
+    def __init__(self, clock, cluster):
         self._maintained = Deferred()
 
     def start(self):

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -16,6 +16,7 @@ import yaml
 from eliot import to_file
 
 from twisted.internet.task import react
+from twisted.python.filepath import FilePath
 from twisted.python.usage import Options, UsageError
 
 from flocker import __version__ as flocker_client_version
@@ -177,7 +178,7 @@ def main():
         usage(options, e.args[0])
 
     if options['uft']:
-        cluster = BenchmarkCluster.from_uft_setup(options['uft'])
+        cluster = BenchmarkCluster.from_uft_setup(FilePath(options['uft']))
     else:
         try:
             cluster = BenchmarkCluster.from_acceptance_test_env(os.environ)

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -71,8 +71,8 @@ class BenchmarkOptions(Options):
     description = "Run benchmark tests."
 
     optParameters = [
-        ['uft', None, None,
-         'Directory containing UFT installer files.  '
+        ['cluster', None, None,
+         'Directory containing cluster configuration files.  '
          'If not set, use acceptance test environment variables.'],
         ['config', None, 'benchmark.yml',
          'YAML file describing benchmark options.'],

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -10,7 +10,7 @@ import os
 from platform import node, platform
 import sys
 
-from jsonschema import FormatChecker, Draft4Validator
+from jsonschema import FormatChecker, Draft4Validator, ValidationError
 import yaml
 
 from eliot import to_file
@@ -194,6 +194,10 @@ def get_cluster(options, env):
             usage(
                 options, 'Environment variable {!r} not set.'.format(e.args[0])
             )
+        except ValueError as e:
+            usage(options, e.args[0])
+        except ValidationError as e:
+            usage(options, e.message)
     return cluster
 
 

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -177,8 +177,9 @@ def main():
     except UsageError as e:
         usage(options, e.args[0])
 
-    if options['uft']:
-        cluster = BenchmarkCluster.from_uft_setup(FilePath(options['uft']))
+    if options['cluster']:
+        cluster = BenchmarkCluster.from_cluster_yaml(
+            FilePath(options['cluster']))
     else:
         try:
             cluster = BenchmarkCluster.from_acceptance_test_env(os.environ)

--- a/benchmark/test/test_cluster.py
+++ b/benchmark/test/test_cluster.py
@@ -1,0 +1,69 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+
+from jsonschema.exceptions import ValidationError
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from benchmark.cluster import validate_cluster_configuration
+
+
+class ValidationTests(SynchronousTestCase):
+    """
+    Tests for configuration file validation.
+    """
+
+    def setUp(self):
+        self.config = {
+            'cluster_name': 'cluster',
+            'agent_nodes': [
+                {'public': '52.26.168.213', 'private': '10.0.36.170'},
+                {'public': '52.34.157.1', 'private': '10.0.84.25'}
+            ],
+            'control_node': 'ec.us-west-2.compute.amazonaws.com',
+            'users': ['user'],
+            'os': 'ubuntu',
+            'private_key_path': '/home/osboxes/devel/flocker/hybrid-master',
+            'agent_config': {
+                'version': 1,
+                'control-service': {
+                    'hostname': 'ec.us-west-2.compute.amazonaws.com',
+                    'port': 4524
+                },
+                'dataset': {
+                    'region': 'us-west-2',
+                    'backend': 'aws',
+                    'secret_access_key': 'XXXXXX',
+                    'zone': 'us-west-2a',
+                    'access_key_id': 'AKIAXXXX'
+                }
+            },
+        }
+
+    def test_valid(self):
+        """
+        Accepts configuration file with valid entries.
+        """
+        validate_cluster_configuration(self.config)
+
+    def test_config_extra_attribute(self):
+        """
+        Accepts configuration file with empty agent node mapping.
+        """
+        self.config['agent_nodes'] = []
+        validate_cluster_configuration(self.config)
+
+    def test_missing_control_node(self):
+        """
+        Rejects configuration with missing control_node property.
+        """
+        del self.config['control_node']
+        with self.assertRaises(ValidationError):
+            validate_cluster_configuration(self.config)
+
+    def test_missing_agent_nodes(self):
+        """
+        Rejects configuration with missing agent_nodes property.
+        """
+        del self.config['agent_nodes']
+        with self.assertRaises(ValidationError):
+            validate_cluster_configuration(self.config)

--- a/benchmark/test/test_cluster.py
+++ b/benchmark/test/test_cluster.py
@@ -105,7 +105,7 @@ class BenchmarkClusterTests(SynchronousTestCase):
         The ``control_service`` method gives expected results.
         """
         self.assertIs(
-            self.cluster.control_service(Clock()), self.control_service)
+            self.cluster.get_control_service(Clock()), self.control_service)
 
     def test_public_address(self):
         """

--- a/benchmark/test/test_cluster.py
+++ b/benchmark/test/test_cluster.py
@@ -75,8 +75,8 @@ class ValidationTests(SynchronousTestCase):
             validate_cluster_configuration(self.config)
 
 
-CONTROL_SERVICE_PUBLIC_IP = '10.0.0.1'
-CONTROL_SERVICE_PRIVATE_IP = '10.1.0.1'
+CONTROL_SERVICE_PUBLIC_IP = IPAddress('10.0.0.1')
+CONTROL_SERVICE_PRIVATE_IP = IPAddress('10.1.0.1')
 
 
 class BenchmarkClusterTests(SynchronousTestCase):
@@ -84,13 +84,12 @@ class BenchmarkClusterTests(SynchronousTestCase):
     def setUp(self):
         node = Node(
             # Node public_address is actually the internal cluster address
-            uuid=uuid4(), public_address=IPAddress(CONTROL_SERVICE_PRIVATE_IP)
+            uuid=uuid4(), public_address=CONTROL_SERVICE_PRIVATE_IP
         )
         self.control_service = FakeFlockerClient([node])
         self.cluster = BenchmarkCluster(
             CONTROL_SERVICE_PUBLIC_IP, lambda reactor: self.control_service, {
-                IPAddress(CONTROL_SERVICE_PRIVATE_IP):
-                    IPAddress(CONTROL_SERVICE_PUBLIC_IP),
+                CONTROL_SERVICE_PRIVATE_IP: CONTROL_SERVICE_PUBLIC_IP,
             }
         )
 
@@ -113,6 +112,6 @@ class BenchmarkClusterTests(SynchronousTestCase):
         The ``public_address`` method gives expected results.
         """
         self.assertEqual(
-            self.cluster.public_address(IPAddress(CONTROL_SERVICE_PRIVATE_IP)),
-            IPAddress(CONTROL_SERVICE_PUBLIC_IP)
+            self.cluster.public_address(CONTROL_SERVICE_PRIVATE_IP),
+            CONTROL_SERVICE_PUBLIC_IP
         )

--- a/benchmark/test/test_cluster.py
+++ b/benchmark/test/test_cluster.py
@@ -28,7 +28,7 @@ class ValidationTests(SynchronousTestCase):
             'control_node': 'ec.region1.compute.amazonaws.com',
             'users': ['user'],
             'os': 'ubuntu',
-            'private_key_path': '/home/XXX/private_key',
+            'private_key_path': '/home/example/private_key',
             'agent_config': {
                 'version': 1,
                 'control-service': {
@@ -38,9 +38,9 @@ class ValidationTests(SynchronousTestCase):
                 'dataset': {
                     'region': 'region1',
                     'backend': 'aws',
-                    'secret_access_key': 'XXXXXX',
+                    'secret_access_key': 'secret',
                     'zone': 'region1a',
-                    'access_key_id': 'AKIAXXXX'
+                    'access_key_id': 'AKIAsecret'
                 }
             },
         }

--- a/benchmark/test/test_driver.py
+++ b/benchmark/test/test_driver.py
@@ -7,6 +7,8 @@ from itertools import count, repeat
 
 from zope.interface import implementer
 
+from eliot.testing import capture_logging
+
 from twisted.internet.defer import Deferred, succeed, fail
 from twisted.trial.unittest import SynchronousTestCase, TestCase
 
@@ -137,7 +139,8 @@ class BenchmarkTest(TestCase):
         samples_ready.addCallback(check)
         return samples_ready
 
-    def test_bad_probes(self):
+    @capture_logging(None)
+    def test_bad_probes(self, logger):
         """
         Sampling returns reasons when probes fail.
         """

--- a/benchmark/test/test_driver.py
+++ b/benchmark/test/test_driver.py
@@ -88,7 +88,8 @@ class SampleTest(SynchronousTestCase):
     Test sample function.
     """
 
-    def test_good_probe(self):
+    @capture_logging(None)
+    def test_good_probe(self, logger):
         """
         Sampling returns value when probe succeeds.
         """
@@ -97,7 +98,8 @@ class SampleTest(SynchronousTestCase):
         self.assertEqual(
             self.successResultOf(sampled), {'success': True, 'value': 5})
 
-    def test_bad_probe(self):
+    @capture_logging(None)
+    def test_bad_probe(self, logger):
         """
         Sampling returns reason when probe fails.
         """
@@ -123,7 +125,8 @@ class BenchmarkTest(TestCase):
     # the `benchmark` function uses `twisted.task.cooperate`, which uses
     # the global reactor.
 
-    def test_good_probes(self):
+    @capture_logging(None)
+    def test_good_probes(self, logger):
         """
         Sampling returns results when probes succeed.
         """

--- a/benchmark/test/test_driver.py
+++ b/benchmark/test/test_driver.py
@@ -17,7 +17,7 @@ from benchmark._interfaces import IScenario, IProbe, IOperation, IMetric
 
 
 @implementer(IMetric)
-class FakeMetric:
+class FakeMetric(object):
 
     def __init__(self, measurements):
         """
@@ -36,7 +36,7 @@ class FakeMetric:
 
 
 @implementer(IProbe)
-class FakeProbe:
+class FakeProbe(object):
     """
     A probe performs a single operation, which can be timed.
     """
@@ -54,7 +54,7 @@ class FakeProbe:
 
 
 @implementer(IOperation)
-class FakeOperation:
+class FakeOperation(object):
 
     def __init__(self, succeeds):
         """
@@ -68,7 +68,7 @@ class FakeOperation:
 
 
 @implementer(IScenario)
-class FakeScenario:
+class FakeScenario(object):
 
     def __init__(self, maintained=Deferred()):
         self._maintained = maintained

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 
+from ipaddr import IPAddress
 from jsonschema.exceptions import ValidationError
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -65,8 +66,8 @@ class ClusterConfigurationTests(SynchronousTestCase):
         options.parseOptions([])
         cluster = get_cluster(options, self.environ)
         self.assertEqual(
-            cluster.control_node_address().exploded,
-            _ENV_CONTROL_SERVICE_ADDRESS
+            cluster.control_node_address(),
+            IPAddress(_ENV_CONTROL_SERVICE_ADDRESS)
         )
 
     def test_yaml_setup(self):
@@ -83,8 +84,8 @@ class ClusterConfigurationTests(SynchronousTestCase):
         options.parseOptions(['--cluster', tmpdir])
         cluster = get_cluster(options, self.environ)
         self.assertEqual(
-            cluster.control_node_address().exploded,
-            _YAML_CONTROL_SERVICE_ADDRESS
+            cluster.control_node_address(),
+            IPAddress(_YAML_CONTROL_SERVICE_ADDRESS)
         )
 
     def test_missing_environment(self):

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -21,7 +21,7 @@ def capture_stderr():
     """
     Context manager to capture stderr.
 
-    Captured output is available
+    Call the returned context variable to obtain captured output.
     """
     s = StringIO()
     out, sys.stderr = sys.stderr, s

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -76,14 +76,12 @@ class ClusterConfigurationTests(SynchronousTestCase):
         This is true even if the environment contains a valid configuration.
         """
         tmpdir = tempfile.mkdtemp()
-        try:
-            with open(os.path.join(tmpdir, 'cluster.yml'), 'wt') as f:
-                f.write(_CLUSTER_YAML_CONTENTS)
-            options = BenchmarkOptions()
-            options.parseOptions(['--cluster', tmpdir])
-            cluster = get_cluster(options, self.environ)
-        finally:
-            shutil.rmtree(tmpdir)
+        self.addCleanup(shutil.rmtree, tmpdir)
+        with open(os.path.join(tmpdir, 'cluster.yml'), 'wt') as f:
+            f.write(_CLUSTER_YAML_CONTENTS)
+        options = BenchmarkOptions()
+        options.parseOptions(['--cluster', tmpdir])
+        cluster = get_cluster(options, self.environ)
         self.assertEqual(
             cluster.control_node_address().exploded,
             _YAML_CONTROL_SERVICE_ADDRESS
@@ -109,16 +107,14 @@ class ClusterConfigurationTests(SynchronousTestCase):
         YAML description.
         """
         tmpdir = tempfile.mkdtemp()
-        try:
-            options = BenchmarkOptions()
-            options.parseOptions(['--cluster', tmpdir])
-            with capture_stderr() as captured_stderr:
-                with self.assertRaises(SystemExit) as e:
-                    get_cluster(options, self.environ)
-                self.assertIn('not found', e.exception.args[0])
-                self.assertIn(options.getUsage(), captured_stderr())
-        finally:
-            shutil.rmtree(tmpdir)
+        self.addCleanup(shutil.rmtree, tmpdir)
+        options = BenchmarkOptions()
+        options.parseOptions(['--cluster', tmpdir])
+        with capture_stderr() as captured_stderr:
+            with self.assertRaises(SystemExit) as e:
+                get_cluster(options, self.environ)
+            self.assertIn('not found', e.exception.args[0])
+            self.assertIn(options.getUsage(), captured_stderr())
 
 
 class ValidationTests(SynchronousTestCase):

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -28,6 +28,8 @@ def capture_stderr():
     yield s.getvalue
     sys.stderr = out
 
+# Addresses must be different, to check that environment is not used
+# during YAML tests.
 _ENV_CONTROL_SERVICE_ADDRESS = '10.0.0.1'
 _YAML_CONTROL_SERVICE_ADDRESS = '10.1.0.1'
 
@@ -102,6 +104,9 @@ class ClusterConfigurationTests(SynchronousTestCase):
     def test_missing_yaml_file(self):
         """
         Script fails if cluster directory does not contain cluster.yml
+
+        There is no fallback to environment if an error occurs reading
+        YAML description.
         """
         tmpdir = tempfile.mkdtemp()
         try:
@@ -109,7 +114,7 @@ class ClusterConfigurationTests(SynchronousTestCase):
             options.parseOptions(['--cluster', tmpdir])
             with capture_stderr() as captured_stderr:
                 with self.assertRaises(SystemExit) as e:
-                    get_cluster(options, {})
+                    get_cluster(options, self.environ)
                 self.assertIn('not found', e.exception.args[0])
                 self.assertIn(options.getUsage(), captured_stderr())
         finally:

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -236,7 +236,9 @@ In this case the acceptance tests need a hint in order to map the private IP add
 E.g. When a test needs to verify that a container on the node is listening on an expected port or to communicate directly with the Docker API on that node.
 The mapping is supplied to the tests in the ``FLOCKER_ACCEPTANCE_HOSTNAME_TO_PUBLIC_ADDRESS`` environment variable.
 
-If you create nodes using ``run-acceptance-tests --runner=aws --keep`` the command will print out the node addresses when it exits. E.g.
+.. _acceptance-testing-cluster-config:
+
+If you create nodes using ``run-acceptance-tests --keep`` the command will print out the cluster configuration when it exits. E.g.
 
 .. code-block:: console
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -238,7 +238,8 @@ The mapping is supplied to the tests in the ``FLOCKER_ACCEPTANCE_HOSTNAME_TO_PUB
 
 .. _acceptance-testing-cluster-config:
 
-If you create nodes using ``run-acceptance-tests --keep`` the command will print out the cluster configuration when it exits. E.g.
+If you create nodes using ``run-acceptance-tests --keep`` the command will print out the cluster configuration when it exits.
+For example:
 
 .. code-block:: console
 

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -23,15 +23,15 @@ The :program:`benchmark` script has the following command line options:
    - ``user.crt`` - a user certificate file; and
    - ``user.key`` - a user private key file.
 
-   These files are equivalent to those created by the  :ref:`Quick Start Flocker Installer <labs-installer>`.
-   See :ref:`below <benchmarking-cluster-description>` for the format of the ``cluster.yml`` file.
+   These files are equivalent to those created by the :ref:`Quick Start Flocker Installer <labs-installer>`.
+   The format of the :file:`cluster.yml` file is specified in the  :ref:`benchmarking-cluster-description` section below.
 
    If this option is not specified, then the benchmark script expects environment variables as set by the :ref:`acceptance test runner <acceptance-testing-cluster-config>` using ```run-acceptance-tests --keep``.
 
 .. option:: --config <benchmark-config>
 
    Specifies a file containing configurations for scenarios, operations, and metrics.
-   See :ref:`below <benchmarking-configuration-file>` for the format of this file.
+   The format of this file is specified in the :ref:`benchmarking-configuration-file` section below.
    Defaults to the file ``./benchmark.yml``.
 
 .. option:: --scenario <scenario>
@@ -59,7 +59,7 @@ The :program:`benchmark` script has the following command line options:
 Cluster Description File
 ------------------------
 
-This file must be named ``cluster.yml`` and must be located in the directory named by the ``--cluster`` option.
+This file must be named :file:`cluster.yml` and must be located in the directory named by the ``--cluster`` option.
 
 An example file:
 

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -3,12 +3,6 @@
 Benchmarking
 ============
 
-.. note::
-
-   For the ``benchmark`` command described on this page, if the cluster uses private addresses for communication (e.g. AWS nodes), set the environment variable ``FLOCKER_ACCEPTANCE_HOSTNAME_TO_PUBLIC_ADDRESS`` to a serialized JSON object mapping cluster internal IP addresses to public IP addresses.
-   This environment variable is provided if the cluster is started using the ``run-acceptance-tests`` command.
-   This is intended to be a temporary requirement, until other mechanisms are available [:issue:`2137`, :issue:`3514`, :issue:`3521`].
-
 Flocker includes a tool for benchmarking operations.
 It is called like this:
 
@@ -20,20 +14,24 @@ The :program:`benchmark` script has the following command line options:
 
 .. program:: benchmark
 
-.. option:: --control <control-service-ipaddr>
+.. option:: --cluster <cluster-config>
 
-   Specifies the IP address for the Flocker cluster control node.
-   This must be specified, unless the ``no-op`` operation is requested.
+   Specifies a directory containing:
 
-.. option:: --certs <directory>
+   - ``cluster.yml`` - a cluster description file;
+   - ``cluster.crt`` - a CA certificate file;
+   - ``user.crt`` - a user certificate file; and
+   - ``user.key`` - a user private key file.
 
-   Specifies the directory containing the user certificates.
-   Defaults to the directory ``./certs``.
+   These files are equivalent to those created by the  :ref:`Quick Start Flocker Installer <labs-installer>`.
+   See :ref:`below <benchmarking-cluster-description>` for the format of the ``cluster.yml`` file.
 
-.. option:: --config <config-file>
+   If this option is not specified, then the benchmark script expects environment variables as set by the :ref:`acceptance test runner <acceptance-testing-cluster-config>` using ```run-acceptance-tests --keep``.
+
+.. option:: --config <benchmark-config>
 
    Specifies a file containing configurations for scenarios, operations, and metrics.
-   See below for the format of this file.
+   See :ref:`below <benchmarking-configuration-file>` for the format of this file.
    Defaults to the file ``./benchmark.yml``.
 
 .. option:: --scenario <scenario>
@@ -55,6 +53,24 @@ The :program:`benchmark` script has the following command line options:
    This is the ``name`` of a metric in the configuration file.
    Defaults to the name ``default``.
 
+
+.. _benchmarking-cluster-description:
+
+Cluster Description File
+------------------------
+
+This file must be named ``cluster.yml`` and must be located in the directory named by the ``--cluster`` option.
+
+An example file:
+
+.. code-block:: yaml
+
+   agent_nodes:
+    - {public: 172.31.105.15, private: 10.0.84.25}
+    - {public: 172.31.105.16, private: 10.0.84.22}
+   control_node: 172.31.105.15
+
+.. _benchmarking-configuration-file:
 
 Configuration File
 ------------------


### PR DESCRIPTION
This PR:
- adds a BenchmarkCluster class that describes the cluster being benchmarked.
- replaces the command line options `--control` and `--certs` with a `--cluster` option to specify the location of cluster description created by the Quick Start Flocker installer.
- creates a BenchmarkCluster from either the files created by the Quick Start Flocker installer, or from the environment variables displayed by `run-acceptance-tests --keep`.
- passes the BenchmarkCluster as a parameter to each benchmark scenario, operation, and metric class, rather than passing the control service.

In particular, this change allows the private to public IP mapping to be made available to the parameter classes.  Hence, the "hack" that reads an environment variable has been removed from the `CPUTime` metric.

