### PR TITLE
[FLOC-3663] Restore Twisted log to _trial_temp/test.log

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,7 +81,9 @@ Install Flocker's development dependencies in a ``virtualenv`` by running the fo
 
    cd /vagrant
    mkvirtualenv flocker
-   pip install --editable .[dev]
+   pip install --process-dependency-links --editable .[dev]
+
+.. Need --process-dependency-links while are using a fork of testtools.
 
 .. _ZFS: http://zfsonlinux.org
 .. _Docker: https://www.docker.com/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -43,7 +43,7 @@ sphinx-prompt==1.0.0
 sphinx-rtd-theme==0.1.8
 sphinxcontrib-httpdomain==1.3.0
 sphinxcontrib-spelling==2.1.2
-testtools==1.8.2chq1
+testtools==1.8.2chq2
 tox==2.1.1
 versioneer==0.15
 virtualenv==13.1.0

--- a/docs/gettinginvolved/infrastructure/packaging.rst
+++ b/docs/gettinginvolved/infrastructure/packaging.rst
@@ -13,7 +13,9 @@ To build omnibus packages, create a VirtualEnv and install Flocker then its rele
    cd /path/to/flocker
    mkvirtualenv flocker-packaging
    pip install .
-   pip install Flocker[dev]
+   pip install --process-dependency-links .[dev]
+
+.. Need --process-dependency-links while we're using a fork of testtools.
 
 Then run the following command from a clean checkout of the Flocker repository:
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -11,7 +11,9 @@ import tempfile
 import testtools
 from testtools.content import text_content
 from testtools.deferredruntest import (
-    AsynchronousDeferredRunTestForBrokenTwisted)
+    AsynchronousDeferredRunTestForBrokenTwisted,
+    CaptureTwistedLogs,
+)
 
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
@@ -70,6 +72,10 @@ class AsyncTestCase(testtools.TestCase):
         super(AsyncTestCase, self).__init__(*args, **kwargs)
         # XXX: Work around testing-cabal/unittest-ext#60
         self.exception_handlers.insert(-1, (unittest.SkipTest, _test_skipped))
+
+    def setUp(self):
+        super(AsyncTestCase, self).setUp()
+        self.useFixture(CaptureTwistedLogs())
 
     def mktemp(self):
         """

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -12,8 +12,19 @@ import testtools
 from testtools.content import text_content
 from testtools.deferredruntest import (
     AsynchronousDeferredRunTestForBrokenTwisted,
-    CaptureTwistedLogs,
 )
+
+try:
+    from testtools.deferredruntest import CaptureTwistedLogs
+except ImportError:
+    # We are using a fork of testtools, which unfortunately means that we need
+    # to do special things to make sure we're using the latest version. Raise
+    # an error message that will help people figure out what they need to do.
+    raise Exception(
+        'Cannot import CaptureTwistedLogs. Maybe upgrade your version of '
+        'testtools: pip install --upgrade --process-dependency-links .[dev]'
+    )
+
 
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -43,7 +43,10 @@ def async_runner(timeout, flaky_output=None):
     # loops the reactor a couple of times after the test is done.
     return retry_flaky(
         AsynchronousDeferredRunTestForBrokenTwisted.make_factory(
-            timeout=timeout.total_seconds()),
+            timeout=timeout.total_seconds(),
+            suppress_twisted_logging=False,
+            store_twisted_logs=False,
+        ),
         output=flaky_output,
     )
 

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -242,7 +242,17 @@ class _RetryFlaky(testtools.RunTest):
         # XXX: Still using internal API of testtools despite improvements in
         # #165. Will need to do follow-up work on testtools to ensure that
         # RunTest.run(case); RunTest.run(case) is supported.
-        case._reset()
+        try:
+            case._reset()
+        except AttributeError:
+            # We are using a fork of testtools, which unfortunately means that
+            # we need to do special things to make sure we're using the latest
+            # version. Raise an error message that will help people figure out
+            # what they need to do.
+            raise Exception(
+                "Could not reset TestCase. Maybe upgrade your version of "
+                "testtools: pip install --upgrade --process-dependency-links "
+                ".[dev]")
         self._run_test(case, tmp_result)
         result_type = _get_result_type(tmp_result)
         details = pmap(case.getDetails())

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -135,6 +135,7 @@ class _RetryFlaky(testtools.RunTest):
     # https://bugs.launchpad.net/testtools/+bug/1515933
 
     def __init__(self, output, run_test_factory, case, *args, **kwargs):
+        super(_RetryFlaky, self).__init__(case)
         self._output = output
         self._run_test_factory = run_test_factory
         self._case = case

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -120,6 +120,19 @@ class AsyncTestCaseTests(TestCase):
             )
         )
 
+    def test_attaches_twisted_log(self):
+        """
+        AsyncTestCases attach the twisted log as a detail.
+        """
+        class SomeTest(AsyncTestCase):
+            def test_something(self):
+                from twisted.python import log
+                log.msg('foo')
+
+        test = SomeTest('test_something')
+        test.run()
+        self.assertThat(test.getDetails(), Equals({'twisted-log': {}}))
+
 
 identifier_characters = string.ascii_letters + string.digits + '_'
 identifiers = text(average_size=20, min_size=1, alphabet=identifier_characters)

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -22,6 +22,7 @@ from testtools.matchers import (
     FileContains,
     Matcher,
     MatchesAny,
+    MatchesDict,
     LessThan,
     Not,
     PathExists,
@@ -131,7 +132,12 @@ class AsyncTestCaseTests(TestCase):
 
         test = SomeTest('test_something')
         test.run()
-        self.assertThat(test.getDetails(), Equals({'twisted-log': {}}))
+        self.assertThat(
+            test.getDetails(),
+            MatchesDict({
+                'twisted-log': AfterPreprocessing(
+                    lambda c: c.as_text(), Contains('foo')),
+            }))
 
 
 identifier_characters = string.ascii_letters + string.digits + '_'

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -123,7 +123,7 @@ class AsyncTestCaseTests(TestCase):
 
     def test_attaches_twisted_log(self):
         """
-        AsyncTestCases attach the twisted log as a detail.
+        AsyncTestCases attach the Twisted log as a detail.
         """
         class SomeTest(AsyncTestCase):
             def test_something(self):

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
         # "git+git" weirdness is due to setuptools expecting:
         #     vcs+proto://host/path@revision#egg=project-version
         # See http://setuptools.readthedocs.org/en/latest/setuptools.html
-        "git+git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools-1.8.2chq1",  # noqa
+        "git+git://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools-1.8.2chq2",  # noqa
     ],
 
     # Some "trove classifiers" which are relevant.


### PR DESCRIPTION
Re-enables logging in acceptance tests to go to _trial_temp/test.log. 

Uses the latest version of our fork of testtools (which applies testing-cabal/testtools#172) to disable the automatic suppression & capture of Twisted logs, and then manually invokes the fixture to capture the logs.

This means that the logs will appear as the `twisted-log` detail, and _also_ in `test.log`.

I couldn't think of a non-awful automated test for the latter, but I did a manual test and it appeared to work.

I've also added a couple of exceptions which I hope will do something to mitigate the awfulness of using the testtools fork.