### PR TITLE
[FLOC-3733] Serialize non-inspectable callables for loop_until logging

### DIFF
--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -43,6 +43,16 @@ def function_serializer(function):
         return {
             "function": str(function),
         }
+    except TypeError:
+        # Callable not supported by inspect module
+        if isinstance(function, partial):
+            return {
+                'partial': function_serializer(function.func)
+            }
+        else:
+            return {
+                "function": str(function),
+            }
 
 
 class LoopExceeded(Exception):

--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -44,7 +44,7 @@ def function_serializer(function):
             "function": str(function),
         }
     except TypeError:
-        # Callable not supported by inspect module
+        # Callable not supported by inspect.getfile
         if isinstance(function, partial):
             return {
                 'partial': function_serializer(function.func)

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -211,7 +211,7 @@ class LoopUntilTests(SynchronousTestCase):
             self.successResultOf(d),
             result)
 
-        action = LoggedAction.of_type(logger.messages, LOOP_UNTIL_ACTION)[0]
+        [action] = LoggedAction.of_type(logger.messages, LOOP_UNTIL_ACTION)
         assertContainsFields(self, action.start_message, {
             'predicate': predicate,
         })


### PR DESCRIPTION
Passing a `functools.partial` to `loop_until` fails to serialize correctly.

Add an extra exception clause to the `function_serializer` function to handle callables that are rejected by the `inspect` module functions.  In particular, handle `partial` usefully by adding the details of the wrapped function.

Although it would be possible, I have not included the partial's arguments in the logging, as they may cause further serialization problems or expose sensitive information.