### PR TITLE
[FLOC-3686] EBS check attachment state

### DIFF
--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -45,7 +45,7 @@ from eliot import Message, register_exception_extractor
 from .blockdevice import (
     IBlockDeviceAPI, IProfiledBlockDeviceAPI, BlockDeviceVolume, UnknownVolume,
     AlreadyAttachedVolume, UnattachedVolume, UnknownInstanceID,
-    MandatoryProfiles, ICloudAPI,
+    MandatoryProfiles
 )
 
 from ..script import StorageInitializationError
@@ -75,6 +75,8 @@ IOPS_MIN_SIZE = 4
 # for error details:
 NOT_FOUND = u'InvalidVolume.NotFound'
 INVALID_PARAMETER_VALUE = u'InvalidParameterValue'
+
+VOLUME_ATTACHMENT_BUSY = u'busy'
 
 
 # Register Eliot field extractor for ClientError responses.
@@ -276,6 +278,14 @@ class AttachFailed(Exception):
     """
 
 
+class DetachFailed(Exception):
+    """
+    A volume could not be detached, due to being in busy state.
+    """
+    def __init__(self, volume):
+        Exception.__init__(volume.id, volume.attachments)
+
+
 class InvalidRegionError(Exception):
     """
     The supplied region is not a valid AWS endpoint.
@@ -389,6 +399,27 @@ def _enable_boto_logging():
     logger.addHandler(EliotLogHandler())
 
 _enable_boto_logging()
+
+
+class AttachUnexpectedInstance(Exception):
+    """
+    An attempt was made to attach a volume to an instance other than the
+    one this ``IBlockDeviceAPI`` implementation is running on.
+    """
+    def __init__(self, blockdevice_id, instance_id, local_instance_id):
+        """
+        :param unicode blockdevice_id: The identity of the block device we
+            are attempting to attach.
+        :param unicode instance_id: The identity of the instance we are
+            attempting to attach the block device to.
+        :param unicode local_instance_id: The identity of the instance this
+            API is running on.
+        """
+        Exception.__init__(
+            self, blockdevice_id, instance_id, local_instance_id)
+        self.blockdevice_id = blockdevice_id
+        self.instance_id = instance_id
+        self.local_instance_id = local_instance_id
 
 
 @with_cmp(["requested", "discovered"])
@@ -524,9 +555,10 @@ def _get_volume_tag(volume, name):
 
     :return: A ``str`` representing the value of the tag.
     """
-    for tag in volume.tags:
-        if tag['Key'] == name:
-            return tag['Value']
+    if volume.tags:
+        for tag in volume.tags:
+            if tag['Key'] == name:
+                return tag['Value']
     raise TagNotFound(volume.id, name, volume.tags)
 
 
@@ -851,7 +883,6 @@ def _get_blockdevices():
 
 @implementer(IBlockDeviceAPI)
 @implementer(IProfiledBlockDeviceAPI)
-@implementer(ICloudAPI)
 class EBSBlockDeviceAPI(object):
     """
     An EBS implementation of ``IBlockDeviceAPI`` which creates
@@ -998,45 +1029,45 @@ class EBSBlockDeviceAPI(object):
         return volume.attach_to_instance(
             InstanceId=instance_id, Device=device)
 
-    def _next_device(self, instance_id, volumes, devices_in_use):
+    def _next_device(self):
         """
-        Get the next available EBS device name for a given EC2 instance.
+        Get the next available EBS device name for this EC2 instance.
 
-        Algorithm:
-        1. Get all ``Block devices`` currently in use by given instance:
-            a) List all volumes visible to this instance.
-            b) Gather device IDs of all devices attached to (a).
-        2. Devices available for EBS volume usage are ``/dev/sd[f-p]``.
-           Find the first device from this set that is currently not
-           in use.
+        Devices available for EBS volume usage are ``/dev/sd[f-p]``.
+        Find the first device from this set that is currently not
+        in use.
         XXX: Handle lack of free devices in ``/dev/sd[f-p]`` range
         (see https://clusterhq.atlassian.net/browse/FLOC-1887).
-
-        :param unicode instance_id: EC2 instance ID.
-        :param volumes: Collection of currently known
-            ``BlockDeviceVolume`` instances.
-        :param set devices_in_use: Unicode names of devices that are
-            probably in use based on observed behavior.
 
         :returns unicode file_name: available device name for attaching
             EBS volume.
         :returns ``None`` if suitable EBS device names on this EC2
             instance are currently occupied.
         """
-        volume_devices = []
-        for v in volumes:
-            volume_attachments = v.attachments
-            for attachment in volume_attachments:
-                if attachment['InstanceId'] == instance_id:
-                    volume_devices.append(attachment['Device'])
-        devices = pset(volume_devices)
-        devices = devices | devices_in_use
-        sorted_devices = sorted(list(thaw(devices)))
+
+        command = [b"/bin/lsblk", b"--output", b"KNAME"]
+        # Command result returns a list of kernel device names
+        # separated by line breaks, with KNAME as the output of the
+        # header row. The top line is therefore ignored in the filter
+        # below.
+        command_result = check_output(command)
+        local_devices = pset(filter(
+            lambda d: d.startswith(b"xvd") or d.startswith('sd'),
+            command_result.split("\n")[1:]
+        ))
+        sorted_devices = sorted(list(thaw(local_devices)))
         IN_USE_DEVICES(devices=sorted_devices).write()
 
         for suffix in b"fghijklmonp":
-            file_name = u'/dev/sd' + suffix
-            if file_name not in devices:
+            next_local_device = b'xvd' + suffix
+            next_local_sd_device = b'sd' + suffix
+            file_name = u'/dev/sd' + unicode(suffix)
+            possible_devices = [
+                next_local_device, next_local_sd_device
+            ]
+            if not any(
+                list(device in local_devices for device in possible_devices)
+            ):
                 return file_name
 
         # Could not find any suitable device that is available
@@ -1178,12 +1209,15 @@ class EBSBlockDeviceAPI(object):
                 ebs_volume.state != VolumeStates.AVAILABLE.value):
             raise AlreadyAttachedVolume(blockdevice_id)
 
+        local_instance_id = self.compute_instance_id()
+        if attach_to != local_instance_id:
+            raise AttachUnexpectedInstance(
+                blockdevice_id, attach_to, local_instance_id)
+
         attached = False
-        ignore_devices = pset([])
         for attach_attempt in range(3):
             with self.lock:
-                volumes = self._list_ebs_volumes()
-                device = self._next_device(attach_to, volumes, ignore_devices)
+                device = self._next_device()
                 if device is None:
                     # XXX: Handle lack of free devices in ``/dev/sd[f-p]``.
                     # (https://clusterhq.atlassian.net/browse/FLOC-1887).
@@ -1202,8 +1236,6 @@ class EBSBlockDeviceAPI(object):
                     )
                     attached_volume = volume.set('attached_to', attach_to)
                     return attached_volume
-                else:
-                    ignore_devices = ignore_devices.add(device)
 
         raise AttachFailed(volume.blockdevice_id, attach_to, device)
 
@@ -1221,6 +1253,11 @@ class EBSBlockDeviceAPI(object):
         ebs_volume = self._get_ebs_volume(blockdevice_id)
         if ebs_volume.state != VolumeStates.IN_USE.value:
             raise UnattachedVolume(blockdevice_id)
+
+        if ebs_volume.attachments:
+            attachment_state = ebs_volume.attachments[0]['State']
+            if attachment_state == VOLUME_ATTACHMENT_BUSY:
+                raise DetachFailed(ebs_volume)
 
         self._detach_ebs_volume(blockdevice_id)
 
@@ -1285,13 +1322,6 @@ class EBSBlockDeviceAPI(object):
             )
 
         return _expected_device(ebs_volume.attachments[0]['Device'])
-
-    # ICloudAPI:
-    @boto3_log
-    def list_live_nodes(self):
-        instances = self.connection.instances.filter(
-            Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
-        return list(instance.id for instance in instances)
 
 
 def aws_from_configuration(region, zone, access_key_id, secret_access_key,


### PR DESCRIPTION
Fixes FLOC-3686. Not sure if we need a functional test for this? it should be possible to do one by calling out to a `mount --rbind` command on the node after creating and mounting a volume, then deleting the volume and seeing the `DetachFailed` exception in the log.