### PR TITLE
[FLOC 3632] Update the Full Install information 

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -1,3 +1,4 @@
+
 .. _installing-flocker:
 
 ==================
@@ -21,7 +22,9 @@ If you want to get started with Flocker quickly, but in your own environment, yo
 Full Installation
 =================
 
-To get the full Flocker functionality, the following installation steps will take you through installing the Flocker client, the Flocker node services, and the Flocker plugin for Docker:
+To get the full Flocker functionality, the following installation steps will take you through installing the :ref:`Flocker client <installing-flocker-cli>`, the :ref:`Flocker node services <installing-flocker-node>`.
+
+If you want to install the :ref:`Flocker plugin for Docker <docker-plugin>`, this is included in the Flocker node services instructions:
 
 .. XXX this introduction could be improved with an image. See FLOC-2077
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -1,4 +1,3 @@
-
 .. _installing-flocker:
 
 ==================


### PR DESCRIPTION
Fixes 3632

The current wording allowed the user to believe that the installation of the plugin was a separate page - this is no longer true, as the Plugin installation is now an optional step in the node services instructions.