### PR TITLE
[FLOC-3498] Use ClusterHQ fork of testtools

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -259,7 +259,7 @@ common_cli:
     \${PARSE_LOGS} pip install . \${PIP_ADDITIONAL_OPTIONS}
     # Install Flocker. Use --process-dependency-links so we can temporarily use
     # testtools fork. See FLOC-3498.
-    \${PARSE_LOGS} pip install --process-dependency-links  "Flocker[dev]" \${PIP_ADDITIONAL_OPTIONS}
+    \${PARSE_LOGS} pip install --process-dependency-links  ".[dev]" \${PIP_ADDITIONAL_OPTIONS}
     # install junix for our coverage report
     \${PARSE_LOGS} pip install python-subunit junitxml \${PIP_ADDITIONAL_OPTIONS}
 

--- a/build.yaml
+++ b/build.yaml
@@ -257,8 +257,9 @@ common_cli:
     # using the caching-layer, install all the dependencies
     \${PARSE_LOGS} pip install --upgrade pip
     \${PARSE_LOGS} pip install . \${PIP_ADDITIONAL_OPTIONS}
-    # install Flocker
-    \${PARSE_LOGS} pip install  "Flocker[dev]" \${PIP_ADDITIONAL_OPTIONS}
+    # Install Flocker. Use --process-dependency-links so we can temporarily use
+    # testtools fork. See FLOC-3498.
+    \${PARSE_LOGS} pip install --process-dependency-links  "Flocker[dev]" \${PIP_ADDITIONAL_OPTIONS}
     # install junix for our coverage report
     \${PARSE_LOGS} pip install python-subunit junitxml \${PIP_ADDITIONAL_OPTIONS}
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -43,7 +43,8 @@ sphinx-prompt==1.0.0
 sphinx-rtd-theme==0.1.8
 sphinxcontrib-httpdomain==1.3.0
 sphinxcontrib-spelling==2.1.2
-testtools==1.8.1
+# Use our fork of testtools until #165, #171, and #172 are merged and released
+-e git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools
 tox==2.1.1
 versioneer==0.15
 virtualenv==13.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -43,8 +43,7 @@ sphinx-prompt==1.0.0
 sphinx-rtd-theme==0.1.8
 sphinxcontrib-httpdomain==1.3.0
 sphinxcontrib-spelling==2.1.2
-# Use our fork of testtools until #165, #171, and #172 are merged and released
--e git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools
+testtools==1.8.1
 tox==2.1.1
 versioneer==0.15
 virtualenv==13.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -43,7 +43,7 @@ sphinx-prompt==1.0.0
 sphinx-rtd-theme==0.1.8
 sphinxcontrib-httpdomain==1.3.0
 sphinxcontrib-spelling==2.1.2
-testtools==1.8.1
+testtools==1.8.2chq1
 tox==2.1.1
 versioneer==0.15
 virtualenv==13.1.0

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -16,7 +16,7 @@ from testtools.deferredruntest import (
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
-from ._flaky import retry_flaky, _reset_case
+from ._flaky import retry_flaky
 
 
 class TestCase(unittest.SynchronousTestCase):
@@ -82,15 +82,6 @@ class AsyncTestCase(testtools.TestCase):
         # XXX: Actually belongs in a mixin or something, not actually specific
         # to async.
         return make_temporary_directory(self).child('temp').path
-
-    def run(self, *args, **kwargs):
-        """
-        Run ``AsyncTestCase``
-        """
-        # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879.
-        # Constructed tests are called more than once when run with `trial -u`.
-        _reset_case(self)
-        super(AsyncTestCase, self).run(*args, **kwargs)
 
 
 def _path_for_test_id(test_id, max_segment_length=32):

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -238,8 +238,9 @@ class _RetryFlaky(testtools.RunTest):
             result was and ``details`` is a dictionary of testtools details.
         """
         tmp_result = testtools.TestResult()
-        # XXX: jml: Argh! Of course putting _reset in TestCase.run() doesn't
-        # help runners that want to re-run.
+        # XXX: Still using internal API of testtools despite improvements in
+        # #165. Will need to do follow-up work on testtools to ensure that
+        # RunTest.run(case); RunTest.run(case) is supported.
         case._reset()
         self._run_test(case, tmp_result)
         result_type = _get_result_type(tmp_result)

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -238,8 +238,9 @@ class _RetryFlaky(testtools.RunTest):
             result was and ``details`` is a dictionary of testtools details.
         """
         tmp_result = testtools.TestResult()
-        # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879
-        _reset_case(case)
+        # XXX: jml: Argh! Of course putting _reset in TestCase.run() doesn't
+        # help runners that want to re-run.
+        case._reset()
         self._run_test(case, tmp_result)
         result_type = _get_result_type(tmp_result)
         details = pmap(case.getDetails())
@@ -311,14 +312,3 @@ def _combine_details(detailses):
     for details in detailses:
         gather_details(details, result)
     return pmap(result)
-
-
-def _reset_case(case):
-    """
-    Reset ``case`` so it can be run again.
-    """
-    # XXX: Work around https://bugs.launchpad.net/testtools/+bug/1517879
-    # Don't want details from last run.
-    case.getDetails().clear()
-    case._TestCase__setup_called = False
-    case._TestCase__teardown_called = False

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,12 @@ setup(
 
     cmdclass=versioneer.get_cmdclass(),
 
+    dependency_links = [
+        # Use our fork of testtools until #165, #171, and #172 are merged and
+        # released.
+        "git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools",
+    ],
+
     # Some "trove classifiers" which are relevant.
     classifiers=[
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -110,8 +110,8 @@ setup(
 
     dependency_links = [
         # Use our fork of testtools until #165, #171, and #172 are merged and
-        # released.
-        "git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools",
+        # released. See FLOC-3498.
+        "git+git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools-1.8.2chq1",  # noqa
     ],
 
     # Some "trove classifiers" which are relevant.

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,10 @@ setup(
     dependency_links = [
         # Use our fork of testtools until #165, #171, and #172 are merged and
         # released. See FLOC-3498.
+        #
+        # "git+git" weirdness is due to setuptools expecting:
+        #     vcs+proto://host/path@revision#egg=project-version
+        # See http://setuptools.readthedocs.org/en/latest/setuptools.html
         "git+git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools-1.8.2chq1",  # noqa
     ],
 


### PR DESCRIPTION
It's taking days to get patches landed in testtools and these delays are having a direct & significant impact on our development velocity (flaky tests; debugging info from failing tests). This patch circumvents  that by using a temporary, dedicated fork: ClusterHQ/testtools#clusterhq-fork

The trade-off is that we'll probably have to do some rework in exchange for advancing our learning from the future to today.

The fork currently incorporates the latest versions of testing-cabal/testtools#165 and testing-cabal/testtool#171.

The astute will note that we've _already_ learned something, which is that testing-cabal/testtools#165 isn't enough for a `RunTest` implementation to be able to run a test case twice. I plan to address that in a follow-up patch on testtools, since 165 is already huge. 