### PR TITLE
[FLOC-3483] Make sure all @flaky tests are retried

### DIFF
--- a/flocker/ca/functional/test_ca.py
+++ b/flocker/ca/functional/test_ca.py
@@ -84,6 +84,7 @@ class FlockerCATests(make_script_tests(EXECUTABLE)):
         """
         Create a root certificate for the test.
         """
+        super(FlockerCATests, self).setUp()
         self.temp_path = FilePath(self.mktemp())
         self.temp_path.makedirs()
         flocker_ca(b"initialize", b"mycluster", cwd=self.temp_path.path)

--- a/flocker/common/functional/test_era.py
+++ b/flocker/common/functional/test_era.py
@@ -23,7 +23,7 @@ class FlockerNodeEraTests(make_script_tests(EXECUTABLE)):
     @skipUnless(which(EXECUTABLE), EXECUTABLE + " not installed")
     @skipUnless(platform.isLinux(), "flocker-node-era only works on Linux")
     def setUp(self):
-        pass
+        super(FlockerNodeEraTests, self).setUp()
 
     def test_output(self):
         """

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -19,6 +19,8 @@ from zope.interface import implementer, Interface, provider
 
 from pyrsistent import PClass, field, pmap_field, pset_field, thaw
 
+from characteristic import with_cmp
+
 from twisted.python.reflect import safe_repr
 from twisted.internet.defer import succeed, fail
 from twisted.python.filepath import FilePath
@@ -433,6 +435,7 @@ def _volume_field():
     )
 
 
+@with_cmp(["blockdevice_id", "dataset_id", "size", "attached_to"])
 class BlockDeviceVolume(PClass):
     """
     A block device that may be attached to a host.

--- a/flocker/node/agents/test/strategies.py
+++ b/flocker/node/agents/test/strategies.py
@@ -1,0 +1,26 @@
+# Copyright ClusterHQ Ltd.  See LICENSE file for details.
+
+"""
+Hypothesis strategies for testing ``flocker.node.agents``.
+"""
+
+from sys import maxint
+
+from hypothesis.strategies import (
+    builds,
+    integers,
+    none,
+    text,
+    uuids,
+)
+
+from ..blockdevice import BlockDeviceVolume
+
+blockdevice_volumes = builds(
+    BlockDeviceVolume,
+    blockdevice_id=text(),
+    # XXX: Probably should be positive integers
+    size=integers(max_value=maxint),
+    attached_to=text() | none(),
+    dataset_id=uuids(),
+)

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -39,7 +39,7 @@ from twisted.internet.defer import succeed
 from twisted.python.components import proxyForInterface
 from twisted.python.runtime import platform
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SynchronousTestCase, SkipTest, TestCase
+from twisted.trial.unittest import SynchronousTestCase, SkipTest
 
 from eliot import start_action, write_traceback, Message, Logger
 from eliot.testing import (
@@ -103,6 +103,7 @@ from ...testtools import (
 )
 from ....testtools import (
     REALISTIC_BLOCKDEVICE_SIZE, run_process, make_with_init_tests, random_name,
+    AsyncTestCase, TestCase,
 )
 from ....control import (
     Dataset, Manifestation, Node, NodeState, Deployment, DeploymentState,
@@ -3627,8 +3628,9 @@ def make_iblockdeviceapi_tests(
     :returns: A ``TestCase`` with tests that will be performed on the
        supplied ``IBlockDeviceAPI`` provider.
     """
-    class Tests(IBlockDeviceAPITestsMixin, SynchronousTestCase):
+    class Tests(IBlockDeviceAPITestsMixin, TestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.api = blockdevice_api_factory(test_case=self)
             self.unknown_blockdevice_id = unknown_blockdevice_id_factory(self)
             check_allocatable_size(
@@ -3711,6 +3713,7 @@ def make_iblockdeviceasyncapi_tests(blockdeviceasync_api_factory):
     """
     class Tests(IBlockDeviceAsyncAPITestsMixin, SynchronousTestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.api = blockdeviceasync_api_factory(test_case=self)
 
     return Tests
@@ -5276,8 +5279,9 @@ def make_icloudapi_tests(
     :returns: A ``TestCase`` with tests that will be performed on the
        supplied ``IBlockDeviceAPI``/``ICloudAPI`` provider.
     """
-    class Tests(TestCase):
+    class Tests(AsyncTestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.api = blockdevice_api_factory(test_case=self)
             self.this_node = self.api.compute_instance_id()
             self.async_cloud_api = _SyncToThreadedAsyncCloudAPIAdapter(

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -34,6 +34,8 @@ from hypothesis.strategies import (
     dictionaries
 )
 
+from testtools.matchers import Equals
+
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
 from twisted.python.components import proxyForInterface
@@ -46,6 +48,8 @@ from eliot.testing import (
     validate_logging, capture_logging,
     LoggedAction, assertHasMessage, assertHasAction
 )
+
+from .strategies import blockdevice_volumes
 
 from .. import blockdevice
 from ...test.istatechange import make_istatechange_tests
@@ -5303,3 +5307,27 @@ def make_icloudapi_tests(
                           self.assertIn(self.api.compute_instance_id(), live))
             return d
     return Tests
+
+
+class BlockDeviceVolumeTests(TestCase):
+    """
+    Tests for ``BlockDeviceVolume``.
+    """
+
+    @given(blockdevice_volumes, blockdevice_volumes)
+    def test_stable_sort_order(self, one, another):
+        """
+        Instances of ``BlockDeviceVolume`` sort in the same order as a tuple
+        made up of the ``blockdevice_id``, ``dataset_id``, ``size``, and
+        ``attached_to`` fields would sort.
+        """
+        self.assertThat(
+            sorted([one, another]),
+            Equals(sorted(
+                [one, another],
+                key=lambda volume: (
+                    volume.blockdevice_id, volume.dataset_id,
+                    volume.size, volume.attached_to
+                ),
+            ))
+        )

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -11,7 +11,6 @@ from pyrsistent import pmap, pvector, pset
 from eliot import Message
 
 from twisted.internet import reactor
-from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
 
 from .. import (
@@ -25,7 +24,9 @@ from ...control._model import (
 from .._docker import DockerClient
 from ..testtools import wait_for_unit_state, if_docker_configured
 from ...testtools import (
-    random_name, DockerImageBuilder, assertContainsAll, flaky)
+    random_name, DockerImageBuilder, assertContainsAll, flaky,
+    AsyncTestCase,
+)
 from ...volume.testtools import create_volume_service
 from ...route import make_memory_network
 from .. import run_state_change
@@ -129,10 +130,11 @@ def find_unit(units, unit_name):
             return unit
 
 
-class DeployerTests(TestCase):
+class DeployerTests(AsyncTestCase):
     """
     Functional tests for ``Deployer``.
     """
+
     @if_docker_configured
     def test_environment(self):
         """

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -64,7 +64,7 @@ class IDockerClientTests(make_idockerclient_tests(
     """
     @if_docker_configured
     def setUp(self):
-        pass
+        super(IDockerClientTests, self).setUp()
 
 
 class IDockerClientNamespacedTests(make_idockerclient_tests(
@@ -77,7 +77,7 @@ class IDockerClientNamespacedTests(make_idockerclient_tests(
     """
     @if_docker_configured
     def setUp(self):
-        pass
+        super(IDockerClientNamespacedTests, self).setUp()
 
     @flaky([u'FLOC-2628', u'FLOC-2874'])
     def test_added_is_listed(self):

--- a/flocker/node/test/test_docker.py
+++ b/flocker/node/test/test_docker.py
@@ -10,10 +10,11 @@ from pyrsistent import pset, pvector
 
 from docker.errors import APIError
 
-from twisted.trial.unittest import TestCase
 from twisted.python.filepath import FilePath
 
-from ...testtools import random_name, make_with_init_tests
+from ...testtools import (
+    AsyncTestCase, TestCase, random_name, make_with_init_tests,
+)
 from ..testtools import add_with_port_collision_retry
 
 from .._docker import (
@@ -39,7 +40,7 @@ def make_idockerclient_tests(fixture):
     :param fixture: A fixture that returns a :class:`IDockerClient`
         provider.
     """
-    class IDockerClientTests(TestCase):
+    class IDockerClientTests(AsyncTestCase):
         """
         Tests for :class:`IDockerClientTests`.
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -7,7 +7,6 @@ Base classes for unit tests.
 from datetime import timedelta
 from itertools import tee
 import json
-import sys
 import tempfile
 
 from eliot.prettyprint import pretty_format

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -55,10 +55,26 @@ class _MktempMixin(object):
         return make_temporary_directory(self).child('temp').path
 
 
+def _retry_runner(runner_factory, flaky_output=None):
+    """
+    Take a standard testtools RunFactory and make it retry @flaky tests.
+
+    :param runner_factory: A RunTest factory.
+    :param file flaky_output: A file-like object to which we'll send output
+        about flaky tests. This is a temporary measure until we fix FLOC-3469,
+        at which point we will just use standard logging.
+    """
+    if flaky_output is None:
+        flaky_output = sys.stdout
+    return retry_flaky(runner_factory, output=flaky_output)
+
+
 class TestCase(testtools.TestCase, _MktempMixin):
     """
     Base class for synchronous test cases.
     """
+
+    run_tests_with = _retry_runner(testtools.RunTest)
 
     def __init__(self, *args, **kwargs):
         super(TestCase, self).__init__(*args, **kwargs)
@@ -80,20 +96,16 @@ def async_runner(timeout, flaky_output=None):
         about flaky tests. This is a temporary measure until we fix FLOC-3469,
         at which point we will just use standard logging.
     """
-    if flaky_output is None:
-        flaky_output = sys.stdout
-    # XXX: Looks like the acceptance tests (which were the first tests that we
-    # tried to migrate) aren't cleaning up after themselves even in the
-    # successful case. Use AsynchronousDeferredRunTestForBrokenTwisted, which
-    # loops the reactor a couple of times after the test is done.
-    return retry_flaky(
-        AsynchronousDeferredRunTestForBrokenTwisted.make_factory(
-            timeout=timeout.total_seconds(),
-            suppress_twisted_logging=False,
-            store_twisted_logs=False,
-        ),
-        output=flaky_output,
+    # XXX: The acceptance tests (which were the first tests that we tried to
+    # migrate) aren't cleaning up after themselves even in the successful
+    # case. Use AsynchronousDeferredRunTestForBrokenTwisted, which loops the
+    # reactor a couple of times after the test is done.
+    async_factory = AsynchronousDeferredRunTestForBrokenTwisted.make_factory(
+        timeout=timeout.total_seconds(),
+        suppress_twisted_logging=False,
+        store_twisted_logs=False,
     )
+    return _retry_runner(async_factory, flaky_output)
 
 
 # By default, asynchronous tests are timed out after 2 minutes.

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -16,7 +16,7 @@ import testtools
 from testtools.content import Content, text_content
 from testtools.content_type import UTF8_TEXT
 from testtools.deferredruntest import (
-    AsynchronousDeferredRunTestForBrokenTwisted,
+    AsynchronousDeferredRunTestForBrokenTwisted, assert_fails_with,
 )
 
 try:
@@ -131,6 +131,15 @@ class AsyncTestCase(testtools.TestCase, _MktempMixin):
     def setUp(self):
         super(AsyncTestCase, self).setUp()
         self.useFixture(_SplitEliotLogs())
+
+    def assertFailure(self, deferred, exception):
+        """
+        ``twisted.trial.unittest.TestCase.assertFailure``-alike.
+
+        This is not completely compatible.  ``assert_fails_with`` should be
+        preferred for new code.
+        """
+        return assert_fails_with(deferred, exception)
 
 
 class _SplitEliotLogs(Fixture):

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -6,7 +6,6 @@ Logic for handling flaky tests.
 
 from functools import partial
 from pprint import pformat
-import sys
 
 from eliot import Message
 from pyrsistent import PClass, field, pmap, pset, pset_field
@@ -110,22 +109,17 @@ def _combine_flaky_annotation(flaky1, flaky2):
     )
 
 
-def retry_flaky(run_test_factory=None, output=None):
+def retry_flaky(run_test_factory=None):
     """
     Wrap a ``RunTest`` object so that flaky tests are retried.
 
     :param run_test_factory: A callable that takes a `TestCase` and returns
         something that behaves like `testtools.RunTest`.
-    :param file output: A file-like object to which we'll send output about
-        flaky tests. This is a temporary measure until we fix FLOC-3469, at
-        which point we will just use standard logging.
     """
     if run_test_factory is None:
         run_test_factory = testtools.RunTest
-    if output is None:
-        output = sys.stdout
 
-    return partial(_RetryFlaky, output, run_test_factory)
+    return partial(_RetryFlaky, run_test_factory)
 
 
 class _RetryFlaky(testtools.RunTest):
@@ -135,9 +129,8 @@ class _RetryFlaky(testtools.RunTest):
     # XXX: This should probably become a part of testtools:
     # https://bugs.launchpad.net/testtools/+bug/1515933
 
-    def __init__(self, output, run_test_factory, case, *args, **kwargs):
+    def __init__(self, run_test_factory, case, *args, **kwargs):
         super(_RetryFlaky, self).__init__(case)
-        self._output = output
         self._run_test_factory = run_test_factory
         self._case = case
         self._args = args

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -8,6 +8,7 @@ from functools import partial
 from pprint import pformat
 import sys
 
+from eliot import Message
 from pyrsistent import PClass, field, pmap, pset, pset_field
 import testtools
 from testtools.content import text_content
@@ -212,13 +213,14 @@ class _RetryFlaky(testtools.RunTest):
                     skip_reported = True
 
             if not skip_reported:
-                self._output.write(
-                    '@flaky(%s): passed %d out of %d runs '
-                    '(min passes: %d; max runs: %d)'
-                    % (case.id(), successes, len(results), flaky.min_passes,
-                       flaky.max_runs)
-                )
-
+                Message.new(
+                    message_type=u"flocker:test:flaky",
+                    id=case.id(),
+                    successes=successes,
+                    passes=len(results),
+                    min_passes=flaky.min_passes,
+                    max_runs=flaky.max_runs,
+                ).write()
                 result.addSuccess(case, details=combined_details)
         else:
             # XXX: How are we going to report on tests that sometimes fail,

--- a/flocker/testtools/_testhelpers.py
+++ b/flocker/testtools/_testhelpers.py
@@ -6,6 +6,7 @@ Helpers for testing our test code.
 Only put stuff here that is specific to testing code about unit testing.
 """
 
+from hypothesis.strategies import sampled_from
 import unittest
 
 from testtools.matchers import (
@@ -13,6 +14,11 @@ from testtools.matchers import (
     Equals,
     MatchesStructure,
 )
+
+from ._base import AsyncTestCase, TestCase
+
+
+base_test_cases = sampled_from([AsyncTestCase, TestCase])
 
 
 def throw(exception):

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -13,8 +13,11 @@ import unittest
 from eliot import MessageType, fields
 from hypothesis import assume, given
 from hypothesis.strategies import binary, integers, lists, text
-from testtools import PlaceHolder, TestResult
+
+# Use testtools' TestCase for most of these tests so that bugs in our base test
+# case classes don't invalidate the tests for those classes.
 from testtools import TestCase as TesttoolsTestCase
+from testtools import PlaceHolder, TestResult
 from testtools.matchers import (
     AllMatch,
     AfterPreprocessing,

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -10,7 +10,7 @@ import unittest
 
 from eliot import MessageType, fields
 from hypothesis import assume, given
-from hypothesis.strategies import binary, integers, lists, sampled_from, text
+from hypothesis.strategies import binary, integers, lists, text
 from testtools import PlaceHolder, TestResult
 from testtools import TestCase as TesttoolsTestCase
 from testtools.matchers import (
@@ -37,8 +37,6 @@ from testtools.matchers import (
 from twisted.python.filepath import FilePath
 
 from .._base import (
-    AsyncTestCase,
-    TestCase,
     make_temporary_directory,
     _SplitEliotLogs,
     _get_eliot_data,
@@ -46,13 +44,11 @@ from .._base import (
     _path_for_test_id,
 )
 from .._testhelpers import (
+    base_test_cases,
     has_results,
     only_skips,
     run_test,
 )
-
-
-base_test_cases = sampled_from([AsyncTestCase, TestCase])
 
 
 class BaseTestCaseTests(TesttoolsTestCase):

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -149,7 +149,7 @@ class BaseTestCaseTests(TesttoolsTestCase):
             test.getDetails(),
             ContainsDict({
                 'twisted-log': match_text_content(MatchesRegex(
-                    r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{4} \[-\] foo$'
+                    r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{4} \[-\] foo$'
                 )),
             }))
 
@@ -173,7 +173,7 @@ class BaseTestCaseTests(TesttoolsTestCase):
             test.getDetails(),
             MatchesDict({
                 'twisted-log': match_text_content(MatchesRegex(
-                    r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{4} \[-\] foo$'
+                    r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{4} \[-\] foo$'
                 )),
                 _SplitEliotLogs._ELIOT_LOG_DETAIL_NAME: match_text_content(
                     Contains("  message_type: 'foo'\n"

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -11,7 +11,8 @@ import unittest
 from eliot import MessageType, fields
 from hypothesis import assume, given
 from hypothesis.strategies import binary, integers, lists, sampled_from, text
-from testtools import PlaceHolder, TestCase, TestResult
+from testtools import PlaceHolder, TestResult
+from testtools import TestCase as TesttoolsTestCase
 from testtools.matchers import (
     AllMatch,
     AfterPreprocessing,
@@ -37,6 +38,7 @@ from twisted.python.filepath import FilePath
 
 from .._base import (
     AsyncTestCase,
+    TestCase,
     make_temporary_directory,
     _SplitEliotLogs,
     _get_eliot_data,
@@ -50,10 +52,10 @@ from .._testhelpers import (
 )
 
 
-base_test_cases = sampled_from([AsyncTestCase])
+base_test_cases = sampled_from([AsyncTestCase, TestCase])
 
 
-class BaseTestCaseTests(TestCase):
+class BaseTestCaseTests(TesttoolsTestCase):
     """
     Tests for our base test cases.
     """
@@ -191,7 +193,7 @@ def match_text_content(matcher):
     return AfterPreprocessing(lambda content: content.as_text(), matcher)
 
 
-class IterLinesTests(TestCase):
+class IterLinesTests(TesttoolsTestCase):
     """
     Tests for ``_iter_lines``.
     """
@@ -226,7 +228,7 @@ class IterLinesTests(TestCase):
         self.assertThat(observed[-1], Not(EndsWith(separator)))
 
 
-class GetEliotDataTests(TestCase):
+class GetEliotDataTests(TesttoolsTestCase):
     """
     Tests for ``_get_eliot_data``.
     """
@@ -269,7 +271,7 @@ tests = lists(identifiers, min_size=3, average_size=5).map(
     lambda xs: PlaceHolder('.'.join(xs)))
 
 
-class MakeTemporaryTests(TestCase):
+class MakeTemporaryTests(TesttoolsTestCase):
     """
     Tests for code for making temporary files and directories for tests.
     """

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -1,3 +1,5 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
 """
 Tests for flocker base test cases.
 """

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -18,7 +18,6 @@ from hypothesis.strategies import (
 )
 import testtools
 from testtools.matchers import (
-    AfterPreprocessing,
     Contains,
     Equals,
     HasLength,

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -128,7 +128,7 @@ class FlakyTests(testtools.TestCase):
         A successful flaky test is considered successful.
         """
 
-        # We use 'unittest' here to avoid accidentally depending on Twisted
+        # We use 'testtools' here to avoid accidentally depending on Twisted
         # TestCase features, thus increasing complexity.
         class SomeTest(testtools.TestCase):
 

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -347,9 +347,9 @@ class FlakyIntegrationTests(testtools.TestCase):
 
         # We expect the result of the run to be that one test was run and that
         # it produced an error that includes a traceback with the strings
-        # "flaky:" (which comes from the flaky decorator) and
-        # "ZeroDivisionError" which describes the exception the test actually
-        # fails with.  Something like:
+        # "flaky:" (which comes from the flaky decorator, proving its effect)
+        # and "ZeroDivisionError" which describes the exception the test
+        # actually fails with.  Something like:
         #
         #  [(test, "error report including the two strings")]
         self.assertThat(

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -341,9 +341,17 @@ class FlakyIntegrationTests(testtools.TestCase):
         class ErroringTest(base_test_case):
             @flaky(jira_keys, max_runs, min_passes)
             def test_error(self):
-                1/0
+                1 / 0
 
         test = ErroringTest('test_error')
+
+        # We expect the result of the run to be that one test was run and that
+        # it produced an error that includes a traceback with the strings
+        # "flaky:" (which comes from the flaky decorator) and
+        # "ZeroDivisionError" which describes the exception the test actually
+        # fails with.  Something like:
+        #
+        #  [(test, "error report including the two strings")]
         self.assertThat(
             run_test(test),
             has_results(
@@ -351,12 +359,9 @@ class FlakyIntegrationTests(testtools.TestCase):
                 errors=MatchesListwise([
                     MatchesListwise([
                         Equals(test),
-                        AfterPreprocessing(
-                            str,
-                            MatchesAll(
-                                Contains('flaky:'),
-                                Contains('ZeroDivisionError'),
-                            ),
+                        MatchesAll(
+                            Contains('flaky:'),
+                            Contains('ZeroDivisionError'),
                         ),
                     ])
                 ]),

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -6,7 +6,6 @@ Tests for ``flocker.testtools._flaky``.
 
 from itertools import repeat
 from pprint import pformat
-from StringIO import StringIO
 import unittest
 
 from hypothesis import given

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -133,7 +133,7 @@ class FlakyTests(testtools.TestCase):
         # TestCase features, thus increasing complexity.
         class SomeTest(testtools.TestCase):
 
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             @flaky(u'FLOC-XXXX')
             def test_something(self):
@@ -153,7 +153,7 @@ class FlakyTests(testtools.TestCase):
 
         class SomeTest(testtools.TestCase):
 
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             @flaky(jira_keys, max_runs=max_runs, min_passes=min_passes)
             def test_something(self):
@@ -192,7 +192,7 @@ class FlakyTests(testtools.TestCase):
 
         class SomeTest(testtools.TestCase):
 
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             @flaky(u'FLOC-XXXX', max_runs=len(test_methods), min_passes=1)
             def test_something(self):
@@ -214,7 +214,7 @@ class FlakyTests(testtools.TestCase):
         executions = iter(test_methods)
 
         class SomeTest(testtools.TestCase):
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             @flaky(u'FLOC-XXXX', max_runs=len(test_methods), min_passes=2)
             def test_something(self):
@@ -240,7 +240,7 @@ class FlakyTests(testtools.TestCase):
         executions = iter(test_methods)
 
         class SomeTest(testtools.TestCase):
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             def test_something(self):
                 next(executions)()
@@ -265,7 +265,7 @@ class FlakyTests(testtools.TestCase):
         observed_reasons = []
 
         class SkippingTest(testtools.TestCase):
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             @flaky(jira_keys, max_runs, min_passes)
             def test_skip(self):
@@ -287,7 +287,7 @@ class FlakyTests(testtools.TestCase):
         log = []
 
         class FlakyTest(testtools.TestCase):
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             @flaky(jira_keys, 1, 1)
             def test_delayed(self):
@@ -320,7 +320,7 @@ class FlakyIntegrationTests(testtools.TestCase):
         observed_reasons = []
 
         class SkippingTest(base_test_case):
-            run_tests_with = retry_flaky(output=StringIO())
+            run_tests_with = retry_flaky()
 
             @flaky(jira_keys, max_runs, min_passes)
             def test_skip(self):

--- a/flocker/testtools/test/test_flaky.py
+++ b/flocker/testtools/test/test_flaky.py
@@ -34,6 +34,7 @@ from .._flaky import (
     retry_flaky,
 )
 from .._testhelpers import (
+    base_test_cases,
     has_results,
     only_skips,
     run_test,
@@ -299,11 +300,15 @@ class FlakyTests(testtools.TestCase):
 
 
 class FlakyIntegrationTests(testtools.TestCase):
+    """
+    Tests that @flaky and retry_flaky interact well with our standard base
+    test cases.
+    """
 
-    @given(jira_keys, num_runs, num_runs,
+    @given(base_test_cases, jira_keys, num_runs, num_runs,
            streaming(text(average_size=10)).map(iter))
-    def test_flaky_skipped_test(self, jira_keys, max_runs, min_passes,
-                                reasons):
+    def test_flaky_skipped_test(self, base_test_case, jira_keys, max_runs,
+                                min_passes, reasons):
         """
         If a test is skipped and also marked @flaky, we report it as skipped.
 
@@ -313,7 +318,7 @@ class FlakyIntegrationTests(testtools.TestCase):
         [min_passes, max_runs] = sorted([min_passes, max_runs])
         observed_reasons = []
 
-        class SkippingTest(AsyncTestCase):
+        class SkippingTest(base_test_case):
             run_tests_with = retry_flaky(output=StringIO())
 
             @flaky(jira_keys, max_runs, min_passes)

--- a/flocker/volume/functional/test_service.py
+++ b/flocker/volume/functional/test_service.py
@@ -4,14 +4,12 @@
 
 from __future__ import absolute_import
 
-from twisted.trial.unittest import TestCase
-
 from ..service import VolumeName
 from ..testtools import create_realistic_servicepair
-from ...testtools import flaky
+from ...testtools import AsyncTestCase, flaky
 
 
-class RealisticTests(TestCase):
+class RealisticTests(AsyncTestCase):
     """
     Tests for realistic scenarios, used to catch integration issues.
     """


### PR DESCRIPTION
We had the `@flaky` decorator on a bunch of tests that weren't being retried, because that requires a base `TestCase` that does the retries and we wanted to fix some regression (esp. re logging) before we spread the new base TestCases around the flocker code base.

Now that the regressions are fixed, we want to start retrying everything decorated with `@flaky`. This is it.

The guts of the change are:

* Change `flocker.testtools.TestCase` to inherit from [testtools](https://testtools.rtfd.org) `TestCase`
* Share compatibility code written to work with `AsyncTestCase` to also work with `TestCase`, and update tests
* Update tests for `@flaky` retries to operate on standard `testtools.TestCase`.
* Fix ordering issue in blockdevice tests that arose out of differences in implementation in `assertItemsEqual`
* Add `assertFailure` compatibility helper w/ tests
* Removed the temporary logging code and replace it with Eliot logs (printing to stdout caused some failures in Jenkins due to subunit parsing issues)
* Update tests to use the new base test cases