### PR TITLE
[FLOC-3790] Move flocker.provision tests to new base cases

### DIFF
--- a/flocker/provision/test/test_ca.py
+++ b/flocker/provision/test/test_ca.py
@@ -7,13 +7,13 @@ Tests for cluster certificate generation.
 from unittest import skipUnless
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.procutils import which
 
+from ...testtools import TestCase
 from .. import Certificates
 
 
-class CertificatesGenerateTests(SynchronousTestCase):
+class CertificatesGenerateTests(TestCase):
     """
     Tests for ``Certificates.generate``.
     """

--- a/flocker/provision/test/test_common.py
+++ b/flocker/provision/test/test_common.py
@@ -4,13 +4,12 @@
 Tests for common provision code.
 """
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from flocker.common.version import make_rpm_version
 from flocker.provision._common import PackageSource
+from flocker.testtools import TestCase
 
 
-class PackageSourceTests(SynchronousTestCase):
+class PackageSourceTests(TestCase):
     """
     Tests for ``PackageSource.os_version``.
     """

--- a/flocker/provision/test/test_install.py
+++ b/flocker/provision/test/test_install.py
@@ -6,8 +6,6 @@ Tests for ``flocker.provision._install``.
 
 import yaml
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from pyrsistent import freeze, thaw
 
 from textwrap import dedent
@@ -23,6 +21,7 @@ from .._install import (
 from .._ssh import Put
 from .._effect import sequence
 from ...acceptance.testtools import DatasetBackend
+from ...testtools import TestCase
 
 from ... import __version__ as flocker_version
 
@@ -40,7 +39,7 @@ BASIC_AGENT_YML = freeze({
 })
 
 
-class ConfigureFlockerAgentTests(SynchronousTestCase):
+class ConfigureFlockerAgentTests(TestCase):
     """
     Tests for ``task_configure_flocker_agent``.
     """
@@ -80,7 +79,7 @@ class ConfigureFlockerAgentTests(SynchronousTestCase):
         )
 
 
-class EnableFlockerAgentTests(SynchronousTestCase):
+class EnableFlockerAgentTests(TestCase):
     """
     Tests for ``task_enable_flocker_agent``.
     """
@@ -198,7 +197,7 @@ def _centos7_install_commands(version):
     ])
 
 
-class GetRepoOptionsTests(SynchronousTestCase):
+class GetRepoOptionsTests(TestCase):
     """
     Tests for ``get_repo_options``.
     """
@@ -220,7 +219,7 @@ class GetRepoOptionsTests(SynchronousTestCase):
             ['--enablerepo=clusterhq-testing'])
 
 
-class GetRepositoryURLTests(SynchronousTestCase):
+class GetRepositoryURLTests(TestCase):
     """
     Tests for ``get_repository_url``.
     """
@@ -309,7 +308,7 @@ class GetRepositoryURLTests(SynchronousTestCase):
         )
 
 
-class PrivateKeyLoggingTest(SynchronousTestCase):
+class PrivateKeyLoggingTest(TestCase):
     """
     Test removal of private keys from logs.
     """
@@ -366,7 +365,7 @@ class PrivateKeyLoggingTest(SynchronousTestCase):
             _remove_private_key(key))
 
 
-class DatasetLoggingTest(SynchronousTestCase):
+class DatasetLoggingTest(TestCase):
     """
     Test removal of sensitive information from logged configuration files.
     """

--- a/flocker/provision/test/test_ssh_conch.py
+++ b/flocker/provision/test/test_ssh_conch.py
@@ -6,26 +6,24 @@ from txeffect import perform
 
 from eliot.testing import capture_logging, assertHasMessage
 
-from twisted.internet import reactor
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import TestCase
-
 
 from .._ssh import run, put, run_remotely
 from .._ssh._conch import make_dispatcher, RUN_OUTPUT_MESSAGE
-
+from ...testtools import AsyncTestCase
 
 from flocker.testtools.ssh import create_ssh_server, create_ssh_agent
 
 skip = "See FLOC-1883. These tests don't properly clean up the reactor."
 
 
-class Tests(TestCase):
+class Tests(AsyncTestCase):
     """
     Tests for conch implementation of ``flocker.provision._ssh.RunRemotely``.
     """
 
     def setUp(self):
+        super(Tests, self).setUp()
         self.sshd_config = FilePath(self.mktemp())
         self.server = create_ssh_server(self.sshd_config)
         self.addCleanup(self.server.restore)
@@ -45,7 +43,7 @@ class Tests(TestCase):
         )
 
         d = perform(
-            make_dispatcher(reactor),
+            make_dispatcher(self.reactor),
             command,
         )
 
@@ -67,7 +65,7 @@ class Tests(TestCase):
         )
 
         d = perform(
-            make_dispatcher(reactor),
+            make_dispatcher(self.reactor),
             command,
         )
 
@@ -92,7 +90,7 @@ class Tests(TestCase):
         )
 
         d = perform(
-            make_dispatcher(reactor),
+            make_dispatcher(self.reactor),
             command,
         )
         return d
@@ -112,7 +110,7 @@ class Tests(TestCase):
         )
 
         d = perform(
-            make_dispatcher(reactor),
+            make_dispatcher(self.reactor),
             command,
         )
         return d

--- a/flocker/provision/test/test_ssh_keys.py
+++ b/flocker/provision/test/test_ssh_keys.py
@@ -6,16 +6,15 @@ Tests for :module:`flocker.provision._ssh._keys`.
 
 import os
 
-from twisted.internet import reactor
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import TestCase
 
 from flocker.testtools.ssh import create_ssh_agent, generate_ssh_key
 
+from ...testtools import AsyncTestCase
 from .._ssh._keys import ensure_agent_has_ssh_key, KeyNotFound, AgentNotFound
 
 
-class EnsureKeyTests(TestCase):
+class EnsureKeyTests(AsyncTestCase):
     """
     Tests for ``ensure_agent_has_ssh_key``.
     """
@@ -30,7 +29,7 @@ class EnsureKeyTests(TestCase):
 
         create_ssh_agent(key_file, self)
 
-        result = ensure_agent_has_ssh_key(reactor, key)
+        result = ensure_agent_has_ssh_key(self.reactor, key)
         # No assertion, since the deferred should fire with a
         # successful result.
         return result
@@ -45,7 +44,7 @@ class EnsureKeyTests(TestCase):
 
         create_ssh_agent(key_file, self)
 
-        result = ensure_agent_has_ssh_key(reactor, key)
+        result = ensure_agent_has_ssh_key(self.reactor, key)
         # No assertion, since the deferred should fire with a
         # successful result.
         return result
@@ -62,7 +61,7 @@ class EnsureKeyTests(TestCase):
 
         other_key = generate_ssh_key(FilePath(self.mktemp())).public()
 
-        result = ensure_agent_has_ssh_key(reactor, other_key)
+        result = ensure_agent_has_ssh_key(self.reactor, other_key)
         return self.assertFailure(result, KeyNotFound)
 
     def test_agent_not_found(self):
@@ -82,5 +81,5 @@ class EnsureKeyTests(TestCase):
         key_file = FilePath(self.mktemp())
         key = generate_ssh_key(key_file)
         return self.assertFailure(
-            ensure_agent_has_ssh_key(reactor, key),
+            ensure_agent_has_ssh_key(self.reactor, key),
             AgentNotFound)


### PR DESCRIPTION
Again, straightforward migration. No tests changed synchronicity. I updated some tests that were importing the reactor to use the one provided by `AsyncTestCase` (actually just the global reactor under the hood, so no real difference).