### PR TITLE
[FLOC-3665] run-acceptance-tests: make cluster clean up more robust

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -1176,16 +1176,15 @@ def main(reactor, args, base_path, top_level):
 
     setup_succeeded = False
     reached_finally = False
-    stop_cluster = True
 
     def cluster_cleanup():
         if not reached_finally:
             print "interrupted..."
-        if stop_cluster:
-            print "stopping cluster"
-            return runner.stop_cluster(reactor)
+        print "stopping cluster"
+        return runner.stop_cluster(reactor)
 
-    reactor.addSystemEventTrigger('before', 'shutdown', cluster_cleanup)
+    cleanup_trigger_id = reactor.addSystemEventTrigger('before', 'shutdown',
+                                                       cluster_cleanup)
 
     try:
         yield runner.ensure_keys(reactor)
@@ -1247,6 +1246,6 @@ def main(reactor, args, base_path, top_level):
                     value=shell_quote(
                         environment_variables[environment_variable]),
                 )
-            stop_cluster = False
+            reactor.removeSystemEventTrigger(cleanup_trigger_id)
 
     raise SystemExit(result)

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -1222,9 +1222,7 @@ def main(reactor, args, base_path, top_level):
             reactor=reactor,
             cluster=cluster,
             trial_args=options['trial-args'])
-    except:
-        result = 1
-        raise
+
     finally:
         reached_finally = True
         # We delete the nodes if the user hasn't asked to keep them

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -1236,7 +1236,6 @@ def main(reactor, args, base_path, top_level):
             print "not keeping cluster"
         else:
             print "--keep specified, not destroying nodes."
-            assert cluster is not None
             print ("To run acceptance tests against these nodes, "
                    "set the following environment variables: ")
 


### PR DESCRIPTION
Because main() is decorated with @inlineCallbacks there is no guarantee
that the control flow always returns to it after a yield statement.
In particular, that's the case if the reactor is stopped.
And that could happen, for instance, if a user presses Ctrl-C because
twisted installs a SIGINT handler which stops the reactor.

Thus, to improve the chances of the cluster clean-up being executed
the clean-up code is moved to a before-shutdown system event trigger.

Also, we now destroy the cluster if we couldn't finish its setup
even if --keep option is set.