### PR TITLE
[FLOC-3685] Expand blockdevice manager for upcoming work protecting our dataset mounts.

### DIFF
--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -6,8 +6,6 @@ Tests for ``flocker.node.agents.blockdevice_manager``.
 
 from uuid import uuid4
 
-from subprocess import check_output
-
 from testtools import ExpectedException
 from testtools.matchers import Equals
 


### PR DESCRIPTION
To do some of the fancy bind mounts, remounts, and tmpfs mounts that are required for FLOC-3254, we'll have to expand the interface with the kernel.

Putting this behind an interface because we've noticed that it behaves slightly different on CentOS and Ubuntu, so I'll probably be writing verified fakes for each of those, and I need some interface in order to be able to inject the different verified fakes.