### PR TITLE
[FLOC-3712] Make flocker-control serve the right service on the right port

### DIFF
--- a/admin/package-files/systemd/flocker-control-agent.socket
+++ b/admin/package-files/systemd/flocker-control-agent.socket
@@ -1,9 +1,0 @@
-[Unit]
-Description=Flocker Control Agent Socket
-
-[Socket]
-ListenStream=4524
-Service=flocker-control.service
-
-[Install]
-WantedBy=sockets.target

--- a/admin/package-files/systemd/flocker-control-api.socket
+++ b/admin/package-files/systemd/flocker-control-api.socket
@@ -1,9 +1,0 @@
-[Unit]
-Description=Flocker Control REST API
-
-[Socket]
-ListenStream=4523
-Service=flocker-control.service
-
-[Install]
-WantedBy=sockets.target

--- a/admin/package-files/systemd/flocker-control.service
+++ b/admin/package-files/systemd/flocker-control.service
@@ -2,9 +2,7 @@
 Description=Flocker Control Service
 
 [Service]
-ExecStart=/usr/sbin/flocker-control -p systemd:INET:0 -a systemd:INET:1 --journald
-Sockets=flocker-control-api.socket flocker-control-agent.socket
-NonBlocking=true
+ExecStart=/usr/sbin/flocker-control --port tcp:4523 --agent-port tcp:4524 --journald
 Restart=always
 
 PrivateTmp=true

--- a/admin/package-files/systemd/flocker-control.service
+++ b/admin/package-files/systemd/flocker-control.service
@@ -7,7 +7,6 @@ Restart=always
 
 PrivateTmp=true
 PrivateDev=true
-PrivateNetwork=true
 ProtectSystem=true
 ProtectHome=true
 ReadonlyDirectories=/

--- a/admin/package-files/upstart/flocker-control.conf
+++ b/admin/package-files/upstart/flocker-control.conf
@@ -10,4 +10,4 @@ env agent_port=4524
 respawn
 
 # Start the process
-exec /usr/sbin/flocker-control -p tcp:$api_port -a tcp:$agent_port --logfile=/var/log/flocker/flocker-control.log
+exec /usr/sbin/flocker-control --port tcp:$api_port --agent-port tcp:$agent_port --logfile=/var/log/flocker/flocker-control.log


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3712

This removes flocker-control socket activation.  The systemd documentation suggests that the way Twisted's systemd socket inheritance feature works makes it unreliable to use that feature to heterogeneous service configuration.

(discovered and fixed while pairing with @jml)