### PR TITLE
[FLOC 3773] Fix broken doc links

### DIFF
--- a/docs/gettinginvolved/infrastructure/release-process.rst
+++ b/docs/gettinginvolved/infrastructure/release-process.rst
@@ -6,7 +6,7 @@ Release Process
 
 .. note::
 
-   Make sure to follow the `latest documentation <http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html>`_ when doing a release.
+   Make sure to follow the `latest documentation <http://clusterhq-staging-docs.s3.amazonaws.com/master/gettinginvolved/infrastructure/release-process.html>`_ when doing a release.
 
 Outcomes
 ========
@@ -168,7 +168,7 @@ It is important to check that the code in the release branch is working before i
 
 .. note::
 
-   Make sure to follow the `latest review process <http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html#pre-tag-review>`_ when reviewing a release.
+   Make sure to follow the `latest review process <http://clusterhq-staging-docs.s3.amazonaws.com/master/gettinginvolved/infrastructure/release-process.html#pre-tag-review>`_ when reviewing a release.
 
 #. Check the changes in the Pull Request:
 


### PR DESCRIPTION
Fixes 3773, which replaces 2 doc-dev links with the new master build from Jenkins.