### PR TITLE
[FLOC-3793] Migrate flocker.test and flocker.testtools to new test base classes.

### DIFF
--- a/flocker/test/test_flocker.py
+++ b/flocker/test/test_flocker.py
@@ -7,13 +7,13 @@ Tests for top-level ``flocker`` package.
 from sys import executable
 from subprocess import check_output, STDOUT
 
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.python.filepath import FilePath
 
 import flocker
+from ..testtools import TestCase
 
 
-class WarningsTests(SynchronousTestCase):
+class WarningsTests(TestCase):
     """
     Tests for warning suppression.
     """

--- a/flocker/test/test_testtools.py
+++ b/flocker/test/test_testtools.py
@@ -6,12 +6,10 @@ Tests for ``flocker.testtools``.
 
 from subprocess import CalledProcessError
 
-from twisted.trial.unittest import SynchronousTestCase
-
-from flocker.testtools import run_process
+from flocker.testtools import run_process, TestCase
 
 
-class RunProcessTests(SynchronousTestCase):
+class RunProcessTests(TestCase):
     """
     Tests for ``run_process``.
     """

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -70,7 +70,7 @@ from twisted.internet.task import Clock
 from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectionDone
 from twisted.internet import reactor
-from twisted.trial.unittest import SynchronousTestCase, SkipTest
+from twisted.trial.unittest import SkipTest
 from twisted.internet.protocol import Factory, ProcessProtocol, Protocol
 from twisted.test.proto_helpers import MemoryReactor
 from twisted.python.procutils import which
@@ -473,7 +473,7 @@ def make_with_init_tests(record_type, kwargs, expected_defaults=None):
     for k, v in expected_defaults.items():
         required_kwargs.pop(k)
 
-    class WithInitTests(SynchronousTestCase):
+    class WithInitTests(TestCase):
         """
         Tests for classes decorated with ``with_init``.
         """

--- a/flocker/testtools/test/test_amp.py
+++ b/flocker/testtools/test/test_amp.py
@@ -7,11 +7,12 @@ Tests for :module:`flocker.testtools.amp`.
 from ..amp import FakeAMPClient, DelayedAMPClient
 from ...control.test.test_protocol import LoopbackAMPClient
 
-from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.error import ConnectionLost
 from twisted.protocols.amp import (
     Command, Integer, ListOf, MAX_VALUE_LENGTH, TooLong, CommandLocator,
 )
+
+from ...testtools import TestCase
 
 
 class TestCommand(Command):
@@ -26,7 +27,7 @@ class TestCommand(Command):
     ]
 
 
-class DelayedAMPClientTests(SynchronousTestCase):
+class DelayedAMPClientTests(TestCase):
     """
     Tests for :class:`DelayedAMPClient`.
     """
@@ -126,7 +127,7 @@ class MinimalLocator(CommandLocator):
         )
 
 
-class LoopbackAMPClientTests(SynchronousTestCase):
+class LoopbackAMPClientTests(TestCase):
     """
     Tests for :class:`LoopbackAMPClient`.
     """

--- a/flocker/testtools/test/test_cluster_utils.py
+++ b/flocker/testtools/test/test_cluster_utils.py
@@ -6,15 +6,14 @@ Tests for ``flocker.testtools.cluster_utils``.
 
 from uuid import UUID
 
-from twisted.trial.unittest import SynchronousTestCase
-
 from ..cluster_utils import (
     VERSION, get_version, make_cluster_id, get_cluster_id_information,
     TestTypes, Providers,
 )
+from ...testtools import TestCase
 
 
-class GetVersionTests(SynchronousTestCase):
+class GetVersionTests(TestCase):
     """
     Tests for ``get_version``.
     """
@@ -39,7 +38,7 @@ class GetVersionTests(SynchronousTestCase):
         )
 
 
-class ClusterIdTests(SynchronousTestCase):
+class ClusterIdTests(TestCase):
     """
     Tests for ``make_cluster_id`` and ``get_cluster_id_information``.
     """


### PR DESCRIPTION
Another mechanical translation.