### PR TITLE
[FLOC-3726] Increase the Jenkins timeouts for running the acceptance test suite.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1426,6 +1426,11 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
+      # Give the acceptance test suite a nice long time to run.  Give it even
+      # longer on CentOS than Ubuntu because Docker configuration on CentOS
+      # causes some things to be particularly slow.  This value is just a guess
+      # at what a reasonable upper-bound for the runtime of the suite to be as
+      # of Dec 2015.
       timeout: 120
 
     run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS:
@@ -1447,6 +1452,8 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      # Similar to the reasoning for run_acceptance_on_AWS_CentOS_7_with_EBS
+      # but slightly shorter since Ubuntu runs the tests faster.
       timeout: 90
 
     run_acceptance_on_Rackspace_CentOS_7_with_Cinder:
@@ -1470,6 +1477,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
+      # Reasoning as for run_acceptance_on_AWS_CentOS_7_with_EBS
       timeout: 120
 
     run_acceptance_on_Rackspace_Ubuntu_Trusty_with_Cinder:
@@ -1493,6 +1501,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      # Reasoning as for run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS
       timeout: 90
 
 #-----------------------------------------------------------------------------#

--- a/build.yaml
+++ b/build.yaml
@@ -1429,8 +1429,8 @@ job_type:
       # Give the acceptance test suite a nice long time to run.  Give it even
       # longer on CentOS than Ubuntu because Docker configuration on CentOS
       # causes some things to be particularly slow.  This value is just a guess
-      # at what a reasonable upper-bound for the runtime of the suite to be as
-      # of Dec 2015.
+      # at what a reasonable upper-bound for the runtime of the suite might be
+      # as of Dec 2015.
       timeout: 120
 
     run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS:

--- a/build.yaml
+++ b/build.yaml
@@ -1426,7 +1426,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
-      timeout: 45
+      timeout: 120
 
     run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS:
       at: '0 6 * * *'
@@ -1447,7 +1447,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
-      timeout: 45
+      timeout: 90
 
     run_acceptance_on_Rackspace_CentOS_7_with_Cinder:
       at: '0 5 * * *'
@@ -1470,7 +1470,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
-      timeout: 45
+      timeout: 120
 
     run_acceptance_on_Rackspace_Ubuntu_Trusty_with_Cinder:
       at: '0 6 * * *'
@@ -1493,7 +1493,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
-      timeout: 45
+      timeout: 90
 
 #-----------------------------------------------------------------------------#
 # View definitions below this point


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3726

Give CentOS, slower probably because of bad Docker configuration, two hours to run the acceptance tests.
Give Ubuntu, which almost always finishes in less than 45 minutes, 90 minutes to be sure we don't hit the timeout.