### PR TITLE
[FLOC-3706]  place a 30 second timeout on a secureConnection() attempt 

### DIFF
--- a/flocker/provision/_ssh/_conch.py
+++ b/flocker/provision/_ssh/_conch.py
@@ -68,7 +68,6 @@ class CommandProtocol(LineOnlyReceiver, object):
     delimiter = b'\n'
 
     def connectionMade(self):
-        from functools import partial
         self.transport.disconnecting = False
         # SSHCommandClientEndpoint doesn't support capturing stderr.
         # We patch the SSHChannel to interleave it.

--- a/flocker/provision/_ssh/_conch.py
+++ b/flocker/provision/_ssh/_conch.py
@@ -30,7 +30,7 @@ from twisted.protocols.basic import LineOnlyReceiver
 from twisted.python.filepath import FilePath
 import os
 
-from ...common import loop_until
+from ...common import loop_until, timeout
 from ._model import (
     Run, Sudo, Put, Comment, RunRemotely, perform_comment, perform_put,
     perform_sudo)
@@ -154,6 +154,7 @@ def perform_run_remotely(reactor, base_dispatcher, intent):
     def connect():
         connection = connection_helper.secureConnection()
         connection.addErrback(write_failure)
+        timeout(reactor, connection, 30)
         return connection
 
     connection = yield loop_until(reactor, connect)

--- a/flocker/provision/_ssh/_conch.py
+++ b/flocker/provision/_ssh/_conch.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from functools import partial
 from characteristic import attributes
 
-from eliot import Message, MessageType, Field
+from eliot import write_failure, Message, MessageType, Field
 
 from effect import TypeDispatcher, ComposedDispatcher
 from txeffect import (
@@ -153,7 +153,7 @@ def perform_run_remotely(reactor, base_dispatcher, intent):
 
     def connect():
         connection = connection_helper.secureConnection()
-        connection.addErrback(lambda _: False)
+        connection.addErrback(write_failure)
         return connection
 
     connection = yield loop_until(reactor, connect)


### PR DESCRIPTION
I've observed an ssh connection getting indefinitely stuck here.

Plus a couple of small improvements in the nearby code.