### PR TITLE
[FLOC 3652] Rename the API User to API Client

### DIFF
--- a/docs/concepts/security.rst
+++ b/docs/concepts/security.rst
@@ -20,7 +20,7 @@ API end users are issued their own certificate and private key, also with a copy
 
 This allows all components of the cluster to establish both a private channel of communication and a means of verifying identity; the client validates the server certificate was signed by the cluster authority, while the server mutually verifies the client's certificate was signed by the same authority.
 
-For instructions on how to set up API user certificates, see :ref:`generate-api`.
+For instructions on how to set up API client certificates, see :ref:`generate-api`.
 
 Security Benefits
 =================

--- a/docs/config/configuring-authentication.rst
+++ b/docs/config/configuring-authentication.rst
@@ -166,5 +166,5 @@ Steps
 
 The next topic is :ref:`generate-api`, which is used to identify yourself when sending instructions to the control service.
 
-If you have chosen to install :ref:`docker-plugin` you will also need to create API user certificates for the plugin, as it requires access to the Flocker REST API.
+If you have chosen to install :ref:`docker-plugin` you will also need to create API client certificates for the plugin, as it requires access to the Flocker REST API.
 In addition to the :ref:`generate-api` steps, you will also need to complete the instructions in :ref:`generate-api-docker-plugin` .

--- a/docs/config/generate-api-certificates.rst
+++ b/docs/config/generate-api-certificates.rst
@@ -1,16 +1,16 @@
 .. _generate-api:
 
-==================================
-Generating an API User Certificate
-==================================
+====================================
+Generating an API Client Certificate
+====================================
 
-To send instructions to the control service, whether it is via the API directly, or the CLI, or by any other method, you will need to follow the instructions below to generate an API user certificate:
+To send instructions to the control service, whether it is via the API directly, or the CLI, or by any other method, you will need to follow the instructions below to generate an API client certificate:
 
-#. Generate an API user certificate:
+#. Generate an API client certificate:
 
    Run the following command from the directory which contains the certificate authority files generated when you first installed the cluster. For more information, see :ref:`authentication`.
 
-   Replace ``<username>`` with a unique username for an API user.
+   Replace ``<username>`` with a unique username for an API client.
 
    .. prompt:: bash $
 
@@ -18,23 +18,23 @@ To send instructions to the control service, whether it is via the API directly,
 
    You will now have the files :file:`<username>.crt` and :file:`<username>.key`.
 
-#. Provide the certificates to the API end user:
+#. Provide the certificates to the API client, or end user:
 
-   You can now copy the following files to the API end user via a secure communication medium, such as SSH, SCP or SFTP:
+   You can now copy the following files to the API client, or end user via a secure communication medium, such as SSH, SCP or SFTP:
    
    * :file:`<username>.crt`
    * :file:`<username>.key`
    * :file:`cluster.crt`
 
-   .. note:: In this example ``<username>`` is a unique username for an API user.
+   .. note:: In this example ``<username>`` is a unique username for an API client.
 			 Please note though that ``flocker-deploy`` requires these files to be renamed :file:`user.crt` and :file:`user.key`.
 
 Using an API Certificate to Authenticate
 ========================================
 
-Once in possession of an API user certificate and the cluster certificate, an API end user must authenticate with those certificates in every request to the cluster REST API.
-The cluster certificate ensures the user is connecting to the genuine API of their cluster.
-The client certificate allows the API server to ensure the request is from a genuine, authorized user.
+Once in possession of an API client certificate and the cluster certificate, an API client must authenticate with those certificates in every request to the cluster REST API.
+The cluster certificate ensures the client is connecting to the genuine API of their cluster.
+The client certificate allows the API server to ensure the request is from a genuine, authorized client.
 
 The following is an example of an authenticated request to create a new container on a cluster, using ``cURL``.
 In this example, ``172.16.255.250`` represents the DNS IP address of the control service.

--- a/docs/config/generate-api-certificates.rst
+++ b/docs/config/generate-api-certificates.rst
@@ -10,23 +10,23 @@ To send instructions to the control service, whether it is via the API directly,
 
    Run the following command from the directory which contains the certificate authority files generated when you first installed the cluster. For more information, see :ref:`authentication`.
 
-   Replace ``<username>`` with a unique username for an API client.
+   Replace ``<client_name>`` with a unique identifier for an API client.
 
    .. prompt:: bash $
 
-      flocker-ca create-api-certificate <username>
+      flocker-ca create-api-certificate <client_name>
 
-   You will now have the files :file:`<username>.crt` and :file:`<username>.key`.
+   You will now have the files :file:`<client_name>.crt` and :file:`<client_name>.key`.
 
 #. Provide the certificates to the API client, or end user:
 
    You can now copy the following files to the API client, or end user via a secure communication medium, such as SSH, SCP or SFTP:
    
-   * :file:`<username>.crt`
-   * :file:`<username>.key`
+   * :file:`<client_name>.crt`
+   * :file:`<client_name>.key`
    * :file:`cluster.crt`
 
-   .. note:: In this example ``<username>`` is a unique username for an API client.
+   .. note:: In this example ``<client_name>`` is a unique username for an API client.
 			 Please note though that ``flocker-deploy`` requires these files to be renamed :file:`user.crt` and :file:`user.key`.
 
 Using an API Certificate to Authenticate
@@ -49,7 +49,7 @@ OS X
 ----
 
 Make sure you know the common name of the client certificate you will use.
-If you just generated the certificate following the :ref:`instructions above <generate-api>`, the common name is ``user-<username>`` where ``<username>`` is whatever argument you passed to ``flocker-ca generate-api-certificate``.
+If you just generated the certificate following the :ref:`instructions above <generate-api>`, the common name is ``user-<client_name>`` where ``<client_name>`` is whatever argument you passed to ``flocker-ca generate-api-certificate``.
 If you're not sure what the username is, you can find the common name like this:
 
 .. prompt:: bash $ auto

--- a/docs/config/generate-api-plugin.rst
+++ b/docs/config/generate-api-plugin.rst
@@ -1,14 +1,14 @@
 .. _generate-api-docker-plugin:
 
-====================================================================
-Generating an API User Certificate for the Flocker Plugin for Docker
-====================================================================
+======================================================================
+Generating an API Client Certificate for the Flocker Plugin for Docker
+======================================================================
 
 The Flocker plugin for Docker requires access to the Flocker REST API.
-To use the plugin, you will need to create an API user certificate and key for a user named ``plugin`` on each node. 
+To use the plugin, you will need to create an API client certificate and key for a user named ``plugin`` on each node. 
 For more information, see the :ref:`generate-api` instructions.
 
-#. Generate an API user certificate for a user named ``plugin``:
+#. Generate an API client certificate for a user named ``plugin``:
 
    .. prompt:: bash $
 

--- a/docs/control/cli/usage.rst
+++ b/docs/control/cli/usage.rst
@@ -42,9 +42,9 @@ Before ``flocker-deploy`` can do this it needs to be able to authenticate itself
 
 Flocker uses TLS mutual authentication to communicate with the control service you specify as the first command line argument.
 
-To authenticate with the control service, you will need a copy of the public cluster certificate created when you first :ref:`installed flocker on your nodes <authentication>` and an API user certificate, which you can :ref:`generate <generate-api>` using the ``flocker-ca`` tool.
+To authenticate with the control service, you will need a copy of the public cluster certificate created when you first :ref:`installed flocker on your nodes <authentication>` and an API client certificate, which you can :ref:`generate <generate-api>` using the ``flocker-ca`` tool.
 
-By default, ``flocker-deploy`` will look for these certificate files in the current working directory and expect them to be named :file:`cluster.crt` (the public cluster certificate), :file:`user.crt` (the API user certificate) and :file:`user.key` (the API user's private key).
+By default, ``flocker-deploy`` will look for these certificate files in the current working directory and expect them to be named :file:`cluster.crt` (the public cluster certificate), :file:`user.crt` (the API client certificate) and :file:`user.key` (the API client's private key).
 
 You can override these defaults with the ``--cacert`` (cluster certificate), ``--cert`` (user certificate) and ``--key`` (user private key) options, specifying the full path to each file.
 

--- a/docs/introduction/flocker-plugin.rst
+++ b/docs/introduction/flocker-plugin.rst
@@ -75,4 +75,4 @@ Get Started with the Flocker Plugin for Docker
 The plugin is installed on each node in your cluster, and can be installed at the same time as the Flocker node services.
 For more information, see :ref:`installing-flocker-node`.
 
-When the plugin has been installed, you will need to :ref:`create API user certificates for access to the Flocker REST API <generate-api-docker-plugin>`, and then :ref:`enable the plugin <enabling-agent-service>` before you can use it to :ref:`control Flocker <using-docker-plugin>`.
+When the plugin has been installed, you will need to :ref:`create API client certificates for access to the Flocker REST API <generate-api-docker-plugin>`, and then :ref:`enable the plugin <enabling-agent-service>` before you can use it to :ref:`control Flocker <using-docker-plugin>`.

--- a/docs/labs/volumes-gui.rst
+++ b/docs/labs/volumes-gui.rst
@@ -42,7 +42,7 @@ Run this command from the directory where you created your cluster configuration
 
 .. warning::
 
-    You must substitute ``your.control.service`` with the name (or IP address, depending on how you configured it) of your control service and ``certuser`` with the name of an API user you generated a key and certificate for (where you have those files in your current working directory).
+    You must substitute ``your.control.service`` with the name (or IP address, depending on how you configured it) of your control service and ``certuser`` with the name of an API client you generated a key and certificate for (where you have those files in your current working directory).
     Refer to the instructions in the :ref:`experimental installer <labs-installer>`.
 
 Step 2 - Load Up the Experimental Flocker GUI


### PR DESCRIPTION
Fixes 3652

"API User" was identified as implying a human user, whereas the API can actually be invoked by either a real user, or a machine. Renamed our use of the API user as the API client. 

In a few situations I specified "the API client, or end user"