### PR TITLE
[FLOC-3755] Fix benchmark no load scenario test

### DIFF
--- a/benchmark/scenarios/test/test_no_load.py
+++ b/benchmark/scenarios/test/test_no_load.py
@@ -32,8 +32,6 @@ class NoLoadScenarioTests(TestCase):
     NoLoadScenario tests
     """
 
-    # XXX: FLOC-3755: This isn't a test since it doesn't start with "test_".
-    # It never runs. If this is fixed so that it runs, it fails.
     def test_no_load_happy(self):
         """
         NoLoadScenario starts and stops without collapsing.
@@ -41,5 +39,5 @@ class NoLoadScenarioTests(TestCase):
         s = NoLoadScenario(Clock(), None)
         d = s.start()
         s.maintained().addBoth(lambda x: self.fail())
-        d.addCallback(s.stop)
+        d.addCallback(lambda _ignore: s.stop())
         self.successResultOf(d)

--- a/benchmark/scenarios/test/test_no_load.py
+++ b/benchmark/scenarios/test/test_no_load.py
@@ -34,7 +34,7 @@ class NoLoadScenarioTests(TestCase):
 
     # XXX: FLOC-3755: This isn't a test since it doesn't start with "test_".
     # It never runs. If this is fixed so that it runs, it fails.
-    def no_load_happy(self):
+    def test_no_load_happy(self):
         """
         NoLoadScenario starts and stops without collapsing.
         """

--- a/benchmark/scenarios/test/test_no_load.py
+++ b/benchmark/scenarios/test/test_no_load.py
@@ -1,4 +1,4 @@
-from zope.interface.verify import verifyObject
+from zope.interface.verify import verifyClass
 
 from twisted.internet.task import Clock
 
@@ -8,29 +8,16 @@ from benchmark.scenarios import NoLoadScenario
 from benchmark._interfaces import IScenario
 
 
-def check_interfaces(factory):
-    """
-    Check interface for IScenario implementation.
-    """
-
-    class ScenarioTests(TestCase):
-
-        def test_interfaces(self):
-            scenario = factory(Clock(), None)
-            verifyObject(IScenario, scenario)
-
-    testname = '{}InterfaceTests'.format(factory.__name__)
-    ScenarioTests.__name__ = testname
-    globals()[testname] = ScenarioTests
-
-for factory in (NoLoadScenario,):
-    check_interfaces(factory)
-
-
 class NoLoadScenarioTests(TestCase):
     """
     NoLoadScenario tests
     """
+
+    def test_implements_IScenario(self):
+        """
+        NoLoadScenario provides the IScenario interface.
+        """
+        verifyClass(IScenario, NoLoadScenario)
 
     def test_no_load_happy(self):
         """


### PR DESCRIPTION
Fixes a non-executed test, that also contained a bug. The test passed a callback result to the `stop` method as an extraneous parameter. This was not detected because the test method did not start with the `test` prefix.

Also, changed interface test to avoid use of `globals()`, following a comment on Slack. https://clusterhqteam.slack.com/archives/flocker-benchmarking/p1450723154000373
