### PR TITLE
[FLOC-3767] Container volume support in API client

### DIFF
--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -155,7 +155,7 @@ class ContainerState(PClass):
     name = field(type=unicode, mandatory=True)
     image = field(type=DockerImage, mandatory=True)
     running = field(type=bool, mandatory=True)
-    volumes = field(initial=None)
+    volumes = field(initial=None, mandatory=True)
 
 
 class Node(PClass):

--- a/flocker/apiclient/_client.py
+++ b/flocker/apiclient/_client.py
@@ -126,12 +126,12 @@ class Container(PClass):
     """
     A container in the configuration.
 
-    :attr UUID node_uuid: The UUID of a node in the cluster where the container
-        will run.
+    :attr UUID node_uuid: The UUID of a node in the cluster where the
+        container will run.
     :attr unicode name: The unique name of the container.
     :attr DockerImage image: The Docker image the container will run.
-    :attr Sequence[MountedDataset] volumes: Flocker volumes mounted in
-        container.
+    :attr Optional[Sequence[MountedDataset]] volumes: Flocker volumes
+        mounted in container.
     """
     node_uuid = field(type=UUID, mandatory=True)
     name = field(type=unicode, mandatory=True)
@@ -143,13 +143,13 @@ class ContainerState(PClass):
     """
     The state of a container in the cluster.
 
-    :attr UUID node_uuid: The UUID of a node in the cluster where the container
-        will run.
+    :attr UUID node_uuid: The UUID of a node in the cluster where the
+        container will run.
     :attr unicode name: The unique name of the container.
     :attr DockerImage image: The name of the Docker image.
     :attr bool running: Whether the container is running.
-    :attr Sequence[MountedDataset] volumes: Flocker volumes mounted in
-        container.
+    :attr Optional[Sequence[MountedDataset]] volumes: Flocker volumes
+        mounted in container.
     """
     node_uuid = field(type=UUID, mandatory=True)
     name = field(type=unicode, mandatory=True)
@@ -339,7 +339,8 @@ class IFlockerAPIV1Client(Interface):
         :param unicode name: The name to assign to the container.
         :param DockerImage image: The Docker image which the container will
             run.
-        :param Sequence[MountedDataset] volumes: Volumes to mount on container.
+        :param Optional[Sequence[MountedDataset]] volumes: Volumes to mount on
+            container.
 
         :return: ``Deferred`` firing with the configured ``Container`` or
             ``ContainerAlreadyExists`` if the supplied container name already
@@ -776,8 +777,10 @@ class FlockerClient(object):
         """
         Parse a list decoded from JSON with volume configuration.
 
-        :param volume_list: List describing mounted datasets.
-        :return: List of MountedDataset, or None if no volumes.
+        :param Optional[Sequence[Mapping[unicode, unicode]]] volume_list: List
+            describing a JSON list of volume objects.
+        :return Optional[Sequence[MountedDataset]]: List of mounted datasets,
+            or None if no volumes.
         """
         if volume_list:
             return [

--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -550,14 +550,14 @@ def make_clientv1_tests():
                     volumes=expected_configuration.volumes,
                 )
 
-                # Check result of create call
+                # Result of create call is stateful container configuration
                 d.addCallback(
                     lambda configuration: self.assertEqual(
                         configuration, expected_configuration
                     )
                 )
 
-                # Check that configuration is correct
+                # Cluster configuration contains stateful container
                 d.addCallback(
                     lambda _ignore: self.client.list_containers_configuration()
                 ).addCallback(
@@ -576,7 +576,7 @@ def make_clientv1_tests():
                     volumes=volumes,
                 )
 
-                # Check that state is correct after convergence
+                # After convergence, cluster state contains stateful container
                 d.addCallback(
                     lambda _ignore: self.client.list_containers_state()
                 ).addCallback(


### PR DESCRIPTION
For benchmarking, we still require the container API. However, the `flocker.apiclient.Client` does not support volumes attached to containers, which is needed for benchmarking.

This PR adds support for stateful containers to the API client, both when creating containers, and when receiving information about container configuration and state.

Note the use of PEP 484 type annotations in the docstrings. Currently we have a variety of patterns for non-primitive docstring types (including `|`, top-level type only (`dict`), verbose descriptions, and leaving them out completely).  Despite there being no implementation support for them in Python 2, the PEP 484 type annotations work particularly well for a function like `_parse_volumes`, where they quickly make apparent the transformation taking place.