### PR TITLE
[FLOC-3670] Define acceptance testing jobs more broadly

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -789,15 +789,9 @@ run_trial_cli_as_root: &run_trial_cli_as_root [
 # run_acceptance_modules contains the list of Flocker modules to be executed
 # during the acceptance tests
 run_acceptance_modules: &run_acceptance_modules
-  - flocker.acceptance.endtoend.test_dataset
-  - flocker.acceptance.endtoend.test_diagnostics
-  - flocker.acceptance.endtoend.test_dockerplugin
-  - flocker.acceptance.endtoend.test_leases
-  - flocker.acceptance.integration.test_mongodb
-  - flocker.acceptance.integration.test_platform
-  - flocker.acceptance.integration.test_postgres
-  - flocker.acceptance.obsolete.test_cli
-  - flocker.acceptance.obsolete.test_containers
+  - flocker.acceptance.endtoend
+  - flocker.acceptance.integration
+  - flocker.acceptance.obsolete
 
 # flocker.node.functional is hanging, so we don't run it
 job_type:


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3670

Maybe also puts less load on cloud providers to run our acceptance tests since it cuts the number of jobs from 9 to 3.