### PR TITLE
[FLOC-3788] Migrate flocker.common tests to new base cases

### DIFF
--- a/flocker/common/functional/test_ipc.py
+++ b/flocker/common/functional/test_ipc.py
@@ -6,11 +6,11 @@ Functional tests for IPC.
 
 from twisted.internet.threads import deferToThread
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import TestCase
 
 from .. import ProcessNode
 from ..test.test_ipc import make_inode_tests
 from ...testtools.ssh import create_ssh_server
+from ...testtools import AsyncTestCase, TestCase
 
 
 def make_prefixless_processnode(test_case):
@@ -110,7 +110,7 @@ def make_sshnode(test_case):
         username=b"root", private_key=server.key_path)
 
 
-class SSHProcessNodeTests(TestCase):
+class SSHProcessNodeTests(AsyncTestCase):
     """Tests for ``ProcessNode.with_ssh``."""
 
     def test_runs_command(self):

--- a/flocker/common/functional/test_script.py
+++ b/flocker/common/functional/test_script.py
@@ -18,7 +18,6 @@ from zope.interface import implementer
 from eliot import Message
 from eliot.testing import assertContainsFields
 
-from twisted.trial.unittest import TestCase
 from twisted.internet import reactor
 from twisted.internet.utils import getProcessOutput
 from twisted.internet.defer import succeed, Deferred
@@ -29,7 +28,7 @@ from twisted.python.usage import Options, UsageError
 
 from ..script import ICommandLineScript, flocker_standard_options
 from ...common import loop_until
-from ...testtools import random_name, if_root
+from ...testtools import random_name, if_root, AsyncTestCase, TestCase
 
 
 def _journald_available():
@@ -115,7 +114,7 @@ FlockerScriptRunner({}(), StandardOptions()).main()
 '''
 
 
-class FlockerScriptRunnerTests(TestCase):
+class FlockerScriptRunnerTests(AsyncTestCase):
     """
     Functional tests for ``FlockerScriptRunner``.
     """
@@ -311,7 +310,7 @@ class FlockerScriptRunnerTests(TestCase):
         return d
 
 
-class FlockerScriptRunnerJournaldTests(TestCase):
+class FlockerScriptRunnerJournaldTests(AsyncTestCase):
     """
     Functional tests for ``FlockerScriptRunner`` journald support.
     """

--- a/flocker/common/test/test_algebraic.py
+++ b/flocker/common/test/test_algebraic.py
@@ -11,11 +11,9 @@ from pyrsistent import (
 )
 from hypothesis import given, strategies as st, assume, example
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from twisted.python.constants import Names, NamedConstant
 
-
+from ...testtools import TestCase
 from ..algebraic import TaggedUnionInvariant, tagged_union_strategy
 
 
@@ -51,7 +49,7 @@ ALGEBRAIC_TYPE_ARGUMENTS_STRATEGY = ALGEBRAIC_TYPE_STRATEGY.map(
     lambda v: v.serialize())
 
 
-class TaggedUnionInvariantTests(SynchronousTestCase):
+class TaggedUnionInvariantTests(TestCase):
     """
     Tests for ``TaggedUnionInvariant``.
     """

--- a/flocker/common/test/test_defer.py
+++ b/flocker/common/test/test_defer.py
@@ -9,10 +9,10 @@ import gc
 from eliot.testing import capture_logging
 
 from .._defer import gather_deferreds
+from ...testtools import TestCase
 
 from twisted.internet.defer import fail, FirstError, succeed, Deferred
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
 
 
 class GatherDeferredsTests(TestCase):

--- a/flocker/common/test/test_era.py
+++ b/flocker/common/test/test_era.py
@@ -7,18 +7,18 @@ Tests for ``flocker.common._era``.
 from uuid import UUID
 from unittest import skipUnless
 
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.runtime import platform
 from .._era import get_era
+from ...testtols import TestCase
 
 
-class EraTests(SynchronousTestCase):
+class EraTests(TestCase):
     """
     Tests for ``get_era``
     """
     @skipUnless(platform.isLinux(), "get_era() only supported on Linux.")
     def setUp(self):
-        pass
+        super(EraTests, self).setUp()
 
     def test_get_era(self):
         """

--- a/flocker/common/test/test_era.py
+++ b/flocker/common/test/test_era.py
@@ -9,7 +9,7 @@ from unittest import skipUnless
 
 from twisted.python.runtime import platform
 from .._era import get_era
-from ...testtols import TestCase
+from ...testtools import TestCase
 
 
 class EraTests(TestCase):

--- a/flocker/common/test/test_interface.py
+++ b/flocker/common/test/test_interface.py
@@ -4,8 +4,6 @@
 Tests for ``flocker.common._interface``.
 """
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from eliot.testing import (
     assertHasMessage, capture_logging
 )
@@ -15,6 +13,7 @@ from pyrsistent import PClass, field, InvariantException
 from zope.interface import Interface, implementer
 
 from .. import interface_decorator, provides
+from ...testtools import TestCase
 
 
 # Eliot structures for testing ``interface_decorator``.
@@ -99,7 +98,7 @@ class LoggingDummy(object):
         self._dummy = dummy
 
 
-class InterfaceDecoratorTests(SynchronousTestCase):
+class InterfaceDecoratorTests(TestCase):
     """
     Tests for ``interface_decorator``.
     """
@@ -142,7 +141,7 @@ class InterfaceHolder(PClass):
     value = field(invariant=provides(IDummy), mandatory=True)
 
 
-class ProvidesTests(SynchronousTestCase):
+class ProvidesTests(TestCase):
     """
     Tests for ``provides``.
     """

--- a/flocker/common/test/test_ipc.py
+++ b/flocker/common/test/test_ipc.py
@@ -6,12 +6,10 @@ Unit tests for IPC.
 
 from __future__ import absolute_import
 
-from unittest import TestCase as PyTestCase
-
 from zope.interface.verify import verifyObject
 
 from .. import INode, FakeNode
-from ...testtools import assertNoFDsLeaked
+from ...testtools import TestCase, assertNoFDsLeaked
 
 
 def make_inode_tests(fixture):
@@ -21,7 +19,7 @@ def make_inode_tests(fixture):
     :param fixture: A fixture that returns a :class:`INode` provider which
         will work with any arbitrary valid program with arguments.
     """
-    class INodeTests(PyTestCase):
+    class INodeTests(TestCase):
         """Tests for :class:`INode` implementors.
 
         May be functional tests depending on the fixture.
@@ -47,9 +45,11 @@ def make_inode_tests(fixture):
             Exceptions raised in the context manager are not swallowed.
             """
             node = fixture(self)
-            with self.assertRaises(RuntimeError):
+
+            def run_node():
                 with node.run([b"cat"]):
                     raise RuntimeError()
+            self.assertRaises(RuntimeError, run_node)
 
         def test_run_no_fd_leakage_exceptions(self):
             """

--- a/flocker/common/test/test_openstack.py
+++ b/flocker/common/test/test_openstack.py
@@ -4,6 +4,7 @@
 Tests for ``flocker.common.auto_openstack_logging``.
 """
 
+from unittest import skipIf
 from twisted.web.http import INTERNAL_SERVER_ERROR
 
 from eliot.testing import LoggedMessage, assertContainsFields, capture_logging
@@ -64,8 +65,10 @@ class AutoOpenStackLoggingTests(TestCase):
     """
     Tests for ``auto_openstack_logging``.
     """
-    if dependency_skip is not None:
-        skip = dependency_skip
+
+    @skipIf(dependency_skip, dependency_skip)
+    def setUp(self):
+        super(AutoOpenStackLoggingTests, self).setUp()
 
     def test_return(self):
         """

--- a/flocker/common/test/test_openstack.py
+++ b/flocker/common/test/test_openstack.py
@@ -4,12 +4,13 @@
 Tests for ``flocker.common.auto_openstack_logging``.
 """
 
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.web.http import INTERNAL_SERVER_ERROR
 
 from eliot.testing import LoggedMessage, assertContainsFields, capture_logging
 
 from zope.interface import Interface, implementer
+
+from ...testtools import TestCase
 
 try:
     from novaclient.exceptions import ClientException as NovaClientException
@@ -59,7 +60,7 @@ class LoggingDummy(object):
         self._dummy = dummy
 
 
-class AutoOpenStackLoggingTests(SynchronousTestCase):
+class AutoOpenStackLoggingTests(TestCase):
     """
     Tests for ``auto_openstack_logging``.
     """

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -21,7 +21,6 @@ from eliot.testing import (
 )
 
 from twisted.internet.defer import succeed, fail, Deferred
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import CancelledError
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
@@ -53,7 +52,7 @@ from .._retry import (
 from ...testtools import TestCase, CustomException
 
 
-class LoopUntilTests(SynchronousTestCase):
+class LoopUntilTests(TestCase):
     """
     Tests for :py:func:`loop_until`.
     """
@@ -356,7 +355,7 @@ class TimeoutTests(TestCase):
 ITERATION_MESSAGE = MessageType("iteration_message", fields(iteration=int))
 
 
-class RetryFailureTests(SynchronousTestCase):
+class RetryFailureTests(TestCase):
     """
     Tests for :py:func:`retry_failure`.
     """
@@ -521,7 +520,7 @@ class RetryFailureTests(SynchronousTestCase):
         self.assertEqual(self.failureResultOf(d), type_error)
 
 
-class PollUntilTests(SynchronousTestCase):
+class PollUntilTests(TestCase):
     """
     Tests for ``poll_until``.
     """
@@ -577,7 +576,7 @@ class PollUntilTests(SynchronousTestCase):
             poll_until(lambda: results.pop(0), steps, lambda ignored: None))
 
 
-class RetryEffectTests(SynchronousTestCase):
+class RetryEffectTests(TestCase):
     """
     Tests for :py:func:`retry_effect_with_timeout`.
     """
@@ -696,7 +695,7 @@ class RetryEffectTests(SynchronousTestCase):
 EXPECTED_RETRY_SOME_TIMES_RETRIES = 1200
 
 
-class GetDefaultRetryStepsTests(testtools.TestCase):
+class GetDefaultRetryStepsTests(TestCase):
     """
     Tests for ``get_default_retry_steps``.
     """
@@ -721,7 +720,7 @@ class GetDefaultRetryStepsTests(testtools.TestCase):
         self.assertThat(steps, AllMatch(GreaterThan(timedelta())))
 
 
-class RetryIfTests(testtools.TestCase):
+class RetryIfTests(TestCase):
     """
     Tests for ``retry_if``.
     """
@@ -806,7 +805,7 @@ class DecorateMethodsTests(testtools.TestCase):
         )
 
 
-class WithRetryTests(testtools.TestCase):
+class WithRetryTests(TestCase):
     """
     Tests for ``with_retry``.
     """

--- a/flocker/common/test/test_retry.py
+++ b/flocker/common/test/test_retry.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 from itertools import repeat, count
 from functools import partial
 
-import testtools
 from testtools.matchers import (
     MatchesPredicate, Equals, AllMatch, IsInstance, GreaterThan, raises
 )
@@ -755,7 +754,7 @@ class RetryIfTests(TestCase):
         )
 
 
-class DecorateMethodsTests(testtools.TestCase):
+class DecorateMethodsTests(TestCase):
     """
     Tests for ``decorate_methods``.
     """

--- a/flocker/common/test/test_runner.py
+++ b/flocker/common/test/test_runner.py
@@ -7,12 +7,11 @@ import os
 
 from eliot.testing import capture_logging, assertHasMessage
 
-from twisted.trial.unittest import TestCase
 from twisted.python.failure import Failure
 from twisted.internet.error import ProcessDone, ProcessTerminated
 
 from flocker.testtools import (
-    MemoryCoreReactor, FakeProcessReactor,
+    MemoryCoreReactor, FakeProcessReactor, TestCase,
 )
 
 from ..runner import (

--- a/flocker/common/test/test_script.py
+++ b/flocker/common/test/test_script.py
@@ -9,7 +9,6 @@ from eliot.testing import validateLogging, assertHasMessage
 from twisted.internet import task
 from twisted.internet.defer import succeed
 from twisted.python import usage
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.failure import Failure
 from twisted.python.log import LogPublisher
 from twisted.python import log as twisted_log
@@ -22,11 +21,11 @@ from ..script import (
     )
 from ...testtools import (
     help_problems, FakeSysModule, StandardOptionsTestsMixin,
-    MemoryCoreReactor,
+    MemoryCoreReactor, TestCase,
     )
 
 
-class FlockerScriptRunnerInitTests(SynchronousTestCase):
+class FlockerScriptRunnerInitTests(TestCase):
     """Tests for :py:meth:`FlockerScriptRunner.__init__`."""
 
     def test_sys_default(self):
@@ -60,7 +59,7 @@ class FlockerScriptRunnerInitTests(SynchronousTestCase):
         )
 
 
-class FlockerScriptRunnerParseOptionsTests(SynchronousTestCase):
+class FlockerScriptRunnerParseOptionsTests(TestCase):
     """Tests for :py:meth:`FlockerScriptRunner._parse_options`."""
 
     def test_parse_options(self):
@@ -108,7 +107,7 @@ class FlockerScriptRunnerParseOptionsTests(SynchronousTestCase):
         )
 
 
-class FlockerScriptRunnerMainTests(SynchronousTestCase):
+class FlockerScriptRunnerMainTests(TestCase):
     """Tests for :py:meth:`FlockerScriptRunner.main`."""
 
     def test_main_uses_sysargv(self):
@@ -168,8 +167,7 @@ class TestOptions(usage.Options):
     """An unmodified ``usage.Options`` subclass for use in testing."""
 
 
-class FlockerStandardOptionsTests(StandardOptionsTestsMixin,
-                                  SynchronousTestCase):
+class FlockerStandardOptionsTests(StandardOptionsTestsMixin, TestCase):
     """Tests for ``flocker_standard_options``
 
     Using a decorating an unmodified ``usage.Options`` subclass.
@@ -194,11 +192,12 @@ class AsyncStopService(Service):
         return self.stop_result
 
 
-class MainForServiceTests(SynchronousTestCase):
+class MainForServiceTests(TestCase):
     """
     Tests for ``main_for_service``.
     """
     def setUp(self):
+        super(MainForServiceTests, self).setUp()
         self.reactor = MemoryCoreReactor()
         self.service = Service()
 
@@ -266,7 +265,7 @@ class MainForServiceTests(SynchronousTestCase):
         self.assertIs(None, self.successResultOf(result))
 
 
-class EliotObserverTests(SynchronousTestCase):
+class EliotObserverTests(TestCase):
     """
     Tests for ``EliotObserver``.
     """

--- a/flocker/common/test/test_thread.py
+++ b/flocker/common/test/test_thread.py
@@ -9,13 +9,13 @@ from zope.interface import Attribute, Interface, implementer
 from eliot import ActionType
 from eliot.testing import capture_logging, assertHasAction, LoggedAction
 
-from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
 
 from pyrsistent import PClass, field
 
 from .. import auto_threaded
+from ...testtools import TestCase, AsyncTestCase
 
 
 class IStub(Interface):
@@ -113,11 +113,12 @@ class NonReactor(object):
         f(*args, **kwargs)
 
 
-class AutoThreadedTests(SynchronousTestCase):
+class AutoThreadedTests(TestCase):
     """
     Tests for ``flocker.common.auto_threaded``.
     """
     def setUp(self):
+        super(AutoThreadedTests, self).setUp()
         self.reactor = NonReactor()
         self.threadpool = NonThreadPool()
         # Some unique objects that support ``+``
@@ -188,7 +189,7 @@ class AutoThreadedTests(SynchronousTestCase):
         )
 
 
-class AutoThreadedIntegrationTests(TestCase):
+class AutoThreadedIntegrationTests(AsyncTestCase):
     """
     Tests for ``auto_threaded`` in combination with a real reactor and a real
     thread pool, ``twisted.python.threads.ThreadPool``.

--- a/flocker/common/test/test_version.py
+++ b/flocker/common/test/test_version.py
@@ -117,7 +117,7 @@ def build_version_test(name, version_case):
     Create a test case that checks that a given version
     is interpreted as expected.
     """
-    class Tests(SynchronousTestCase):
+    class Tests(TestCase):
         def test_flocker_version(self):
             """
             The parsed version matches the expected parsed version.
@@ -379,7 +379,7 @@ LegacyDocReleaseTests = build_version_test(
 )
 
 
-class GetPreReleaseTests(SynchronousTestCase):
+class GetPreReleaseTests(TestCase):
     """
     Tests for :function:`get_pre_release`.
     """

--- a/flocker/common/test/test_version.py
+++ b/flocker/common/test/test_version.py
@@ -5,8 +5,6 @@ Tests for :module:`flocker.docs.version`.
 """
 
 
-from twisted.trial.unittest import SynchronousTestCase
-
 try:
     from packaging.version import Version as PEP440Version
     PACKAGING_INSTALLED = True
@@ -26,9 +24,10 @@ from ..version import (
 )
 
 from flocker.common.version import RPMVersion, make_rpm_version
+from flocker.testtools import TestCase
 
 
-class MakeRpmVersionTests(SynchronousTestCase):
+class MakeRpmVersionTests(TestCase):
     """
     Tests for ``make_rpm_version``.
     """
@@ -71,7 +70,7 @@ class MakeRpmVersionTests(SynchronousTestCase):
             make_rpm_version('0.1.2rcX')
 
 
-class InvalidVersionTests(SynchronousTestCase):
+class InvalidVersionTests(TestCase):
     """
     Tests for invalid versions.
     """
@@ -400,7 +399,7 @@ class GetPreReleaseTests(SynchronousTestCase):
         self.assertEqual(get_pre_release('0.3.2rc3'), 3)
 
 
-class TargetReleaseTests(SynchronousTestCase):
+class TargetReleaseTests(TestCase):
     """
     Tests for :function:`target_release`.
     """
@@ -420,7 +419,7 @@ class TargetReleaseTests(SynchronousTestCase):
         self.assertEqual(target_release('0.3.2rc3'), '0.3.2')
 
 
-class GetPackageKeySuffixTests(SynchronousTestCase):
+class GetPackageKeySuffixTests(TestCase):
     """
     Tests for :function:`get_package_key_suffix`.
     """

--- a/flocker/common/test/test_version.py
+++ b/flocker/common/test/test_version.py
@@ -180,7 +180,7 @@ def build_version_test(name, version_case):
                 version_case.is_pre_release,
             )
 
-        @skipUnless(PACKAGING_INSTALLED, "``packaing`` not installed.")
+        @skipUnless(PACKAGING_INSTALLED, "``packaging`` not installed.")
         def test_pep_440(self):
             """
             The version is a valid PEP440 version.
@@ -189,7 +189,7 @@ def build_version_test(name, version_case):
             """
             PEP440Version(version_case.version)
 
-        @skipUnless(PACKAGING_INSTALLED, "``packaing`` not installed.")
+        @skipUnless(PACKAGING_INSTALLED, "``packaging`` not installed.")
         @skipIf(version_case.is_legacy, "Legacy version isn't normalized.")
         def test_normalization(self):
             """


### PR DESCRIPTION
Mostly mechanical. Some tests have been changed to be synchronous where they weren't before.

In modules that were already using absolute imports, I used absolute imports