### PR TITLE
[FLOC-3680] Increase the Jenkins timeouts for running the Cinder functional test suite

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1134,6 +1134,9 @@ job_type:
       publish_test_results: true
       coverage_report: true
       clean_repo: true
+      # Give this job a slightly longer timeout because it has to interact with
+      # the cloud-supplied Cinder which can be a bit sluggish even in the best
+      # of times.
       timeout: 90
 
     run_trial_for_cinder_storage_driver_on_Ubuntu_trusty:
@@ -1153,6 +1156,8 @@ job_type:
       publish_test_results: true
       coverage_report: true
       clean_repo: true
+      # Reasoning for run_trial_for_cinder_storage_driver_on_CentOS_7's timeout
+      # applies here as well.
       timeout: 90
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -1134,7 +1134,7 @@ job_type:
       publish_test_results: true
       coverage_report: true
       clean_repo: true
-      timeout: 45
+      timeout: 90
 
     run_trial_for_cinder_storage_driver_on_Ubuntu_trusty:
       on_nodes_with_labels: 'rackspace-jenkins-slave-ubuntu14-standard-4-dfw'
@@ -1153,7 +1153,7 @@ job_type:
       publish_test_results: true
       coverage_report: true
       clean_repo: true
-      timeout: 45
+      timeout: 90
 
 
   # http://build.clusterhq.com/builders/flocker-docs


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3680

Give them twice as long to run on the premise that they pass most of the time now so
they should have a really, really good chance of passing all the time with twice as
long.