### PR TITLE
[FLOC 3651] Update how we refer to the control service in the docs

### DIFF
--- a/docs/concepts/architecture.rst
+++ b/docs/concepts/architecture.rst
@@ -14,8 +14,8 @@ The Flocker cluster is comprised of the following sets of services:
 
 .. _control-service:
 
-The Control Service
-===================
+Flocker Control Service
+=======================
 
 The control service is the brain of Flocker.
 It enables a user, or an automated orchestration framework, to monitor and modify the cluster state.

--- a/docs/concepts/architecture.rst
+++ b/docs/concepts/architecture.rst
@@ -6,7 +6,7 @@ Flocker Cluster Architecture
 
 The Flocker cluster is comprised of the following sets of services:
 
-* :ref:`The control service <control-service>` exposes the :ref:`api`, with which you can manage and modify the configuration of your cluster.
+* :ref:`The Flocker control service <control-service>` exposes the :ref:`api`, with which you can manage and modify the configuration of your cluster.
 * :ref:`Flocker agents <flocker-agents>` are installed on each node in the cluster, and are used to modify the node to match the desired configuration of your cluster.
 * :ref:`The Flocker plugin for Docker <plugin>` is also installed on each node in your cluster if you want Flocker to manage your data volumes, while using other tools such as Docker, Docker Swarm, or Mesos to manage your containers.
 
@@ -42,7 +42,7 @@ Flocker agents can:
 
 Multiple agents can also run on a specific node depending on the cluster setup.
 
-Each Flocker agent runs the following loop to converge the local state it manages with the desired cluster configuration, as managed by the control service:
+Each Flocker agent runs the following loop to converge the local state it manages with the desired cluster configuration, as managed by the Flocker control service:
 
 #. Checks the local state that it is in charge of.
 #. Notifies the control service of the local state.

--- a/docs/concepts/leases.rst
+++ b/docs/concepts/leases.rst
@@ -9,7 +9,7 @@ Leases prevent multiple applications from requesting the same dataset on differe
 Requesting Leases
 =================
 
-Leases are accessed via the :ref:`api` exposed by the control service, however most users will interact with leases through the :ref:`docker-plugin`, which will handle requesting leases for you.
+Leases are accessed via the :ref:`api` exposed by the Flocker control service, however most users will interact with leases through the :ref:`docker-plugin`, which will handle requesting leases for you.
 
 Acquiring and Releasing Leases
 ==============================

--- a/docs/concepts/security.rst
+++ b/docs/concepts/security.rst
@@ -13,7 +13,7 @@ This ensures that the control service, convergence agents, and API end users are
 Mutual Authentication Overview
 ==============================
 
-When :ref:`installing the flocker-node package <installing-flocker>`, the ``flocker-ca`` tool (provided as part of ``flocker-cli``) generates a root certificate for your cluster, comprising a private key and public certificate, as well as certificates and private keys for the control service and convergence agents.
+When :ref:`installing the flocker-node package <installing-flocker>`, the ``flocker-ca`` tool (provided as part of ``flocker-cli``) generates a root certificate for your cluster, comprising a private key and public certificate, as well as certificates and private keys for the Flocker control service and convergence agents.
 The certificates and private keys for the control service and nodes are installed on the cluster alongside the cluster's root public certificate file.
 
 API end users are issued their own certificate and private key, also with a copy of the cluster's public certificate file.
@@ -27,8 +27,8 @@ Security Benefits
 
 The TLS client certification layer used by Flocker provides a number of security benefits to a cluster.
 
-- Prevents unauthorized requests to the REST API.
-- Prevents unauthorized connections to the control service and convergence agents.
+- Prevents unauthorized requests to the Flocker REST API.
+- Prevents unauthorized connections to the Flocker control service and convergence agents.
 - Encrypts communications between all components of the cluster.
 
 Risks
@@ -36,9 +36,9 @@ Risks
 
 Flocker's authentication layer does not completely guarantee the security of a cluster; it relies on the private keys of the cluster's certificate authority, control service, convergence agents, and API users being kept secret.
 
-For example, if a malicious user were able to gain root SSH access to the machine running the control service, they would be able to copy the control service's private key and therefore be able to set up another machine to act and identify as the legitimate control service for that cluster.
+For example, if a malicious user were able to gain root SSH access to the machine running the Flocker control service, they would be able to copy the control service's private key and therefore be able to set up another machine to act and identify as the legitimate control service for that cluster.
 
-Similarly, if the private key of an API end user is compromised, anyone with that key will be able to authenticate as that authorized user, and therefore make requests to the REST API to read or change the state of a cluster.
+Similarly, if the private key of an API end user is compromised, anyone with that key will be able to authenticate as that authorized user, and therefore make requests to the Flocker REST API to read or change the state of a cluster.
 
 It is therefore very important that you ensure the private keys are kept secure; they should not be copied or shared insecurely.
 When copying certificates and private keys to your cluster nodes as part of the ``flocker-node`` installation process, the files must be copied using a secure and encrypted transfer medium such as SSH, SCP or SFTP.

--- a/docs/config/configuring-nodes-storage.rst
+++ b/docs/config/configuring-nodes-storage.rst
@@ -26,7 +26,7 @@ The file must always include ``version`` and ``control-service`` items, and will
 
 The value of the ``hostname`` field should be a hostname or IP that is routable from all your node agents.
 
-When configuring node agents, consider whether the control service location you choose will have multiple possible addresses, and ensure the hostname you provide is the correct one.
+When configuring node agents, consider whether the location you choose for the Flocker control service will have multiple possible addresses, and ensure the hostname you provide is the correct one.
 
 .. warning::
 	You should never choose ``127.0.0.1`` or ``localhost`` as the hostname, even if the control service is on same machine as the node agent, as this will keep the control service from correctly identifying the agent's IP address.

--- a/docs/config/enabling-control-service.rst
+++ b/docs/config/enabling-control-service.rst
@@ -6,6 +6,8 @@ Enabling the Flocker Control Service
 
 The control service is the brain of Flocker; it can live anywhere in your cluster, and enabling it is an essential step in setting up your cluster.
 
+For more information about the control service, see :ref:`architecture`.
+
 CentOS 7
 ========
 

--- a/docs/config/generate-api-certificates.rst
+++ b/docs/config/generate-api-certificates.rst
@@ -4,7 +4,7 @@
 Generating an API Client Certificate
 ====================================
 
-To send instructions to the control service, whether it is via the API directly, or the CLI, or by any other method, you will need to follow the instructions below to generate an API client certificate:
+To send instructions to the Flocker control service, whether it is via the API directly, or the CLI, or by any other method, you will need to follow the instructions below to generate an API client certificate:
 
 #. Generate an API client certificate:
 
@@ -37,7 +37,7 @@ The cluster certificate ensures the client is connecting to the genuine API of t
 The client certificate allows the API server to ensure the request is from a genuine, authorized client.
 
 The following is an example of an authenticated request to create a new container on a cluster, using ``cURL``.
-In this example, ``172.16.255.250`` represents the DNS IP address of the control service.
+In this example, ``172.16.255.250`` represents the DNS IP address of the Flocker control service.
 If you used a DNS name when creating the control certificate, then replace the IP address with the DNS name.
 
 .. contents::

--- a/docs/config/generate-api-certificates.rst
+++ b/docs/config/generate-api-certificates.rst
@@ -4,7 +4,7 @@
 Generating an API Client Certificate
 ====================================
 
-To send instructions to the Flocker control service, whether it is via the API directly, or the CLI, or by any other method, you will need to follow the instructions below to generate an API client certificate:
+To send instructions to the :ref:`Flocker control service <control-service>`, whether it is via the API directly, or the CLI, or by any other method, you will need to follow the instructions below to generate an API client certificate:
 
 #. Generate an API client certificate:
 

--- a/docs/control/administering/debugging.rst
+++ b/docs/control/administering/debugging.rst
@@ -11,7 +11,7 @@ Logging
 
 Flocker processes use the `Eliot`_ framework for logging.
 Eliot structures logs as a tree of actions, which means given an error you can see what Flocker actions caused the errors by finding the other messages in the tree.
-The tree of actions can also span processes; thus you can trace API calls from within the Docker plugin and see the effects in the control service logs.
+The tree of actions can also span processes; thus you can trace API calls from within the Docker plugin and see the effects in the Flocker control service logs.
 Messages can be rendered into a human-readable tree using the `eliot-tree`_ command line tool, which is pre-installed with Flocker.
 Eliot also includes a tool called ``eliot-prettyprint`` which renders messages into a more human-readable format but does not present them in a tree structure.
 
@@ -193,13 +193,13 @@ Profiling
 
    It is not recommended to use profiling while relying on Flocker within a production environment as there is a performance overhead.
 
-Control Service
-^^^^^^^^^^^^^^^
+Flocker Control Service
+^^^^^^^^^^^^^^^^^^^^^^^
 
-It is possible to obtain :py:mod:`cProfile` profiling data of the :ref:`Control Service <control-service>` between two user defined intervals.
+It is possible to obtain :py:mod:`cProfile` profiling data of the :ref:`control-service` between two user defined intervals.
 
 Profiling is disabled by default.
-To enable profiling of the Control Service run the following command as root on the control node:
+To enable profiling of the control service run the following command as root on the control node:
 
 .. prompt:: bash #
 

--- a/docs/control/administering/upgrading.rst
+++ b/docs/control/administering/upgrading.rst
@@ -7,7 +7,7 @@ Upgrading
 A Flocker cluster can be upgraded to a newer version of Flocker while preserving all data and configuration of the Flocker cluster provided certain steps are followed.
 The correct steps to follow may vary depending on the versions of Flocker being upgraded from and to.
 
-.. note:: A common requirement for all currently supported upgrade paths is that all nodes and the control service must be running the same version of Flocker.
+.. note:: A common requirement for all currently supported upgrade paths is that all nodes and the Flocker control service must be running the same version of Flocker.
 
 Flocker v1.0.2
 --------------
@@ -15,7 +15,7 @@ Flocker v1.0.2
 Recommended Steps
 ^^^^^^^^^^^^^^^^^
 
-#. Stop the agent services on all nodes, and then stop control service.
+#. Stop the agent services on all nodes, and then stop the control service.
 #. Install Flocker v1.0.2 on all nodes in the Flocker cluster.
 #. If you are running on CentOS, run ``systemctl restart rsyslog`` on all machines running Flocker services.
 #. Restart the Docker service.
@@ -32,7 +32,7 @@ Flocker v1.0.1
 Recommended Steps
 ^^^^^^^^^^^^^^^^^
 
-#. Stop the agent services on all nodes, and then stop control service.
+#. Stop the agent services on all nodes, and then stop the control service.
 #. Install Flocker v1.0.1 on all nodes in the Flocker cluster.
 #. Restart the control service.
 #. If you are using the EBS storage backend, reboot each of the agent nodes.

--- a/docs/control/cli/usage.rst
+++ b/docs/control/cli/usage.rst
@@ -14,7 +14,7 @@ Command Line Arguments
 
 ``flocker-deploy`` takes three arguments:
 
-1. The hostname of the machine where the control service (including the Flocker REST API) is running.
+1. The hostname of the machine where the Flocker control service (including the Flocker REST API) is running.
 2. The path to a deployment configuration file.
 3. The path to an application configuration file.
 

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -121,7 +121,7 @@ Operation Types
 
 .. option:: read-request
 
-   Read the current cluster state from the control service.
+   Read the current cluster state from the Flocker control service.
 
 .. option:: wait
 

--- a/docs/install/setup-aws.rst
+++ b/docs/install/setup-aws.rst
@@ -47,7 +47,7 @@ You can also refer to `the full documentation for interacting with EC2 from Amaz
    * **Configure security group**:
       
      * If you wish to customize the instance's security settings, make sure to permit SSH access from the administrators machine (for example, your laptop).
-     * To enable Flocker agents to communicate with the :ref:`control service <enabling-control-service>` and for external access to the API, add a custom TCP security rule enabling access to ports 4523-4524.
+     * To enable Flocker agents to communicate with the :ref:`Flocker control service <enabling-control-service>` and for external access to the API, add a custom TCP security rule enabling access to ports 4523-4524.
      * Keep in mind that (quite reasonably) the default security settings firewall off all ports other than SSH.
      * You can choose to expose these ports but keep in mind the consequences of exposing unsecured services to the Internet.
      * Links between nodes will also use public ports but you can configure the AWS VPC to allow network connections between nodes and disallow them from the Internet.

--- a/docs/introduction/flocker-basics.rst
+++ b/docs/introduction/flocker-basics.rst
@@ -3,7 +3,7 @@ Flocker Basics
 ==============
 
 Flocker works by exposing a simple :ref:`REST API<api>` on its Control Service.
-The Flocker Control Service communicates with Flocker Agents running on each node in the cluster to carry out commands.
+The :ref:`control-service` communicates with Flocker Agents running on each node in the cluster to carry out commands.
 
 To interact with the Flocker API you can use the :ref:`Flocker CLI<cli>`, or access it directly in popular programming languages like Go, Python and Ruby.
 

--- a/docs/introduction/flocker-basics.rst
+++ b/docs/introduction/flocker-basics.rst
@@ -2,8 +2,8 @@
 Flocker Basics
 ==============
 
-Flocker works by exposing a simple :ref:`REST API<api>` on its Control Service.
-The :ref:`control-service` communicates with Flocker Agents running on each node in the cluster to carry out commands.
+Flocker works by exposing a simple :ref:`REST API<api>` on its control service.
+The :ref:`Flocker control service <control-service>` communicates with Flocker Agents running on each node in the cluster to carry out commands.
 
 To interact with the Flocker API you can use the :ref:`Flocker CLI<cli>`, or access it directly in popular programming languages like Go, Python and Ruby.
 

--- a/docs/labs/installer-getstarted.rst
+++ b/docs/labs/installer-getstarted.rst
@@ -83,7 +83,7 @@ Getting Started with the Installer
 
      .. note::
 
-        By default, the installer will launch one master node (where the control service runs) and two agent nodes (where volumes get attached and containers run).
+        By default, the installer will launch one master node (where the Flocker control service runs) and two agent nodes (where volumes get attached and containers run).
         Please refer to the `AWS pricing guide <https://aws.amazon.com/ec2/pricing/>`_ to understand how much this will cost you.
 
    * Now run the following command to automatically provision some nodes.
@@ -112,7 +112,7 @@ Getting Started with the Installer
    This step should take about 5 minutes, and will:
 
    * Install the OS packages on your nodes required to run Flocker, including Docker.
-   * Configure certificates, push them to your nodes, set up firewall rules for the control service.
+   * Configure certificates, push them to your nodes, set up firewall rules for the Flocker control service.
    * Start all the requisite Flocker services.
    * Install the Flocker plugin for Docker, so that you can control Flocker directly from the Docker CLI.
 

--- a/docs/labs/volumes-gui.rst
+++ b/docs/labs/volumes-gui.rst
@@ -42,7 +42,7 @@ Run this command from the directory where you created your cluster configuration
 
 .. warning::
 
-    You must substitute ``your.control.service`` with the name (or IP address, depending on how you configured it) of your control service and ``certuser`` with the name of an API client you generated a key and certificate for (where you have those files in your current working directory).
+    You must substitute ``your.control.service`` with the name (or IP address, depending on how you configured it) of your Flocker control service and ``certuser`` with the name of an API client you generated a key and certificate for (where you have those files in your current working directory).
     Refer to the instructions in the :ref:`experimental installer <labs-installer>`.
 
 Step 2 - Load Up the Experimental Flocker GUI


### PR DESCRIPTION
Fixes 3651

Identified in the Generating API certificates documentation, we refer to "the control service" throughout the docs, but in most cases this should be "the Flocker control service", which can be linked to the control service description in the concepts section.

This PR amends these instances, and adds the link in key places.