### PR TITLE
[FLOC-3637] Removing Ubuntu 15.04 from supported distros for nodes in acceptance …

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -1176,7 +1176,7 @@ def main(reactor, args, base_path, top_level):
                                                node.address,
                                                remote_logs_file)
                                )
-        elif options['distribution'] in ('ubuntu-14.04', 'ubuntu-15.04'):
+        elif options['distribution'] in ('ubuntu-14.04',):
             remote_logs_file = open("remote_logs.log", "a")
             for node in cluster.all_nodes:
                 results.append(capture_upstart(reactor,


### PR DESCRIPTION
…test runner

And that is what happens when working in two different branches in the same area of code.
Moving to 15.10 in one branch, pulling the logs from ubuntu nodes in another branch. Merge. And bad code there.
I had removed 15.04 instead of changing it to 15.10 because we do not support 15.10 for nodes as far as I know, only for the client.