### PR TITLE
[FLOC-3435] upload and consume clusterhq vagrant boxes from S3

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -88,6 +88,9 @@ common_cli:
   # TODO: https://clusterhq.atlassian.net/browse/FLOC-2986
   add_shell_functions: &add_shell_functions |
 
+    # set a default AWS endpoint for S3 operations
+    export S3_ENDPOINT=us-west-2
+
     # The long directory names where we build our code cause pip to fail.
     # https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/issues/20
     # http://stackoverflow.com/questions/10813538/shebang-line-limit-in-bash-and-linux-kernel
@@ -199,7 +202,7 @@ common_cli:
     function s3_upload() {
       echo "uploading \${2} to S3 bucket ${1} ..."
       retry_n_times_with_timeout 3 900 \
-        aws --region us-west-2 s3 cp "\${2}" s3://\${1}/
+        aws --region \${S3_ENDPOINT} s3 cp "\${2}" s3://\${1}/
     }
 
     # creates a metadata file to be used with vagrant up; vagrant box update
@@ -688,7 +691,7 @@ common_cli:
        config.vm.synced_folder '.', '/vagrant', disabled: true
        config.vm.provider 'virtualbox' do |vb|
           vb.memory = '1024'
-          # VirtualBox 5 now supports para-virtualization, lets use it.
+          # VirtualBox 5 now supports para-virtualization, let's use it.
           vb.customize("pre-boot", ["modifyvm", :id, "--paravirtprovider", "KVM"])
        end
     end
@@ -814,21 +817,21 @@ common_cli:
   get_s3_creds_for_bucket_vagrant_jenkins_boxes: &get_s3_creds_for_bucket_vagrant_jenkins_boxes |
     # collects the S3 credentials that allows us to upload files to the S3
     # vagrant-jenkins_boxes for our vagrant boxes
-    # the file with the credentials are deployed by the jenkins master to the
+    # the file with the credentials is deployed by the jenkins master to the
     # /tmp of the slave when the slave is instantiated.
     . /tmp/s3_vagrant_jenkins_boxes_clusterhq.com
 
   get_s3_creds_for_clusterhq_dev_archive: &get_s3_creds_for_clusterhq_dev_archive |
     # collects the S3 credentials that allows us to upload files to the S3
     # clusterhq-dev-archive for our vagrant boxes
-    # the file with the credentials are deployed by the jenkins master to the
+    # the file with the credentials is deployed by the jenkins master to the
     # /tmp of the slave when the slave is instantiated.
     . /tmp/s3_dev_archive_clusterhq.com
 
   upload_new_docs_html_to_s3_staging_docs: &upload_new_docs_html_to_s3_staging_docs |
     # uploads the new generated html to a folder on the S3 staging-docs bucket
     cd _build/html
-    aws --region us-west-2 s3 sync . s3://clusterhq-staging-docs/\$TRIGGERED_BRANCH
+    aws --region \${S3_ENDPOINT} s3 sync . s3://clusterhq-staging-docs/\$TRIGGERED_BRANCH
     echo "This branch is available at :"
     echo "http://clusterhq-staging-docs.s3.amazonaws.com/\$TRIGGERED_BRANCH/index.html"
 
@@ -852,22 +855,15 @@ common_cli:
     VAGRANT_BOX_VERSION="\$( echo \${FLOCKER_VERSION} | cut -f 1,2,3 -d "." )"
 
     cd \$BOX_PATH
+
     # generates the metadata.json, it used by vagrant box update operations.
-    cat <<EOF_METADATA > metadata.json
-    {
-      "name": "clusterhq/flocker-tutorial",
-      "description": "This box contains the flocker-tutorial VM.",
-      "versions": [{
-        "version": "\${VAGRANT_BOX_VERSION}",
-        "providers": [{
-          "name": "virtualbox",
-          "url": "\${HTTP_BOX_URL}",
-          "checksum_type": "sha1",
-          "checksum": "\${SHA1}"
-        }]
-      }]
-    }
-    EOF_METADATA
+    create_vagrant_metadata_file \
+      metadata.json \
+      clusterhq/flocker-tutorial \
+      'This box contains the flocker-tutorial VM.' \
+      \${VAGRANT_BOX_VERSION} \
+      \${HTTP_BOX_URL} \
+      \${SHA1}
 
     cp metadata.json \${BOX_NAME}.json
 
@@ -925,8 +921,7 @@ common_cli:
       s3_upload \${S3_BUCKET} "metadata.json"
     ) || abort_build
 
-    echo "This vagrant box is available is available at :"
-    echo "\${S3_BOX_JSON_LATEST}"
+    echo "This vagrant box is available at : \${S3_BOX_JSON_LATEST}"
 
 
   run_lint: &run_lint |
@@ -1468,8 +1463,8 @@ job_type:
                    *install_pkgs_on_vanilla_osx_yosemite_box,
                    *end_build_sh_EOF,
 
-                  # starts and provisions an OSX vagrant machine
-                  # using the build.sh script created above
+                   # starts and provisions an OSX vagrant machine
+                   # using the build.sh script created above
                    *start_vanilla_osx_yosemite_vagrant_box,
                    *run_build_sh_script_on_vagrant_box,
 

--- a/build.yaml
+++ b/build.yaml
@@ -696,7 +696,7 @@ common_cli:
 
 
   source_git_commit: &source_git_commit |
-    # we use a script 'git-commit.sh' to pass any variables from the host
+    # we use a script 'git-commit.sh' to pass any the git commit sha1
     # to our vagrant machine. This file is copied and sourced as part of our
     # build.sh run inside the virtual machine.
     chmod 755 git-commit.sh

--- a/build.yaml
+++ b/build.yaml
@@ -359,14 +359,14 @@ common_cli:
       --no-passthrough --output-to=results.xml
 
   run_sphinx: &run_sphinx |
-    parse_logs \${venv}/bin/python setup.py --version
+    \${venv}/bin/python setup.py --version
     cd docs
     # check spelling
-    parse_logs \${venv}/bin/sphinx-build -d _build/doctree -b spelling . _build/spelling
+    \${venv}/bin/sphinx-build -d _build/doctree -b spelling . _build/spelling
     # check links
-    parse_logs \${venv}/bin/sphinx-build -d _build/doctree -b linkcheck . _build/linkcheck
+    \${venv}/bin/sphinx-build -d _build/doctree -b linkcheck . _build/linkcheck
     # build html pages
-    parse_logs \${venv}/bin/sphinx-build -d _build/doctree -b html . _build/html
+    \${venv}/bin/sphinx-build -d _build/doctree -b html . _build/html
 
   # flocker artifacts contains the list of files we want to collect from our
   # _main_multijob. These are used to produce the coverage, test reports.

--- a/build.yaml
+++ b/build.yaml
@@ -73,7 +73,8 @@ git_url: 'https://github.com/ClusterHQ/flocker.git'
 common_cli:
   hashbang: &hashbang |
     #!/bin/bash -l
-    set -x
+    # don't leak secrets
+    set +x
     set -e
 
 
@@ -134,14 +135,6 @@ common_cli:
       fi
     }
 
-    # This is a function that we can use to transform log output before it is
-    # sent to the Jenkins console view.  It could be used to color-code certain
-    # results, for example.
-    function parse_logs {
-      "\$@"
-      return \${PIPESTATUS[0]}
-    }
-
     # fix the docker permission issue, the base image doesn't have the correct
     # permissions/owners.
     # This is to be tackled as part of:
@@ -167,6 +160,105 @@ common_cli:
              echo 1
          fi
       fi
+    }
+
+    # Retries a command if it fails, using the exponential backoff algorithm.
+    # Usage:
+    # retry_n_times_with_timeout <max retries> <timeout in seconds> command
+    #
+    function retry_n_times_with_timeout {
+      set +e
+      max_tries=\${1}
+      seconds=\${2}
+      shift 2
+
+      let delay=15
+      let tries=0
+      while [ \${tries} -lt \${max_tries} ]; do
+        echo "executing...  \${*}"
+        if (timeout --foreground --signal=SIGKILL \${seconds} bash -c "\${*}"); then
+            break
+        fi
+        echo Command failed, waiting \${delay}...
+        sleep \${delay}
+        let delay=delay*2
+        let tries=tries+1
+
+        # abort on too many failures
+        if [ \${tries} -eq \${max_tries} ]; then
+          echo "too many failed retries... aborting"
+          exit 1
+        fi
+
+      done
+    }
+
+    # uploads a file to S3, retrying on failure.
+    # usage:
+    # s3_upload <bucket> <filename>
+    function s3_upload() {
+      echo "uploading \${2} to S3 bucket ${1} ..."
+      retry_n_times_with_timeout 3 900 \
+        aws --region us-west-2 s3 cp "\${2}" s3://\${1}/
+    }
+
+    # creates a metadata file to be used with vagrant up; vagrant box update
+    # usage: create_vagrant_metadata_file
+    #   <filename> <box_name> <description> <version> <url> <sha1>
+    function create_vagrant_metadata_file() {
+      cat <<EOF_METADATA > \${1}
+      {
+        "name": "\${2}",
+        "description": "\${3}",
+        "versions": [{
+          "version": "\${4}",
+          "providers": [{
+            "name": "virtualbox",
+            "url": "\${5}",
+            "checksum_type": "sha1",
+            "checksum": "\${6}"
+          }]
+        }]
+      }
+    EOF_METADATA
+    }
+
+    # destroy the vagrant box and aborts the build
+    # this is used when one the of the intermediate steps has failed
+    # usage:
+    # <some code> || abort_build
+    function abort_build() {
+      echo "aborting ..."
+      vagrant destroy -f
+      exit 1
+    }
+
+    # attempts a vagrant up, and aborts the build on failure
+    # usage:
+    # vagrant_up
+    function vagrant_up() {
+      (
+        retry_n_times_with_timeout 3 1200 \
+          vagrant up
+      ) || abort_build
+    }
+
+    # attempts to refresh the local vagrant box, and aborts the build on error
+    # make sure we are using the latest available version of this vagrant box
+    # usage:
+    # vagrant_box_update
+    function vagrant_box_update() {
+      (
+        retry_n_times_with_timeout 2 1800 \
+          vagrant box update
+      ) || abort_build
+    }
+
+    # destroys the vagrant box
+    # usage:
+    # vagrant_box_destroy
+    function vagrant_destroy() {
+      vagrant destroy -f
     }
 
   # TODO: do we need to clean up old files on ubuntu and centos or
@@ -219,20 +311,14 @@ common_cli:
                                 --trusted-host \${TRUSTED_HOST} "
     fi
 
-    # parse_logs() currently only works on Ubuntu or Centos builds
-    # due to a different awk implementation on OSX cloudbees servers
-    if is_ubuntu || is_centos; then
-        PARSE_LOGS="parse_logs "
-    fi
-
     # using the caching-layer, install all the dependencies
-    \${PARSE_LOGS} pip install --upgrade pip
-    \${PARSE_LOGS} pip install . \${PIP_ADDITIONAL_OPTIONS}
+    pip install --upgrade pip
+    pip install . \${PIP_ADDITIONAL_OPTIONS}
     # Install Flocker. Use --process-dependency-links so we can temporarily use
     # testtools fork. See FLOC-3498.
-    \${PARSE_LOGS} pip install --process-dependency-links  ".[dev]" \${PIP_ADDITIONAL_OPTIONS}
+    pip install --process-dependency-links  ".[dev]" \${PIP_ADDITIONAL_OPTIONS}
     # install junix for our coverage report
-    \${PARSE_LOGS} pip install python-subunit junitxml \${PIP_ADDITIONAL_OPTIONS}
+    pip install python-subunit junitxml \${PIP_ADDITIONAL_OPTIONS}
 
   setup_aws_env_vars: &setup_aws_env_vars |
     # set vars and run tests
@@ -261,11 +347,11 @@ common_cli:
     # downstream child jobs to the parent job and processing those files
     # one last time through the cobertura plugin.
     # The resulting report wil contain stats from every single job.
-    parse_logs pip install coverage  \${PIP_ADDITIONAL_OPTIONS}
+    pip install coverage  \${PIP_ADDITIONAL_OPTIONS}
 
   run_coverage: &run_coverage |
     # run coverage and produce a report
-    parse_logs coverage xml --include=flocker*
+    coverage xml --include=flocker*
 
   convert_results_to_junit: &convert_results_to_junit |
     # pip the trial.log results through subunit and export them as junit in xml
@@ -314,7 +400,7 @@ common_cli:
     # This is how we tell trial which flocker module to call.
     coverage run \${venv}/bin/trial \
       --debug-stacktraces --reporter=subunit \
-      \${MODULE} 2>&1 | parse_logs tee trial.log
+      \${MODULE} 2>&1 | tee trial.log
 
   run_trial_with_coverage_as_root: &run_trial_with_coverage_as_root |
     # The jobs.groovy.j2 file produces jobs that contain a parameterized job
@@ -326,7 +412,7 @@ common_cli:
     # This is how we tell trial which flocker module to call.
     sudo \${venv}/bin/coverage run \${venv}/bin/trial \
       --debug-stacktraces --reporter=subunit \
-      \${MODULE} 2>&1 | parse_logs tee trial.log
+      \${MODULE} 2>&1 | tee trial.log
 
   run_trial_for_storage_drivers_with_coverage: &run_trial_for_storage_drivers_with_coverage |
     # The jobs.groovy.j2 file produces jobs that contain a parameterized job
@@ -337,7 +423,7 @@ common_cli:
     # Consume the MODULE parameter set in the job configuration
     sudo -E \${venv}/bin/coverage run \${venv}/bin/trial \
       --debug-stacktraces --reporter=subunit \
-      --testmodule \${MODULE} 2>&1 | parse_logs tee trial.log
+      --testmodule \${MODULE} 2>&1 | tee trial.log
 
   setup_authentication: &setup_authentication |
     # acceptance tests rely on this file existing
@@ -363,7 +449,7 @@ common_cli:
     # which are made available through a webserver running on port 80.
     # We pass the URL of our Jenkins Slave to the acceptance test nodes
     # through the --build-server parameter below.
-    parse_logs \${venv}/bin/python admin/run-acceptance-tests \
+    \${venv}/bin/python admin/run-acceptance-tests \
     --distribution \${DISTRIBUTION_NAME} \
     --provider aws --dataset-backend aws --branch \${TRIGGERED_BRANCH} \
     --build-server  \
@@ -380,7 +466,7 @@ common_cli:
     # The admin/run-acceptance-tests will provision a flocker cluster with a
     # single node since the loopback backend doesn't support moving data across
     # hosts.
-    parse_logs \${venv}/bin/python admin/run-acceptance-tests \
+    \${venv}/bin/python admin/run-acceptance-tests \
     --distribution \${DISTRIBUTION_NAME} --number-of-nodes 1 \
     --provider aws --dataset-backend loopback --branch \${TRIGGERED_BRANCH} \
     --build-server  \
@@ -402,7 +488,7 @@ common_cli:
     # which are made available through a webserver running on port 80.
     # We pass the URL of our Jenkins Slave to the acceptance test nodes
     # through the --build-server parameter below.
-    parse_logs \${venv}/bin/python admin/run-acceptance-tests \
+    \${venv}/bin/python admin/run-acceptance-tests \
     --distribution \${DISTRIBUTION_NAME} \
     --provider rackspace --dataset-backend rackspace \
     --branch \${TRIGGERED_BRANCH} \
@@ -416,7 +502,7 @@ common_cli:
     # We gather the return code but make sure we come out of these tests with 0
     # we store that code and pass it to the end of the job execution,
     # as part of the JOB_EXIT_STATUS variable.
-    parse_logs \${venv}/bin/python admin/run-client-tests \
+    \${venv}/bin/python admin/run-client-tests \
     --distribution \${DISTRIBUTION_NAME} \
     --branch \${TRIGGERED_BRANCH} \
     --build-server  \
@@ -431,11 +517,11 @@ common_cli:
 
   build_sdist: &build_sdist  |
     # package the goodies
-    parse_logs \${venv}/bin/python setup.py sdist
+    \${venv}/bin/python setup.py sdist
 
   build_package: &build_package  |
     # and build a rpm/deb package using docker
-    parse_logs \${venv}/bin/python admin/build-package \
+    \${venv}/bin/python admin/build-package \
     --destination-path repo \
     --distribution \${DISTRIBUTION_NAME} \
     /flocker/dist/Flocker-\${FLOCKER_VERSION}.tar.gz
@@ -513,9 +599,9 @@ common_cli:
   # By doing this we speed up the bootstrapping of our client/acceptance tests.
   #
   build_dockerfile_centos7: &build_dockerfile_centos7 |
-    # Download the latest pip requirements file from master branch of flocker
+    # Download the latest pip requirements file from flocker
     wget -c \
-    https://raw.githubusercontent.com/ClusterHQ/flocker/master/requirements.txt
+    https://raw.githubusercontent.com/ClusterHQ/flocker/\${TRIGGERED_BRANCH}/requirements.txt
     # don't waste time installing ruby or fpm, use an image containing fpm
     # https://github.com/alanfranz/fpm-within-docker
     echo "FROM alanfranz/fwd-centos-7:latest" > Dockerfile
@@ -534,9 +620,9 @@ common_cli:
     echo "RUN pip install -r /tmp/requirements.txt" >> Dockerfile
 
   build_dockerfile_ubuntu_trusty: &build_dockerfile_ubuntu_trusty |
-    # Download the latest pip requirements file from master branch of flocker
+    # Download the latest pip requirements file from flocker
     wget -c \
-    https://raw.githubusercontent.com/ClusterHQ/flocker/master/requirements.txt
+    https://raw.githubusercontent.com/ClusterHQ/flocker/\${TRIGGERED_BRANCH}/requirements.txt
     # don't waste time installing ruby or fpm, use an image containing fpm
     # https://github.com/alanfranz/fpm-within-docker
     echo "FROM alanfranz/fwd-ubuntu-trusty:latest" > Dockerfile
@@ -549,9 +635,9 @@ common_cli:
     echo "RUN pip install -r /tmp/requirements.txt" >> Dockerfile
 
   build_dockerfile_ubuntu_wily: &build_dockerfile_ubuntu_wily |
-    # Download the latest pip requirements file from master branch of flocker
+    # Download the latest pip requirements file from flocker
     wget -c \
-    https://raw.githubusercontent.com/ClusterHQ/flocker/master/requirements.txt
+    https://raw.githubusercontent.com/ClusterHQ/flocker/\${TRIGGERED_BRANCH}/requirements.txt
     # don't waste time installing ruby or fpm, use an image containing fpm
     # https://github.com/alanfranz/fpm-within-docker
     echo "FROM alanfranz/fwd-ubuntu-wily:latest" > Dockerfile
@@ -565,10 +651,19 @@ common_cli:
 
   build_vagrant_tutorial_basebox: &build_vagrant_tutorial_basebox |
     vagrant destroy -f
-    parse_logs \$venv/bin/python admin/build-vagrant-box --box tutorial \
-      --branch \${TRIGGERED_BRANCH} --build-server  http://\${eth0_ip}
-    parse_logs vagrant box add --force "clusterhq/flocker-tutorial" \
-      vagrant/tutorial/flocker-tutorial-\${FLOCKER_VERSION}.box
+    (
+      retry_n_times_with_timeout 3 1800 \
+        \$venv/bin/python admin/build-vagrant-box \
+          --box tutorial \
+          --branch \${TRIGGERED_BRANCH} \
+          --build-server http://\${eth0_ip}
+    )|| abort_build
+
+    (
+      retry_n_times_with_timeout 2 1200 \
+        vagrant box add --force "clusterhq/flocker-tutorial" \
+          vagrant/tutorial/flocker-tutorial-\${FLOCKER_VERSION}.box
+    ) || abort_build
 
   do_not_abort_on_errors: &do_not_abort_on_errors |
     # make sure we don't abort the job on the first error we find.
@@ -586,22 +681,26 @@ common_cli:
   new_vagrantfile_for_osx_yosemite: &new_vagrantfile_for_osx_yosemite |
     # this builds a Vagrantfile which will use the latest jenkins-osx-yosemite
     # vagrant box built overnight.
-    cat <<'EOF' >Vagrantfile
+    cat <<EOF_VAGRANTFILE >Vagrantfile
     Vagrant.configure(2) do |config|
-       config.vm.box = 'jenkins-osx-yosemite'
+       config.vm.box = 'clusterhq/jenkins-osx-yosemite'
+       config.vm.box_url = "s3://\${ENV['S3_BUCKET']}/metadata.json"
        config.vm.synced_folder '.', '/vagrant', disabled: true
        config.vm.provider 'virtualbox' do |vb|
           vb.memory = '1024'
+          # VirtualBox 5 now supports para-virtualization, lets use it.
+          vb.customize("pre-boot", ["modifyvm", :id, "--paravirtprovider", "KVM"])
        end
     end
-    EOF
+    EOF_VAGRANTFILE
 
-  source_extra_vars: &source_extra_vars |
-    # we use a script 'extra-vars.sh' to pass any variables from the host
+
+  source_git_commit: &source_git_commit |
+    # we use a script 'git-commit.sh' to pass any variables from the host
     # to our vagrant machine. This file is copied and sourced as part of our
     # build.sh run inside the virtual machine.
-    chmod 755 extra-vars.sh
-    . extra-vars.sh
+    chmod 755 git-commit.sh
+    . git-commit.sh
 
   set_home_variable_on_mesos: &set_home_variable_on_mesos |
     # mesos is not setting HOME, so we set it here.
@@ -612,35 +711,37 @@ common_cli:
   # this is a wrapper that we can use for building a script that will be
   # populated with different cli actions.
   # we copy the resulting build.sh file to the vagrant box for execution.
-  begin_build_sh_EOF: &begin_build_sh_EOF cat <<'EOF' > build.sh
+  begin_build_sh_EOF: &begin_build_sh_EOF cat <<'EOF_BUILD_SH' > build.sh
 
   end_build_sh_EOF: &end_build_sh_EOF |
-     EOF
+     EOF_BUILD_SH
      chmod 755 build.sh
 
-  copy_files_to_osx_yosemite_box: &copy_files_to_osx_yosemite_box |
-    # this sets some variables used by the tests, since the tests run inside
-    # virtualbox we store them to a file and copy them to the vagrant box.
-    echo "export GIT_COMMIT=\${GIT_COMMIT}" > extra-vars.sh
-    chmod 755 extra-vars.sh
-    # gather the connection string for this vagrantbox
+  run_build_sh_script_on_vagrant_box: &run_build_sh_script_on_vagrant_box |
+    # copy project files to the vagrant box
     vagrant ssh-config > ssh-config
     rsync -ave 'ssh -F ssh-config' . default:.
-    vagrant scp /tmp/pip.sh /tmp/pip.sh
-    vagrant scp build.sh build.sh
-    vagrant ssh -c 'chmod 755 /tmp/pip.sh'
-    vagrant ssh -c 'chmod 755 build.sh'
 
-  run_build_sh_script_on_vagrant_box: &run_build_sh_script_on_vagrant_box |
+    # this sets some variables used by the tests, since the tests run inside
+    # virtualbox we store them to a file and copy them to the vagrant box.
+    echo "export GIT_COMMIT=\${GIT_COMMIT}" > git-commit.sh
+    for item in /tmp/pip.sh build.sh git-commit.sh
+    do
+      vagrant scp \${item} default:\${item}
+      vagrant ssh -c "chmod 755 \${item}"
+    done
+
     # make sure we don't abort on the first error
     set +e
     # run the build.sh script inside our vagrant box
-    vagrant ssh -c 'bash build.sh'
-    JOB_EXIT_STATUS="\$( updateExitStatus \$? )"
+    vagrant ssh -c 'bash build.sh' || abort_build
 
-  destroy_vagrant_box: &destroy_vagrant_box |
-    vagrant destroy -f
-    JOB_EXIT_STATUS="\$( updateExitStatus \$? )"
+    # this removes the secrets files we used during provisioning
+    for item in "/tmp/pip.sh build.sh git-commit.sh"
+    do
+      vagrant ssh -c "rm -f \${item}"
+    done
+
 
   install_pkgs_on_vanilla_osx_yosemite_box: &install_pkgs_on_vanilla_osx_yosemite_box |
     # permissions are not right, lets fix them here
@@ -663,29 +764,45 @@ common_cli:
     pip install virtualenv
     brew install libffi
     export PKG_CONFIG_PATH=/usr/local/Cellar/libffi/3.0.13/lib/pkgconfig/; pip install bcrypt
+    # brew test is failling unless we install these packages
+    pip install docutils
+    pip install botocore
+    pip install boto
 
   package_jenkins_osx_yosemite_box: &package_jenkins_osx_yosemite_box |
     # we now proceed to package our vagrant box
-    vagrant halt
-    vagrant package --output jenkins-osx-yosemite.box
-    JOB_EXIT_STATUS="\$( updateExitStatus \$? )"
-    vagrant box add --force 'jenkins-osx-yosemite'   jenkins-osx-yosemite.box
-    JOB_EXIT_STATUS="\$( updateExitStatus \$? )"
-    rm -f jenkins-osx-yosemite.box
-    vagrant destroy -f
-    JOB_EXIT_STATUS="\$( updateExitStatus \$? )"
-    exit \${JOB_EXIT_STATUS}
+    # let's stop it and wait a bit, as sometimes the box is not fully down
+    # when the vagrant halt command finishes.
+    vagrant halt ; sleep 60
+    BOX_NAME="jenkins-osx-yosemite-\${FLOCKER_VERSION}.box"
+    (
+      retry_n_times_with_timeout 2 1800 \
+        vagrant package --output "\${BOX_NAME}"
+    ) || abort_build
 
   start_vanilla_osx_yosemite_vagrant_box: &start_vanilla_osx_yosemite_vagrant_box |
-    # gather the vanilla Vagrantfile from upstream and do a vagrant up
-    rm -f Vagrantfile
-    wget https://raw.githubusercontent.com/AndrewDryga/vagrant-box-osx/master/Vagrantfile
-    vagrant up
+    cat <<EOF_VAGRANTFILE >Vagrantfile
+    Vagrant.configure(2) do |config|
+      config.vm.box = "AndrewDryga/vagrant-box-osx"
+      config.vm.provider "virtualbox" do |vb|
+        # increase the virtualbox instance RAM size
+        # our mesos executor will have 2GB, we'll stick to 1GB for the vagrant instance
+        vb.memory = "1024"
+        # VirtualBox 5 now supports para-virtualization.
+        vb.customize("pre-boot", ["modifyvm", :id, "--paravirtprovider", "KVM"])
+      end
+    end
+    EOF_VAGRANTFILE
+
+    (
+      retry_n_times_with_timeout 3 600 \
+        vagrant up
+    ) || abort_build
 
   install_aws_cli: &install_aws_cli |
     # installs the AWS python based cli
     # we use the aws cli to upload the docs files to S3
-    \${PARSE_LOGS}  pip install awscli \${PIP_ADDITIONAL_OPTIONS}
+    pip install awscli \${PIP_ADDITIONAL_OPTIONS}
 
   get_s3_creds_for_bucket_staging_docs: &get_s3_creds_for_bucket_staging_docs |
     # collects the S3 credentials that allows us to upload files to the S3
@@ -694,12 +811,123 @@ common_cli:
     # /tmp of the slave when the slave is instantiated.
     . /tmp/s3_staging_docs_clusterhq_com.sh
 
+  get_s3_creds_for_bucket_vagrant_jenkins_boxes: &get_s3_creds_for_bucket_vagrant_jenkins_boxes |
+    # collects the S3 credentials that allows us to upload files to the S3
+    # vagrant-jenkins_boxes for our vagrant boxes
+    # the file with the credentials are deployed by the jenkins master to the
+    # /tmp of the slave when the slave is instantiated.
+    . /tmp/s3_vagrant_jenkins_boxes_clusterhq.com
+
+  get_s3_creds_for_clusterhq_dev_archive: &get_s3_creds_for_clusterhq_dev_archive |
+    # collects the S3 credentials that allows us to upload files to the S3
+    # clusterhq-dev-archive for our vagrant boxes
+    # the file with the credentials are deployed by the jenkins master to the
+    # /tmp of the slave when the slave is instantiated.
+    . /tmp/s3_dev_archive_clusterhq.com
+
   upload_new_docs_html_to_s3_staging_docs: &upload_new_docs_html_to_s3_staging_docs |
     # uploads the new generated html to a folder on the S3 staging-docs bucket
     cd _build/html
-    aws s3 sync . s3://clusterhq-staging-docs/\$TRIGGERED_BRANCH
+    aws --region us-west-2 s3 sync . s3://clusterhq-staging-docs/\$TRIGGERED_BRANCH
     echo "This branch is available at :"
     echo "http://clusterhq-staging-docs.s3.amazonaws.com/\$TRIGGERED_BRANCH/index.html"
+
+  upload_vagrant_tutorial_basebox_to_s3: &upload_vagrant_tutorial_basebox_to_s3 |
+    # uploads the generated vagrant box to a folder on the S3
+    # clusterhq-dev-archive bucket.
+    FLOCKER_TUTORIAL=flocker-tutorial-\${FLOCKER_VERSION}
+    BOX_NAME=\${FLOCKER_TUTORIAL}.box
+    BOX_PATH=vagrant/tutorial
+    SHA1=\$( sha1sum \${BOX_NAME} | cut -f 1 -d " " )
+    HTTP_BOX_URL=http://\${S3_BUCKET}.s3.amazonaws.com/\${BOX_PATH}/\${BOX_NAME}
+
+    # the JSON metadata for our box is flocker-tutorial.version.box.json
+    HTTP_BOX_JSON=http://\${S3_BUCKET}.s3.amazonaws.com/\${BOX_PATH}/\${BOX_NAME}.json
+
+    # the JSON url below is what the vagrant file will consume
+    HTTP_BOX_JSON_LATEST=http://\${S3_BUCKET}.s3.amazonaws.com/\${BOX_PATH}/metadata.json
+
+    # vagrant doesn't support fully semantic versioning, numbering must be x.y.z
+    # https://github.com/mitchellh/vagrant/issues/6052
+    VAGRANT_BOX_VERSION="\$( echo \${FLOCKER_VERSION} | cut -f 1,2,3 -d "." )"
+
+    cd \$BOX_PATH
+    # generates the metadata.json, it used by vagrant box update operations.
+    cat <<EOF_METADATA > metadata.json
+    {
+      "name": "clusterhq/flocker-tutorial",
+      "description": "This box contains the flocker-tutorial VM.",
+      "versions": [{
+        "version": "\${VAGRANT_BOX_VERSION}",
+        "providers": [{
+          "name": "virtualbox",
+          "url": "\${HTTP_BOX_URL}",
+          "checksum_type": "sha1",
+          "checksum": "\${SHA1}"
+        }]
+      }]
+    }
+    EOF_METADATA
+
+    cp metadata.json \${BOX_NAME}.json
+
+    # uploads the vagrant box and metadata files to S3
+    # We won't overwrite the json metadata files if the upload of the box
+    # failed
+    box_files="\${BOX_NAME} \${BOX_NAME}.json metadata.json"
+    (
+      s3_upload \
+        \${S3_BUCKET}/\${BOX_PATH}/ "\${BOX_NAME}" && \
+      s3_upload \
+        \${S3_BUCKET}/\${BOX_PATH}/ "\${BOX_NAME}.json" && \
+      s3_upload \
+        \${S3_BUCKET}/\${BOX_PATH}/ "metadata.json"
+    ) ||  abort_build
+
+    cd -
+    echo "This vagrant box is available at : \${HTTP_BOX_JSON_LATEST}"
+
+  upload_vagrant_basebox_osx_yosemite_to_s3: &upload_vagrant_basebox_osx_yosemite_to_s3 |
+    # uploads the generated vagrant box to a folder on the S3
+    # clusterhq-vagrant-jenkins-boxes bucket.
+    BOX_NAME="jenkins-osx-yosemite-\${FLOCKER_VERSION}.box"
+    SHA1=\$( sha1sum \${BOX_NAME} | cut -f 1 -d " " )
+
+    S3_BOX_URL=s3://\${S3_BUCKET}/\${BOX_NAME}
+
+    # the JSON metadata for our box is jenkins-osx-yosemite-version.box.json
+    S3_BOX_JSON=s3://\${S3_BUCKET}/\${BOX_PATH}/\${BOX_NAME}.json
+
+    # the JSON url below is what the vagrant file will consume
+    S3_BOX_JSON_LATEST=s3://\${S3_BUCKET}/\${BOX_PATH}/metadata.json
+
+    # vagrant doesn't support fully semantic versioning, numbering must be x.y.z
+    # https://github.com/mitchellh/vagrant/issues/6052
+    VAGRANT_BOX_VERSION="\$( date +%s).0.0"
+
+    # generates the metadata.json, it used by vagrant box update operations.
+    create_vagrant_metadata_file \
+      metadata.json \
+      clusterhq/jenkins-osx-yosemite \
+      'This box contains the OSX box used for the client tests.' \
+      \${VAGRANT_BOX_VERSION} \
+      \${S3_BOX_URL} \
+      \${SHA1}
+
+    cp metadata.json \${BOX_NAME}.json
+
+    # uploads the vagrant box and metadata.json files
+    # We won't overwrite the json metadata files if the upload of the box
+    # failed
+    (
+      s3_upload \${S3_BUCKET} "\${BOX_NAME}" &&  \
+      s3_upload \${S3_BUCKET} "\${BOX_NAME}.json" &&  \
+      s3_upload \${S3_BUCKET} "metadata.json"
+    ) || abort_build
+
+    echo "This vagrant box is available is available at :"
+    echo "\${S3_BOX_JSON_LATEST}"
+
 
   run_lint: &run_lint |
     # we need to unset PIP_INDEX_URL since it causes tox to fail.
@@ -711,7 +939,7 @@ common_cli:
 
   install_flake8: &install_flake8 |
     # flake8 is used by lint tests on Flocker source code
-    \${PARSE_LOGS} pip install flake8 \${PIP_ADDITIONAL_OPTIONS}
+    pip install flake8 \${PIP_ADDITIONAL_OPTIONS}
 
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point
@@ -1110,12 +1338,11 @@ job_type:
       clean_repo: true
       timeout: 30
     run_client_installation_on_OSX:
-      on_nodes_with_labels: 'mesos-1GB'
+      on_nodes_with_labels: 'mesos-4GB'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,
                    *add_shell_functions,
-                   *new_vagrantfile_for_osx_yosemite,
 
                    *begin_build_sh_EOF,
                    *hashbang,
@@ -1125,7 +1352,7 @@ job_type:
                    *setup_venv,
                    *setup_flocker_modules,
                    'export DISTRIBUTION_NAME=OSX',
-                   *source_extra_vars,
+                   *source_git_commit,
                    *check_version,
                    *build_sdist,
                    *build_homebrew_package,
@@ -1135,10 +1362,12 @@ job_type:
                    '# Execution starts here:',
                    *set_home_variable_on_mesos,
                    *do_not_abort_on_errors,
-                   'vagrant up',
-                   *copy_files_to_osx_yosemite_box,
+                   *get_s3_creds_for_bucket_vagrant_jenkins_boxes,
+                   *new_vagrantfile_for_osx_yosemite,
+                   'vagrant_box_update',
+                   'vagrant_up',
                    *run_build_sh_script_on_vagrant_box,
-                   *destroy_vagrant_box]
+                   'vagrant_destroy']
           }
       clean_repo: false
       # FLOC-3597: Importing base box 'jenkins-osx-yosemite' step can
@@ -1199,7 +1428,7 @@ job_type:
       timeout: 30
     build_vagrant_basebox_for_flocker_tutorial:
       at: '0 4 * * *'
-      on_nodes_with_labels: 'mesos-512MB'
+      on_nodes_with_labels: 'mesos-2GB'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions, *setup_pip_cache,
@@ -1210,26 +1439,59 @@ job_type:
                    *build_repo_metadata,
                    'export HOME=/root',
                    *build_vagrant_tutorial_basebox,
-                   *clean_packages
+
+                   # upload this new vagrant box to S3
+                   *install_aws_cli,
+                   *get_s3_creds_for_clusterhq_dev_archive,
+                   *upload_vagrant_tutorial_basebox_to_s3,
+                   *clean_packages,
+                   'vagrant_destroy'
                 ]
           }
       timeout: 60
     build_vagrant_basebox_for_osx_yosemite:
       at: '0 5 * * *'
-      on_nodes_with_labels: 'mesos-1GB'
+      on_nodes_with_labels: 'mesos-2GB'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang,
                    *add_shell_functions,
                    *set_home_variable_on_mesos,
                    *do_not_abort_on_errors,
-                   *start_vanilla_osx_yosemite_vagrant_box,
+
+                   # we create a build.sh script which will be used to
+                   # provision the OSX machine.
+                   # it installs XCode command line tools and other required
+                   # packages.
                    *begin_build_sh_EOF,
+                   *add_shell_functions,
                    *install_pkgs_on_vanilla_osx_yosemite_box,
                    *end_build_sh_EOF,
-                   *copy_files_to_osx_yosemite_box,
+
+                  # starts and provisions an OSX vagrant machine
+                  # using the build.sh script created above
+                   *start_vanilla_osx_yosemite_vagrant_box,
                    *run_build_sh_script_on_vagrant_box,
-                   *package_jenkins_osx_yosemite_box ]
+
+                   # packages the vagrant box so that we can upload it to S3
+                   # we need to install pip and flocker deps, as we need
+                   # to find out the Flocker version
+                   *setup_pip_cache,
+                   *cleanup,
+                   *setup_venv,
+                   *setup_flocker_modules,
+                   *check_version,
+                   *package_jenkins_osx_yosemite_box,
+
+                   # upload this new vagrant box to S3
+                   *install_aws_cli,
+                   *get_s3_creds_for_bucket_vagrant_jenkins_boxes,
+                   *upload_vagrant_basebox_osx_yosemite_to_s3,
+
+                   # cleanup
+                   *clean_packages,
+                   'vagrant_destroy'
+            ]
           }
       timeout: 120
 

--- a/build.yaml
+++ b/build.yaml
@@ -655,7 +655,7 @@ common_cli:
   build_vagrant_tutorial_basebox: &build_vagrant_tutorial_basebox |
     vagrant destroy -f
     (
-      retry_n_times_with_timeout 3 1800 \
+      retry_n_times_with_timeout 3 2400 \
         \$venv/bin/python admin/build-vagrant-box \
           --box tutorial \
           --branch \${TRIGGERED_BRANCH} \

--- a/build.yaml
+++ b/build.yaml
@@ -798,7 +798,7 @@ common_cli:
     EOF_VAGRANTFILE
 
     (
-      retry_n_times_with_timeout 3 600 \
+      retry_n_times_with_timeout 3 1200 \
         vagrant up
     ) || abort_build
 

--- a/vagrant/dev/Vagrantfile
+++ b/vagrant/dev/Vagrantfile
@@ -34,7 +34,7 @@ unless Vagrant.has_plugin?("vagrant-vbguest")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "box-cutter/centos70"
+  config.vm.box = "box-cutter/centos71"
   # Update kernel and start to configure base system
   config.vm.provision :shell, :path => "bootstrap.sh", :privileged => true
   config.vm.provision :reload

--- a/vagrant/tutorial/Vagrantfile
+++ b/vagrant/tutorial/Vagrantfile
@@ -11,7 +11,14 @@ unless Vagrant.has_plugin?('vagrant-reload')
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'box-cutter/centos70'
+
+  config.vm.provider :virtualbox do |vb|
+    # VirtualBox 5 now supports paravirtualization
+    vb.customize("pre-boot", ["modifyvm", :id, "--paravirtprovider", "KVM"])
+    vb.customize [ "modifyvm", :id, "--memory", "1024" ]
+  end
+
+  config.vm.box = 'box-cutter/centos71'
   # Copy credential files
   config.vm.provision :file,
                       source: 'credentials',


### PR DESCRIPTION
* unsets 'set -x' so that we won't leak secrets to the logs
* removes a chunk of dead code (parse_logs)
* adds a retry function, to retry the most common failures with the vagrant build jobs
* adds a few helper functions for the vagrant operations
* fixes some issues where the vagrant boxes would run out of mem
* updates the vagrant box to use centos 7.1 and not spend too much time updating the OS
* OSX client tests will now pull the latest OSX box from S3
* OSX and tutorial will now upload the nightly built box to S3


This PR will make sure our vagrant builds will upload the resulting arfifacts to a bucket in S3.
This will allows us to grown our mesos cluster and remove a dependency where the OSX client instalation tests would fail if the OSX vagrant basebox hadn't been built yet. This so far worked as our mesos cluster is a single box, as we move to multiple boxes the client tests would fail as the OSX basebox wasn't available locally on the host.
The client tests now will pull the latest box from S3 through a 'vagrant box update'