### PR TITLE
[FLOC-3775] Clean up OS X Vagrant boxes

### DIFF
--- a/admin/ci-tools/cleanup-vagrant-boxes
+++ b/admin/ci-tools/cleanup-vagrant-boxes
@@ -13,37 +13,54 @@ Usage::
   cleanup-vagrant-boxes <name of box>
 """
 
+from __future__ import unicode_literals, print_function
+
+from distutils.version import LooseVersion
 from subprocess import check_output
 
 
 class Box(object):
     def __init__(self, name, rest):
+        """
+        :param bytes rest: The second columne from a ``vagrant box list``
+            command, eg ``b"(virtualbox, 0.3.2.doc1.2008.g63e63f2)"``
+        """
+        self._version_string = rest[1:-1].split()[1]
+        self.version = LooseVersion(self._version_string)
         self.name = name
-        self._rest = rest
+
 
     def remove(self):
-        # self._rest is like "(virtualbox, 0.3.2.doc1.2008.g63e63f2)"
-        box_version = self._rest[1:-1].split()[1]
         check_output([
             b"vagrant", b"box", b"remove",
-            b"--box-version", box_version, self.name,
+            b"--box-version", self._version_string, self.name,
         ])
 
 
 def list_vagrant_boxes():
     boxes = check_output([b"vagrant", b"box", b"list"])
-    return (Box(name, rest) for (name, rest) in boxes.splitlines())
+    return (
+        Box(*line.split(None, 1))
+        for line
+        in boxes.splitlines()
+        if b" " in line
+    )
 
 
 def main(box_name):
     boxes = list(
         box for box in list_vagrant_boxes() if box.name == box_name
     )
-    boxes.sort(lambda box: box.version.split(b"."))
+    boxes.sort(key=lambda box: box.version)
 
     # Remove all but the newest version of the box.  Keeping the newest version
     # means we don't have to re-download it all the time whenever the version
     # hasn't changed.
-    boxes.pop()
+    print("Keeping {}".format(boxes.pop().version))
     for box in boxes:
+        print("Removing {}".format(box.version))
         box.remove()
+
+if __name__ == '__main__':
+    from sys import argv
+    main(argv[1])

--- a/admin/ci-tools/cleanup-vagrant-boxes
+++ b/admin/ci-tools/cleanup-vagrant-boxes
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+"""
+A tool for use by the CI system to clean up old versions of Vagrant boxes that
+get downloaded as part of CI work.  This helps keep disks of slaves from
+filling up with useless old boxes and eventually failing when there are too
+many.
+
+The newest version of the box is kept.
+
+Usage::
+
+  cleanup-vagrant-boxes <name of box>
+"""
+
+from subprocess import check_output
+
+
+class Box(object):
+    def __init__(self, name, rest):
+        self.name = name
+        self._rest = rest
+
+    def remove(self):
+        # self._rest is like "(virtualbox, 0.3.2.doc1.2008.g63e63f2)"
+        box_version = self._rest[1:-1].split()[1]
+        check_output([
+            b"vagrant", b"box", b"remove",
+            b"--box-version", box_version, self.name,
+        ])
+
+
+def list_vagrant_boxes():
+    boxes = check_output([b"vagrant", b"box", b"list"])
+    return (Box(name, rest) for (name, rest) in boxes.splitlines())
+
+
+def main(box_name):
+    boxes = list(
+        box for box in list_vagrant_boxes() if box.name == box_name
+    )
+    boxes.sort(lambda box: box.version.split(b"."))
+
+    # Remove all but the newest version of the box.  Keeping the newest version
+    # means we don't have to re-download it all the time whenever the version
+    # hasn't changed.
+    boxes.pop()
+    for box in boxes:
+        box.remove()

--- a/admin/ci-tools/cleanup-vagrant-boxes
+++ b/admin/ci-tools/cleanup-vagrant-boxes
@@ -20,6 +20,14 @@ from subprocess import check_output
 
 
 class Box(object):
+    """
+    Representation of some trivial metadata for a version of a Vagrant box.
+
+    :ivar bytes _version_string: The uninterpreted version string as reported
+        by Vagrant.
+    :ivar LooseVersion version: The parsed form of the version.
+    :ivar bytes name: The name of the box as reported by Vagrant.
+    """
     def __init__(self, name, rest):
         """
         :param bytes rest: The second columne from a ``vagrant box list``
@@ -31,6 +39,9 @@ class Box(object):
 
 
     def remove(self):
+        """
+        Remove this version of this box from the system.
+        """
         check_output([
             b"vagrant", b"box", b"remove",
             b"--box-version", self._version_string, self.name,
@@ -38,6 +49,10 @@ class Box(object):
 
 
 def list_vagrant_boxes():
+    """
+    :return: An iterator of ``Box`` instances, one for each version of each box
+        on the system.
+    """
     boxes = check_output([b"vagrant", b"box", b"list"])
     return (
         Box(*line.split(None, 1))
@@ -48,6 +63,11 @@ def list_vagrant_boxes():
 
 
 def main(box_name):
+    """
+    Remove all but the most recent version of a Vagrant box.
+
+    :param bytes box_name: The name of the Vagrant box to manipulate.
+    """
     boxes = list(
         box for box in list_vagrant_boxes() if box.name == box_name
     )

--- a/build.yaml
+++ b/build.yaml
@@ -74,7 +74,7 @@ common_cli:
   hashbang: &hashbang |
     #!/bin/bash -l
     # don't leak secrets
-    set -x # leak everything please for debugging
+    set +x
     set -e
 
 
@@ -687,14 +687,6 @@ common_cli:
   new_vagrantfile_for_osx_yosemite: &new_vagrantfile_for_osx_yosemite |
     # this builds a Vagrantfile which will use the latest jenkins-osx-yosemite
     # vagrant box built overnight.
-    echo "Dumping environment"
-    echo "==================="
-    env
-    echo "==================="
-    echo "S3_BUCKET is ${ENV['S3_BUCKET']}"
-    echo "box_url will be s3://${ENV['S3_BUCKET']}/metadata.json"
-    echo "==================="
-    echo "Alternately, S3_BUCKET is ${S3_BUCKET} and box_url could be s3://${S3_BUCKET}/metadata.json"
     cat <<EOF_VAGRANTFILE >Vagrantfile
     Vagrant.configure(2) do |config|
        config.vm.box = 'clusterhq/jenkins-osx-yosemite'

--- a/build.yaml
+++ b/build.yaml
@@ -687,6 +687,13 @@ common_cli:
   new_vagrantfile_for_osx_yosemite: &new_vagrantfile_for_osx_yosemite |
     # this builds a Vagrantfile which will use the latest jenkins-osx-yosemite
     # vagrant box built overnight.
+    echo "Dumping environment"
+    echo "==================="
+    env
+    echo "==================="
+    echo "S3_BUCKET is ${ENV['S3_BUCKET']}"
+    echo "box_url will be s3://${ENV['S3_BUCKET']}/metadata.json"
+    echo "==================="
     cat <<EOF_VAGRANTFILE >Vagrantfile
     Vagrant.configure(2) do |config|
        config.vm.box = 'clusterhq/jenkins-osx-yosemite'

--- a/build.yaml
+++ b/build.yaml
@@ -232,7 +232,7 @@ common_cli:
     # <some code> || abort_build
     function abort_build() {
       echo "aborting ..."
-      vagrant destroy -f
+      vagrant_destroy
       exit 1
     }
 

--- a/build.yaml
+++ b/build.yaml
@@ -924,6 +924,11 @@ common_cli:
 
     echo "This vagrant box is available at : ${S3_BOX_JSON_LATEST}"
 
+    # The box is supposed to be a gzipped tar file.  Validate that here.  Only
+    # do this *after* the upload so that the corrupt box is available online
+    # for inspection to debug the build failure.
+    gzip --verbose --test "${BOX_NAME}" || abort_build
+    tar --verbose --list --file "${BOX_NAME}" || abort_build
 
   run_lint: &run_lint |
     # we need to unset PIP_INDEX_URL since it causes tox to fail.

--- a/build.yaml
+++ b/build.yaml
@@ -226,7 +226,7 @@ common_cli:
     EOF_METADATA
     }
 
-    # destroy the vagrant box and aborts the build
+    # destroy the vagrant vm and aborts the build
     # this is used when one the of the intermediate steps has failed
     # usage:
     # <some code> || abort_build
@@ -257,9 +257,9 @@ common_cli:
       ) || abort_build
     }
 
-    # destroys the vagrant box
+    # destroys the vagrant vm
     # usage:
-    # vagrant_box_destroy
+    # vagrant_destroy
     function vagrant_destroy() {
       vagrant destroy -f
     }

--- a/build.yaml
+++ b/build.yaml
@@ -694,6 +694,7 @@ common_cli:
     echo "S3_BUCKET is ${ENV['S3_BUCKET']}"
     echo "box_url will be s3://${ENV['S3_BUCKET']}/metadata.json"
     echo "==================="
+    echo "Alternately, S3_BUCKET is ${S3_BUCKET} and box_url could be s3://${S3_BUCKET}/metadata.json"
     cat <<EOF_VAGRANTFILE >Vagrantfile
     Vagrant.configure(2) do |config|
        config.vm.box = 'clusterhq/jenkins-osx-yosemite'

--- a/build.yaml
+++ b/build.yaml
@@ -687,7 +687,7 @@ common_cli:
     cat <<EOF_VAGRANTFILE >Vagrantfile
     Vagrant.configure(2) do |config|
        config.vm.box = 'clusterhq/jenkins-osx-yosemite'
-       config.vm.box_url = "s3://${ENV['S3_BUCKET']}/metadata.json"
+       config.vm.box_url = "s3://${S3_BUCKET}/metadata.json"
        config.vm.synced_folder '.', '/vagrant', disabled: true
        config.vm.provider 'virtualbox' do |vb|
           vb.memory = '1024'

--- a/build.yaml
+++ b/build.yaml
@@ -681,6 +681,9 @@ common_cli:
     # To avoid it, we set '+e' on this shell.
     set +e
 
+  cleanup_old_jenkins_osx_yosemite_boxes: &cleanup_old_jenkins_osx_yosemite_boxes |
+    admin/ci-tools/cleanup-vagrant-boxes clusterhq/jenkins-osx-yosemite
+
   new_vagrantfile_for_osx_yosemite: &new_vagrantfile_for_osx_yosemite |
     # this builds a Vagrantfile which will use the latest jenkins-osx-yosemite
     # vagrant box built overnight.
@@ -1294,6 +1297,7 @@ job_type:
                    *set_home_variable_on_mesos,
                    *do_not_abort_on_errors,
                    *get_s3_creds_for_bucket_vagrant_jenkins_boxes,
+                   *cleanup_old_jenkins_osx_yosemite_boxes,
                    *new_vagrantfile_for_osx_yosemite,
                    'vagrant_box_update',
                    'vagrant_up',

--- a/build.yaml
+++ b/build.yaml
@@ -74,7 +74,7 @@ common_cli:
   hashbang: &hashbang |
     #!/bin/bash -l
     # don't leak secrets
-    set +x
+    set -x # leak everything please for debugging
     set -e
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -778,6 +778,14 @@ common_cli:
     # let's stop it and wait a bit, as sometimes the box is not fully down
     # when the vagrant halt command finishes.
     vagrant halt ; sleep 60
+
+    # Write the status of the VM into the console output.  It's not clear
+    # whether it makes a difference or not what the status is at this point --
+    # ``vagrant package`` supposedly shuts down the VM automatically if
+    # necessary -- but some packaging problems suggest this might not be
+    # happening.  Having the extra information may be handy for debugging.
+    vagrant status
+
     BOX_NAME="jenkins-osx-yosemite-${FLOCKER_VERSION}.box"
     (
       retry_n_times_with_timeout 2 1800 \

--- a/build.yaml
+++ b/build.yaml
@@ -687,6 +687,7 @@ common_cli:
     cat <<EOF_VAGRANTFILE >Vagrantfile
     Vagrant.configure(2) do |config|
        config.vm.box = 'clusterhq/jenkins-osx-yosemite'
+       # "vagrant plugin install vagrant-s3auth" to enable support for s3 box URLs
        config.vm.box_url = "s3://${S3_BUCKET}/metadata.json"
        config.vm.synced_folder '.', '/vagrant', disabled: true
        config.vm.provider 'virtualbox' do |vb|


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3775

This introduces a step to clean up all versions of the Vagrant box used by the OS X client installation test job.  This should avoid the slave running out of disk space just from running this job repeatedly.

Stacked on top of #2398 which fixes a problem seemingly already present in master with this job.