### PR TITLE
[FLOC-3641] Improve Docker plugin logs

### DIFF
--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -45,6 +45,10 @@ _LOG_HTTP_REQUEST = ActionType(
      Field("response_body", lambda o: o, "JSON response body.")],
     "A HTTP request.")
 
+_LOG_CONDITIONAL_CREATE = ActionType(
+    u"flocker:apiclient:conditional_create", [], [],
+    u"Conditionally create a dataset.")
+
 
 NoneType = type(None)
 
@@ -809,15 +813,23 @@ def conditional_create(client, reactor, condition, *args, **kwargs):
     :return: ``Deferred`` firing with resulting ``Dataset`` if creation
         succeeded, or the relevant exception if creation failed.
     """
+    context = _LOG_CONDITIONAL_CREATE()
+
     def create():
         d = client.list_datasets_configuration()
 
         def got_config(config):
             condition(config)
-            return deferLater(reactor, 0.001, client.create_dataset,
+            return deferLater(reactor, 0.001, context.run,
+                              client.create_dataset,
                               *args, configuration_tag=config.tag,
                               **kwargs)
         d.addCallback(got_config)
         return d
-    return retry_failure(reactor, create, [ConfigurationChanged],
-                         [0.001] * 19)
+
+    with context.context():
+        result = DeferredContext(
+            retry_failure(reactor, create, [ConfigurationChanged],
+                          [0.001] * 19))
+        result.addActionFinish()
+        return result.result

--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -34,6 +34,7 @@ from .._client import (
     DatasetState, FlockerClient, ResponseError, _LOG_HTTP_REQUEST,
     Lease, LeaseAlreadyHeld, Node, Container, ContainerAlreadyExists,
     DatasetsConfiguration, ConfigurationChanged, conditional_create,
+    _LOG_CONDITIONAL_CREATE,
 )
 from ...ca import rest_api_context_factory
 from ...ca.testtools import get_credential_sets
@@ -815,7 +816,8 @@ class ConditionalCreateTests(SynchronousTestCase):
                     raise CustomException()
         return condition
 
-    def test_simple_success(self):
+    @capture_logging(assertHasAction, _LOG_CONDITIONAL_CREATE, True)
+    def test_simple_success(self, logger):
         """
         If no configuration changes or condition violations occur the creation
         succeeds.


### PR DESCRIPTION
The Docker plugin, and utilities it relied on, don't preserve Eliot context. Fix that so it's easier to read a trace of what happened.