### PR TITLE
[FLOC-3768] Stop using Trial SkipTest

### DIFF
--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -10,7 +10,6 @@ from distutils.version import LooseVersion
 from testtools import run_test_with
 
 from twisted.internet import reactor
-from twisted.trial.unittest import SkipTest
 
 from hypothesis.strategies import integers
 
@@ -47,7 +46,7 @@ class DockerPluginTests(AsyncTestCase):
         client_version = LooseVersion(client.version()['Version'])
         minimum_version = LooseVersion(required_version)
         if client_version < minimum_version:
-            raise SkipTest(
+            self.skipTest(
                 'This test requires at least Docker {}. '
                 'Actual version: {}'.format(minimum_version, client_version)
             )

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -24,7 +24,6 @@ from keystoneclient.openstack.common.apiclient.exceptions import Unauthorized
 
 from twisted.python.filepath import FilePath
 from twisted.python.procutils import which
-from twisted.trial.unittest import SkipTest
 
 from flocker.ca import (
     RootCredential, AUTHORITY_CERTIFICATE_FILENAME, NodeCredential
@@ -119,7 +118,7 @@ class CinderBlockDeviceAPIInterfaceTests(
         try:
             config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
-            raise SkipTest(str(e))
+            self.skipTest(str(e))
         session = get_keystone_session(**config)
         region = get_openstack_region_for_test()
         return get_cinder_v1_client(session, region)
@@ -223,7 +222,7 @@ class CinderHttpsTests(TestCase):
         try:
             config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
-            raise SkipTest(str(e))
+            self.skipTest(str(e))
         config['peer_verify'] = False
         session = get_keystone_session(**config)
         region = get_openstack_region_for_test()
@@ -241,7 +240,7 @@ class CinderHttpsTests(TestCase):
         try:
             config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
-            raise SkipTest(str(e))
+            self.skipTest(str(e))
         config['backend'] = 'openstack'
         config['auth_plugin'] = 'password'
         config['password'] = 'password'

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -5,7 +5,7 @@ Test for real world behaviour of Cinder implementations to validate some of our
 basic assumptions/understandings of how Cinder works in the real world.
 """
 
-from twisted.trial.unittest import SkipTest
+from unittest import SkipTest
 
 from ..cinder import (
     get_keystone_session, get_cinder_v1_client, wait_for_volume_state

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -11,7 +11,6 @@ from bitmath import Byte, GiB
 from botocore.exceptions import ClientError
 
 from twisted.python.constants import Names, NamedConstant
-from twisted.trial.unittest import SkipTest
 from eliot.testing import LoggedAction, capture_logging, assertHasMessage
 
 from ..blockdevice import MandatoryProfiles
@@ -73,7 +72,7 @@ class EBSBlockDeviceAPIInterfaceTests(
         try:
             config = get_blockdevice_config(ProviderType.aws)
         except InvalidConfig as e:
-            raise SkipTest(str(e))
+            self.skipTest(str(e))
         ec2_client = get_ec2_client_for_test(config)
         meta_client = ec2_client.connection.meta.client
         requested_volume = meta_client.create_volume(
@@ -109,7 +108,7 @@ class EBSBlockDeviceAPIInterfaceTests(
         try:
             config = get_blockdevice_config(ProviderType.aws)
         except InvalidConfig as e:
-            raise SkipTest(str(e))
+            self.skipTest(str(e))
 
         dataset_id = uuid4()
         flocker_volume = self.api.create_volume(

--- a/flocker/node/agents/test/blockdevicefactory.py
+++ b/flocker/node/agents/test/blockdevicefactory.py
@@ -19,11 +19,11 @@ See `acceptance testing <acceptance-testing>`_ for details.
 """
 
 from os import environ
+from unittest import SkipTest
 
 import yaml
 from bitmath import GiB
 
-from twisted.trial.unittest import SkipTest
 from twisted.python.constants import Names, NamedConstant
 
 from ..cinder import cinder_from_configuration

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -42,7 +42,6 @@ from twisted.internet.defer import succeed
 from twisted.python.components import proxyForInterface
 from twisted.python.runtime import platform
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SkipTest
 
 from eliot import start_action, write_traceback, Message, Logger
 from eliot.testing import (
@@ -3816,7 +3815,7 @@ def loopbackblockdeviceapi_for_test(test_case, allocation_unit=None):
     """
     user_id = getuid()
     if user_id != 0:
-        raise SkipTest(
+        raise test_case.skipTest(
             "``LoopbackBlockDeviceAPI`` uses ``losetup``, "
             "which requires root privileges. "
             "Required UID: 0, Found UID: {!r}".format(user_id)

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3815,7 +3815,7 @@ def loopbackblockdeviceapi_for_test(test_case, allocation_unit=None):
     """
     user_id = getuid()
     if user_id != 0:
-        raise test_case.skipTest(
+        test_case.skipTest(
             "``LoopbackBlockDeviceAPI`` uses ``losetup``, "
             "which requires root privileges. "
             "Required UID: 0, Found UID: {!r}".format(user_id)

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -13,7 +13,6 @@ from hypothesis.strategies import lists, sampled_from, builds
 from bitmath import GiB
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SkipTest
 
 from ..ebs import (
     AttachedUnexpectedDevice, _expected_device,
@@ -168,7 +167,7 @@ class AttachVolumeAndWaitTests(TestCase):
             #
             # With apologies,
             #  -jean-paul
-            raise SkipTest(
+            raise self.skipTest(
                 "Could not find a suitable device to use as a bad device."
             )
 

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -85,7 +85,9 @@ class TestCase(testtools.TestCase, _MktempMixin, _DeferredAssertionMixin):
 
     def __init__(self, *args, **kwargs):
         super(TestCase, self).__init__(*args, **kwargs)
-        # XXX: Work around testing-cabal/unittest-ext#60
+        # XXX: Work around testing-cabal/unittest-ext#60. Delete after
+        # https://github.com/testing-cabal/testtools/pull/189 lands, is
+        # released, and we use it.
         self.exception_handlers.insert(-1, (unittest.SkipTest, _test_skipped))
 
     def setUp(self):
@@ -134,7 +136,9 @@ class AsyncTestCase(testtools.TestCase, _MktempMixin):
 
     def __init__(self, *args, **kwargs):
         super(AsyncTestCase, self).__init__(*args, **kwargs)
-        # XXX: Work around testing-cabal/unittest-ext#60
+        # XXX: Work around testing-cabal/unittest-ext#60. Delete after
+        # https://github.com/testing-cabal/testtools/pull/189 lands, is
+        # released, and we use it.
         self.exception_handlers.insert(-1, (unittest.SkipTest, _test_skipped))
 
     def setUp(self):

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from itertools import tee
 import json
 import tempfile
+from unittest import SkipTest
 
 from eliot.prettyprint import pretty_format
 from fixtures import Fixture
@@ -75,6 +76,12 @@ class TestCase(testtools.TestCase, _MktempMixin, _DeferredAssertionMixin):
     """
 
     run_tests_with = retry_flaky(testtools.RunTest)
+    # Eliot's validateLogging hard-codes a check for SkipTest when deciding
+    # whether to check for valid logging, which is fair enough, since there's
+    # no other API for checking whether a test has skipped. Setting
+    # skipException tells testtools to treat unittest.SkipTest as the
+    # exception that signals skipping.
+    skipException = SkipTest
 
     def __init__(self, *args, **kwargs):
         super(TestCase, self).__init__(*args, **kwargs)
@@ -122,6 +129,8 @@ class AsyncTestCase(testtools.TestCase, _MktempMixin):
     """
 
     run_tests_with = async_runner(timeout=DEFAULT_ASYNC_TIMEOUT)
+    # See comment on TestCase.skipException.
+    skipException = SkipTest
 
     def __init__(self, *args, **kwargs):
         super(AsyncTestCase, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Makes it easier to grep for things that are still using Trial base cases.

In particular, I want to grep with:

```
$ grep -l 'from twisted.trial.unittest import'
```
