### PR TITLE
[FLOC-3668] Nightly cloud acceptance

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1150,7 +1150,7 @@ job_type:
           }
       timeout: 120
 
-    run_acceptance_on_AWS_CentOS_7_for:
+    run_acceptance_on_AWS_CentOS_7_with_EBS:
       at: '0 5 * * *'
       on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_steps:
@@ -1171,7 +1171,7 @@ job_type:
       archive_artifacts: *acceptance_tests_artifacts
       timeout: 45
 
-    run_acceptance_on_AWS_Ubuntu_Trusty_for:
+    run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS:
       at: '0 6 * * *'
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_steps:
@@ -1192,7 +1192,7 @@ job_type:
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
       timeout: 45
 
-    run_acceptance_on_Rackspace_CentOS_7_for:
+    run_acceptance_on_Rackspace_CentOS_7_with_Cinder:
       at: '0 5 * * *'
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS
@@ -1215,7 +1215,7 @@ job_type:
       archive_artifacts: *acceptance_tests_artifacts
       timeout: 45
 
-    run_acceptance_on_Rackspace_Ubuntu_Trusty_for:
+    run_acceptance_on_Rackspace_Ubuntu_Trusty_with_Cinder:
       at: '0 6 * * *'
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS

--- a/build.yaml
+++ b/build.yaml
@@ -950,90 +950,6 @@ job_type:
 
   # http://build.clusterhq.com/builders/flocker%2Facceptance%2Faws%2Fcentos-7%2Faws
   run_acceptance:
-    run_acceptance_on_AWS_CentOS_7_for:
-      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
-      with_modules: *run_acceptance_modules
-      with_steps:
-        - { type: 'shell',
-            cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
-                   *cleanup, *setup_venv, *setup_flocker_modules,
-                   'export DISTRIBUTION_NAME=centos-7',
-                   *setup_aws_env_vars, *check_version,
-                   *build_sdist, *build_package,
-                   *build_repo_metadata,
-                   *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
-                   *run_acceptance_aws_tests,
-                   *clean_packages,
-                   *exit_with_return_code_from_test ]
-          }
-      clean_repo: true
-      archive_artifacts: *acceptance_tests_artifacts
-      timeout: 45
-    run_acceptance_on_AWS_Ubuntu_Trusty_for:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
-      with_modules: *run_acceptance_modules
-      with_steps:
-        - { type: 'shell',
-            cli: [ *hashbang, *add_shell_functions, *setup_pip_cache,
-                   *cleanup, *setup_venv, *setup_flocker_modules,
-                   *setup_aws_env_vars, *check_version,
-                   'export DISTRIBUTION_NAME=ubuntu-14.04',
-                   *build_sdist, *build_package,
-                   *build_repo_metadata,
-                   *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
-                   *run_acceptance_aws_tests,
-                   *clean_packages,
-                   *exit_with_return_code_from_test ]
-          }
-      clean_repo: true
-      archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
-      timeout: 45
-    run_acceptance_on_Rackspace_CentOS_7_for:
-      # flocker.provision is responsible for creating the test nodes on
-      # Rackspace, so we can actually run run-acceptance-tests from AWS
-      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
-      with_modules: *run_acceptance_modules
-      with_steps:
-        - { type: 'shell',
-            cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
-                   *cleanup, *setup_venv, *setup_flocker_modules,
-                   'export DISTRIBUTION_NAME=centos-7',
-                   *setup_aws_env_vars, *check_version,
-                   *build_sdist, *build_package,
-                   *build_repo_metadata,
-                   *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
-                   *run_acceptance_rackspace_tests,
-                   *clean_packages,
-                   *exit_with_return_code_from_test ]
-          }
-      clean_repo: true
-      archive_artifacts: *acceptance_tests_artifacts
-      timeout: 45
-    run_acceptance_on_Rackspace_Ubuntu_Trusty_for:
-      # flocker.provision is responsible for creating the test nodes on
-      # Rackspace, so we can actually run run-acceptance-tests from AWS
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
-      with_modules: *run_acceptance_modules
-      with_steps:
-        - { type: 'shell',
-            cli: [ *hashbang, *add_shell_functions, *setup_pip_cache,
-                   *cleanup, *setup_venv, *setup_flocker_modules,
-                   *setup_aws_env_vars, *check_version,
-                   'export DISTRIBUTION_NAME=ubuntu-14.04',
-                   *build_sdist, *build_package,
-                   *build_repo_metadata,
-                   *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
-                   *run_acceptance_rackspace_tests,
-                   *clean_packages,
-                   *exit_with_return_code_from_test ]
-          }
-      clean_repo: true
-      archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
-      timeout: 45
     run_acceptance_loopback_on_AWS_CentOS_7_for:
       on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_modules: *run_full_acceptance_modules
@@ -1232,6 +1148,98 @@ job_type:
                    *package_jenkins_osx_yosemite_box ]
           }
       timeout: 120
+
+    run_acceptance_on_AWS_CentOS_7_for:
+      at: '0 5 * * *'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
+      with_modules: *run_acceptance_modules
+      with_steps:
+        - { type: 'shell',
+            cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
+                   *cleanup, *setup_venv, *setup_flocker_modules,
+                   'export DISTRIBUTION_NAME=centos-7',
+                   *setup_aws_env_vars, *check_version,
+                   *build_sdist, *build_package,
+                   *build_repo_metadata,
+                   *setup_authentication,
+                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   *run_acceptance_aws_tests,
+                   *clean_packages,
+                   *exit_with_return_code_from_test ]
+          }
+      clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts
+      timeout: 45
+
+    run_acceptance_on_AWS_Ubuntu_Trusty_for:
+      at: '0 6 * * *'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
+      with_modules: *run_acceptance_modules
+      with_steps:
+        - { type: 'shell',
+            cli: [ *hashbang, *add_shell_functions, *setup_pip_cache,
+                   *cleanup, *setup_venv, *setup_flocker_modules,
+                   *setup_aws_env_vars, *check_version,
+                   'export DISTRIBUTION_NAME=ubuntu-14.04',
+                   *build_sdist, *build_package,
+                   *build_repo_metadata,
+                   *setup_authentication,
+                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   *run_acceptance_aws_tests,
+                   *clean_packages,
+                   *exit_with_return_code_from_test ]
+          }
+      clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      timeout: 45
+
+    run_acceptance_on_Rackspace_CentOS_7_for:
+      at: '0 5 * * *'
+      # flocker.provision is responsible for creating the test nodes on
+      # Rackspace, so we can actually run run-acceptance-tests from AWS
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
+      with_modules: *run_acceptance_modules
+      with_steps:
+        - { type: 'shell',
+            cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
+                   *cleanup, *setup_venv, *setup_flocker_modules,
+                   'export DISTRIBUTION_NAME=centos-7',
+                   *setup_aws_env_vars, *check_version,
+                   *build_sdist, *build_package,
+                   *build_repo_metadata,
+                   *setup_authentication,
+                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   *run_acceptance_rackspace_tests,
+                   *clean_packages,
+                   *exit_with_return_code_from_test ]
+          }
+      clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts
+      timeout: 45
+
+    run_acceptance_on_Rackspace_Ubuntu_Trusty_for:
+      at: '0 6 * * *'
+      # flocker.provision is responsible for creating the test nodes on
+      # Rackspace, so we can actually run run-acceptance-tests from AWS
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
+      with_modules: *run_acceptance_modules
+      with_steps:
+        - { type: 'shell',
+            cli: [ *hashbang, *add_shell_functions, *setup_pip_cache,
+                   *cleanup, *setup_venv, *setup_flocker_modules,
+                   *setup_aws_env_vars, *check_version,
+                   'export DISTRIBUTION_NAME=ubuntu-14.04',
+                   *build_sdist, *build_package,
+                   *build_repo_metadata,
+                   *setup_authentication,
+                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   *run_acceptance_rackspace_tests,
+                   *clean_packages,
+                   *exit_with_return_code_from_test ]
+          }
+      clean_repo: true
+      archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      timeout: 45
 
 #-----------------------------------------------------------------------------#
 # View definitions below this point

--- a/build.yaml
+++ b/build.yaml
@@ -970,6 +970,7 @@ job_type:
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
       timeout: 45
+
     run_acceptance_loopback_on_AWS_Ubuntu_Trusty_for:
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_modules: *run_full_acceptance_modules
@@ -1152,7 +1153,6 @@ job_type:
     run_acceptance_on_AWS_CentOS_7_for:
       at: '0 5 * * *'
       on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
-      with_modules: *run_acceptance_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1162,7 +1162,7 @@ job_type:
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_aws_tests,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
@@ -1174,7 +1174,6 @@ job_type:
     run_acceptance_on_AWS_Ubuntu_Trusty_for:
       at: '0 6 * * *'
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
-      with_modules: *run_acceptance_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions, *setup_pip_cache,
@@ -1184,7 +1183,7 @@ job_type:
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_aws_tests,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
@@ -1198,7 +1197,6 @@ job_type:
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS
       on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
-      with_modules: *run_acceptance_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1208,7 +1206,7 @@ job_type:
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_rackspace_tests,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
@@ -1222,7 +1220,6 @@ job_type:
       # flocker.provision is responsible for creating the test nodes on
       # Rackspace, so we can actually run run-acceptance-tests from AWS
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
-      with_modules: *run_acceptance_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions, *setup_pip_cache,
@@ -1232,7 +1229,7 @@ job_type:
                    *build_sdist, *build_package,
                    *build_repo_metadata,
                    *setup_authentication,
-                   'export ACCEPTANCE_TEST_MODULE=\${MODULE}',
+                   'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_rackspace_tests,
                    *clean_packages,
                    *exit_with_return_code_from_test ]


### PR DESCRIPTION
Run Cinder and EBS acceptance tests as a nightly cron job, for now.