### PR TITLE
[FLOC-3695] Fix broken run_sphinx job by fixing broken docs links

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -271,14 +271,14 @@ common_cli:
       --no-passthrough --output-to=results.xml
 
   run_sphinx: &run_sphinx |
-    parse_logs python setup.py --version
+    parse_logs \${venv}/bin/python setup.py --version
     cd docs
     # check spelling
-    parse_logs sphinx-build -d _build/doctree -b spelling . _build/spelling
+    parse_logs \${venv}/bin/sphinx-build -d _build/doctree -b spelling . _build/spelling
     # check links
-    parse_logs sphinx-build -d _build/doctree -b linkcheck . _build/linkcheck
+    parse_logs \${venv}/bin/sphinx-build -d _build/doctree -b linkcheck . _build/linkcheck
     # build html pages
-    parse_logs sphinx-build -d _build/doctree -b html . _build/html
+    parse_logs \${venv}/bin/sphinx-build -d _build/doctree -b html . _build/html
 
   # flocker artifacts contains the list of files we want to collect from our
   # _main_multijob. These are used to produce the coverage, test reports.

--- a/build.yaml
+++ b/build.yaml
@@ -185,9 +185,11 @@ common_cli:
     rm -rf \${venv}
 
   setup_venv: &setup_venv |
-    # setup the new venv
+    # Set up the new venv.
     virtualenv -p python2.7 --clear \${venv}
     . \${venv}/bin/activate
+    # Report the version of Python we're using, to aid debugging.
+    \${venv}/bin/python --version
 
   setup_pip_cache: &setup_pip_cache |
     # exports the PIP_INDEX_URL, TRUSTED_HOST variables to the environment.

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 #
 # build.yaml
 #
-# This file contains the Jenkins job defintions for the Flocker project.
+# This file contains the Jenkins job definitions for the Flocker project.
 #
 # We add new or reconfigure existing jobs in Jenkins using the Job DSL plugin.
 # https://github.com/jenkinsci/job-dsl-plugin
@@ -30,6 +30,7 @@
 #
 # We pass the branch name as a parameter to the setup_clusterhq_flocker job,
 # the parameter is shown as 'RECONFIGURE_BRANCH'.
+#
 # The setup job only produces jobs for a single branch . We don't produce jobs
 # for every branch due to the large number of branches in the repository, which
 # would generate over 16000 jobs and take over an hour to run.
@@ -45,8 +46,10 @@
 # she/he can see a job called '_main_multijob'. This job is responsible for
 # executing all other jobs in parallel and collecting the produced artifacts
 # from each job after its execution.
+#
 # The artifacts in this case are trial logs, coverage xml reports, subunit
 # reports.
+#
 # Those artifacts are consumed by the _main_multijob to produce an overall
 # coverage report, and an aggregated summary of all the executed tests and
 # their failures/skips/successes.

--- a/docs/control/cli/application-config.rst
+++ b/docs/control/cli/application-config.rst
@@ -163,4 +163,4 @@ Here's an example of a simple but complete configuration defining one applicatio
        "name": "on-failure"
        "maximum_retry_count": 10
 
-.. _`Docker Run reference`: http://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources
+.. _`Docker Run reference`: https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources

--- a/docs/control/cli/docker-compose-config.rst
+++ b/docs/control/cli/docker-compose-config.rst
@@ -129,5 +129,5 @@ Here's a complete example of a ``docker-compose`` compatible application configu
      volumes:
        - "/var/lib/mysql"
 
-.. _`Docker-compose`: http://docs.docker.com/compose/yml/
+.. _`Docker-compose`: https://docs.docker.com/compose/yml/
 .. _`Fig`: http://www.fig.sh/yml.html

--- a/docs/gettinginvolved/plugins/building-driver.rst
+++ b/docs/gettinginvolved/plugins/building-driver.rst
@@ -72,10 +72,6 @@ Testing Your Driver
 #. Setup a Continuous Integration environment for tests.
 
    After your acceptance tests pass, we recommend you set up a CI environment for functional and acceptance tests for your driver.
-   For example:
-   
-   * `EBS functional tests <http://build.clusterhq.com/builders/flocker%2Ffunctional%2Faws%2Fubuntu-14.04%2Fstorage-driver>`_
-   * `EBS acceptance tests <http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fubuntu-14.04%2Faws>`_
 
 
 Enabling Flocker Users to Install Your Storage Driver


### PR DESCRIPTION
Docker probably changed their SSL configuration, which broke our links that were redirecting from http://docs.docker.com to https://docs.docker.com. Updating the links to correctly point to https://docs.docker.com removes these errors from the build. Unfortunately, it does so because we do not check https links. Fixing that problem is out of scope for this patch, since the priority is to unbreak master.

In addition, since master started breaking due to https links, we added extra failures by deleting some buildbot jobs. I've taken the liberty of updating the documentation that used those examples. 
