### PR TITLE
[FLOC-3711] Fix count of iterations in failure message.

### DIFF
--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -26,6 +26,8 @@ from pyrsistent import (
     PClass, field, discard, pmap, pvector,
 )
 
+from characteristic import attributes
+
 from hypothesis import given, note, assume
 from hypothesis.strategies import (
     uuids, text, lists, just, integers, builds, sampled_from,
@@ -1159,10 +1161,13 @@ def compare_dataset_states(discovered_datasets, desired_datasets):
     return True
 
 
+@attributes(["iteration_count"])
 class DidNotConverge(Exception):
     """
     Raised if running convergence with an ``ICalculator`` does not converge
     in the specified number of iterations.
+
+    :ivar iteration_count: The count of iterations before this was raised.
     """
 
 
@@ -1223,7 +1228,7 @@ class BlockDeviceCalculatorTests(SynchronousTestCase):
             ):
                 break
         else:
-            raise DidNotConverge()
+            raise DidNotConverge(iteration_count=max_iterations)
 
     @given(
         initial_dataset=DESIRED_DATASET_STRATEGY,
@@ -1246,14 +1251,17 @@ class BlockDeviceCalculatorTests(SynchronousTestCase):
         # Converge to the initial state.
         try:
             self.run_to_convergence([initial_dataset])
-        except DidNotConverge:
-            self.fail("Did not converge to initial state after 10 iterations")
+        except DidNotConverge as e:
+            self.fail(
+                "Did not converge to initial state after %d iterations." %
+                e.iteration_count)
 
         # Converge from the initial state to the next state.
         try:
             self.run_to_convergence([initial_dataset.set(state=next_state)])
-        except DidNotConverge:
-            self.fail("Did not converge to next state after 10 iterations")
+        except DidNotConverge as e:
+            self.fail("Did not converge to next state after %d iterations." %
+                      e.iteration_count)
 
     test_simple_transitions.skip = (
         "This test sometimes fails in a way that cause a failure cascade."


### PR DESCRIPTION
Fixes FLOC-3711 by passing number of iterations through in the Exception and using that count in the error message.