### PR TITLE
[FLOC-3764] Use flocker test cases in flocker.node

### DIFF
--- a/flocker/common/test/test_thread.py
+++ b/flocker/common/test/test_thread.py
@@ -79,6 +79,8 @@ class AsyncSpy(PClass):
     threadpool = field()
 
 
+# XXX: NonThreadPool and NonReactor are used outside of test_thread. They
+# should be moved into flocker.testtools.
 class NonThreadPool(object):
     """
     A stand-in for ``twisted.python.threadpool.ThreadPool`` so that the

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -2,7 +2,6 @@
 
 """
 Functional tests for ``flocker.node.agents.ebs`` using an EC2 cluster.
-
 """
 
 import time

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -34,6 +34,7 @@ from hypothesis.strategies import (
     dictionaries, tuples
 )
 
+from testtools.deferredruntest import SynchronousDeferredRunTest
 from testtools.matchers import Equals
 
 from twisted.internet import reactor
@@ -576,6 +577,10 @@ class BlockDeviceDeployerTests(
     """
     Tests for ``BlockDeviceDeployer``.
     """
+
+    # This test returns Deferreds but doesn't use the reactor. It uses
+    # NonReactor instead.
+    run_tests_with = SynchronousDeferredRunTest
 
 
 class BlockDeviceDeployerAsyncAPITests(TestCase):

--- a/flocker/node/agents/testtools.py
+++ b/flocker/node/agents/testtools.py
@@ -6,8 +6,7 @@ Test helpers for ``flocker.node.agents``.
 
 from zope.interface.verify import verifyObject
 
-from twisted.trial.unittest import SynchronousTestCase
-
+from flocker.testtools import TestCase
 from .cinder import (
     ICinderVolumeManager, INovaVolumeManager,
 )
@@ -29,8 +28,9 @@ def make_icindervolumemanager_tests(client_factory):
     Build a ``TestCase`` for verifying that an implementation of
     ``ICinderVolumeManager`` adheres to that interface.
     """
-    class Tests(ICinderVolumeManagerTestsMixin, SynchronousTestCase):
+    class Tests(ICinderVolumeManagerTestsMixin, TestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.client = client_factory(test_case=self)
 
     return Tests
@@ -52,8 +52,9 @@ def make_inovavolumemanager_tests(client_factory):
     Build a ``TestCase`` for verifying that an implementation of
     ``INovaVolumeManager`` adheres to that interface.
     """
-    class Tests(INovaVolumeManagerTestsMixin, SynchronousTestCase):
+    class Tests(INovaVolumeManagerTestsMixin, TestCase):
         def setUp(self):
+            super(Tests, self).setUp()
             self.client = client_factory(test_case=self)
 
     return Tests

--- a/flocker/node/test/istatechange.py
+++ b/flocker/node/test/istatechange.py
@@ -17,9 +17,9 @@ from eliot import Logger, start_action
 from pyrsistent import PClass, field
 from characteristic import attributes
 
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import succeed
 
+from flocker.testtools import TestCase
 from .. import IStateChange
 
 
@@ -43,7 +43,7 @@ def make_comparison_tests(klass, kwargs1, kwargs2):
             return klass(**kwargs)
         return klass(**kwargs())
 
-    class Tests(SynchronousTestCase):
+    class Tests(TestCase):
         def test_equality(self):
             """
             Instances with the same arguments are equal.

--- a/flocker/node/test/istatechange.py
+++ b/flocker/node/test/istatechange.py
@@ -19,7 +19,7 @@ from characteristic import attributes
 
 from twisted.internet.defer import succeed
 
-from flocker.testtools import TestCase
+from ...testtools import TestCase
 from .. import IStateChange
 
 

--- a/flocker/node/test/test_deploy.py
+++ b/flocker/node/test/test_deploy.py
@@ -4,25 +4,12 @@
 Tests for ``flocker.node._deploy``.
 """
 
-from twisted.internet.defer import succeed
-
 from zope.interface.verify import verifyObject
 
-from ..testtools import (
-    ControllableAction, ControllableDeployer, ideployer_tests_factory,
-    EMPTY_NODE_STATE,
-)
+from ..testtools import EMPTY_NODE_STATE
 from ...testtools import TestCase
-from ...control import (
-    NodeState,
-)
 
-from .. import in_parallel
-
-from .._deploy import (
-    ILocalState, NodeLocalState,
-)
-from .istatechange import make_istatechange_tests
+from .._deploy import ILocalState, NodeLocalState
 
 
 class NodeLocalStateTests(TestCase):
@@ -48,29 +35,3 @@ class NodeLocalStateTests(TestCase):
         object_under_test = NodeLocalState(node_state=node_state)
         self.assertEqual((node_state,),
                          object_under_test.shared_state_changes())
-
-
-class ControllableActionIStateChangeTests(
-        make_istatechange_tests(
-            ControllableAction,
-            kwargs1=dict(result=1),
-            kwargs2=dict(result=2),
-        )
-):
-    """
-    Tests for ``ControllableAction``.
-    """
-
-
-class ControllableDeployerInterfaceTests(
-        ideployer_tests_factory(
-            lambda test: ControllableDeployer(
-                hostname=u"192.0.2.123",
-                local_states=[succeed(NodeState(hostname=u'192.0.2.123'))],
-                calculated_actions=[in_parallel(changes=[])],
-            )
-        )
-):
-    """
-    ``IDeployer`` tests for ``ControllableDeployer``.
-    """

--- a/flocker/node/test/test_testtools.py
+++ b/flocker/node/test/test_testtools.py
@@ -8,9 +8,11 @@ from twisted.internet.defer import succeed
 
 from .. import sequentially
 from ..testtools import (
-    DummyDeployer, ControllableDeployer, ideployer_tests_factory,
+    DummyDeployer, ControllableAction, ControllableDeployer,
+    ideployer_tests_factory,
 )
 from ...control import NodeState
+from .istatechange import make_istatechange_tests
 
 
 class DummyDeployerIDeployerTests(
@@ -34,5 +36,17 @@ class ControllableDeployerIDeployerTests(
     )
 ):
     """
-    Tests for the ``IDeployer`` implementation of ``DummyDeployer``.
+    Tests for the ``IDeployer`` implementation of ``ControllableDeployer``.
+    """
+
+
+class ControllableActionIStateChangeTests(
+        make_istatechange_tests(
+            ControllableAction,
+            kwargs1=dict(result=1),
+            kwargs2=dict(result=2),
+        )
+):
+    """
+    Tests for ``ControllableAction``.
     """

--- a/flocker/node/test/test_testtools.py
+++ b/flocker/node/test/test_testtools.py
@@ -4,6 +4,7 @@
 Tests for ``flocker.node.testtools``.
 """
 
+from testtools.deferredruntest import SynchronousDeferredRunTest
 from twisted.internet.defer import succeed
 
 from .. import sequentially
@@ -39,6 +40,9 @@ class ControllableDeployerIDeployerTests(
     Tests for the ``IDeployer`` implementation of ``ControllableDeployer``.
     """
 
+    # This test returns Deferreds but doesn't use the reactor.
+    run_tests_with = SynchronousDeferredRunTest
+
 
 class ControllableActionIStateChangeTests(
         make_istatechange_tests(
@@ -50,3 +54,6 @@ class ControllableActionIStateChangeTests(
     """
     Tests for ``ControllableAction``.
     """
+
+    # This test returns Deferreds but doesn't use the reactor.
+    run_tests_with = SynchronousDeferredRunTest

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -18,7 +18,7 @@ from zope.interface import implementer
 
 from characteristic import attributes
 
-from twisted.trial.unittest import TestCase, SkipTest
+from twisted.trial.unittest import SkipTest
 from twisted.internet.defer import succeed
 
 from zope.interface.verify import verifyObject
@@ -29,7 +29,7 @@ from . import (
     ILocalState, IDeployer, NodeLocalState, IStateChange, sequentially
 )
 from ..common import loop_until
-from ..testtools import find_free_port
+from ..testtools import AsyncTestCase, find_free_port
 from ..control import (
     IClusterStateChange, Node, NodeState, Deployment, DeploymentState)
 from ..control._model import ip_to_uuid, Leases
@@ -248,7 +248,7 @@ def ideployer_tests_factory(fixture):
 
     :return: ``TestCase`` subclass that will test the given fixture.
     """
-    class IDeployerTests(TestCase):
+    class IDeployerTests(AsyncTestCase):
         """
         Tests for ``IDeployer``.
         """

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -252,11 +252,18 @@ def ideployer_tests_factory(fixture):
         """
         Tests for ``IDeployer``.
         """
+
+        def _make_deployer(self):
+            """
+            Make the ``IDeployer`` under test.
+            """
+            return fixture(self)
+
         def test_interface(self):
             """
             The object claims to provide the interface.
             """
-            self.assertTrue(verifyObject(IDeployer, fixture(self)))
+            self.assertTrue(verifyObject(IDeployer, self._make_deployer()))
 
         def _discover_state(self):
             """
@@ -265,7 +272,9 @@ def ideployer_tests_factory(fixture):
             :return: The return value of the object's ``discover_state``
                 method.
             """
-            self._deployer = fixture(self)
+            # XXX: Why is this set on the instance? Is it re-used? Does it
+            # cache?
+            self._deployer = self._make_deployer()
             result = self._deployer.discover_state(
                 NodeState(hostname=b"10.0.0.1"))
             return result

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -7,7 +7,7 @@ Testing utilities for ``flocker.node``.
 from functools import wraps
 import os
 import pwd
-from unittest import skipIf
+from unittest import skipIf, SkipTest
 from uuid import uuid4
 from datetime import timedelta
 from distutils.version import LooseVersion
@@ -18,7 +18,6 @@ from zope.interface import implementer
 
 from characteristic import attributes
 
-from twisted.trial.unittest import SkipTest
 from twisted.internet.defer import succeed
 
 from zope.interface.verify import verifyObject
@@ -74,6 +73,7 @@ def require_docker_version(minimum_docker_version, message):
         minimum_docker_version
     )
 
+    # XXX: Can we change this to use skipIf?
     def decorator(wrapped):
         @wraps(wrapped)
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
`git grep -l 'from twisted.trial.unittest import .*TestCase'` revealed that there were still a few references to Twisted test cases after #2383. This polishes those off.