### PR TITLE
[FLOC-3798] Update Docker container name constraints.

### DIFF
--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -177,7 +177,7 @@ definitions:
     title: "Container name"
     description: "The name of the container."
     type: string
-    pattern: "^[a-zA-Z0-9_-]+$"
+    pattern: "^[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
 
   container_image:
     title: "Container image"

--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -177,7 +177,7 @@ definitions:
     title: "Container name"
     description: "The name of the container."
     type: string
-    pattern: "^[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
+    pattern: "^/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
 
   container_image:
     title: "Container image"

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -442,7 +442,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
         {
             'node_uuid': a_uuid,
             'image': 'postgres',
-            'name': 'postgres-8.1_server'
+            'name': '/postgres-8.1_server'
         },
         {
             'node_uuid': a_uuid,

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -441,6 +441,11 @@ ConfigurationContainersSchemaTests = build_schema_test(
         },
         {
             'node_uuid': a_uuid,
+            'image': 'postgres',
+            'name': 'postgres-8.1_server'
+        },
+        {
+            'node_uuid': a_uuid,
             'image': 'docker/postgres',
             'name': 'postgres'
         },


### PR DESCRIPTION
Docker accepts container names according to the pattern at https://github.com/docker/docker/blob/09ad1bbc5897e34c6e6d5612b0e1ba709ed28a7d/utils/names.go

`flocker-deploy` does not perform any validation of the name, but Flocker's HTTP API constrains JSON requests and responses to a more restricted pattern. This can cause status 500 errors if containers are created using `flocker-deploy` and then interrogated using the HTTP API. Update the HTTP API to match the Docker pattern.