### PR TITLE
[FLOC-3676] Separate Eliot logs from Twisted logs in acceptance test failures

### DIFF
--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -94,6 +94,11 @@ class AsyncTestCase(testtools.TestCase):
     def setUp(self):
         super(AsyncTestCase, self).setUp()
         # Need this to run _after_ the clean-up in CaptureTwistedLogs.
+        #
+        # Would ideally like to move post-processing to its own fixture that
+        # wraps up CaptureTwistedLogs, but there doesn't seem to be a way to
+        # do that. https://github.com/testing-cabal/fixtures/pull/20 for
+        # details.
         self.addCleanup(self._post_process_twisted_logs)
         self.useFixture(CaptureTwistedLogs())
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -196,7 +196,6 @@ def _prettyformat_lines(lines):
 
 
 _ELIOT_MARKER = ' [-] ELIOT: '
-_ELIOT_MARKER_LENGTH = len(_ELIOT_MARKER)
 
 
 def _get_eliot_data(twisted_log_line):
@@ -210,10 +209,9 @@ def _get_eliot_data(twisted_log_line):
         ``None``.
     :rtype: unicode or ``NoneType``.
     """
-    index = twisted_log_line.find(_ELIOT_MARKER)
-    if index < 0:
-        return None
-    return twisted_log_line[index + _ELIOT_MARKER_LENGTH:].strip()
+    _, _, eliot_data = twisted_log_line.partition(_ELIOT_MARKER)
+    if eliot_data:
+        return eliot_data.strip()
 
 
 def _iter_content_lines(content):

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -178,7 +178,7 @@ def _prettyformat_lines(lines):
     """
     for line in lines:
         data = json.loads(line)
-        yield pretty_format(data)
+        yield pretty_format(data) + '\n'
 
 
 _ELIOT_MARKER = ' [-] ELIOT: '

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -224,12 +224,12 @@ def _iter_content_lines(content):
     return _iter_lines(content.iter_bytes(), '\n')
 
 
-def _iter_lines(byte_iter, separator='\n'):
+def _iter_lines(byte_iter, line_separator):
     """
     Iterate over the lines that make up ``content``.
 
     :param iter(bytes) byte_iter: An iterable of bytes.
-    :param bytes separator: A single byte that marks the end of a line.
+    :param bytes line_separator: The bytes that mark the end of a line.
     :yield: Separator-terminated bytestrings.
     """
     # XXX: Someone must have written this before.
@@ -237,13 +237,12 @@ def _iter_lines(byte_iter, separator='\n'):
     chunks = []
     for data in byte_iter:
         while data:
-            index = data.find(separator)
-            if index < 0:
-                chunks.append(data)
+            head, sep, data = data.partition(line_separator)
+            if not sep:
+                chunks.append(head)
                 break
 
-            head, data = data[:index + 1], data[index + 1:]
-            chunks.append(head)
+            chunks.append(head + sep)
             yield ''.join(chunks)
             chunks = []
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -115,13 +115,11 @@ class _SplitEliotLogs(Fixture):
     """
     Split the Eliot logs out of Twisted logs.
 
-    Assumes that Twisted logs contain Eliot logs as per
-    ``flocker._redirect_eliot_logs_for_trial``, and that these logs have been
-    attached to a test case as a detail named with the value of
-    ``CaptureTwistedLogs.LOG_DETAIL_NAME``.
-
-    Takes the Eliot logs that are in the Trial logs and splits them into a
-    separate detail that contains only the pretty printed Eliot logs.
+    Captures Twisted logs that contain Eliot logs as per
+    ``flocker._redirect_eliot_logs_for_trial``, and ensures these logs are
+    attached to a test case as details: one that contains the pure Twisted
+    logs without Eliot logs, and one that contains only the pretty printed
+    Eliot logs.
     """
 
     _ELIOT_LOG_DETAIL_NAME = 'twisted-eliot-log'

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -80,6 +80,8 @@ class AsyncTestCase(testtools.TestCase):
     Base class for asynchronous test cases.
     """
 
+    _ELIOT_LOG_DETAIL_NAME = 'twisted-eliot-log'
+
     run_tests_with = async_runner(timeout=DEFAULT_ASYNC_TIMEOUT)
 
     def __init__(self, *args, **kwargs):
@@ -97,11 +99,11 @@ class AsyncTestCase(testtools.TestCase):
         """
         Split the eliot logs out of the Twisted logs.
         """
-        twisted_log = self.getDetails()['twisted-log']
+        twisted_log = self.getDetails()[CaptureTwistedLogs.LOG_DETAIL_NAME]
         new_twisted_log, eliot_log = _fix_twisted_logs(twisted_log)
         # Overrides the existing Twisted log.
-        self.addDetail('twisted-log', new_twisted_log)
-        self.addDetail('eliot-log', eliot_log)
+        self.addDetail(CaptureTwistedLogs.LOG_DETAIL_NAME, new_twisted_log)
+        self.addDetail(self._ELIOT_LOG_DETAIL_NAME, eliot_log)
 
     def mktemp(self):
         """

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -93,12 +93,16 @@ class AsyncTestCase(testtools.TestCase):
 
     def setUp(self):
         super(AsyncTestCase, self).setUp()
-        # Need this to run _after_ the clean-up in CaptureTwistedLogs.
+        # Need this to run _after_ the clean-up in CaptureTwistedLogs, so add
+        # it first, because cleanups are run in reverse order.
         #
         # Would ideally like to move post-processing to its own fixture that
         # wraps up CaptureTwistedLogs, but there doesn't seem to be a way to
         # do that. https://github.com/testing-cabal/fixtures/pull/20 for
         # details.
+        #
+        # XXX: Would also be useful for synchronous test cases, once they're
+        # migrated over to testtools.
         self.addCleanup(self._post_process_twisted_logs)
         self.useFixture(CaptureTwistedLogs())
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -129,6 +129,18 @@ def _fix_twisted_logs(log_content):
     return log_content, text_content('')
 
 
+def _iter_content_lines(content):
+    """
+    Iterate over the lines that make up ``content``.
+
+    :param Content content: Text content.
+    :raise ValueError: If content is not text content.
+    :yield: Newline-terminated UTF8-encoded bytestrings that make up content.
+    """
+    # XXX: Make this lazy.
+    return (line.encode('utf8') for line in content.as_text().splitlines(True))
+
+
 def _path_for_test_id(test_id, max_segment_length=32):
     """
     Get the temporary directory path for a test ID.

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -127,9 +127,6 @@ class _SplitEliotLogs(Fixture):
     _ELIOT_LOG_DETAIL_NAME = 'twisted-eliot-log'
 
     def _setUp(self):
-        # Need the cleanups in this to run *after* the cleanup in
-        # CaptureTwistedLogs, so add it first, because cleanups are run in
-        # reverse order.
         twisted_logs = self.useFixture(CaptureTwistedLogs())
         self._fix_twisted_logs(twisted_logs, twisted_logs.LOG_DETAIL_NAME)
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -216,6 +216,7 @@ def _iter_lines(byte_iter, separator='\n'):
     :yield: Separator-terminated bytestrings.
     """
     # XXX: Someone must have written this before.
+    # XXX: Move this to flocker.common?
     chunks = []
     for data in byte_iter:
         while data:

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -17,6 +17,7 @@ from testtools.matchers import (
     AfterPreprocessing,
     Annotate,
     Contains,
+    ContainsDict,
     DirExists,
     HasLength,
     Equals,
@@ -136,7 +137,7 @@ class AsyncTestCaseTests(TestCase):
         test.run()
         self.assertThat(
             test.getDetails(),
-            MatchesDict({
+            ContainsDict({
                 'twisted-log': match_text_content(MatchesRegex(
                     r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{4} \[-\] foo$'
                 )),

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -206,13 +206,14 @@ class IterLinesTests(TestCase):
         observed = list(_iter_lines(iter(data), separator))
         self.assertThat(observed, AllMatch(EndsWith(separator)))
 
-    @given(lists(binary(), min_size=1), binary(min_size=1, max_size=1))
+    @given(lists(binary(min_size=1), min_size=1),
+           binary(min_size=1, max_size=1))
     def test_nonterminated_line(self, data, separator):
         """
         If the input data does not end with a separator, then every line ends
         with a separator *except* the last line.
         """
-        assume(not data[-1].endswith(separator) and sum(map(len, data)) > 0)
+        assume(not data[-1].endswith(separator))
         observed = list(_iter_lines(iter(data), separator))
         self.expectThat(observed[:-1], AllMatch(EndsWith(separator)))
         self.assertThat(observed[-1], Not(EndsWith(separator)))

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -169,12 +169,9 @@ class AsyncTestCaseTests(TestCase):
                 'twisted-log': match_text_content(MatchesRegex(
                     r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{4} \[-\] foo$'
                 )),
-                AsyncTestCase._ELIOT_LOG_DETAIL_NAME: AfterPreprocessing(
-                    lambda content: json.loads(content.as_text()),
-                    ContainsDict({
-                        'name': Equals('qux'),
-                        'message_type': Equals('foo'),
-                    })
+                AsyncTestCase._ELIOT_LOG_DETAIL_NAME: match_text_content(
+                    Contains("  message_type: 'foo'\n"
+                             "  name: 'qux'\n")
                 ),
             }))
 

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -12,6 +12,7 @@ from eliot import MessageType, fields
 from hypothesis import assume, given
 from hypothesis.strategies import integers, lists, text
 from testtools import PlaceHolder, TestCase, TestResult
+from testtools.content import text_content
 from testtools.matchers import (
     AllMatch,
     AfterPreprocessing,
@@ -36,6 +37,7 @@ from twisted.python.filepath import FilePath
 from .._base import (
     AsyncTestCase,
     make_temporary_directory,
+    _iter_content_lines,
     _path_for_test_id,
 )
 from .._testhelpers import (
@@ -172,6 +174,18 @@ def match_text_content(matcher):
     Match the text of a ``Content`` instance.
     """
     return AfterPreprocessing(lambda content: content.as_text(), matcher)
+
+
+class IterContentLinesTests(TestCase):
+    """
+    Tests for ``_iter_content_lines``.
+    """
+
+    @given(text())
+    def test_splits_into_lines(self, data):
+        content = text_content(data)
+        expected = list(line.encode('utf8') for line in data.splitlines(True))
+        self.assertThat(list(_iter_content_lines(content)), Equals(expected))
 
 
 identifier_characters = string.ascii_letters + string.digits + '_'

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -188,7 +188,7 @@ class IterLinesTests(TestCase):
     Tests for ``_iter_lines``.
     """
 
-    @given(lists(binary()), binary(min_size=1, max_size=1))
+    @given(lists(binary()), binary(min_size=1))
     def test_preserves_data(self, data, separator):
         """
         Splitting into lines loses no data.
@@ -196,7 +196,7 @@ class IterLinesTests(TestCase):
         observed = _iter_lines(iter(data), separator)
         self.assertThat(''.join(observed), Equals(''.join(data)))
 
-    @given(lists(binary()), binary(min_size=1, max_size=1))
+    @given(lists(binary()), binary(min_size=1))
     def test_separator_terminates(self, data, separator):
         """
         After splitting into lines, each line ends with the separator.
@@ -206,8 +206,7 @@ class IterLinesTests(TestCase):
         observed = list(_iter_lines(iter(data), separator))
         self.assertThat(observed, AllMatch(EndsWith(separator)))
 
-    @given(lists(binary(min_size=1), min_size=1),
-           binary(min_size=1, max_size=1))
+    @given(lists(binary(min_size=1), min_size=1), binary(min_size=1))
     def test_nonterminated_line(self, data, separator):
         """
         If the input data does not end with a separator, then every line ends

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -12,7 +12,6 @@ from eliot import MessageType, fields
 from hypothesis import assume, given
 from hypothesis.strategies import binary, integers, lists, text
 from testtools import PlaceHolder, TestCase, TestResult
-from testtools.content import text_content
 from testtools.matchers import (
     AllMatch,
     AfterPreprocessing,
@@ -39,6 +38,7 @@ from twisted.python.filepath import FilePath
 from .._base import (
     AsyncTestCase,
     make_temporary_directory,
+    _SplitEliotLogs,
     _get_eliot_data,
     _iter_lines,
     _path_for_test_id,
@@ -169,7 +169,7 @@ class AsyncTestCaseTests(TestCase):
                 'twisted-log': match_text_content(MatchesRegex(
                     r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{4} \[-\] foo$'
                 )),
-                AsyncTestCase._ELIOT_LOG_DETAIL_NAME: match_text_content(
+                _SplitEliotLogs._ELIOT_LOG_DETAIL_NAME: match_text_content(
                     Contains("  message_type: 'foo'\n"
                              "  name: 'qux'\n")
                 ),

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -143,7 +143,7 @@ class AsyncTestCaseTests(TestCase):
                 )),
             }))
 
-    def test_separate_eliot_log(self):
+    def disabled_test_separate_eliot_log(self):
         """
         AsyncTestCases attach the eliot log as a detail separate from the
         Twisted log.

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -169,7 +169,7 @@ class AsyncTestCaseTests(TestCase):
                 'twisted-log': match_text_content(MatchesRegex(
                     r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{4} \[-\] foo$'
                 )),
-                'eliot-log': AfterPreprocessing(
+                AsyncTestCase._ELIOT_LOG_DETAIL_NAME: AfterPreprocessing(
                     lambda content: json.loads(content.as_text()),
                     ContainsDict({
                         'name': Equals('qux'),


### PR DESCRIPTION
testtools tests can attach content that shows up when tests fail. This PR attaches the Twisted log _but_ it processes the Twisted log, separating out the `ELIOT` lines from the rest of the log and pretty prints the Eliot logs.

