### PR TITLE
[FLOC 3650] Update the intro to the API User Cert doc

### DIFF
--- a/docs/config/generate-api-certificates.rst
+++ b/docs/config/generate-api-certificates.rst
@@ -4,7 +4,7 @@
 Generating an API User Certificate
 ==================================
 
-If you wish to send instructions to the control service, by using the API directly, via the CLI, or any other method, you will need to follow the instructions below to generate an API user certificate:
+To send instructions to the control service, whether it is via the API directly, or the CLI, or by any other method, you will need to follow the instructions below to generate an API user certificate:
 
 #. Generate an API user certificate:
 


### PR DESCRIPTION
Fixes 3650

The current wording allowed the user to believe that generating API User Cert was optional. This PR rewords the intro to make it clear all users must do this step.