### PR TITLE
[FLOC-3628] Add elapsed wallclock time to CPU time samples.

### DIFF
--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -93,7 +93,7 @@ class CPUParser(LineOnlyReceiver):
         self.result[name] = self.result.get(name, 0) + cputime
 
 
-class SSHRunner:
+class SSHRunner(object):
     """
     Run a command using ssh.
 

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -86,7 +86,7 @@ class CPUParseTests(SynchronousTestCase):
         self.assertEqual(e.exception.args[-1], 'proc 20:34')
 
 
-class _LocalRunner:
+class _LocalRunner(object):
     """
     Like SSHRunner, but runs command locally.
     """

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -14,7 +14,7 @@ from flocker.apiclient._client import FakeFlockerClient, Node
 
 from benchmark._interfaces import IMetric
 from benchmark.metrics.cputime import (
-    CPUTime, CPUParser, get_node_cpu_times, compute_change,
+    WALLCLOCK_LABEL, CPUTime, CPUParser, get_node_cpu_times, compute_change,
 )
 
 
@@ -41,33 +41,37 @@ class CPUParseTests(SynchronousTestCase):
         """
         Blank lines are ignored.
         """
-        parser = CPUParser()
+        parser = CPUParser(Clock())
         parser.lineReceived('')
-        self.assertEqual(parser.result, {})
+        self.assertEqual(parser.result, {WALLCLOCK_LABEL: 0})
 
     def test_nodays(self):
         """
         CPU time line with no days part parses correctly.
         """
-        parser = CPUParser()
+        parser = CPUParser(Clock())
         parser.lineReceived('proc  12:34:56')
         expected_cputime = (12 * 60 + 34) * 60 + 56
-        self.assertEqual(parser.result, {'proc': expected_cputime})
+        self.assertEqual(
+            parser.result, {'proc': expected_cputime, WALLCLOCK_LABEL: 0}
+        )
 
     def test_days(self):
         """
         CPU time line with a days part parses correctly.
         """
-        parser = CPUParser()
+        parser = CPUParser(Clock())
         parser.lineReceived('proc  5-12:34:56')
         expected_cputime = ((5 * 24 + 12) * 60 + 34) * 60 + 56
-        self.assertEqual(parser.result, {'proc': expected_cputime})
+        self.assertEqual(
+            parser.result, {'proc': expected_cputime, WALLCLOCK_LABEL: 0}
+        )
 
     def test_unexpected_line(self):
         """
         Line that doesn't fit expected pattern raises exception.
         """
-        parser = CPUParser()
+        parser = CPUParser(Clock())
         with self.assertRaises(ValueError) as e:
             parser.lineReceived('Unexpected Error Message')
         self.assertEqual(e.exception.args[-1], 'Unexpected Error Message')
@@ -76,7 +80,7 @@ class CPUParseTests(SynchronousTestCase):
         """
         Line that has incorrectly formatted time raises exception.
         """
-        parser = CPUParser()
+        parser = CPUParser(Clock())
         with self.assertRaises(ValueError) as e:
             parser.lineReceived('proc 20:34')
         self.assertEqual(e.exception.args[-1], 'proc 20:34')
@@ -108,13 +112,16 @@ class GetNodeCPUTimeTests(TestCase):
         Success results in output of dictionary containing process names.
         """
         d = get_node_cpu_times(
+            Clock(),
             _LocalRunner(),
             Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1')),
             [_standard_process],
         )
 
         def check(result):
-            self.assertEqual(result.keys(), [_standard_process])
+            self.assertEqual(
+                result.keys(), [_standard_process, WALLCLOCK_LABEL]
+            )
 
         d.addCallback(check)
 
@@ -123,15 +130,16 @@ class GetNodeCPUTimeTests(TestCase):
     @on_linux
     def test_no_such_process(self):
         """
-        If processes do not exist, empty directory is returned.
+        If processes do not exist, only wallclock time is returned.
         """
         d = get_node_cpu_times(
+            Clock(),
             _LocalRunner(),
             Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1')),
             ['n0n-exist'],
         )
 
-        d.addCallback(self.assertEqual, {})
+        d.addCallback(self.assertEqual, {WALLCLOCK_LABEL: 0.0})
 
         return d
 
@@ -191,12 +199,13 @@ class CPUTimeTests(TestCase):
         """
         Fake Flocker cluster gives expected results.
         """
+        clock = Clock()
         node1 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1'))
         node2 = Node(uuid=uuid4(), public_address=IPAddress('10.0.0.2'))
         metric = CPUTime(
-            Clock(), FakeFlockerClient([node1, node2]),
+            clock, FakeFlockerClient([node1, node2]),
             _LocalRunner(), processes=[_standard_process])
-        d = metric.measure(lambda: None)  # measure a fast no-op command
+        d = metric.measure(lambda: clock.advance(5))
 
         # Although it is unlikely, it's possible that we could get a CPU
         # time != 0, so filter values out.
@@ -204,7 +213,8 @@ class CPUTimeTests(TestCase):
             for process_times in node_cpu_times.values():
                 if process_times:
                     for process in process_times:
-                        process_times[process] = 0
+                        if process != WALLCLOCK_LABEL:
+                            process_times[process] = 0
             return node_cpu_times
         d.addCallback(filter)
 
@@ -212,8 +222,8 @@ class CPUTimeTests(TestCase):
             self.assertEqual(
                 result,
                 {
-                    '10.0.0.1': {_standard_process: 0},
-                    '10.0.0.2': {_standard_process: 0}
+                    '10.0.0.1': {_standard_process: 0, WALLCLOCK_LABEL: 5},
+                    '10.0.0.2': {_standard_process: 0, WALLCLOCK_LABEL: 5}
                 }
             )
         d.addCallback(check)


### PR DESCRIPTION
Add wallclock times to CPU time samples to enable calculation of CPU load % from raw CPU times.

Wallclock times are calculated per node, to handle any delays for an individual node's network.

The wallclock time is measured at the start of parsing the output. This would seem to be the point on the local side with the fewest opportunities for added latency from external conditions.