### PR TITLE
[FLOC 3622] add a list of the backends that support profiles

### DIFF
--- a/docs/concepts/storage-profiles.rst
+++ b/docs/concepts/storage-profiles.rst
@@ -22,7 +22,12 @@ Flocker Storage Profiles require support from your storage driver, and you are a
 Please be aware that the actual specification of these profiles may differ between each storage provider.
 The definition for each profile should be documented in the storage providers documentation.
 
-Currently, only a selection of :ref:`backends supported by Flocker <supported-backends>` support Flocker Storage Profiles.
+Currently, the following community supported drivers support Flocker Storage Profiles:
+
+* :ref:`Dell SC Series <dell-dataset-backend>`
+* :ref:`ConvergeIO <convergeio-backend>`
+* :ref:`Hedvig <hedvig-backend>`
+
 More information about support for profiles can be found in the :ref:`configuration documentation for each backend <supported-backends>`.
 
 .. note::

--- a/docs/concepts/storage-profiles.rst
+++ b/docs/concepts/storage-profiles.rst
@@ -28,8 +28,6 @@ Currently, the following community supported drivers support Flocker Storage Pro
 * `ConvergeIO`_
 * `Hedvig`_
 
-More information about support for profiles can be found in the :ref:`configuration documentation for each backend <supported-backends>`.
-
 .. note::
 	Flocker Storage Profiles is a new Flocker feature, and we're hoping to iterate on the functionality in future releases.
 	If you use a Storage Profile, it would be great to :ref:`hear from you <talk-to-us>` about how it is being used and what features you would like to see in the future.
@@ -39,3 +37,5 @@ More information about support for profiles can be found in the :ref:`configurat
 .. _Hedvig: http://www.hedviginc.com/blog/flocker-storage-profiles-for-docker
 
 .. end-body
+
+More information about support for profiles can be found in the :ref:`configuration documentation for each backend <supported-backends>`.

--- a/docs/concepts/storage-profiles.rst
+++ b/docs/concepts/storage-profiles.rst
@@ -24,14 +24,18 @@ The definition for each profile should be documented in the storage providers do
 
 Currently, the following community supported drivers support Flocker Storage Profiles:
 
-* :ref:`Dell SC Series <dell-dataset-backend>`
-* :ref:`ConvergeIO <convergeio-backend>`
-* :ref:`Hedvig <hedvig-backend>`
+* `Dell SC Series`_
+* `ConvergeIO`_
+* `Hedvig`_
 
 More information about support for profiles can be found in the :ref:`configuration documentation for each backend <supported-backends>`.
 
 .. note::
 	Flocker Storage Profiles is a new Flocker feature, and we're hoping to iterate on the functionality in future releases.
 	If you use a Storage Profile, it would be great to :ref:`hear from you <talk-to-us>` about how it is being used and what features you would like to see in the future.
+
+.. _Dell SC Series: https://github.com/dellstorage/storagecenter-flocker-driver/blob/master/dell_storagecenter_driver/dell_storagecenter_blockdevice.py
+.. _ConvergeIO: https://github.com/ConvergeIO/cio-flocker-driver/blob/gh-pages/driver/cio.py#L133
+.. _Hedvig: http://www.hedviginc.com/blog/flocker-storage-profiles-for-docker
 
 .. end-body

--- a/docs/concepts/storage-profiles.rst
+++ b/docs/concepts/storage-profiles.rst
@@ -34,7 +34,7 @@ Currently, the following community supported drivers support Flocker Storage Pro
 
 .. _Dell SC Series: https://github.com/dellstorage/storagecenter-flocker-driver/blob/master/dell_storagecenter_driver/dell_storagecenter_blockdevice.py
 .. _ConvergeIO: https://github.com/ConvergeIO/cio-flocker-driver/blob/gh-pages/driver/cio.py#L133
-.. _Hedvig: http://www.hedviginc.com/blog/flocker-storage-profiles-for-docker
+.. _Hedvig: http://hedviginc.com/blog/flocker-storage-profiles-for-docker
 
 .. end-body
 

--- a/docs/config/convergeio-configuration.rst
+++ b/docs/config/convergeio-configuration.rst
@@ -8,6 +8,9 @@ ConvergeIO provides a plugin for Flocker integration with their storage solution
 
 For more information, visit the following GitHub repository: `ConvergeIO Flocker driver on GitHub`_
 
+ConvergeIO also support `Flocker Storage Profiles`_.
+
 .. XXX FLOC 2443 to expand this Backend storage section
 
 .. _ConvergeIO Flocker driver on GitHub: https://github.com/ConvergeIO/cio-flocker-driver
+.. _Flocker Storage Profiles: https://github.com/ConvergeIO/cio-flocker-driver/blob/gh-pages/driver/cio.py#L133

--- a/docs/config/dell-configuration.rst
+++ b/docs/config/dell-configuration.rst
@@ -8,5 +8,8 @@ Dell provides a plugin for Flocker integration with `SC Series`_ storage arrays.
 
 For more information and installation instructions, visit the following GitHub repository: `Dell Storage Center Flocker driver on GitHub`_
 
+Dell SC Series also support `Flocker Storage Profiles`_.
+
 .. _SC Series: http://www.dell.com/us/business/p/dell-compellent
 .. _Dell Storage Center Flocker driver on GitHub: https://github.com/dellstorage/storagecenter-flocker-driver
+.. _Flocker Storage Profiles: https://github.com/dellstorage/storagecenter-flocker-driver/blob/master/dell_storagecenter_driver/dell_storagecenter_blockdevice.py

--- a/docs/config/hedvig-configuration.rst
+++ b/docs/config/hedvig-configuration.rst
@@ -13,4 +13,4 @@ Hedvig also support `Flocker Storage Profiles`_.
 .. XXX FLOC 2443 to expand this Backend storage section
 
 .. _Hedvig Flocker driver on GitHub: https://github.com/hedvig/hedvig-flocker-driver
-.. _Flocker Storage Profiles: http://www.hedviginc.com/blog/flocker-storage-profiles-for-docker
+.. _Flocker Storage Profiles: http://hedviginc.com/blog/flocker-storage-profiles-for-docker

--- a/docs/config/hedvig-configuration.rst
+++ b/docs/config/hedvig-configuration.rst
@@ -8,6 +8,9 @@ Hedvig provides a plugin for Flocker integration with their storage solution, al
 
 For more information, visit the following GitHub repository: `Hedvig Flocker driver on GitHub`_
 
+Hedvig also support `Flocker Storage Profiles`_.
+
 .. XXX FLOC 2443 to expand this Backend storage section
 
 .. _Hedvig Flocker driver on GitHub: https://github.com/hedvig/hedvig-flocker-driver
+.. _Flocker Storage Profiles: http://www.hedviginc.com/blog/flocker-storage-profiles-for-docker


### PR DESCRIPTION
Fixes 3622

Note, this content appears on 2 pages:
config/configuring-nodes-storage
concepts/storage-profiles

the wording has been chosen so the content makes sense in both locations.