### PR TITLE
[FLOC-3750] Change flocker.node to use new Flocker test case base classes

### DIFF
--- a/flocker/common/_defer.py
+++ b/flocker/common/_defer.py
@@ -6,7 +6,8 @@ Various helpers for dealing with Deferred APIs in flocker.
 """
 
 from twisted.internet.defer import gatherResults
-from twisted.python import log
+
+from eliot import write_failure
 
 
 def gather_deferreds(deferreds):
@@ -41,7 +42,7 @@ def gather_deferreds(deferreds):
 
         :param Failure failure: The ``Failure`` to be logged.
         """
-        log.err(failure)
+        write_failure(failure)
 
     for deferred in deferreds:
         deferred.addErrback(log_and_discard)

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -24,7 +24,7 @@ from keystoneclient.openstack.common.apiclient.exceptions import Unauthorized
 
 from twisted.python.filepath import FilePath
 from twisted.python.procutils import which
-from twisted.trial.unittest import SkipTest, SynchronousTestCase
+from twisted.trial.unittest import SkipTest
 
 from flocker.ca import (
     RootCredential, AUTHORITY_CERTIFICATE_FILENAME, NodeCredential
@@ -40,7 +40,9 @@ from ..test.blockdevicefactory import (
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
     get_minimum_allocatable_size, get_openstack_region_for_test,
 )
-from ....testtools import REALISTIC_BLOCKDEVICE_SIZE, flaky, run_process
+from ....testtools import (
+    REALISTIC_BLOCKDEVICE_SIZE, TestCase, flaky, run_process,
+)
 
 from ..cinder import (
     get_keystone_session, get_cinder_v1_client, get_nova_v2_client,
@@ -195,7 +197,7 @@ class CinderCloudAPIInterfaceTests(
     """
 
 
-class CinderHttpsTests(SynchronousTestCase):
+class CinderHttpsTests(TestCase):
     """
     Test connections to HTTPS-enabled OpenStack.
     """
@@ -376,7 +378,7 @@ class OpenStackFixture(object):
         self.cinder.volumes.delete(volume.id)
 
 
-class CinderAttachmentTests(SynchronousTestCase):
+class CinderAttachmentTests(TestCase):
     """
     Cinder volumes can be attached and return correct device path.
     """
@@ -429,7 +431,7 @@ class CinderAttachmentTests(SynchronousTestCase):
         self.assertEqual(device_path.realpath(), new_device)
 
 
-class VirtIOCinderAttachmentTests(SynchronousTestCase):
+class VirtIOCinderAttachmentTests(TestCase):
     @require_virtio
     def setUp(self):
         super(VirtIOCinderAttachmentTests, self).setUp()
@@ -622,11 +624,12 @@ class FakeTime(object):
         self._current_time += interval
 
 
-class BlockDeviceAPIDestroyTests(SynchronousTestCase):
+class BlockDeviceAPIDestroyTests(TestCase):
     """
     Test for ``cinder.CinderBlockDeviceAPI.destroy_volume``
     """
     def setUp(self):
+        super(BlockDeviceAPIDestroyTests, self).setUp()
         self.api = cinderblockdeviceapi_for_test(test_case=self)
 
     def test_destroy_timesout(self):

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -5,7 +5,7 @@ Test for real world behaviour of Cinder implementations to validate some of our
 basic assumptions/understandings of how Cinder works in the real world.
 """
 
-from twisted.trial.unittest import SkipTest, SynchronousTestCase
+from twisted.trial.unittest import SkipTest
 
 from ..cinder import (
     get_keystone_session, get_cinder_v1_client, wait_for_volume_state
@@ -16,7 +16,7 @@ from ..test.blockdevicefactory import (
     get_openstack_region_for_test,
     get_blockdevice_config,
 )
-from ....testtools import random_name
+from ....testtools import TestCase, random_name
 
 from .logging import CINDER_VOLUME
 
@@ -40,11 +40,12 @@ def cinder_volume_manager():
 # ``make_icindervolumemanager_tests`` instead.
 # https://clusterhq.atlassian.net/browse/FLOC-1846
 
-class VolumesCreateTests(SynchronousTestCase):
+class VolumesCreateTests(TestCase):
     """
     Tests for ``cinder.Client.volumes.create``.
     """
     def setUp(self):
+        super(VolumesCreateTests, self).setUp()
         self.cinder_volumes = cinder_volume_manager()
 
     def test_create_metadata_is_listed(self):
@@ -78,11 +79,12 @@ class VolumesCreateTests(SynchronousTestCase):
         )
 
 
-class VolumesSetMetadataTests(SynchronousTestCase):
+class VolumesSetMetadataTests(TestCase):
     """
     Tests for ``cinder.Client.volumes.set_metadata``.
     """
     def setUp(self):
+        super(VolumesSetMetadataTests, self).setUp()
         self.cinder_volumes = cinder_volume_manager()
 
     def test_updated_metadata_is_listed(self):

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -12,7 +12,7 @@ from bitmath import Byte, GiB
 from botocore.exceptions import ClientError
 
 from twisted.python.constants import Names, NamedConstant
-from twisted.trial.unittest import SkipTest, TestCase
+from twisted.trial.unittest import SkipTest
 from eliot.testing import LoggedAction, capture_logging, assertHasMessage
 
 from ..blockdevice import MandatoryProfiles
@@ -23,7 +23,7 @@ from ..ebs import (
     TimeoutException, _should_finish, UnexpectedStateException,
     EBSMandatoryProfileAttributes, _get_volume_tag,
 )
-from ....testtools import flaky
+from ....testtools import AsyncTestCase, flaky
 
 from .._logging import (
     AWS_CODE, AWS_MESSAGE, AWS_REQUEST_ID, BOTO_LOG_HEADER,
@@ -358,7 +358,7 @@ class VolumeStub(object):
         return not self.__eq__(other)
 
 
-class VolumeStateTransitionTests(TestCase):
+class VolumeStateTransitionTests(AsyncTestCase):
     """
     Tests for volume state operations and resulting volume state changes.
     """
@@ -638,7 +638,7 @@ class VolumeStateTransitionTests(TestCase):
         volume = self._process_volume(self.V.DESTROY, self.S.DESTINATION_STATE)
         self.assertEquals(volume.state, u'')
 
-    def test_attach_sucess(self):
+    def test_attach_success(self):
         """
         Test if successful attach volume operation leads to expected state.
         """

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3898,6 +3898,7 @@ class LoopbackBlockDeviceAPIImplementationTests(TestCase):
         )
 
     def setUp(self):
+        super(LoopbackBlockDeviceAPIImplementationTests, self).setUp()
         self.api = loopbackblockdeviceapi_for_test(
             test_case=self,
             allocation_unit=LOOPBACK_ALLOCATION_UNIT,

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -41,7 +41,7 @@ from twisted.internet.defer import succeed
 from twisted.python.components import proxyForInterface
 from twisted.python.runtime import platform
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SynchronousTestCase, SkipTest
+from twisted.trial.unittest import SkipTest
 
 from eliot import start_action, write_traceback, Message, Logger
 from eliot.testing import (
@@ -364,11 +364,12 @@ def delete_manifestation(node_state, manifestation):
     return node_state
 
 
-class BlockDeviceDeployerLocalStateTests(SynchronousTestCase):
+class BlockDeviceDeployerLocalStateTests(TestCase):
     """
     Tests for ``BlockDeviceDeployerLocalState``.
     """
     def setUp(self):
+        super(BlockDeviceDeployerLocalStateTests, self).setUp()
         self.node_uuid = uuid4()
         self.hostname = u"192.0.2.1"
 
@@ -577,7 +578,7 @@ class BlockDeviceDeployerTests(
     """
 
 
-class BlockDeviceDeployerAsyncAPITests(SynchronousTestCase):
+class BlockDeviceDeployerAsyncAPITests(TestCase):
     """
     Tests for ``BlockDeviceDeployer.async_block_device_api``.
     """
@@ -661,12 +662,13 @@ def assert_discovered_state(
     )
 
 
-class BlockDeviceDeployerDiscoverRawStateTests(SynchronousTestCase):
+class BlockDeviceDeployerDiscoverRawStateTests(TestCase):
     """
     Tests for ``BlockDeviceDeployer._discover_raw_state``.
     """
 
     def setUp(self):
+        super(BlockDeviceDeployerDiscoverRawStateTests, self).setUp()
         self.expected_hostname = u'192.0.2.123'
         self.expected_uuid = uuid4()
         self.api = loopbackblockdeviceapi_for_test(self)
@@ -746,11 +748,12 @@ class BlockDeviceDeployerDiscoverRawStateTests(SynchronousTestCase):
                 without_fs=False))
 
 
-class BlockDeviceDeployerDiscoverStateTests(SynchronousTestCase):
+class BlockDeviceDeployerDiscoverStateTests(TestCase):
     """
     Tests for ``BlockDeviceDeployer.discover_state``.
     """
     def setUp(self):
+        super(BlockDeviceDeployerDiscoverStateTests, self).setUp()
         self.expected_hostname = u'192.0.2.123'
         self.expected_uuid = uuid4()
         self.api = loopbackblockdeviceapi_for_test(self)
@@ -1090,7 +1093,7 @@ def make_icalculator_tests(calculator_factory):
 
     :return: A ``TestCase`` subclass.
     """
-    class ICalculatorTests(SynchronousTestCase):
+    class ICalculatorTests(TestCase):
         """
         Tests of an ``ICalculator`` implementation.
         """
@@ -1198,11 +1201,12 @@ class DidNotConverge(Exception):
     """
 
 
-class BlockDeviceCalculatorTests(SynchronousTestCase):
+class BlockDeviceCalculatorTests(TestCase):
     """
     Tests for ``BlockDeviceCalculator``.
     """
     def setUp(self):
+        super(BlockDeviceCalculatorTests, self).setUp()
         self.deployer = create_blockdevicedeployer(self)
 
     def teardown_example(self, token):
@@ -1393,11 +1397,12 @@ def assert_desired_datasets(
     )
 
 
-class CalculateDesiredStateTests(SynchronousTestCase):
+class CalculateDesiredStateTests(TestCase):
     """
     Tests for ``BlockDeviceDeployer._calculate_desired_state``.
     """
     def setUp(self):
+        super(CalculateDesiredStateTests, self).setUp()
         self.hostname = ScenarioMixin.NODE
         self.node_uuid = ScenarioMixin.NODE_UUID
         self.api = UnusableAPI()
@@ -1851,7 +1856,7 @@ def local_state_from_shared_state(
     )
 
 
-class LocalStateFromSharedStateTests(SynchronousTestCase):
+class LocalStateFromSharedStateTests(TestCase):
     """
     Tests for ``local_state_from_shared_state``.
     """
@@ -1882,7 +1887,7 @@ class LocalStateFromSharedStateTests(SynchronousTestCase):
 
 
 class BlockDeviceDeployerAlreadyConvergedCalculateChangesTests(
-        SynchronousTestCase, ScenarioMixin
+        TestCase, ScenarioMixin
 ):
     """
     Tests for the cases of ``BlockDeviceDeployer.calculate_changes`` where no
@@ -1935,7 +1940,7 @@ class BlockDeviceDeployerAlreadyConvergedCalculateChangesTests(
 
 
 class BlockDeviceDeployerIgnorantCalculateChangesTests(
-        SynchronousTestCase, ScenarioMixin
+        TestCase, ScenarioMixin
 ):
     """
     Tests for the cases of ``BlockDeviceDeployer.calculate_changes`` where no
@@ -1977,7 +1982,7 @@ class BlockDeviceDeployerIgnorantCalculateChangesTests(
 
 
 class BlockDeviceDeployerDestructionCalculateChangesTests(
-        SynchronousTestCase, ScenarioMixin
+        TestCase, ScenarioMixin
 ):
     """
     Tests for ``BlockDeviceDeployer.calculate_changes`` in the cases relating
@@ -2249,7 +2254,7 @@ class BlockDeviceDeployerDestructionCalculateChangesTests(
 
 
 class BlockDeviceDeployerAttachCalculateChangesTests(
-        SynchronousTestCase, ScenarioMixin
+        TestCase, ScenarioMixin
 ):
     """
     Tests for ``BlockDeviceDeployer.calculate_changes`` in the cases relating
@@ -2308,7 +2313,7 @@ class BlockDeviceDeployerAttachCalculateChangesTests(
 
 
 class BlockDeviceDeployerMountCalculateChangesTests(
-    SynchronousTestCase, ScenarioMixin
+    TestCase, ScenarioMixin
 ):
     """
     Tests for ``BlockDeviceDeployer.calculate_changes`` in the cases relating
@@ -2361,7 +2366,7 @@ class BlockDeviceDeployerMountCalculateChangesTests(
 
 
 class BlockDeviceDeployerCreateFilesystemCalculateChangesTests(
-    SynchronousTestCase, ScenarioMixin
+    TestCase, ScenarioMixin
 ):
     """
     Tests for ``BlockDeviceDeployer.calculate_changes`` in the cases relating
@@ -2407,7 +2412,7 @@ class BlockDeviceDeployerCreateFilesystemCalculateChangesTests(
 
 
 class BlockDeviceDeployerUnmountCalculateChangesTests(
-    SynchronousTestCase, ScenarioMixin
+    TestCase, ScenarioMixin
 ):
     """
     Tests for ``BlockDeviceDeployer.calculate_changes`` in the cases relating
@@ -2531,7 +2536,7 @@ class BlockDeviceDeployerUnmountCalculateChangesTests(
 
 
 class BlockDeviceDeployerCreationCalculateChangesTests(
-        SynchronousTestCase,
+        TestCase,
         ScenarioMixin
 ):
     """
@@ -2887,7 +2892,7 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
 
 
 class BlockDeviceDeployerDetachCalculateChangesTests(
-        SynchronousTestCase, ScenarioMixin
+        TestCase, ScenarioMixin
 ):
     def test_detach_manifestation(self):
         """
@@ -2961,7 +2966,7 @@ class BlockDeviceDeployerDetachCalculateChangesTests(
         )
 
 
-class BlockDeviceInterfaceTests(SynchronousTestCase):
+class BlockDeviceInterfaceTests(TestCase):
     """
     Tests for ``IBlockDeviceAPI`` and ``IBlockDeviceAsyncAPI``.
     """
@@ -2992,12 +2997,13 @@ class BlockDeviceInterfaceTests(SynchronousTestCase):
 
 
 class BlockDeviceDeployerCalculateChangesTests(
-        SynchronousTestCase, ScenarioMixin
+        TestCase, ScenarioMixin
 ):
     """
     Tests for ``BlockDeviceDeployer.calculate_changes``.
     """
     def setUp(self):
+        super(BlockDeviceDeployerCalculateChangesTests, self).setUp()
         self.expected_change = ControllableAction(
             result=succeed(None),
         )
@@ -3717,8 +3723,9 @@ def make_iprofiledblockdeviceapi_tests(profiled_blockdevice_api_factory,
     :returns: A ``TestCase`` with tests that will be performed on the
        supplied ``IProfiledBlockDeviceAPI`` provider.
     """
-    class Tests(IProfiledBlockDeviceAPITestsMixin, SynchronousTestCase):
+    class Tests(IProfiledBlockDeviceAPITestsMixin, TestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.api = profiled_blockdevice_api_factory(self)
             self.dataset_size = dataset_size
 
@@ -3745,7 +3752,7 @@ def make_iblockdeviceasyncapi_tests(blockdeviceasync_api_factory):
         because we currently assume ``make_iblockdeviceapi_tests`` will be used
         on the wrapped object.
     """
-    class Tests(IBlockDeviceAsyncAPITestsMixin, SynchronousTestCase):
+    class Tests(IBlockDeviceAsyncAPITestsMixin, TestCase):
         def setUp(self):
             super(Tests, self).setUp()
             self.api = blockdeviceasync_api_factory(test_case=self)
@@ -3836,7 +3843,7 @@ class LoopbackBlockDeviceAPITests(
     """
 
 
-class LoopbackBlockDeviceAPIConstructorTests(SynchronousTestCase):
+class LoopbackBlockDeviceAPIConstructorTests(TestCase):
     """
     Implementation specific constructor tests.
     """
@@ -3864,7 +3871,7 @@ class LoopbackBlockDeviceAPIConstructorTests(SynchronousTestCase):
         )
 
 
-class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
+class LoopbackBlockDeviceAPIImplementationTests(TestCase):
     """
     Implementation specific tests for ``LoopbackBlockDeviceAPI``.
     """
@@ -4036,7 +4043,7 @@ class LoopbackBlockDeviceAPIImplementationTests(SynchronousTestCase):
             'Could not find valid instance ID for %r' % (api,), str(e))
 
 
-class LosetupListTests(SynchronousTestCase):
+class LosetupListTests(TestCase):
     """
     Tests for ``_losetup_list_parse``.
     """
@@ -4817,8 +4824,9 @@ def make_createblockdevicedataset_mixin(profiled_api):
         if you want self.api not to provide ``IProfiledBlockDeviceAPI``.
     """
     class Mixin(CreateBlockDeviceDatasetImplementationMixin,
-                SynchronousTestCase):
+                TestCase):
         def setUp(self):
+            super(Mixin, self).setUp()
             if profiled_api:
                 self.api = fakeprofiledloopbackblockdeviceapi_for_test(
                     self,
@@ -5066,7 +5074,7 @@ class ActionNeededTests(
     """
 
 
-class AllocatedSizeTypeTests(SynchronousTestCase):
+class AllocatedSizeTypeTests(TestCase):
     """
     Tests for type coercion of parameters supplied to
     ``allocated_size``.
@@ -5147,8 +5155,9 @@ def make_allocated_size_tests(allocation_unit):
         against the supplied ``allocation_unit``. The name of the test
         contains the classname of ``allocation_unit``.
     """
-    class Tests(AllocatedSizeTestsMixin, SynchronousTestCase):
+    class Tests(AllocatedSizeTestsMixin, TestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.allocation_unit = int(allocation_unit.to_Byte().value)
 
     Tests.__name__ = (
@@ -5223,11 +5232,12 @@ class CountingProxy(object):
         return counting_proxy
 
 
-class ProcessLifetimeCacheTests(SynchronousTestCase):
+class ProcessLifetimeCacheTests(TestCase):
     """
     Tests for the caching logic in ``ProcessLifetimeCache``.
     """
     def setUp(self):
+        super(ProcessLifetimeCacheTests, self).setUp()
         self.api = loopbackblockdeviceapi_for_test(self)
         self.counting_proxy = CountingProxy(self.api)
         self.cache = ProcessLifetimeCache(self.counting_proxy)

--- a/flocker/node/agents/test/test_cinder.py
+++ b/flocker/node/agents/test/test_cinder.py
@@ -4,12 +4,12 @@
 Tests for ``flocker.node.agents.cinder``.
 """
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from ..cinder import _openstack_verify_from_config
 
+from ....testtools import TestCase
 
-class VerifyTests(SynchronousTestCase):
+
+class VerifyTests(TestCase):
     """
     Tests for _openstack_verify_from_config.
     """

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -13,7 +13,7 @@ from hypothesis.strategies import lists, sampled_from, builds
 from bitmath import GiB
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SkipTest, SynchronousTestCase
+from twisted.trial.unittest import SkipTest
 
 from ..ebs import (
     AttachedUnexpectedDevice, _expected_device,
@@ -22,7 +22,7 @@ from ..ebs import (
 )
 from ..blockdevice import BlockDeviceVolume
 
-from ....testtools import CustomException
+from ....testtools import CustomException, TestCase
 
 
 # A Hypothesis strategy for generating /dev/sd?
@@ -32,7 +32,7 @@ device_path = builds(
 )
 
 
-class AttachedUnexpectedDeviceTests(SynchronousTestCase):
+class AttachedUnexpectedDeviceTests(TestCase):
     """
     Tests for ``AttachedUnexpectedDevice``.
     """
@@ -89,11 +89,12 @@ class AttachedUnexpectedDeviceTests(SynchronousTestCase):
         )
 
 
-class AttachVolumeAndWaitTests(SynchronousTestCase):
+class AttachVolumeAndWaitTests(TestCase):
     """
     Tests for ``_attach_volume_and_wait_for_device``.
     """
     def setUp(self):
+        super(AttachVolumeAndWaitTests, self).setUp()
         self.volume = BlockDeviceVolume(
             dataset_id=uuid4(),
             blockdevice_id=u"opaque storage backend id",
@@ -190,7 +191,7 @@ class AttachVolumeAndWaitTests(SynchronousTestCase):
         )
 
 
-class ExpectedDeviceTests(SynchronousTestCase):
+class ExpectedDeviceTests(TestCase):
     """
     Tests for ``_expected_device``.
     """

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -10,7 +10,6 @@ from zope.interface import implementer
 
 from pyrsistent import PClass, field
 
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import FirstError, Deferred, succeed, fail
 from twisted.python.components import proxyForInterface
 
@@ -22,7 +21,7 @@ from ..testtools import (
     CONTROLLABLE_ACTION_TYPE, ControllableAction, ControllableDeployer,
     DummyDeployer
 )
-from ...testtools import CustomException
+from ...testtools import CustomException, TestCase
 
 from .. import IStateChange, sequentially, in_parallel, run_state_change, NoOp
 from .._change import LOG_IN_PARALLEL, LOG_SEQUENTIALLY
@@ -231,7 +230,7 @@ def _test_nested_change(case, outer_factory, inner_factory):
     )
 
 
-class SequentiallyTests(SynchronousTestCase):
+class SequentiallyTests(TestCase):
     """
     Tests for handling of ``sequentially`` by ``run_state_changes``.
     """
@@ -334,7 +333,7 @@ class SequentiallyTests(SynchronousTestCase):
         self.assertEqual(sequentially(changes=[NoOp(), NoOp()]), NoOp())
 
 
-class InParallelTests(SynchronousTestCase):
+class InParallelTests(TestCase):
     """
     Tests for handling of ``in_parallel`` by ``run_state_changes``.
     """
@@ -384,7 +383,10 @@ class InParallelTests(SynchronousTestCase):
                   subchanges[1].called]
         self.assertEqual(called, [True, True])
 
-    def test_exception_result(self):
+    @capture_logging(
+        lambda self, logger: logger.flush_tracebacks(CustomException)
+    )
+    def test_exception_result(self, logger):
         """
         When called with the result of ``in_parallel``, ``run_state_changes``
         returns a ``Deferred`` that fires with the first exception raised
@@ -395,7 +397,6 @@ class InParallelTests(SynchronousTestCase):
         result = run_state_change(change, DEPLOYER)
         failure = self.failureResultOf(result, FirstError)
         self.assertEqual(failure.value.subFailure.type, CustomException)
-        self.flushLoggedErrors(CustomException)
 
     def test_changes_run_after_exception(self):
         """
@@ -413,7 +414,7 @@ class InParallelTests(SynchronousTestCase):
         change = in_parallel(changes=subchanges)
         result = run_state_change(change, DEPLOYER)
         self.failureResultOf(result, FirstError)
-        self.flushLoggedErrors(CustomException)
+        # self.flushLoggedErrors(CustomException)
         self.assertEqual(
             (some_change.called, other_change.called),
             (True, True),
@@ -431,9 +432,10 @@ class InParallelTests(SynchronousTestCase):
         result = run_state_change(change, DEPLOYER)
         failure = self.failureResultOf(result, FirstError)
         self.assertEqual(failure.value.subFailure.type, RuntimeError)
-        self.flushLoggedErrors(RuntimeError)
+        # self.flushLoggedErrors(RuntimeError)
 
-    def test_failure_all_logged(self):
+    @capture_logging(None)
+    def test_failure_all_logged(self, logger):
         """
         When multiple changes passed to ``in_parallel`` fail,
         ``run_state_changes`` logs those failures.
@@ -449,7 +451,7 @@ class InParallelTests(SynchronousTestCase):
 
         self.assertEqual(
             len(subchanges),
-            len(self.flushLoggedErrors(ZeroDivisionError))
+            len(logger.flush_tracebacks(ZeroDivisionError))
         )
 
     def test_nested_in_parallel(self):
@@ -479,7 +481,7 @@ class InParallelTests(SynchronousTestCase):
         self.assertEqual(in_parallel(changes=[NoOp(), NoOp()]), NoOp())
 
 
-class RunStateChangeTests(SynchronousTestCase):
+class RunStateChangeTests(TestCase):
     """
     Direct unit tests for ``run_state_change``.
     """

--- a/flocker/node/test/test_change.py
+++ b/flocker/node/test/test_change.py
@@ -383,10 +383,7 @@ class InParallelTests(TestCase):
                   subchanges[1].called]
         self.assertEqual(called, [True, True])
 
-    @capture_logging(
-        lambda self, logger: logger.flush_tracebacks(CustomException)
-    )
-    def test_exception_result(self, logger):
+    def test_exception_result(self):
         """
         When called with the result of ``in_parallel``, ``run_state_changes``
         returns a ``Deferred`` that fires with the first exception raised
@@ -414,7 +411,6 @@ class InParallelTests(TestCase):
         change = in_parallel(changes=subchanges)
         result = run_state_change(change, DEPLOYER)
         self.failureResultOf(result, FirstError)
-        # self.flushLoggedErrors(CustomException)
         self.assertEqual(
             (some_change.called, other_change.called),
             (True, True),
@@ -432,7 +428,6 @@ class InParallelTests(TestCase):
         result = run_state_change(change, DEPLOYER)
         failure = self.failureResultOf(result, FirstError)
         self.assertEqual(failure.value.subFailure.type, RuntimeError)
-        # self.flushLoggedErrors(RuntimeError)
 
     @capture_logging(None)
     def test_failure_all_logged(self, logger):

--- a/flocker/node/test/test_container.py
+++ b/flocker/node/test/test_container.py
@@ -12,6 +12,8 @@ from pyrsistent import pset, pvector
 
 from bitmath import GiB
 
+from eliot.testing import capture_logging
+
 from twisted.internet.defer import FirstError
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
@@ -1924,7 +1926,8 @@ class SetProxiesTests(SynchronousTestCase):
             set(fake_network.enumerate_proxies())
         )
 
-    def test_delete_proxy_errors_as_errbacks(self):
+    @capture_logging(None)
+    def test_delete_proxy_errors_as_errbacks(self, logger):
         """
         Exceptions raised in `delete_proxy` operations are reported as
         failures in the returned deferred.
@@ -1943,7 +1946,7 @@ class SetProxiesTests(SynchronousTestCase):
             exception.value.subFailure.value,
             ZeroDivisionError
         )
-        self.flushLoggedErrors(ZeroDivisionError)
+        logger.flush_tracebacks(ZeroDivisionError)
 
     def test_create_proxy_errors_as_errbacks(self):
         """
@@ -1965,7 +1968,8 @@ class SetProxiesTests(SynchronousTestCase):
         )
         self.flushLoggedErrors(ZeroDivisionError)
 
-    def test_create_proxy_errors_all_logged(self):
+    @capture_logging(None)
+    def test_create_proxy_errors_all_logged(self, logger):
         """
         Exceptions raised in `create_proxy_to` operations are all logged.
         """
@@ -1984,7 +1988,7 @@ class SetProxiesTests(SynchronousTestCase):
 
         self.failureResultOf(d, FirstError)
 
-        failures = self.flushLoggedErrors(ZeroDivisionError)
+        failures = logger.flush_tracebacks(ZeroDivisionError)
         self.assertEqual(3, len(failures))
 
 
@@ -2094,7 +2098,8 @@ class OpenPortsTests(SynchronousTestCase):
         )
         self.flushLoggedErrors(ZeroDivisionError)
 
-    def test_open_ports_errors_all_logged(self):
+    @capture_logging(None)
+    def test_open_ports_errors_all_logged(self, logger):
         """
         Exceptions raised in `OpenPorts` operations are all logged.
         """
@@ -2113,5 +2118,5 @@ class OpenPortsTests(SynchronousTestCase):
 
         self.failureResultOf(d, FirstError)
 
-        failures = self.flushLoggedErrors(ZeroDivisionError)
+        failures = logger.flush_tracebacks(ZeroDivisionError)
         self.assertEqual(3, len(failures))

--- a/flocker/node/test/test_container.py
+++ b/flocker/node/test/test_container.py
@@ -15,7 +15,6 @@ from bitmath import GiB
 from eliot.testing import capture_logging
 
 from twisted.internet.defer import FirstError
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 
 from .. import (
@@ -26,6 +25,7 @@ from ..testtools import (
     EMPTY_STATE, empty_node_local_state,
     assert_calculated_changes_for_deployer, to_node,
 )
+from ...testtools import TestCase
 from ...control import (
     Application, DockerImage, Deployment, Node, Port, Link,
     NodeState, DeploymentState, RestartNever, RestartAlways, RestartOnFailure
@@ -114,7 +114,7 @@ def assert_application_calculated_changes(
     )
 
 
-class ApplicationNodeDeployerAttributesTests(SynchronousTestCase):
+class ApplicationNodeDeployerAttributesTests(TestCase):
     """
     Tests for attributes and initialiser arguments of
     `ApplicationNodeDeployer`.
@@ -186,7 +186,7 @@ SetProxiesIStateChangeTests = make_istatechange_tests(
 )
 
 
-class StartApplicationTests(SynchronousTestCase):
+class StartApplicationTests(TestCase):
     """
     Tests for ``StartApplication``.
     """
@@ -472,7 +472,7 @@ class StartApplicationTests(SynchronousTestCase):
         )
 
 
-class LinkEnviromentTests(SynchronousTestCase):
+class LinkEnviromentTests(TestCase):
     """
     Tests for ``_link_environment``.
     """
@@ -500,7 +500,7 @@ class LinkEnviromentTests(SynchronousTestCase):
             })
 
 
-class StopApplicationTests(SynchronousTestCase):
+class StopApplicationTests(TestCase):
     """
     Tests for ``StopApplication``.
     """
@@ -575,11 +575,14 @@ EMPTY_NODESTATE = NodeState(hostname=u"example.com", uuid=uuid4(),
 
 
 class ApplicationNodeDeployerDiscoverNodeConfigurationTests(
-        SynchronousTestCase):
+        TestCase):
     """
     Tests for ``ApplicationNodeDeployer.discover_local_state``.
     """
     def setUp(self):
+        super(
+            ApplicationNodeDeployerDiscoverNodeConfigurationTests, self
+        ).setUp()
         self.hostname = u"example.com"
         self.network = make_memory_network()
         self.node_uuid = uuid4()
@@ -873,7 +876,7 @@ def no_change():
     return NoOp()
 
 
-class ApplicationNodeDeployerCalculateVolumeChangesTests(SynchronousTestCase):
+class ApplicationNodeDeployerCalculateVolumeChangesTests(TestCase):
     """
     Tests for ``ApplicationNodeDeployer.calculate_changes`` specifically as it
     relates to volume state and configuration.
@@ -1093,7 +1096,7 @@ class ApplicationNodeDeployerCalculateVolumeChangesTests(SynchronousTestCase):
         )
 
 
-class ApplicationNodeDeployerCalculateChangesTests(SynchronousTestCase):
+class ApplicationNodeDeployerCalculateChangesTests(TestCase):
     """
     Tests for ``ApplicationNodeDeployer.calculate_changes``.
     """
@@ -1860,7 +1863,7 @@ class ApplicationNodeDeployerCalculateChangesTests(SynchronousTestCase):
         )
 
 
-class SetProxiesTests(SynchronousTestCase):
+class SetProxiesTests(TestCase):
     """
     Tests for ``SetProxies``.
     """
@@ -1948,7 +1951,8 @@ class SetProxiesTests(SynchronousTestCase):
         )
         logger.flush_tracebacks(ZeroDivisionError)
 
-    def test_create_proxy_errors_as_errbacks(self):
+    @capture_logging(None)
+    def test_create_proxy_errors_as_errbacks(self, logger):
         """
         Exceptions raised in `create_proxy_to` operations are reported as
         failures in the returned deferred.
@@ -1966,7 +1970,7 @@ class SetProxiesTests(SynchronousTestCase):
             exception.value.subFailure.value,
             ZeroDivisionError
         )
-        self.flushLoggedErrors(ZeroDivisionError)
+        logger.flush_tracebacks(ZeroDivisionError)
 
     @capture_logging(None)
     def test_create_proxy_errors_all_logged(self, logger):
@@ -1992,7 +1996,7 @@ class SetProxiesTests(SynchronousTestCase):
         self.assertEqual(3, len(failures))
 
 
-class OpenPortsTests(SynchronousTestCase):
+class OpenPortsTests(TestCase):
     """
     Tests for ``OpenPorts``.
     """
@@ -2057,7 +2061,8 @@ class OpenPortsTests(SynchronousTestCase):
             set(fake_network.enumerate_open_ports())
         )
 
-    def test_delete_open_port_errors_as_errbacks(self):
+    @capture_logging(None)
+    def test_delete_open_port_errors_as_errbacks(self, logger):
         """
         Exceptions raised in `delete_open_port` operations are reported as
         failures in the returned deferred.
@@ -2076,9 +2081,10 @@ class OpenPortsTests(SynchronousTestCase):
             exception.value.subFailure.value,
             ZeroDivisionError
         )
-        self.flushLoggedErrors(ZeroDivisionError)
+        logger.flush_tracebacks(ZeroDivisionError)
 
-    def test_open_port_errors_as_errbacks(self):
+    @capture_logging(None)
+    def test_open_port_errors_as_errbacks(self, logger):
         """
         Exceptions raised in `open_port` operations are reported as
         failures in the returned deferred.
@@ -2096,7 +2102,7 @@ class OpenPortsTests(SynchronousTestCase):
             exception.value.subFailure.value,
             ZeroDivisionError
         )
-        self.flushLoggedErrors(ZeroDivisionError)
+        logger.flush_tracebacks(ZeroDivisionError)
 
     @capture_logging(None)
     def test_open_ports_errors_all_logged(self, logger):

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -6,14 +6,13 @@ Tests for ``flocker.node._deploy``.
 
 from twisted.internet.defer import succeed
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from zope.interface.verify import verifyObject
 
 from ..testtools import (
     ControllableAction, ControllableDeployer, ideployer_tests_factory,
     EMPTY_NODE_STATE,
 )
+from ...testtools import TestCase
 from ...control import (
     NodeState,
 )
@@ -26,7 +25,7 @@ from .._deploy import (
 from .istatechange import make_istatechange_tests
 
 
-class NodeLocalStateTests(SynchronousTestCase):
+class NodeLocalStateTests(TestCase):
     """
     Tests for ``NodeLocalState``
     """

--- a/flocker/node/test/test_diagnostics.py
+++ b/flocker/node/test/test_diagnostics.py
@@ -2,12 +2,12 @@ import json
 from unittest import skipUnless
 
 from twisted.python.procutils import which
-from twisted.trial.unittest import SynchronousTestCase
 
 from flocker.node.diagnostics import list_hardware
+from flocker.testtools import TestCase
 
 
-class ListHardwareTests(SynchronousTestCase):
+class ListHardwareTests(TestCase):
 
     @skipUnless(which('lshw'), 'Tests require the ``lshw`` command.')
     def test_list_hardware(self):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -15,7 +15,6 @@ from machinist import LOG_FSM_TRANSITION
 
 from pyrsistent import pset
 
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.internet.defer import succeed, Deferred, fail
@@ -28,7 +27,7 @@ from twisted.test.iosim import connectedServerAndClient
 from ...testtools.amp import (
     FakeAMPClient, DelayedAMPClient, connected_amp_protocol,
 )
-from ...testtools import CustomException
+from ...testtools import CustomException, TestCase
 from .._loop import (
     build_cluster_status_fsm, ClusterStatusInputs, _ClientStatusUpdate,
     _StatusUpdate, _ConnectedToControlService, ConvergenceLoopInputs,
@@ -58,11 +57,12 @@ class StubFSM(object):
         self.inputted.append(symbol)
 
 
-class ClusterStatusFSMTests(SynchronousTestCase):
+class ClusterStatusFSMTests(TestCase):
     """
     Tests for the cluster status FSM.
     """
     def setUp(self):
+        super(ClusterStatusFSMTests, self).setUp()
         self.convergence_loop = StubFSM()
         self.fsm = build_cluster_status_fsm(self.convergence_loop)
 
@@ -247,7 +247,7 @@ def no_action():
     return ControllableAction(result=succeed(None))
 
 
-class SleepTests(SynchronousTestCase):
+class SleepTests(TestCase):
     """
     Tests for ``_Sleep``.
     """
@@ -270,7 +270,7 @@ class SleepTests(SynchronousTestCase):
                  spread=True))
 
 
-class ConvergenceLoopFSMTests(SynchronousTestCase):
+class ConvergenceLoopFSMTests(TestCase):
     """
     Tests for FSM created by ``build_convergence_loop_fsm``.
     """
@@ -1136,11 +1136,12 @@ class UpdateNodeEraLocator(CommandLocator):
         return {}
 
 
-class AgentLoopServiceTests(SynchronousTestCase):
+class AgentLoopServiceTests(TestCase):
     """
     Tests for ``AgentLoopService``.
     """
     def setUp(self):
+        super(AgentLoopServiceTests, self).setUp()
         self.deployer = ControllableDeployer(u"127.0.0.1", [], [])
         self.reactor = MemoryReactorClock()
         self.service = AgentLoopService(

--- a/flocker/node/test/test_p2p.py
+++ b/flocker/node/test/test_p2p.py
@@ -13,7 +13,6 @@ from pytz import UTC
 from eliot.testing import validate_logging
 
 from twisted.internet.defer import fail, Deferred
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 
 from .. import (
@@ -33,7 +32,7 @@ from .._p2p import (
     CreateDataset, HandoffDataset, PushDataset, ResizeDataset,
     _to_volume_name, DeleteDataset
 )
-from ...testtools import AsyncTestCase, CustomException
+from ...testtools import AsyncTestCase, TestCase, CustomException
 from .. import _p2p
 from ...control._model import (
     AttachedVolume, Dataset, Manifestation, Leases
@@ -116,11 +115,12 @@ EMPTY_NODESTATE = NodeState(hostname=u"example.com", uuid=uuid4(),
                             applications=[])
 
 
-class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
+class P2PManifestationDeployerDiscoveryTests(TestCase):
     """
     Tests for ``P2PManifestationDeployer`` discovery.
     """
     def setUp(self):
+        super(P2PManifestationDeployerDiscoveryTests, self).setUp()
         self.volume_service = create_volume_service(self)
         self.node_uuid = uuid4()
         # https://clusterhq.atlassian.net/browse/FLOC-1926
@@ -239,7 +239,7 @@ class P2PManifestationDeployerDiscoveryTests(SynchronousTestCase):
             manifestation)
 
 
-class P2PManifestationDeployerLeaseTests(SynchronousTestCase):
+class P2PManifestationDeployerLeaseTests(TestCase):
     """
     Tests for impact of leases on
     ``P2PManifestationDeployer.calculate_changes``.
@@ -342,7 +342,7 @@ class P2PManifestationDeployerLeaseTests(SynchronousTestCase):
         self.assertEqual(expected, changes)
 
 
-class P2PManifestationDeployerCalculateChangesTests(SynchronousTestCase):
+class P2PManifestationDeployerCalculateChangesTests(TestCase):
     """
     Tests for
     ``P2PManifestationDeployer.calculate_changes``.
@@ -810,7 +810,7 @@ class P2PManifestationDeployerCalculateChangesTests(SynchronousTestCase):
         self.assertEqual(expected, changes)
 
 
-class CreateDatasetTests(SynchronousTestCase):
+class CreateDatasetTests(TestCase):
     """
     Tests for ``CreateDataset``.
     """
@@ -866,11 +866,12 @@ class CreateDatasetTests(SynchronousTestCase):
             _to_volume_name(volume.dataset.dataset_id)))
 
 
-class DeleteDatasetTests(SynchronousTestCase):
+class DeleteDatasetTests(TestCase):
     """
     Tests for ``DeleteDataset``.
     """
     def setUp(self):
+        super(DeleteDatasetTests, self).setUp()
         self.volume_service = create_volume_service(self)
         self.deployer = P2PManifestationDeployer(
             u'example.com', self.volume_service)
@@ -951,7 +952,7 @@ class ResizeVolumeTests(AsyncTestCase):
         return d
 
 
-class HandoffVolumeTests(SynchronousTestCase):
+class HandoffVolumeTests(TestCase):
     """
     Tests for ``HandoffVolume``.
     """
@@ -997,7 +998,7 @@ class HandoffVolumeTests(SynchronousTestCase):
         self.assertIs(handoff_result, result)
 
 
-class PushVolumeTests(SynchronousTestCase):
+class PushVolumeTests(TestCase):
     """
     Tests for ``PushVolume``.
     """

--- a/flocker/node/test/test_p2p.py
+++ b/flocker/node/test/test_p2p.py
@@ -13,7 +13,7 @@ from pytz import UTC
 from eliot.testing import validate_logging
 
 from twisted.internet.defer import fail, Deferred
-from twisted.trial.unittest import SynchronousTestCase, TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 
 from .. import (
@@ -33,7 +33,7 @@ from .._p2p import (
     CreateDataset, HandoffDataset, PushDataset, ResizeDataset,
     _to_volume_name, DeleteDataset
 )
-from ...testtools import CustomException
+from ...testtools import AsyncTestCase, CustomException
 from .. import _p2p
 from ...control._model import (
     AttachedVolume, Dataset, Manifestation, Leases
@@ -912,7 +912,7 @@ class DeleteDatasetTests(SynchronousTestCase):
         self.successResultOf(delete.run(self.deployer))
 
 
-class ResizeVolumeTests(TestCase):
+class ResizeVolumeTests(AsyncTestCase):
     """
     Tests for ``ResizeVolume``.
     """

--- a/flocker/node/test/test_p2p.py
+++ b/flocker/node/test/test_p2p.py
@@ -866,7 +866,7 @@ class CreateDatasetTests(SynchronousTestCase):
             _to_volume_name(volume.dataset.dataset_id)))
 
 
-class DeleteDatasetTests(TestCase):
+class DeleteDatasetTests(SynchronousTestCase):
     """
     Tests for ``DeleteDataset``.
     """

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -20,7 +20,6 @@ from zope.interface.verify import verifyObject
 
 from twisted.internet.defer import Deferred
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.application.service import Service
 from twisted.python.runtime import platform
 
@@ -39,7 +38,7 @@ from ..agents.cinder import CinderBlockDeviceAPI
 from ..agents.ebs import EBSBlockDeviceAPI
 
 from .._loop import AgentLoopService
-from ...testtools import MemoryCoreReactor, random_name
+from ...testtools import MemoryCoreReactor, TestCase, random_name
 from ...ca.testtools import get_credential_sets
 
 from .dummybackend import DUMMY_API
@@ -119,12 +118,13 @@ class DummyAgentService(PClass):
         return self.loop_service
 
 
-class DatasetServiceFactoryTests(SynchronousTestCase):
+class DatasetServiceFactoryTests(TestCase):
     """
     Generic tests for ``DatasetServiceFactory``, independent of the storage
     driver being used.
     """
     def setUp(self):
+        super(DatasetServiceFactoryTests, self).setUp()
         setup_config(self)
 
     def test_config_validated(self):
@@ -182,7 +182,7 @@ def agent_service_setup(test):
     )
 
 
-class AgentServiceFromConfigurationTests(SynchronousTestCase):
+class AgentServiceFromConfigurationTests(TestCase):
     """
     Tests for ``AgentService.from_configuration``
     """
@@ -230,11 +230,13 @@ class AgentServiceFromConfigurationTests(SynchronousTestCase):
         )
 
 
-class AgentServiceGetAPITests(SynchronousTestCase):
+class AgentServiceGetAPITests(TestCase):
     """
     Tests for ``AgentService.get_api``.
     """
-    setUp = agent_service_setup
+    def setUp(self):
+        super(AgentServiceGetAPITests, self).setUp()
+        agent_service_setup(self)
 
     def test_backend_selection(self):
         """
@@ -406,11 +408,13 @@ class AgentServiceGetAPITests(SynchronousTestCase):
                          "built-in backend nor a 3rd party module.")
 
 
-class AgentServiceDeployerTests(SynchronousTestCase):
+class AgentServiceDeployerTests(TestCase):
     """
     Tests for ``AgentService.get_deployer``.
     """
-    setUp = agent_service_setup
+    def setUp(self):
+        super(AgentServiceDeployerTests, self).setUp()
+        agent_service_setup(self)
 
     def test_backend_selection(self):
         """
@@ -465,11 +469,13 @@ class AgentServiceDeployerTests(SynchronousTestCase):
         )
 
 
-class AgentServiceLoopTests(SynchronousTestCase):
+class AgentServiceLoopTests(TestCase):
     """
     Tests for ``AgentService.get_loop_service``.
     """
-    setUp = agent_service_setup
+    def setUp(self):
+        super(AgentServiceLoopTests, self).setUp()
+        agent_service_setup(self)
 
     @skipUnless(platform.isLinux(), "get_era() only supports Linux.")
     def test_agentloopservice(self):
@@ -494,11 +500,12 @@ class AgentServiceLoopTests(SynchronousTestCase):
         )
 
 
-class AgentServiceFactoryTests(SynchronousTestCase):
+class AgentServiceFactoryTests(TestCase):
     """
     Tests for ``AgentServiceFactory``.
     """
     def setUp(self):
+        super(AgentServiceFactoryTests, self).setUp()
         setup_config(self)
 
     def service_factory(self, deployer_factory):
@@ -648,11 +655,12 @@ class AgentServiceFactoryTests(SynchronousTestCase):
         )
 
 
-class AgentScriptTests(SynchronousTestCase):
+class AgentScriptTests(TestCase):
     """
     Tests for ``AgentScript``.
     """
     def setUp(self):
+        super(AgentScriptTests, self).setUp()
         self.reactor = MemoryCoreReactor()
         self.options = DatasetAgentOptions()
 
@@ -740,12 +748,13 @@ def make_amp_agent_options_tests(options_type):
 
     :param options_type: An ``Options`` subclass  to be tested.
 
-    :return: A ``SynchronousTestCase`` subclass defining tests for that options
+    :return: A ``TestCase`` subclass defining tests for that options
         type.
     """
 
-    class Tests(SynchronousTestCase):
+    class Tests(TestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.options = options_type()
             self.scratch_directory = FilePath(self.mktemp())
             self.scratch_directory.makedirs()
@@ -783,12 +792,13 @@ def make_amp_agent_options_tests(options_type):
     return Tests
 
 
-class ValidateConfigurationTests(SynchronousTestCase):
+class ValidateConfigurationTests(TestCase):
     """
     Tests for :func:`validate_configuration`.
     """
 
     def setUp(self):
+        super(ValidateConfigurationTests, self).setUp()
         # This is a sample working configuration which tests can modify.
         self.configuration = {
             u"control-service": {
@@ -944,11 +954,12 @@ class ContainerAgentOptionsTests(
     """
 
 
-class GetExternalIPTests(SynchronousTestCase):
+class GetExternalIPTests(TestCase):
     """
     Tests for ``_get_external_ip``.
     """
     def setUp(self):
+        super(GetExternalIPTests, self).setUp()
         server = socket.socket()
         server.bind(('127.0.0.1', 0))
         server.listen(5)


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3750

This also makes a change to `flocker.common.gather_deferreds`.  That function now logs failures using Eliot rather than Twisted.  This supports porting of some `flocker.node` tests which were previously using `flushLoggedErrors` (a feature of Twisted not available from testtools).