### PR TITLE
[FLOC-3291] Benchmark read request parametization

### DIFF
--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -6,6 +6,10 @@ operations:
   - name: default
     type: read-request
 
+  - name: list_datasets_state
+    type: read-request
+    method: list_datasets_state
+
   - name: no-op
     type: no-op
 

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -2,7 +2,36 @@ from zope.interface import implementer
 
 from twisted.internet.defer import succeed
 
+from flocker.apiclient import IFlockerAPIV1Client
+
 from .._interfaces import IProbe, IOperation
+
+
+class InvalidMethod(Exception):
+    """
+    Method not suitable for use with ReadRequest operation.
+
+    The method must be provided by the IFlockerAPIV1Client interface,
+    and require no parameters.
+    """
+
+
+def validate_method_name(interface, method_name):
+    """
+    Check that method name exists in interface and requires no parameters.
+
+    :param zope.interface.Interface interface: Interface to validate against.
+    :param str method_name: Method name to validate.
+    :raise InvalidMethod: if name is not valid or requires parameters.
+    """
+    for name, method in interface.namesAndDescriptions():
+        if name == method_name:
+            if len(method.getSignatureInfo()['required']) > 0:
+                raise InvalidMethod('Require no-arg method')
+            return
+    raise InvalidMethod(
+        'Method not found in interface {}'.format(interface.__name__)
+    )
 
 
 @implementer(IProbe)
@@ -11,12 +40,11 @@ class ReadRequestProbe(object):
     A probe to perform a read request on the control service.
     """
 
-    def __init__(self, control_service):
-        self.control_service = control_service
+    def __init__(self, request):
+        self.request = request
 
     def run(self):
-        d = self.control_service.list_datasets_state()
-        return d
+        return self.request()
 
     def cleanup(self):
         return succeed(None)
@@ -28,8 +56,9 @@ class ReadRequest(object):
     An operation to perform a read request on the control service.
     """
 
-    def __init__(self, reactor, cluster):
-        self.control_service = cluster.get_control_service(reactor)
+    def __init__(self, reactor, cluster, method='version'):
+        validate_method_name(IFlockerAPIV1Client, method)
+        self.request = getattr(cluster.get_control_service(reactor), method)
 
     def get_probe(self):
-        return ReadRequestProbe(control_service=self.control_service)
+        return ReadRequestProbe(self.request)

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -27,10 +27,13 @@ def validate_method_name(interface, method_name):
     for name, method in interface.namesAndDescriptions():
         if name == method_name:
             if len(method.getSignatureInfo()['required']) > 0:
-                raise InvalidMethod('Require no-arg method')
+                raise InvalidMethod(
+                    'Method {!r} requires parameters'.format(method_name)
+                )
             return
     raise InvalidMethod(
-        'Method not found in interface {}'.format(interface.__name__)
+        'Method {!r} not found in interface {}'.format(
+            method_name, interface.__name__)
     )
 
 

--- a/benchmark/operations/test/test_read_request.py
+++ b/benchmark/operations/test/test_read_request.py
@@ -15,7 +15,9 @@ from flocker.apiclient import IFlockerAPIV1Client, FakeFlockerClient
 
 from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IOperation
-from benchmark.operations import ReadRequest
+from benchmark.operations.read_request import (
+    ReadRequest, InvalidMethod, validate_method_name
+)
 
 
 class FastConvergingFakeFlockerClient(
@@ -51,6 +53,35 @@ class FastConvergingFakeFlockerClient(
         return result
 
 
+class ValidMethodNameTests(SynchronousTestCase):
+    """
+    Check that method name validation works.
+    """
+
+    def test_no_parameter_method(self):
+        name = 'version'
+        self.assertIn(name, IFlockerAPIV1Client.names())
+        validate_method_name(IFlockerAPIV1Client, name)
+
+    def test_method_with_parameters(self):
+        """
+        Rejects method that requires parameters.
+        """
+        name = 'create_dataset'
+        self.assertIn(name, IFlockerAPIV1Client.names())
+        with self.assertRaises(InvalidMethod):
+            validate_method_name(IFlockerAPIV1Client, name)
+
+    def test_not_found_method(self):
+        """
+        Rejects name not found in interface.
+        """
+        name = 'non_existent'
+        self.assertNotIn(name, IFlockerAPIV1Client.names())
+        with self.assertRaises(InvalidMethod):
+            validate_method_name(IFlockerAPIV1Client, name)
+
+
 class ReadRequestTests(SynchronousTestCase):
     """
     ReadRequest operation tests.
@@ -77,7 +108,7 @@ class ReadRequestTests(SynchronousTestCase):
             cluster = BenchmarkCluster(
                 IPAddress('10.0.0.1'), lambda reactor: control_service, {}
             )
-            request = ReadRequest(Clock(), cluster)
+            request = ReadRequest(Clock(), cluster, 'list_datasets_state')
             return request.get_probe()
         d.addCallback(start_read_request)
 

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -121,12 +121,16 @@ Operation Types
 
 .. option:: read-request
 
-   Read the current cluster state from the control service.
+   Perform a read operation on the control service.
+
+   Specify the operation to be performed using an additional ``method`` property.
+   The value must be the name of a zero-parameter method in the ``flocker.apiclient.IFlockerAPIV1Client`` interface, and defaults to ``version``.
 
 .. option:: wait
 
    Wait for a number of seconds between measurements.
-   The number of seconds to wait must be provided as an additional ``wait_seconds`` property.
+   Specify the number of seconds to wait using an additional ``wait_seconds`` property.
+   The default is 10 seconds.
 
 Metric Types
 ~~~~~~~~~~~~
@@ -134,6 +138,8 @@ Metric Types
 .. option:: cputime
 
    CPU time elapsed.
+   Specify the process names to be monitored using an additional ``processes`` property.
+   The value must be a list of process name strings, and defaults to the names of the Flocker services.
 
 .. option:: wallclock
 


### PR DESCRIPTION
This PR allows the user to select a method to be called during a benchmark read request operation.  The allowed methods are the zero-parameter methods of the interface `IFlockerAPIV1Client`.

The default method is the relatively simple `version` method, but other methods can be set to observe if they behave differently during the benchmarks.
