### PR TITLE
[FLOC-3678] Fix tox to work with forked testtools.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ minversion = 1.6
 [testenv]
 commands =
     pip install -r requirements.txt
-    pip install -r dev-requirements.txt
+    pip install --process-dependency-links .[dev]
     trial --rterrors {posargs:flocker}
 setenv =
     PYTHONHASHSEED=random
@@ -28,7 +28,7 @@ basepython = python2.7
 changedir = {toxinidir}
 commands =
     pip install -r requirements.txt
-    pip install -r dev-requirements.txt
+    pip install --process-dependency-links .[dev]
     rm -rf docs/_build/html
     sphinx-build -a -b spelling docs/ docs/_build/spelling
     sphinx-build -a -b html docs/ docs/_build/html
@@ -39,5 +39,5 @@ usedevelop = True
 changedir = {toxinidir}
 commands =
     pip install -r requirements.txt
-    pip install -r dev-requirements.txt
+    pip install --process-dependency-links .[dev]
     trial --rterrors admin


### PR DESCRIPTION
You can test by running `tox -e py27`, `tox -e sphinx`, `tox -e admin` - previously they'd blow up because they couldn't find forked testtools.