### PR TITLE
[FLOC-3792] Migrate restapi tests to flocker.testtools base classes

### DIFF
--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -2148,50 +2148,6 @@ class UpdatePrimaryDatasetTestsMixin(APITestsMixin):
             self.NODE_A_UUID, self.NODE_A_UUID
         )
 
-    @skip(
-        "XXX: Perhaps this test isn't necessary. "
-        "There should always be a primary."
-        "But perhaps there should be a test that demonstrates the general 500 "
-        "response message format."
-        "See https://clusterhq.atlassian.net/browse/FLOC-1393 and "
-        "https://clusterhq.atlassian.net/browse/FLOC-1403")
-    def test_only_replicas(self):
-        """
-        If there are only replica manifestations of the requested dataset, 500
-        response is returned and ``IndexError`` is logged.
-
-        XXX The 500 error message really should be clearer.
-        See https://clusterhq.atlassian.net/browse/FLOC-1393
-
-        XXX This situation should return a more friendly error code and
-        message.
-        See https://clusterhq.atlassian.net/browse/FLOC-1403.
-        """
-        expected_manifestation = _manifestation(primary=False)
-        node_a = Node(
-            uuid=self.NODE_A_UUID,
-            applications=frozenset(),
-            manifestations={expected_manifestation.dataset_id:
-                            expected_manifestation}
-        )
-        node_b = Node(uuid=self.NODE_B_UUID)
-        deployment = Deployment(nodes=frozenset([node_a, node_b]))
-        saving = self.persistence_service.save(deployment)
-
-        def saved(ignored):
-            creating = self.assertResult(
-                b"POST",
-                b"/configuration/datasets/%s" % (
-                    expected_manifestation.dataset.dataset_id.encode('ascii')
-                ),
-                {u"primary": self.NODE_B},
-                INTERNAL_SERVER_ERROR,
-                u'ELIOT LOG REFERENCE'
-            )
-            return creating
-        saving.addCallback(saved)
-        return saving
-
     def test_primary_invalid(self):
         """
         A request with an invalid (non-IPv4) primary IP address is rejected

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -6,6 +6,7 @@ Tests for ``flocker.control.httpapi``.
 from uuid import uuid4
 from copy import deepcopy
 from datetime import datetime
+from unittest import skip
 
 from pyrsistent import pmap, thaw
 
@@ -1697,6 +1698,10 @@ class CreateDatasetTestsMixin(APITestsMixin):
         """
         return self._dataset_id_collision_test(self.NODE_A, unicode.title)
 
+    @skip(
+        "See FLOC-1278.  Make this pass by inspecting cluster state "
+        "instead of desired configuration to determine whether a node is "
+        "valid or not.")
     def test_unknown_primary_node(self):
         """
         If a ``POST`` request made to the endpoint indicates a non-existent
@@ -1710,11 +1715,6 @@ class CreateDatasetTestsMixin(APITestsMixin):
                     u"The provided primary node is not part of the cluster."
             }
         )
-    test_unknown_primary_node.todo = (
-        "See FLOC-1278.  Make this pass by inspecting cluster state "
-        "instead of desired configuration to determine whether a node is "
-        "valid or not."
-    )
 
     def test_minimal_create_dataset(self):
         """
@@ -2069,6 +2069,10 @@ class UpdatePrimaryDatasetTestsMixin(APITestsMixin):
             self.NODE_A_UUID, self.NODE_B_UUID
         )
 
+    @skip(
+        "See FLOC-1278.  Make this pass by inspecting cluster state "
+        "instead of desired configuration to determine whether a node is "
+        "valid or not.")
     def test_unknown_primary_node(self):
         """
         A dataset's primary IP address must belong to a node in the cluster.
@@ -2104,11 +2108,6 @@ class UpdatePrimaryDatasetTestsMixin(APITestsMixin):
             return creating
         saving.addCallback(saved)
         return saving
-    test_unknown_primary_node.todo = (
-        "See FLOC-1278.  Make this pass by inspecting cluster state "
-        "instead of desired configuration to determine whether a node is "
-        "valid or not."
-    )
 
     def test_change_primary_to_configured_node(self):
         """
@@ -2149,6 +2148,13 @@ class UpdatePrimaryDatasetTestsMixin(APITestsMixin):
             self.NODE_A_UUID, self.NODE_A_UUID
         )
 
+    @skip(
+        "XXX: Perhaps this test isn't necessary. "
+        "There should always be a primary."
+        "But perhaps there should be a test that demonstrates the general 500 "
+        "response message format."
+        "See https://clusterhq.atlassian.net/browse/FLOC-1393 and "
+        "https://clusterhq.atlassian.net/browse/FLOC-1403")
     def test_only_replicas(self):
         """
         If there are only replica manifestations of the requested dataset, 500
@@ -2185,14 +2191,6 @@ class UpdatePrimaryDatasetTestsMixin(APITestsMixin):
             return creating
         saving.addCallback(saved)
         return saving
-    test_only_replicas.todo = (
-        "XXX: Perhaps this test isn't necessary. "
-        "There should always be a primary."
-        "But perhaps there should be a test that demonstrates the general 500 "
-        "response message format."
-        "See https://clusterhq.atlassian.net/browse/FLOC-1393 and "
-        "https://clusterhq.atlassian.net/browse/FLOC-1403"
-    )
 
     def test_primary_invalid(self):
         """
@@ -2425,13 +2423,13 @@ class DeleteDatasetTestsMixin(APITestsMixin):
             additional_headers={IF_MATCHES_HEADER:
                                 [b"willnotmatch"]})
 
+    @skip("Implement in FLOC-1240")
     def test_multiple_manifestations(self):
         """
         If there are multiple manifestations on multiple nodes the ``DELETE``
         action will mark all of their datasets as deleted.
         """
         raise NotImplementedError()
-    test_multiple_manifestations.todo = "Implement in FLOC-1240"
 
 
 RealTestsDeleteDataset, MemoryTestsDeleteDataset = (

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -19,7 +19,7 @@ from twisted.internet.defer import gatherResults
 from twisted.internet.endpoints import TCP4ServerEndpoint
 from twisted.test.proto_helpers import MemoryReactor
 from twisted.web.http import (
-    CREATED, OK, CONFLICT, BAD_REQUEST, NOT_FOUND, INTERNAL_SERVER_ERROR,
+    CREATED, OK, CONFLICT, BAD_REQUEST, NOT_FOUND,
     NOT_ALLOWED as METHOD_NOT_ALLOWED, PRECONDITION_FAILED,
 )
 from twisted.web.client import readBody

--- a/flocker/restapi/docs/test/test_publicapi.py
+++ b/flocker/restapi/docs/test/test_publicapi.py
@@ -6,10 +6,12 @@ Tests for ``flocker.restapi.docs.publicapi``.
 from yaml import safe_dump
 
 from twisted.python.filepath import FilePath
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.reflect import namedModule
 
 from klein import Klein
+
+from ....testtools import TestCase
+
 
 try:
     namedModule("sphinxcontrib")
@@ -26,7 +28,7 @@ else:
 from ..._infrastructure import user_documentation, structured, private_api
 
 
-class GetRoutesTests(SynchronousTestCase):
+class GetRoutesTests(TestCase):
     """
     Tests for L{getRoutes}.
     """
@@ -55,7 +57,7 @@ class GetRoutesTests(SynchronousTestCase):
                        attributes={'attr': 'G'})])
 
 
-class MakeRstTests(SynchronousTestCase):
+class MakeRstTests(TestCase):
     """
     Tests for L{makeRst}.
     """
@@ -709,7 +711,7 @@ class MakeRstTests(SynchronousTestCase):
             ])
 
 
-class FormatExampleTests(SynchronousTestCase):
+class FormatExampleTests(TestCase):
     """
     Tests for L{_formatExample}.
     """
@@ -780,7 +782,7 @@ class FormatExampleTests(SynchronousTestCase):
              u''], lines)
 
 
-class LoadExamplesTests(SynchronousTestCase):
+class LoadExamplesTests(TestCase):
     """
     Tests for L{_loadExamples}.
     """
@@ -808,7 +810,7 @@ class LoadExamplesTests(SynchronousTestCase):
         self.assertRaises(Exception, _loadExamples, path)
 
 
-class VariableInterpolationTests(SynchronousTestCase):
+class VariableInterpolationTests(TestCase):
     """
     Tests for interpolation into route bodies done by L{makeRst}.
     """
@@ -873,7 +875,7 @@ class VariableInterpolationTests(SynchronousTestCase):
         )
 
 
-class ExampleFromDictionaryTests(SynchronousTestCase):
+class ExampleFromDictionaryTests(TestCase):
     """
     Tests for ``Example.fromDictionary``.
     """

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -21,8 +21,6 @@ from twisted.web.http import (
     BAD_REQUEST, INTERNAL_SERVER_ERROR, PAYMENT_REQUIRED, GONE,
     NOT_ALLOWED, NOT_FOUND, OK)
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from .._infrastructure import (
     EndpointResponse, user_documentation, structured, UserDocumentation)
 from .._logging import REQUEST, JSON_REQUEST
@@ -31,6 +29,7 @@ from .._error import DECODING_ERROR_DESCRIPTION, BadRequest
 from ..testtools import (EventChannel, dumps, loads,
                          CloseEnoughJSONResponse, dummyRequest, render,
                          asResponse)
+from ...testtools import TestCase
 from .utils import (
     _assertRequestLogged, _assertTracebackLogged, FAILED_INPUT_VALIDATION)
 
@@ -360,7 +359,7 @@ class Execution(Names):
 
 
 class SynchronousStructuredResultHandlingTests(StructuredResultHandlingMixin,
-                                               SynchronousTestCase):
+                                               TestCase):
     """
     Apply the tests defined by L{StructuredResultHandlingMixin} to an
     application which returns results synchronously without involving
@@ -374,7 +373,7 @@ class SynchronousStructuredResultHandlingTests(StructuredResultHandlingMixin,
 
 
 class SynchronousDeferredStructuredResultHandlingTests(
-        StructuredResultHandlingMixin, SynchronousTestCase):
+        StructuredResultHandlingMixin, TestCase):
     """
     Apply the tests defined by L{StructuredResultHandlingMixin} to an
     application which returns results synchronously as the result of an
@@ -389,7 +388,7 @@ class SynchronousDeferredStructuredResultHandlingTests(
 
 
 class AsynchronousStructuredResultHandlingTests(StructuredResultHandlingMixin,
-                                                SynchronousTestCase):
+                                                TestCase):
     """
     Apply the tests defined by L{StructuredResultHandlingMixin} to an
     application which returns results asynchronously as the future result of a
@@ -410,7 +409,7 @@ class AsynchronousStructuredResultHandlingTests(StructuredResultHandlingMixin,
         return app
 
 
-class StructuredJSONTests(SynchronousTestCase):
+class StructuredJSONTests(TestCase):
     """
     Tests for the L{structured} behavior related to decoding JSON requests and
     serializing JSON responses.
@@ -609,7 +608,7 @@ class StructuredJSONTests(SynchronousTestCase):
             {"jsonValue": True, "routingValue": "quux"}, app.kwargs)
 
 
-class UserDocumentationTests(SynchronousTestCase):
+class UserDocumentationTests(TestCase):
     """
     Tests for L{user_documentation}.
     """
@@ -633,7 +632,7 @@ class UserDocumentationTests(SynchronousTestCase):
             ))
 
 
-class NotAllowedTests(SynchronousTestCase):
+class NotAllowedTests(TestCase):
     """
     Tests for the HTTP method restriction functionality imposed by the routing
     decorator.
@@ -658,7 +657,7 @@ class NotAllowedTests(SynchronousTestCase):
         self.assertEqual(NOT_ALLOWED, request._code)
 
 
-class NotFoundTests(SynchronousTestCase):
+class NotFoundTests(TestCase):
     """
     Tests for the response behavior relating to requests for non-existent
     resources.
@@ -683,7 +682,7 @@ class NotFoundTests(SynchronousTestCase):
         self.assertEqual(NOT_FOUND, request._code)
 
 
-class TracingTests(SynchronousTestCase):
+class TracingTests(TestCase):
     """
     Tests for cross-process tracing with Eliot.
     """

--- a/flocker/restapi/test/test_schema.py
+++ b/flocker/restapi/test/test_schema.py
@@ -5,15 +5,14 @@ Tests for ``flocker.restapi._schema``.
 
 import copy
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from jsonschema.exceptions import RefResolutionError, ValidationError
 
 from .._schema import (
     LocalRefResolver, SchemaNotProvided, getValidator, resolveSchema)
+from ...testtools import TestCase
 
 
-class LocalResolverTests(SynchronousTestCase):
+class LocalResolverTests(TestCase):
     """
     Tests for L{LocalRefResolver}.
     """
@@ -39,7 +38,7 @@ class LocalResolverTests(SynchronousTestCase):
         self.assertIsInstance(e.args[0], SchemaNotProvided)
 
 
-class GetValidatorTests(SynchronousTestCase):
+class GetValidatorTests(TestCase):
     """
     Tests for L{getValidator}.
     """
@@ -65,7 +64,7 @@ class GetValidatorTests(SynchronousTestCase):
         self.assertRaises(ValidationError, validator.validate, {})
 
 
-class ResolveSchemaTests(SynchronousTestCase):
+class ResolveSchemaTests(TestCase):
     """
     Tests for L{ResolveSchema}.
     """

--- a/flocker/restapi/testtools.py
+++ b/flocker/restapi/testtools.py
@@ -19,7 +19,6 @@ from twisted.internet import defer
 from twisted.web.client import ProxyAgent, readBody, FileBodyProducer
 from twisted.web.server import NOT_DONE_YET, Site
 from twisted.web.resource import getChildForRequest
-from twisted.trial.unittest import SynchronousTestCase, TestCase
 from twisted.web.http import urlparse, unquote
 from twisted.internet.address import IPv4Address
 from twisted.test.proto_helpers import StringTransport
@@ -32,6 +31,7 @@ from twisted.web.http_headers import Headers
 from pyrsistent import pmap
 
 from flocker.restapi._schema import getValidator
+from ..testtools import AsyncTestCase, TestCase
 
 
 __all__ = ["buildIntegrationTests", "dumps",
@@ -161,20 +161,20 @@ def extractSuccessfulJSONResult(response):
 
 def buildIntegrationTests(mixinClass, name, fixture):
     """
-    Build L{TestCase} classes that runs the tests in the mixin class with both
-    real and in-memory queries.
+    Build L{AsyncTestCase} classes that runs the tests in the mixin class with
+    both real and in-memory queries.
 
-    @param mixinClass: A mixin class for L{TestCase} that relies on having a
-        C{self.scenario}.
+    @param mixinClass: A mixin class for L{AsyncTestCase} that relies on having
+        a C{self.scenario}.
 
     @param name: A C{str}, the name of the test category.
 
-    :param fixture: A callable that takes a ``TestCase`` and returns a
+    :param fixture: A callable that takes a ``AsyncTestCase`` and returns a
         ``klein.Klein`` object.
 
-    @return: A pair of L{TestCase} classes.
+    @return: A pair of L{AsyncTestCase} classes.
     """
-    class RealTests(mixinClass, TestCase):
+    class RealTests(mixinClass, AsyncTestCase):
         """
         Tests that endpoints are available over the network interfaces that
         real API users will be connecting from.
@@ -195,7 +195,7 @@ def buildIntegrationTests(mixinClass, name, fixture):
             )
             super(RealTests, self).setUp()
 
-    class MemoryTests(mixinClass, TestCase):
+    class MemoryTests(mixinClass, AsyncTestCase):
         """
         Tests that endpoints are available in the appropriate place, without
         testing that the correct network interfaces are listened on.
@@ -214,20 +214,20 @@ def buildIntegrationTests(mixinClass, name, fixture):
 
 def build_UNIX_integration_tests(mixin_class, name, fixture):
     """
-    Build ``TestCase`` class that runs the tests in the mixin class with
+    Build ``AsyncTestCase`` class that runs the tests in the mixin class with
     real queries over a UNIX socket.
 
-    :param mixin_class: A mixin class for ``TestCase`` that relies on having a
-        ``self.scenario``.
+    :param mixin_class: A mixin class for ``AsyncTestCase`` that relies on
+        having a ``self.scenario``.
 
     :param name: A ``str``, the name of the test category.
 
-    :param fixture: A callable that takes a ``TestCase`` and returns a
+    :param fixture: A callable that takes a ``AsyncTestCase`` and returns a
         ``klein.Klein`` object.
 
-    :return: A L``TestCase`` class.
+    :return: A L``AsyncTestCase`` class.
     """
-    class RealTests(mixin_class, TestCase):
+    class RealTests(mixin_class, AsyncTestCase):
         """
         Tests that endpoints are available over the network interfaces that
         real API users will be connecting from.
@@ -579,7 +579,7 @@ def build_schema_test(name, schema, schema_store,
     :param list failing_instances: Instances which should fail validation.
     :param list passing_instances: Instances which should pass validation.
 
-    :returns: The test case; a ``SynchronousTestCase`` subclass.
+    :returns: The test case; a ``TestCase`` subclass.
     """
     body = {
         'schema': schema,
@@ -601,7 +601,7 @@ def build_schema_test(name, schema, schema_store,
         test.__name__ = 'test_passes_validation_%d' % (i,)
         body[test.__name__] = test
 
-    return type(name, (SynchronousTestCase, object), body)
+    return type(name, (TestCase, object), body)
 
 
 class APIAssertionsMixin(object):

--- a/flocker/restapi/testtools.py
+++ b/flocker/restapi/testtools.py
@@ -170,7 +170,7 @@ def buildIntegrationTests(mixinClass, name, fixture):
 
     @param name: A C{str}, the name of the test category.
 
-    :param fixture: A callable that takes a ``AsyncTestCase`` and returns a
+    :param fixture: A callable that takes an ``AsyncTestCase`` and returns a
         ``klein.Klein`` object.
 
     @return: A pair of L{AsyncTestCase} classes.

--- a/flocker/restapi/testtools.py
+++ b/flocker/restapi/testtools.py
@@ -6,6 +6,7 @@ Public utilities for testing code that uses the REST API.
 
 from io import BytesIO
 from json import dumps, loads as _loads
+import os.path
 from itertools import count
 
 from jsonschema.exceptions import ValidationError
@@ -233,7 +234,12 @@ def build_UNIX_integration_tests(mixin_class, name, fixture):
         real API users will be connecting from.
         """
         def setUp(self):
-            path = self.mktemp()
+            # We use relpath as you can't bind to a path longer than 107
+            # chars. You can easily get an absolute path that long
+            # from mktemp, but rather strangely bind doesn't care
+            # how long the abspath is, so we call relpath here and
+            # it should work as long as our method names aren't too long
+            path = os.path.relpath(self.mktemp())
             self.app = fixture(self)
             self.port = reactor.listenUNIX(
                 path, Site(self.app.resource()),


### PR DESCRIPTION
This change was entirely mechanical.

Thanks,

James
