### PR TITLE
[FLOC-3740] Add call to obtain container state

### DIFF
--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -122,12 +122,12 @@ class ContainerState(PClass):
     :attr UUID node_uuid: The UUID of a node in the cluster where the container
         will run.
     :attr unicode name: The unique name of the container.
-    :attr unicode image: The name of the Docker image.
+    :attr DockerImage image: The name of the Docker image.
     :attr bool running: Whether the container is running.
     """
     node_uuid = field(type=UUID, mandatory=True)
     name = field(type=unicode, mandatory=True)
-    image = field(type=unicode, mandatory=True)
+    image = field(type=DockerImage, mandatory=True)
     running = field(type=bool, mandatory=True)
 
 
@@ -438,7 +438,7 @@ class FakeFlockerClient(object):
             ContainerState(
                 node_uuid=container.node_uuid,
                 name=container.name,
-                image=unicode(container.image.full_name),
+                image=container.image,
                 running=True,
             ) for container in self._configured_containers.values()
         ]
@@ -786,7 +786,7 @@ class FlockerClient(object):
             return ContainerState(
                 node_uuid=UUID(container[u'node_uuid']),
                 name=container[u'name'],
-                image=container[u'image'],
+                image=DockerImage.from_string(container[u'image']),
                 running=container[u'running'],
             )
         d.addCallback(

--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -784,10 +784,10 @@ class FlockerClient(object):
 
         def parse(container):
             return ContainerState(
-                node_uuid=UUID(container['node_uuid']),
-                name=container['name'],
-                image=container['image'],
-                running=container['running'],
+                node_uuid=UUID(container[u'node_uuid']),
+                name=container[u'name'],
+                image=container[u'image'],
+                running=container[u'running'],
             )
         d.addCallback(
             lambda containers: [parse(container) for container in containers])

--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -507,12 +507,13 @@ def make_clientv1_tests():
             d.addCallback(lambda _ignored: self.client.list_containers_state())
 
             d.addCallback(
-                lambda containers: [(c.node_uuid, c.name) for c in containers]
-            )
-
-            d.addCallback(
                 lambda containers: self.assertIn(
-                    (expected.node_uuid, expected.name),
+                    ContainerState(
+                        node_uuid=expected.node_uuid,
+                        name=expected.name,
+                        image=expected.image,
+                        running=True,
+                    ),
                     containers
                 )
             )

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -151,7 +151,7 @@ class DockerImage(PClass):
 
     @property
     def full_name(self):
-        return "{repository}:{tag}".format(
+        return u"{repository}:{tag}".format(
             repository=self.repository, tag=self.tag)
 
     @classmethod


### PR DESCRIPTION
The `flocker.apiclient.FlockerClient` does not contain an operation to call the `/state/containers` API.

Adding it to support the benchmarking requirement to measure creation of a container and waiting for it to start.

The code is almost a combination of the call to obtain Dataset state and obtain Container configuration.  

Code for both the fake and real containers need additional information to be transferred from configuration to state during synchronization.  The `FakeFlockerClient` copies configuration to state during synchronization.  The tests for the real `FlockerClient` copy the applications data from the persistence service to the cluster state service.
