### PR TITLE
[FLOC-3499,FLOC-3511] Call startTest as soon as the test starts

### DIFF
--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -180,6 +180,7 @@ class _RetryFlaky(testtools.RunTest):
 
         :return: A ``TestResult`` with the result of running the flaky test.
         """
+        result.startTest(case)
         successes = 0
         results = []
 
@@ -202,7 +203,6 @@ class _RetryFlaky(testtools.RunTest):
         combined_details = _combine_details(
             [flaky_details] + list(r[1] for r in results))
 
-        result.startTest(case)
         if successful:
             skip_reported = False
             for result_type, details in results:

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -25,6 +25,7 @@ from testtools.matchers import (
     HasLength,
     MatchesAll,
 )
+from testtools.testresult.doubles import ExtendedTestResult
 
 from .. import AsyncTestCase, async_runner
 from .._flaky import (
@@ -297,3 +298,27 @@ class FlakyTests(testtools.TestCase):
 
         test = SkippingTest('test_skip')
         self.assertThat(run_test(test), only_skips(1, observed_reasons))
+
+    @given(jira_keys)
+    def test_sends_start_on_start(self, jira_keys):
+        """
+        Flaky tests send ``startTest`` as soon as they start.
+
+        This means that we see the name of the test in the trial reporter
+        (FLOC-3511) and that the recorded duration of the test is more-or-less
+        accurate (FLOC-3499)
+        """
+        log = []
+
+        class FlakyTest(AsyncTestCase):
+            run_tests_with = retry_flaky(output=StringIO())
+
+            @flaky(jira_keys, 1, 1)
+            def test_delayed(self):
+                # Get a copy of the event log at this point of the test.
+                self.log = list(log)
+
+        test = FlakyTest('test_delayed')
+        result = ExtendedTestResult(log)
+        test.run(result)
+        self.assertThat(test.log, Equals([('startTest', test)]))


### PR DESCRIPTION
Fixes two issues in `@flaky` decorator where test names would not be reported until they were finished (FLOC-3511), and where the reported duration of the test would be very very low (FLOC-3499).

The fix for both issues is the same thing, because they have the same underlying cause: we were only calling `startTest` after the test had actually run.

I didn't write tests for the symptoms because that involves pulling in large amounts of Trial infrastructure. Testing the cause + useful test docstring seemed sufficient to me.