### PR TITLE
[FLOC-3794] replace FlockerScriptTestsMixin should follow the make_foo_tests pattern

### DIFF
--- a/flocker/ca/test/test_script.py
+++ b/flocker/ca/test/test_script.py
@@ -4,7 +4,7 @@ import os
 
 from twisted.python.filepath import FilePath
 from ...testtools import (
-    make_flocker_script_test, StandardOptionsTestsMixin, TestCase,
+    make_flocker_script_test, make_standard_options_test, TestCase,
 )
 from .._script import CAScript, CAOptions
 
@@ -17,11 +17,10 @@ class FlockerCATests(
     """
 
 
-class CAOptionsTests(StandardOptionsTestsMixin, TestCase):
+class CAOptionsTests(make_standard_options_test(CAOptions)):
     """
     Tests for :class:`CAOptions`.
     """
-    options = CAOptions
 
 
 class FlockerCAMainTests(TestCase):

--- a/flocker/ca/test/test_script.py
+++ b/flocker/ca/test/test_script.py
@@ -4,18 +4,17 @@ import os
 
 from twisted.python.filepath import FilePath
 from ...testtools import (
-    FlockerScriptTestsMixin, StandardOptionsTestsMixin, TestCase,
+    make_flocker_script_test, StandardOptionsTestsMixin, TestCase,
 )
 from .._script import CAScript, CAOptions
 
 
-class FlockerCATests(FlockerScriptTestsMixin, TestCase):
+class FlockerCATests(
+        make_flocker_script_test(CAScript, CAOptions, u'flocker-ca')
+):
     """
     Tests for ``flocker-ca`` CLI.
     """
-    script = CAScript
-    options = CAOptions
-    command_name = u'flocker-ca'
 
 
 class CAOptionsTests(StandardOptionsTestsMixin, TestCase):

--- a/flocker/cli/test/test_cli_script.py
+++ b/flocker/cli/test/test_cli_script.py
@@ -1,7 +1,7 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
-from twisted.trial.unittest import TestCase, SynchronousTestCase
-from ...testtools import make_flocker_script_test, StandardOptionsTestsMixin
+from twisted.trial.unittest import TestCase
+from ...testtools import make_flocker_script_test, make_standard_options_test
 from ..script import CLIScript, CLIOptions
 
 
@@ -11,9 +11,8 @@ class FlockerCLITests(
     """Tests for ``flocker`` CLI."""
 
 
-class CLIOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
+class CLIOptionsTests(make_standard_options_test(CLIOptions)):
     """Tests for :class:`CLIOptions`."""
-    options = CLIOptions
 
 
 class FlockerCLIMainTests(TestCase):

--- a/flocker/cli/test/test_cli_script.py
+++ b/flocker/cli/test/test_cli_script.py
@@ -1,15 +1,14 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 from twisted.trial.unittest import TestCase, SynchronousTestCase
-from ...testtools import FlockerScriptTestsMixin, StandardOptionsTestsMixin
+from ...testtools import make_flocker_script_test, StandardOptionsTestsMixin
 from ..script import CLIScript, CLIOptions
 
 
-class FlockerCLITests(FlockerScriptTestsMixin, TestCase):
+class FlockerCLITests(
+        make_flocker_script_test(CLIScript, CLIOptions, u'flocker')
+):
     """Tests for ``flocker`` CLI."""
-    script = CLIScript
-    options = CLIOptions
-    command_name = u'flocker'
 
 
 class CLIOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):

--- a/flocker/cli/test/test_deploy_script.py
+++ b/flocker/cli/test/test_deploy_script.py
@@ -6,19 +6,18 @@ Unit tests for the implementation of ``flocker-deploy``.
 
 from twisted.python.filepath import FilePath
 from twisted.python.usage import UsageError
-from twisted.trial.unittest import TestCase, SynchronousTestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from ...testtools import (
-    FlockerScriptTestsMixin, StandardOptionsTestsMixin)
+    make_flocker_script_test, StandardOptionsTestsMixin)
 from ..script import DeployScript, DeployOptions
 from ...control.httpapi import REST_API_PORT
 
 
-class FlockerDeployTests(FlockerScriptTestsMixin, TestCase):
+class FlockerDeployTests(
+        make_flocker_script_test(DeployScript, DeployOptions, u'flocker-deploy')
+):
     """Tests for ``flocker-deploy``."""
-    script = DeployScript
-    options = DeployOptions
-    command_name = u'flocker-deploy'
 
 
 CONTROL_HOST = u"192.168.1.1"

--- a/flocker/cli/test/test_deploy_script.py
+++ b/flocker/cli/test/test_deploy_script.py
@@ -14,9 +14,9 @@ from ..script import DeployScript, DeployOptions
 from ...control.httpapi import REST_API_PORT
 
 
-class FlockerDeployTests(
-        make_flocker_script_test(DeployScript, DeployOptions, u'flocker-deploy')
-):
+class FlockerDeployTests(make_flocker_script_test(
+        DeployScript, DeployOptions, u'flocker-deploy'
+)):
     """Tests for ``flocker-deploy``."""
 
 

--- a/flocker/cli/test/test_deploy_script.py
+++ b/flocker/cli/test/test_deploy_script.py
@@ -6,10 +6,9 @@ Unit tests for the implementation of ``flocker-deploy``.
 
 from twisted.python.filepath import FilePath
 from twisted.python.usage import UsageError
-from twisted.trial.unittest import SynchronousTestCase
 
 from ...testtools import (
-    make_flocker_script_test, StandardOptionsTestsMixin)
+    make_flocker_script_test, make_standard_options_test)
 from ..script import DeployScript, DeployOptions
 from ...control.httpapi import REST_API_PORT
 
@@ -23,15 +22,14 @@ class FlockerDeployTests(
 CONTROL_HOST = u"192.168.1.1"
 
 
-class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
+class DeployOptionsTests(make_standard_options_test(DeployOptions)):
     """Tests for :class:`DeployOptions`."""
-    options = DeployOptions
 
     def default_port(self):
         """
         The default port to connect to is the REST API port.
         """
-        options = self.options()
+        options = DeployOptions()
         deploy = FilePath(self.mktemp())
         app = FilePath(self.mktemp())
 
@@ -46,7 +44,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the ``certificates-directory`` and any
         of ``cacert``, ``cert`` or ``key`` options are mixed together.
         """
-        options = self.options()
+        options = DeployOptions()
         app = self.mktemp()
         FilePath(app).touch()
         deploy = self.mktemp()
@@ -70,7 +68,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the specified ``cacert`` cluster
         certificate does not exist.
         """
-        options = self.options()
+        options = DeployOptions()
         app = self.mktemp()
         FilePath(app).touch()
         deploy = self.mktemp()
@@ -95,7 +93,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the specified ``cert`` user
         certificate does not exist.
         """
-        options = self.options()
+        options = DeployOptions()
         app = self.mktemp()
         FilePath(app).touch()
         deploy = self.mktemp()
@@ -123,7 +121,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the specified ``key`` user
         private key does not exist.
         """
-        options = self.options()
+        options = DeployOptions()
         app = self.mktemp()
         FilePath(app).touch()
         deploy = self.mktemp()
@@ -154,7 +152,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the ``deployment_config`` file does not
         exist.
         """
-        options = self.options()
+        options = DeployOptions()
         app = self.mktemp()
         FilePath(app).touch()
         deploy = b"/path/to/non-existent-file.cfg"
@@ -168,7 +166,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the ``app_config`` file does not
         exist.
         """
-        options = self.options()
+        options = DeployOptions()
         deploy = self.mktemp()
         FilePath(deploy).touch()
         app = b"/path/to/non-existent-file.cfg"
@@ -182,7 +180,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the supplied deployment
         configuration cannot be parsed as YAML.
         """
-        options = self.options()
+        options = DeployOptions()
         deploy = FilePath(self.mktemp())
         app = FilePath(self.mktemp())
 
@@ -204,7 +202,7 @@ class DeployOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
         A ``UsageError`` is raised if the supplied application
         configuration cannot be parsed as YAML.
         """
-        options = self.options()
+        options = DeployOptions()
         deploy = FilePath(self.mktemp())
         app = FilePath(self.mktemp())
 

--- a/flocker/common/test/test_script.py
+++ b/flocker/common/test/test_script.py
@@ -21,7 +21,7 @@ from ..script import (
     EliotObserver, TWISTED_LOG_MESSAGE,
     )
 from ...testtools import (
-    help_problems, FakeSysModule, StandardOptionsTestsMixin,
+    help_problems, FakeSysModule, make_standard_options_test,
     MemoryCoreReactor,
     )
 
@@ -168,13 +168,11 @@ class TestOptions(usage.Options):
     """An unmodified ``usage.Options`` subclass for use in testing."""
 
 
-class FlockerStandardOptionsTests(StandardOptionsTestsMixin,
-                                  SynchronousTestCase):
+class FlockerStandardOptionsTests(make_standard_options_test(TestOptions)):
     """Tests for ``flocker_standard_options``
 
     Using a decorating an unmodified ``usage.Options`` subclass.
     """
-    options = TestOptions
 
 
 class AsyncStopService(Service):

--- a/flocker/control/test/test_script.py
+++ b/flocker/control/test/test_script.py
@@ -4,19 +4,17 @@ from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 
 from ..script import ControlOptions, ControlScript
-from ...testtools import MemoryCoreReactor, StandardOptionsTestsMixin
+from ...testtools import MemoryCoreReactor, make_standard_options_test
 from .._clusterstate import ClusterStateService
 from ..httpapi import REST_API_PORT
 
 from ...ca.testtools import get_credential_sets
 
 
-class ControlOptionsTests(StandardOptionsTestsMixin,
-                          SynchronousTestCase):
+class ControlOptionsTests(make_standard_options_test(ControlOptions)):
     """
     Tests for ``ControlOptions``.
     """
-    options = ControlOptions
 
     def test_default_port(self):
         """

--- a/flocker/control/test/test_script.py
+++ b/flocker/control/test/test_script.py
@@ -3,7 +3,7 @@
 from twisted.python.filepath import FilePath
 
 from ..script import ControlOptions, ControlScript
-from ...testtools import MemoryCoreReactor, make_standard_options_test
+from ...testtools import MemoryCoreReactor, make_standard_options_test, TestCase
 from .._clusterstate import ClusterStateService
 from ..httpapi import REST_API_PORT
 

--- a/flocker/control/test/test_script.py
+++ b/flocker/control/test/test_script.py
@@ -3,7 +3,9 @@
 from twisted.python.filepath import FilePath
 
 from ..script import ControlOptions, ControlScript
-from ...testtools import MemoryCoreReactor, make_standard_options_test, TestCase
+from ...testtools import (
+    MemoryCoreReactor, make_standard_options_test, TestCase,
+)
 from .._clusterstate import ClusterStateService
 from ..httpapi import REST_API_PORT
 

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -15,7 +15,7 @@ __all__ = [
     'FlockerScriptTestsMixin',
     'MemoryCoreReactor',
     'REALISTIC_BLOCKDEVICE_SIZE',
-    'StandardOptionsTestsMixin',
+    'make_standard_options_tests',
     'TestCase',
     'assertContainsAll',
     'assertNoFDsLeaked',
@@ -294,7 +294,7 @@ def make_flocker_script_test(script, options, command_name):
     """
     class FlockerScriptTestCase(TestCase):
         """
-        Test for classes that implement ICommandLineScript
+        Test for classes that implement ``ICommandLineScript``
         """
 
         def test_interface(self):
@@ -323,134 +323,138 @@ def make_flocker_script_test(script, options, command_name):
     return FlockerScriptTestCase
 
 
-class StandardOptionsTestsMixin(object):
-    """Tests for classes decorated with ``flocker_standard_options``.
-
-    Tests for the standard options that should be available on every flocker
-    command.
+def make_standard_options_test(options):
+    """
+    Return a ``FlockerScriptTestCase`` which tests that the script
+    class provides ICommandLineScript
 
     :ivar usage.Options options: The ``usage.Options`` class under test.
+
+    :returns: a ``TestCase``
     """
-    options = None
+    class StandardOptionsTestCase(TestCase):
+        """
+        Test for classes that implement ICommandLineScript
+        """
+        def test_sys_module_default(self):
+            """
+            ``flocker_standard_options`` adds a ``_sys_module`` attribute which is
+            ``sys`` by default.
+            """
+            self.assertIs(sys, options()._sys_module)
 
-    def test_sys_module_default(self):
-        """
-        ``flocker_standard_options`` adds a ``_sys_module`` attribute which is
-        ``sys`` by default.
-        """
-        self.assertIs(sys, self.options()._sys_module)
+        def test_sys_module_override(self):
+            """
+            ``flocker_standard_options`` adds a ``sys_module`` argument to the
+            initialiser which is assigned to ``_sys_module``.
+            """
+            fake_sys_module = FakeSysModule()
+            self.assertIs(
+                fake_sys_module,
+                options(sys_module=fake_sys_module)._sys_module
+            )
 
-    def test_sys_module_override(self):
-        """
-        ``flocker_standard_options`` adds a ``sys_module`` argument to the
-        initialiser which is assigned to ``_sys_module``.
-        """
-        fake_sys_module = FakeSysModule()
-        self.assertIs(
-            fake_sys_module,
-            self.options(sys_module=fake_sys_module)._sys_module
-        )
+        def test_version(self):
+            """
+            Flocker commands have a `--version` option which prints the current
+            version string to stdout and causes the command to exit with status
+            `0`.
+            """
+            sys = FakeSysModule()
+            error = self.assertRaises(
+                SystemExit,
+                options(sys_module=sys).parseOptions,
+                ['--version']
+            )
+            self.assertEqual(
+                (__version__ + '\n', 0),
+                (sys.stdout.getvalue(), error.code)
+            )
 
-    def test_version(self):
-        """
-        Flocker commands have a `--version` option which prints the current
-        version string to stdout and causes the command to exit with status
-        `0`.
-        """
-        sys = FakeSysModule()
-        error = self.assertRaises(
-            SystemExit,
-            self.options(sys_module=sys).parseOptions,
-            ['--version']
-        )
-        self.assertEqual(
-            (__version__ + '\n', 0),
-            (sys.stdout.getvalue(), error.code)
-        )
+        def test_verbosity_default(self):
+            """
+            Flocker commands have `verbosity` of `0` by default.
+            """
+            options_instance = options()
+            self.assertEqual(0, options_instance['verbosity'])
 
-    def test_verbosity_default(self):
-        """
-        Flocker commands have `verbosity` of `0` by default.
-        """
-        options = self.options()
-        self.assertEqual(0, options['verbosity'])
+        def test_verbosity_option(self):
+            """
+            Flocker commands have a `--verbose` option which increments the
+            configured verbosity by `1`.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError
+            # "Wrong number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
+            # which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions(['--verbose'])
+            self.assertEqual(1, options_instance['verbosity'])
 
-    def test_verbosity_option(self):
-        """
-        Flocker commands have a `--verbose` option which increments the
-        configured verbosity by `1`.
-        """
-        options = self.options()
-        # The command may otherwise give a UsageError
-        # "Wrong number of arguments." if there are arguments required.
-        # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-        # which does not involve patching.
-        self.patch(options, "parseArgs", lambda: None)
-        options.parseOptions(['--verbose'])
-        self.assertEqual(1, options['verbosity'])
+        def test_verbosity_option_short(self):
+            """
+            Flocker commands have a `-v` option which increments the configured
+            verbosity by 1.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError
+            # "Wrong number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
+            # which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions(['-v'])
+            self.assertEqual(1, options_instance['verbosity'])
 
-    def test_verbosity_option_short(self):
-        """
-        Flocker commands have a `-v` option which increments the configured
-        verbosity by 1.
-        """
-        options = self.options()
-        # The command may otherwise give a UsageError
-        # "Wrong number of arguments." if there are arguments required.
-        # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-        # which does not involve patching.
-        self.patch(options, "parseArgs", lambda: None)
-        options.parseOptions(['-v'])
-        self.assertEqual(1, options['verbosity'])
+        def test_verbosity_multiple(self):
+            """
+            `--verbose` can be supplied multiple times to increase the verbosity.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError
+            # "Wrong number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
+            # which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions(['-v', '--verbose'])
+            self.assertEqual(2, options_instance['verbosity'])
 
-    def test_verbosity_multiple(self):
-        """
-        `--verbose` can be supplied multiple times to increase the verbosity.
-        """
-        options = self.options()
-        # The command may otherwise give a UsageError
-        # "Wrong number of arguments." if there are arguments required.
-        # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-        # which does not involve patching.
-        self.patch(options, "parseArgs", lambda: None)
-        options.parseOptions(['-v', '--verbose'])
-        self.assertEqual(2, options['verbosity'])
+        def test_logfile_default(self):
+            """
+            `--logfile` is optional and if ommited, logs will be directed to
+            ``stdout``.
+            """
+            sys = FakeSysModule()
+            options_instance = options(sys_module=sys)
+            # The command may otherwise give a UsageError
+            # "Wrong number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
+            # which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            options_instance.parseOptions([])
+            self.assertIs(sys.stdout, options_instance.eliot_destination.file)
 
-    def test_logfile_default(self):
-        """
-        `--logfile` is optional and if ommited, logs will be directed to
-        ``stdout``.
-        """
-        sys = FakeSysModule()
-        options = self.options(sys_module=sys)
-        # The command may otherwise give a UsageError
-        # "Wrong number of arguments." if there are arguments required.
-        # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-        # which does not involve patching.
-        self.patch(options, "parseArgs", lambda: None)
-        options.parseOptions([])
-        self.assertIs(sys.stdout, options.eliot_destination.file)
+        def test_logfile_override(self):
+            """
+            If `--logfile` is supplied, the Eliot logging destination wraps
+            ``twisted.python.logfile.LogFile``.
+            """
+            options_instance = options()
+            # The command may otherwise give a UsageError
+            # "Wrong number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
+            # which does not involve patching.
+            self.patch(options_instance, "parseArgs", lambda: None)
+            expected_path = FilePath(self.mktemp()).path
+            options_instance.parseOptions(['--logfile={}'.format(expected_path)])
+            logfile = options_instance.eliot_destination.file
+            self.assertEqual(
+                (LogFile, expected_path, int(MiB(100).to_Byte().value), 5),
+                (logfile.__class__, logfile.path,
+                 logfile.rotateLength, logfile.maxRotatedFiles)
+            )
 
-    def test_logfile_override(self):
-        """
-        If `--logfile` is supplied, the Eliot logging destination wraps
-        ``twisted.python.logfile.LogFile``.
-        """
-        options = self.options()
-        # The command may otherwise give a UsageError
-        # "Wrong number of arguments." if there are arguments required.
-        # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-        # which does not involve patching.
-        self.patch(options, "parseArgs", lambda: None)
-        expected_path = FilePath(self.mktemp()).path
-        options.parseOptions(['--logfile={}'.format(expected_path)])
-        logfile = options.eliot_destination.file
-        self.assertEqual(
-            (LogFile, expected_path, int(MiB(100).to_Byte().value), 5),
-            (logfile.__class__, logfile.path,
-             logfile.rotateLength, logfile.maxRotatedFiles)
-        )
-
+    return StandardOptionsTestCase
 
 def make_with_init_tests(record_type, kwargs, expected_defaults=None):
     """

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -320,13 +320,14 @@ def make_flocker_script_test(script, options, command_name):
                 (1, []),
                 (error.code, help_problems(command_name, error_text))
             )
+
     return FlockerScriptTestCase
 
 
 def make_standard_options_test(options):
     """
-    Return a ``FlockerScriptTestCase`` which tests that the script
-    class provides ICommandLineScript
+    Return a ``StandardOptionsTestCase`` which tests that the passed in
+    options class provides the expected defaults and basic functionality.
 
     :ivar usage.Options options: The ``usage.Options`` class under test.
 
@@ -334,12 +335,13 @@ def make_standard_options_test(options):
     """
     class StandardOptionsTestCase(TestCase):
         """
-        Test for classes that implement ICommandLineScript
+        Tests for the standard options that should be available for every
+        flocker command.
         """
         def test_sys_module_default(self):
             """
-            ``flocker_standard_options`` adds a ``_sys_module`` attribute which is
-            ``sys`` by default.
+            ``flocker_standard_options`` adds a ``_sys_module`` attribute
+            which is ``sys`` by default.
             """
             self.assertIs(sys, options()._sys_module)
 
@@ -384,10 +386,10 @@ def make_standard_options_test(options):
             configured verbosity by `1`.
             """
             options_instance = options()
-            # The command may otherwise give a UsageError
-            # "Wrong number of arguments." if there are arguments required.
-            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-            # which does not involve patching.
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
             self.patch(options_instance, "parseArgs", lambda: None)
             options_instance.parseOptions(['--verbose'])
             self.assertEqual(1, options_instance['verbosity'])
@@ -398,23 +400,24 @@ def make_standard_options_test(options):
             verbosity by 1.
             """
             options_instance = options()
-            # The command may otherwise give a UsageError
-            # "Wrong number of arguments." if there are arguments required.
-            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-            # which does not involve patching.
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
             self.patch(options_instance, "parseArgs", lambda: None)
             options_instance.parseOptions(['-v'])
             self.assertEqual(1, options_instance['verbosity'])
 
         def test_verbosity_multiple(self):
             """
-            `--verbose` can be supplied multiple times to increase the verbosity.
+            `--verbose` can be supplied multiple times to increase the
+            verbosity.
             """
             options_instance = options()
-            # The command may otherwise give a UsageError
-            # "Wrong number of arguments." if there are arguments required.
-            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-            # which does not involve patching.
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
             self.patch(options_instance, "parseArgs", lambda: None)
             options_instance.parseOptions(['-v', '--verbose'])
             self.assertEqual(2, options_instance['verbosity'])
@@ -426,10 +429,10 @@ def make_standard_options_test(options):
             """
             sys = FakeSysModule()
             options_instance = options(sys_module=sys)
-            # The command may otherwise give a UsageError
-            # "Wrong number of arguments." if there are arguments required.
-            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-            # which does not involve patching.
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
             self.patch(options_instance, "parseArgs", lambda: None)
             options_instance.parseOptions([])
             self.assertIs(sys.stdout, options_instance.eliot_destination.file)
@@ -440,13 +443,15 @@ def make_standard_options_test(options):
             ``twisted.python.logfile.LogFile``.
             """
             options_instance = options()
-            # The command may otherwise give a UsageError
-            # "Wrong number of arguments." if there are arguments required.
-            # See https://clusterhq.atlassian.net/browse/FLOC-184 about a solution
-            # which does not involve patching.
+            # The command may otherwise give a UsageError "Wrong
+            # number of arguments." if there are arguments required.
+            # See https://clusterhq.atlassian.net/browse/FLOC-184
+            # about a solution which does not involve patching.
             self.patch(options_instance, "parseArgs", lambda: None)
             expected_path = FilePath(self.mktemp()).path
-            options_instance.parseOptions(['--logfile={}'.format(expected_path)])
+            options_instance.parseOptions(
+                ['--logfile={}'.format(expected_path)]
+            )
             logfile = options_instance.eliot_destination.file
             self.assertEqual(
                 (LogFile, expected_path, int(MiB(100).to_Byte().value), 5),
@@ -455,6 +460,7 @@ def make_standard_options_test(options):
             )
 
     return StandardOptionsTestCase
+
 
 def make_with_init_tests(record_type, kwargs, expected_defaults=None):
     """

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -288,7 +288,8 @@ def make_flocker_script_test(script, options, command_name):
 
     :param ICommandLineScript script: The script class under test.
     :param usage.Options options: The options parser class to use in the test.
-    :param text command_name: The name of the command represented by ``script``.
+    :param text command_name: The name of the command represented by
+    ``script``.
 
     :returns: A ``TestCase``.
     """

--- a/flocker/volume/test/test_script.py
+++ b/flocker/volume/test/test_script.py
@@ -10,7 +10,7 @@ from twisted.application.service import Service
 from twisted.python.usage import Options
 
 from ...testtools import (
-    StandardOptionsTestsMixin
+    make_standard_options_test
 )
 from ..testtools import (
     make_volume_options_tests
@@ -36,11 +36,10 @@ class VolumeManagerScriptMainTests(SynchronousTestCase):
         self.assertIs(None, self.successResultOf(result))
 
 
-class VolumeOptionsTests(StandardOptionsTestsMixin, SynchronousTestCase):
+class VolumeOptionsTests(make_standard_options_test(VolumeOptions)):
     """
     Tests for :class:`VolumeOptions`.
     """
-    options = VolumeOptions
 
 
 @flocker_volume_options


### PR DESCRIPTION
As requested in the Jira ticket, replaces inheritence based classes with a class generator.