### PR TITLE
[FLOC-3461] EBS validate region

### DIFF
--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -253,7 +253,8 @@ class FlockerScriptRunner(object):
 
             def got_error(failure):
                 if failure.check(UsageError):
-                    err(message=str(failure.value))
+                    err(': '.join(failure.value.args))
+                    raise SystemExit(1)
                 elif not failure.check(SystemExit):
                     err(failure)
                 return failure

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -253,7 +253,7 @@ class FlockerScriptRunner(object):
 
             def got_error(failure):
                 if failure.check(UsageError):
-                    err(': '.join(failure.value.args))
+                    err(failure.value.args)
                     raise SystemExit(1)
                 elif not failure.check(SystemExit):
                     err(failure)

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -17,6 +17,7 @@ from twisted.python.log import textFromEventDict, startLoggingWithObserver, err
 from twisted.python import log as twisted_log
 from twisted.python.logfile import LogFile
 from twisted.python.filepath import FilePath
+from twisted.python.usage import UsageError
 
 from zope.interface import Interface
 
@@ -251,7 +252,9 @@ class FlockerScriptRunner(object):
             d = maybeDeferred(self.script.main, reactor, options)
 
             def got_error(failure):
-                if not failure.check(SystemExit):
+                if failure.check(UsageError):
+                    err(message=str(failure.value))
+                elif not failure.check(SystemExit):
                     err(failure)
                 return failure
             d.addErrback(got_error)

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -169,16 +169,6 @@ class ICalculator(Interface):
         """
 
 
-class BlockDeviceInitializationError(Exception):
-    """
-    An exception raised when an ``IBlockDeviceAPI`` implementer cannot
-    be successfully initialized, for example due to an invalid
-    configuration.
-    """
-    def __init__(self, *args):
-        Exception.__init__(self, *args)
-
-
 class VolumeException(Exception):
     """
     A base class for exceptions raised by  ``IBlockDeviceAPI`` operations.

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -169,6 +169,16 @@ class ICalculator(Interface):
         """
 
 
+class BlockDeviceInitializationError(Exception):
+    """
+    An exception raised when an ``IBlockDeviceAPI`` implementer cannot
+    be successfully initialized, for example due to an invalid
+    configuration.
+    """
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
+
+
 class VolumeException(Exception):
     """
     A base class for exceptions raised by  ``IBlockDeviceAPI`` operations.

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -290,10 +290,12 @@ class InvalidZoneError(Exception):
     """
     The supplied zone is not valid for the given AWS region.
     """
-    def __init__(self, message, zone, available_zones):
+    def __init__(self, zone, available_zones):
         message = u"The specified AWS zone is not valid"
         Exception.__init__(
-            self, message, zone, u"available_zones", available_zones)
+            self, message, zone,
+            u"available_zones", ', '.join(available_zones)
+        )
         self.zone = zone
         self.available_zones = available_zones
 

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -453,7 +453,7 @@ def _expected_device(requested_device):
 
 
 def ec2_client(region, zone, access_key_id,
-               secret_access_key, validate_region):
+               secret_access_key, validate_region=True):
     """
     Establish connection to EC2 client.
 

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -45,8 +45,11 @@ from eliot import Message, register_exception_extractor
 from .blockdevice import (
     IBlockDeviceAPI, IProfiledBlockDeviceAPI, BlockDeviceVolume, UnknownVolume,
     AlreadyAttachedVolume, UnattachedVolume, UnknownInstanceID,
-    MandatoryProfiles, BlockDeviceInitializationError,
+    MandatoryProfiles
 )
+
+from ..script import StorageInitializationError
+
 from ...control import pmap_field
 
 from ._logging import (
@@ -278,7 +281,8 @@ class InvalidRegionError(Exception):
     The supplied region is not a valid AWS endpoint.
     """
     def __init__(self, region):
-        Exception.__init__(self, region)
+        message = u"The specified AWS region is not valid."
+        Exception.__init__(self, message, region)
         self.region = region
 
 
@@ -286,8 +290,9 @@ class InvalidZoneError(Exception):
     """
     The supplied zone is not valid for the given AWS region.
     """
-    def __init__(self, zone, available_zones):
-        Exception.__init__(self, zone, available_zones)
+    def __init__(self, message, zone, available_zones):
+        message = u"The specified AWS zone is not valid."
+        Exception.__init__(self, message, zone, available_zones)
         self.zone = zone
         self.available_zones = available_zones
 
@@ -1306,4 +1311,5 @@ def aws_from_configuration(region, zone, access_key_id, secret_access_key,
             cluster_id=cluster_id,
         )
     except (InvalidRegionError, InvalidZoneError) as e:
-        raise BlockDeviceInitializationError(e.args)
+        raise StorageInitializationError(
+            StorageInitializationError.CONFIGURATION_ERROR, e.args)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -1302,8 +1302,8 @@ def aws_from_configuration(region, zone, access_key_id, secret_access_key,
     :param UUID cluster_id: The unique identifier of the cluster with which to
         associate the resulting object.  It will only manipulate volumes
         belonging to this cluster.
-    :param bool no_validate: If False, do not attempt to validate the region
-        and zone by calling out to AWS. Useful for testing.
+    :param bool validate_region: If False, do not attempt to validate the
+        region and zone by calling out to AWS. Useful for testing.
 
     :return: A ``EBSBlockDeviceAPI`` instance using the given parameters.
     """

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -281,7 +281,7 @@ class InvalidRegionError(Exception):
     The supplied region is not a valid AWS endpoint.
     """
     def __init__(self, region):
-        message = u"The specified AWS region is not valid"
+        message = u"The specified AWS region is not valid."
         Exception.__init__(self, message, region)
         self.region = region
 
@@ -291,11 +291,9 @@ class InvalidZoneError(Exception):
     The supplied zone is not valid for the given AWS region.
     """
     def __init__(self, zone, available_zones):
-        message = u"The specified AWS zone is not valid"
+        message = u"The specified AWS zone is not valid."
         Exception.__init__(
-            self, message, zone,
-            u"available_zones", ', '.join(available_zones)
-        )
+            self, message, zone, u"Available zones:", available_zones)
         self.zone = zone
         self.available_zones = available_zones
 

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -281,7 +281,7 @@ class InvalidRegionError(Exception):
     The supplied region is not a valid AWS endpoint.
     """
     def __init__(self, region):
-        message = u"The specified AWS region is not valid."
+        message = u"The specified AWS region is not valid"
         Exception.__init__(self, message, region)
         self.region = region
 
@@ -291,8 +291,9 @@ class InvalidZoneError(Exception):
     The supplied zone is not valid for the given AWS region.
     """
     def __init__(self, message, zone, available_zones):
-        message = u"The specified AWS zone is not valid."
-        Exception.__init__(self, message, zone, available_zones)
+        message = u"The specified AWS zone is not valid"
+        Exception.__init__(
+            self, message, zone, u"available_zones", available_zones)
         self.zone = zone
         self.available_zones = available_zones
 
@@ -1312,4 +1313,4 @@ def aws_from_configuration(region, zone, access_key_id, secret_access_key,
         )
     except (InvalidRegionError, InvalidZoneError) as e:
         raise StorageInitializationError(
-            StorageInitializationError.CONFIGURATION_ERROR, e.args)
+            StorageInitializationError.CONFIGURATION_ERROR, *e.args)

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -621,6 +621,8 @@ class AgentService(PClass):
         except StorageInitializationError as e:
             if e.code == StorageInitializationError.CONFIGURATION_ERROR:
                 raise UsageError(u"Configuration error", *e.args)
+            else:
+                raise
 
     def get_deployer(self, api):
         """

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -42,7 +42,7 @@ from .diagnostics import (
     lookup_distribution,
 )
 from .agents.blockdevice import (
-    BlockDeviceDeployer, ProcessLifetimeCache,
+    BlockDeviceDeployer, ProcessLifetimeCache, BlockDeviceInitializationError,
 )
 from .agents.loopback import (
     LoopbackBlockDeviceAPI,
@@ -600,7 +600,11 @@ class AgentService(PClass):
         if backend.needs_reactor:
             api_args = api_args.set("reactor", self.reactor)
 
-        return backend.api_factory(**api_args)
+        try:
+            return backend.api_factory(**api_args)
+        except BlockDeviceInitializationError as e:
+            # import pdb;pdb.set_trace()
+            pass
 
     def get_deployer(self, api):
         """

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -620,7 +620,7 @@ class AgentService(PClass):
             return backend.api_factory(**api_args)
         except StorageInitializationError as e:
             if e.code == StorageInitializationError.CONFIGURATION_ERROR:
-                raise UsageError(e.args)
+                raise UsageError(u"Configuration error", *e.args)
 
     def get_deployer(self, api):
         """

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -356,6 +356,7 @@ class AgentServiceGetAPITests(SynchronousTestCase):
                 "access_key_id": "XXXXXXXXXX",
                 "secret_access_key": "YYYYYYYYYY",
                 "cluster_id": "123456789",
+                "validate_region": False,
             }
         )
         ebs = agent_service.get_api()


### PR DESCRIPTION
Fixes FLOC-3461. Gives error messages in the logs for incorrect AWS region or zone config, e.g.:

```
Dec 11 16:54:18 ip-172-31-8-201 flocker-dataset-agent[23631]: {"task_uuid": "478c2863-c875-47a9-87d5-c3a772ddd907", "error": false, "timestamp": 1449852858.826969, "message": "Log opened.", "message_type": "twisted:log", "task_level": [1]}
Dec 11 16:54:26 ip-172-31-8-201 flocker-dataset-agent[23631]: {"task_uuid": "77afedae-ed6c-4ed1-8cba-e20edc6243a0", "error": true, "timestamp": 1449852866.720357, "message": "(u'Configuration error', u'The specified AWS region is not valid', 'us-west-9')", "message_type": "twisted:log", "task_level": [1]}
Dec 11 16:54:26 ip-172-31-8-201 flocker-dataset-agent[23631]: {"task_uuid": "5d36dd5f-63d4-4e19-aa12-3a0047fe8c94", "error": false, "timestamp": 1449852866.721898, "message": "Main loop terminated.", "message_type": "twisted:log", "task_level": [1]}
Dec 11 16:54:26 ip-172-31-8-201 systemd[1]: flocker-dataset-agent.service: main process exited, code=exited, status=1/FAILURE
```

and

```
Dec 11 16:53:50 ip-172-31-8-201 flocker-dataset-agent[23536]: {"task_uuid": "83225e11-1c67-4d4f-af9a-982130a2d185", "error": false, "timestamp": 1449852830.485937, "message": "Log opened.", "message_type": "twisted:log", "task_level": [1]}
Dec 11 16:53:50 ip-172-31-8-201 flocker-dataset-agent[23536]: {"task_uuid": "70f0d44d-fe59-419d-864a-d1a401e074ea", "error": true, "timestamp": 1449852830.751518, "message": "(u'Configuration error', u'The specified AWS zone is not valid', 'us-west-2z', u'Available zones:', ['us-west-2a', 'us-west-2b', 'us-west-2c'])", "message_type": "twisted:log", "task_level": [1]}
Dec 11 16:53:50 ip-172-31-8-201 flocker-dataset-agent[23536]: {"task_uuid": "97e9f2d7-cf5e-42ee-bab6-7d49d3ee81fb", "error": false, "timestamp": 1449852830.7533, "message": "Main loop terminated.", "message_type": "twisted:log", "task_level": [1]}
Dec 11 16:53:50 ip-172-31-8-201 systemd[1]: flocker-dataset-agent.service: main process exited, code=exited, status=1/FAILURE
```