### PR TITLE
[FLOC-3705] Add default volume size, if available, to benchmark cluster

### DIFF
--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -208,7 +208,8 @@ class CPUTimeTests(TestCase):
             BenchmarkCluster(
                 IPAddress('10.0.0.1'),
                 lambda reactor: FakeFlockerClient([node1, node2]),
-                {}
+                {},
+                None,
             ),
             _LocalRunner(),
             processes=[_standard_process]

--- a/benchmark/operations/test/test_read_request.py
+++ b/benchmark/operations/test/test_read_request.py
@@ -106,7 +106,10 @@ class ReadRequestTests(SynchronousTestCase):
         # Get the probe to read the state of the cluster
         def start_read_request(result):
             cluster = BenchmarkCluster(
-                IPAddress('10.0.0.1'), lambda reactor: control_service, {}
+                IPAddress('10.0.0.1'),
+                lambda reactor: control_service,
+                {},
+                None,
             )
             request = ReadRequest(Clock(), cluster, 'list_datasets_state')
             return request.get_probe()

--- a/benchmark/test/test_cluster.py
+++ b/benchmark/test/test_cluster.py
@@ -78,6 +78,8 @@ class ValidationTests(SynchronousTestCase):
 CONTROL_SERVICE_PUBLIC_IP = IPAddress('10.0.0.1')
 CONTROL_SERVICE_PRIVATE_IP = IPAddress('10.1.0.1')
 
+DEFAULT_VOLUME_SIZE = 1073741824
+
 
 class BenchmarkClusterTests(SynchronousTestCase):
 
@@ -88,9 +90,12 @@ class BenchmarkClusterTests(SynchronousTestCase):
         )
         self.control_service = FakeFlockerClient([node])
         self.cluster = BenchmarkCluster(
-            CONTROL_SERVICE_PUBLIC_IP, lambda reactor: self.control_service, {
+            CONTROL_SERVICE_PUBLIC_IP,
+            lambda reactor: self.control_service,
+            {
                 CONTROL_SERVICE_PRIVATE_IP: CONTROL_SERVICE_PUBLIC_IP,
-            }
+            },
+            DEFAULT_VOLUME_SIZE,
         )
 
     def test_control_node_address(self):
@@ -115,3 +120,10 @@ class BenchmarkClusterTests(SynchronousTestCase):
             self.cluster.public_address(CONTROL_SERVICE_PRIVATE_IP),
             CONTROL_SERVICE_PUBLIC_IP
         )
+
+    def test_default_volume_size(self):
+        """
+        The ``default_volume_size`` method gives expected results.
+        """
+        self.assertEqual(
+            self.cluster.default_volume_size(), DEFAULT_VOLUME_SIZE)

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -192,6 +192,21 @@ class ClusterConfigurationTests(SynchronousTestCase):
             self.assertIn('notanipaddress', e.exception.args[0])
             self.assertIn(options.getUsage(), captured_stderr())
 
+    def test_environment_invalid_volume_size(self):
+        """
+        Rejects configuration if volume size is invalid.
+        """
+        options = BenchmarkOptions()
+        options.parseOptions([])
+        self.environ['FLOCKER_ACCEPTANCE_DEFAULT_VOLUME_SIZE'] = 'A'
+        with capture_stderr() as captured_stderr:
+            with self.assertRaises(SystemExit) as e:
+                get_cluster(options, self.environ)
+            self.assertIn(
+                'FLOCKER_ACCEPTANCE_DEFAULT_VOLUME_SIZE', e.exception.args[0]
+            )
+            self.assertIn(options.getUsage(), captured_stderr())
+
 
 class ValidationTests(SynchronousTestCase):
     """


### PR DESCRIPTION
In order to introduce a "create dataset" operation, it is useful to have a size for the dataset. Since valid sizes differ by clouds platform, it is great if the user gives us this information.

If we use the acceptance test environment variables (currently our preferred solution), an appropriate value is available in one of the environment variables.

If we use the UFT Flocker Installer, there is no value provided. However, the API allows `None` to be provided as this parameter.  We can live with this, as benchmarking is an internal process, and if it causes problems, we may find them before someone else.
