### PR TITLE
[FLOC-3765] Use flocker base test cases in acceptance tests

### DIFF
--- a/flocker/acceptance/endtoend/test_benchmark.py
+++ b/flocker/acceptance/endtoend/test_benchmark.py
@@ -6,17 +6,16 @@ Tests for ``flocker-benchmark``.
 
 import json
 
-from twisted.internet import reactor
-from twisted.trial.unittest import TestCase
-
 from ...common.runner import run_ssh
+from ...testtools import AsyncTestCase
 from ..testtools import require_cluster
 
 
-class BenchmarkTests(TestCase):
+class BenchmarkTests(AsyncTestCase):
     """
     Tests for ``flocker-benchmark``.
     """
+
     @require_cluster(1)
     def test_export(self, cluster):
         """
@@ -28,7 +27,7 @@ class BenchmarkTests(TestCase):
         def run_report():
             output = []
             return run_ssh(
-                reactor,
+                self.reactor,
                 'root',
                 node_address,
                 ['flocker-benchmark', 'hardware-report'],

--- a/flocker/acceptance/integration/test_mongodb.py
+++ b/flocker/acceptance/integration/test_mongodb.py
@@ -59,4 +59,4 @@ class MongoIntegrationTests(make_dataset_integration_testcase(
     """
     @require_mongo
     def setUp(self):
-        pass
+        super(MongoIntegrationTests, self).setUp()

--- a/flocker/acceptance/integration/test_platform.py
+++ b/flocker/acceptance/integration/test_platform.py
@@ -5,13 +5,13 @@ Tests for integration with the host operating system which runs Flocker.
 """
 
 from ..testtools import require_cluster
+from ...testtools import AsyncTestCase
 from ...common.runner import RemoteFileNotFound
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SkipTest, TestCase
 
 
-class SyslogTests(TestCase):
+class SyslogTests(AsyncTestCase):
     """
     Tests for Flocker's integration with syslog.
     """
@@ -38,7 +38,7 @@ class SyslogTests(TestCase):
             #
             # Currently, CentOS and Ubuntu are supported and CentOS is expected
             # to have this log file and Ubuntu is expected not to.
-            raise SkipTest("{} not found".format(reason.value))
+            self.skipTest("{} not found".format(reason.value))
         getting.addErrback(check_missing_messages)
 
         def got_messages(path):

--- a/flocker/acceptance/integration/test_postgres.py
+++ b/flocker/acceptance/integration/test_postgres.py
@@ -116,4 +116,4 @@ class PostgresIntegrationTests(make_dataset_integration_testcase(
     """
     @skipUnless(PG8000_INSTALLED, "pg8000 not installed")
     def setUp(self):
-        pass
+        super(PostgresIntegrationTests, self).setUp()

--- a/flocker/acceptance/integration/testtools.py
+++ b/flocker/acceptance/integration/testtools.py
@@ -4,10 +4,8 @@
 Testing infrastructure for integration tests.
 """
 
-from twisted.trial.unittest import TestCase
-
 from ..testtools import require_cluster, create_dataset
-from ...testtools import random_name
+from ...testtools import AsyncTestCase, random_name
 
 
 def make_dataset_integration_testcase(image_name, volume_path, internal_port,
@@ -29,7 +27,7 @@ def make_dataset_integration_testcase(image_name, volume_path, internal_port,
 
     :return: ``TestCase`` subclass.
     """
-    class IntegrationTests(TestCase):
+    class IntegrationTests(AsyncTestCase):
         """
         Test that the given application can start and restart with Flocker
         datasets as volumes.

--- a/flocker/acceptance/test/test_testtools.py
+++ b/flocker/acceptance/test/test_testtools.py
@@ -11,12 +11,12 @@ from eliot.testing import (
     capture_logging,
 )
 from twisted.internet.defer import succeed
-from twisted.trial.unittest import SynchronousTestCase
 
 from ..testtools import (log_method, _ensure_encodeable)
+from ...testtools import TestCase
 
 
-class EnsureEncodeableTests(SynchronousTestCase):
+class EnsureEncodeableTests(TestCase):
     """
     Tests for ``_ensure_encodeable``.
 
@@ -51,7 +51,7 @@ class EnsureEncodeableTests(SynchronousTestCase):
         self.assertEqual(repr(value), _ensure_encodeable(value))
 
 
-class LogMethodTests(SynchronousTestCase):
+class LogMethodTests(TestCase):
     """
     Tests for ``log_method``.
     """

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -116,6 +116,9 @@ def _test_skipped(case, result, exception):
 class AsyncTestCase(testtools.TestCase, _MktempMixin):
     """
     Base class for asynchronous test cases.
+
+    :ivar reactor: The Twisted reactor that the test is being run in. Set by
+        ``async_runner`` and only available for the duration of the test.
     """
 
     run_tests_with = async_runner(timeout=DEFAULT_ASYNC_TIMEOUT)


### PR DESCRIPTION
Previously, almost but not all of the acceptance tests used the new `flocker.testtools.TestCase` and `AsyncTestCase` base classes. This patch make it all.

Things to watch out for:

* Update trial `SkipTest` references to `self.skipTest`
* Use the `reactor` instance variable that's available on `AsyncTestCase`

This is part of a general migration to use the new base test cases. See [FLOC-3281](https://clusterhq.atlassian.net/browse/FLOC-3281).