### PR TITLE
[FLOC-3806] More reliable way to find always-present process name

### DIFF
--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -18,19 +18,14 @@ from benchmark.metrics.cputime import (
     WALLCLOCK_LABEL, CPUTime, CPUParser, get_node_cpu_times, compute_change,
 )
 
-# Process 1 (usually `init` or `systemd`) provides a process name that
-# is always present.
-try:
-    _standard_process = subprocess.check_output(
-        ['ps', '-p', '1', '-o', 'comm=']
-    ).strip()
-except subprocess.CalledProcessError:
-    _standard_process = None
+# Process 1 (usually `init`, `systemd`, or `launchd`) provides a process
+# name that is always present.
+_standard_process = subprocess.check_output(
+    ['ps', '-p', '1', '-o', 'comm=']
+).strip()
 
+# The command used to check cputimes only works on Linux
 on_linux = skipIf(platform.system() != 'Linux', 'Requires Linux')
-
-supported_linux = skipIf(
-    _standard_process is None, 'Requires supported version of Linux')
 
 
 class CPUParseTests(TestCase):
@@ -113,7 +108,7 @@ class GetNodeCPUTimeTests(AsyncTestCase):
     Test ``get_node_cpu_times`` command.
     """
 
-    @supported_linux
+    @on_linux
     def test_get_node_cpu_times(self):
         """
         Success results in output of dictionary containing process names.
@@ -201,7 +196,7 @@ class CPUTimeTests(AsyncTestCase):
         """
         verifyClass(IMetric, CPUTime)
 
-    @supported_linux
+    @on_linux
     def test_cpu_time(self):
         """
         Fake Flocker cluster gives expected results.

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -18,14 +18,14 @@ from benchmark.metrics.cputime import (
     WALLCLOCK_LABEL, CPUTime, CPUParser, get_node_cpu_times, compute_change,
 )
 
-
-# A process name that is expected to always be present on a distribution
-_always_present = {
-    'centos': 'systemd',
-    'Ubuntu': 'init',
-}
-_distribution = platform.linux_distribution(full_distribution_name=False)[0]
-_standard_process = _always_present.get(_distribution)
+# Process 1 (usually `init` or `systemd`) provides a process name that
+# is always present.
+try:
+    _standard_process = subprocess.check_output(
+        ['ps', '-p', '1', '-o', 'comm=']
+    ).strip()
+except subprocess.CalledProcessError:
+    _standard_process = None
 
 on_linux = skipIf(platform.system() != 'Linux', 'Requires Linux')
 


### PR DESCRIPTION
The current code for testing the cputime benchmark requires knowledge of an always present process name, and assumes that Ubuntu uses `init` and CentOS uses `systemd`. However, Ubuntu 15.10 uses `systemd`.  Rather than update the current distribution detection, make it more robust by getting the name of process 1, and using that.

This has been tested on Ubuntu 14.04, 15.10, and OS X (where it skips the tests that use `_standard_process`).