### PR TITLE
[FLOC-3294] Benchmark container creation

### DIFF
--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -32,6 +32,9 @@ operations:
   - name: create-dataset
     type: create-dataset
 
+  - name: create-container
+    type: create-container
+
 metrics:
   - name: default
     type: wallclock

--- a/benchmark/operations/__init__.py
+++ b/benchmark/operations/__init__.py
@@ -1,3 +1,4 @@
+from .create_container import CreateContainer
 from .create_dataset import CreateDataset
 from .no_op import NoOperation
 from .read_request import ReadRequest

--- a/benchmark/operations/_common.py
+++ b/benchmark/operations/_common.py
@@ -1,0 +1,20 @@
+import random
+
+
+class EmptyClusterError(Exception):
+    """
+    Exception indicating that the cluster contains no nodes.
+    """
+
+
+def select_node(nodes):
+    """
+    Select a node from a list of nodes.
+
+    :param Sequence[Node] nodes: Sequence of nodes.
+    :return Node: Selected node.
+    """
+    if nodes:
+        return random.choice(nodes)
+    else:
+        raise EmptyClusterError("Cluster contains no nodes.")

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -4,7 +4,6 @@ Operation to create a container.
 """
 
 from functools import partial
-import random
 from uuid import UUID, uuid4
 
 from pyrsistent import PClass, field
@@ -14,13 +13,8 @@ from flocker.apiclient import MountedDataset
 from flocker.common import gather_deferreds, loop_until
 from flocker.control import DockerImage
 
-from .._interfaces import IProbe, IOperation
-
-
-class EmptyClusterError(Exception):
-    """
-    Exception indicating that the cluster contains no nodes.
-    """
+from benchmark._interfaces import IProbe, IOperation
+from benchmark.operations._common import select_node
 
 
 def loop_until_state_found(reactor, get_states, state_matches):
@@ -201,12 +195,6 @@ class CreateContainerProbe(PClass):
         d = control_service.list_nodes()
 
         # Select an arbitrary node on which to create the container.
-        def select_node(nodes):
-            if nodes:
-                return random.choice(nodes)
-            else:
-                # Cannot proceed if there are no nodes in the cluster!
-                raise EmptyClusterError("Cluster contains no nodes.")
         d.addCallback(select_node)
 
         def parallel_setup(node):

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -111,7 +111,7 @@ def create_container(
             return (
                 expected.name == inspecting.name and
                 expected.node_uuid == inspecting.node_uuid and
-                inspecting.running is True
+                inspecting.running
             )
 
         def find_match(existing_state):
@@ -160,7 +160,7 @@ def delete_container(reactor, control_service, container):
             return (
                 expected.name == inspecting.name and
                 expected.node_uuid == inspecting.node_uuid and
-                inspecting.running is True
+                inspecting.running
             )
 
         def no_running_match(existing_state):

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -296,7 +296,7 @@ class CreateContainerProbe(PClass):
 class CreateContainer(object):
 
     def __init__(
-        self, reactor, cluster, image=u'debian', volume_size=None,
+        self, reactor, cluster, image=u'clusterhq/mongodb', volume_size=None,
         mountpoint=u'/data'
     ):
         self.reactor = reactor

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -4,6 +4,7 @@ Operation to create a container.
 """
 
 from functools import partial
+from itertools import repeat
 import random
 from uuid import UUID, uuid4
 
@@ -124,7 +125,9 @@ def create_container(
     d = control_service.create_container(node_uuid, name, image, volumes)
 
     def loop_until_container_started(expected):
-        return loop_until(reactor, partial(container_started, expected))
+        return loop_until(
+            reactor, partial(container_started, expected), repeat(0.25, 1200)
+        )
     d.addCallback(loop_until_container_started)
 
     return d
@@ -213,7 +216,7 @@ class CreateContainerProbe(PClass):
             if nodes:
                 return random.choice(nodes)
             else:
-                # Cannot proceed if there arbitraryre no nodes in the cluster!
+                # Cannot proceed if there are no nodes in the cluster!
                 raise EmptyClusterError("Cluster contains no nodes.")
         d.addCallback(select_node)
 

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -1,4 +1,4 @@
-# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+# Copyright 2016 ClusterHQ Inc.  See LICENSE file for details.
 """
 Operation to create a container.
 """

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -1,0 +1,316 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+"""
+Operation to create a container.
+"""
+
+from functools import partial
+import random
+from uuid import UUID, uuid4
+
+from pyrsistent import PClass, field
+from zope.interface import implementer
+
+from flocker.apiclient import MountedDataset
+from flocker.common import gather_deferreds, loop_until
+from flocker.control import DockerImage
+
+from .._interfaces import IProbe, IOperation
+
+
+class EmptyClusterError(Exception):
+    """
+    Exception indicating that the cluster contains no nodes.
+    """
+
+
+def create_dataset(
+    reactor, control_service, node_uuid, dataset_id, volume_size
+):
+    """
+    Create a dataset, then wait for it to be mounted.
+
+    :param IReactorTime reactor: Twisted Reactor.
+    :param IFlockerAPIV1Client control_service: Benchmark control
+        service.
+    :param UUID node_uuid: Node on which to create dataset.
+    :param UUID dataset_id: ID for created dataset.
+    :param int volume_size: Size of volume in bytes.
+    :return Deferred[DatasetState]: The state of the created dataset.
+    """
+
+    def dataset_mounted(expected):
+        """
+        Check whether a dataset has been created and mounted.
+
+        :param Dataset expected: A dataset configuration to match against the
+            results of ``list_datasets_state``.
+        :return Deferred[Optional[DatasetState]]: The matching dataset state,
+            or None if the expected dataset is not found.
+        """
+        d = control_service.list_datasets_state()
+
+        def dataset_matches(inspecting, expected):
+            return (
+                expected.dataset_id == inspecting.dataset_id and
+                expected.primary == inspecting.primary and
+                inspecting.path is not None
+            )
+
+        def find_match(existing_state):
+            for state in existing_state:
+                if dataset_matches(state, expected):
+                    return state
+            return None
+        d.addCallback(find_match)
+        return d
+
+    d = control_service.create_dataset(
+        primary=node_uuid,
+        maximum_size=volume_size,
+        dataset_id=dataset_id,
+    )
+
+    def loop_until_dataset_mounted(expected):
+        return loop_until(reactor, partial(dataset_mounted, expected))
+    d.addCallback(loop_until_dataset_mounted)
+
+    return d
+
+
+def create_container(
+    reactor, control_service, node_uuid, name, image, volumes=None
+):
+    """
+    Create a container, then wait for it to be running.
+
+    :param IReactorTime reactor: Twisted Reactor.
+    :param IFlockerAPIV1Client control_service: Benchmark control
+        service.
+    :param UUID node_uuid: Node on which to start the container.
+    :param unicode name: Name of the container.
+    :param DockerImage image: Docker image for the container.
+    :param Optional[Sequence[MountedDataset]] volumes: Volumes to attach
+        to the container.
+    :return Deferred[ContainerState]: The state of the created container.
+    """
+
+    def container_started(expected):
+        """
+        Check whether a container has been created and started.
+
+        :param Container expected: A container configuration to match against
+            the results of ``list_containers_state``.
+        :return Deferred[Optional[ContainerState]]: The matching container
+            state, or None if the expected container is not found or is not
+            running.
+        """
+        d = control_service.list_containers_state()
+
+        def container_matches(inspecting, expected):
+            return (
+                expected.name == inspecting.name and
+                expected.node_uuid == inspecting.node_uuid and
+                inspecting.running is True
+            )
+
+        def find_match(existing_state):
+            for state in existing_state:
+                if container_matches(state, expected):
+                    return state
+            return None
+        d.addCallback(find_match)
+        return d
+
+    d = control_service.create_container(node_uuid, name, image, volumes)
+
+    def loop_until_container_started(expected):
+        return loop_until(reactor, partial(container_started, expected))
+    d.addCallback(loop_until_container_started)
+
+    return d
+
+
+def delete_container(reactor, control_service, container):
+    """
+    Delete a container, then wait for it to be removed.
+
+    :param IReactorTime reactor: Twisted Reactor.
+    :param IFlockerAPIV1Client control_service: Benchmark control
+        service.
+    :param ContainerState container: Container to be removed.
+    :return Deferred[ContainerState]: The state before removal.
+    """
+
+    def container_removed(expected):
+        """
+        Check whether a container has been removed (deleted and stopped).
+
+        :param ContainerState expected: A container state to match against the
+            results of ``list_containers_state``.
+        :return Deferred[Optional[ContainerState]]: ``None`` if the
+            ``expected`` container is found, or ``expected`` if it is not
+            found.
+        """
+        d = control_service.list_containers_state()
+
+        def container_matches(inspecting, expected):
+            return (
+                expected.name == inspecting.name and
+                expected.node_uuid == inspecting.node_uuid and
+                inspecting.running is True
+            )
+
+        def no_running_match(existing_state):
+            for state in existing_state:
+                if container_matches(state, expected):
+                    return None
+            return expected
+        d.addCallback(no_running_match)
+        return d
+
+    d = control_service.delete_container(container.name)
+
+    def loop_until_container_removed(_ignore):
+        return loop_until(reactor, partial(container_removed, container))
+    d.addCallback(loop_until_container_removed)
+
+    return d
+
+
+@implementer(IProbe)
+class CreateContainerProbe(PClass):
+    """
+    Probe to create a container and wait for cluster to converge.
+    """
+
+    reactor = field(mandatory=True)
+    control_service = field(mandatory=True)
+    node_uuid = field(type=UUID, mandatory=True)
+    name = field(type=unicode, mandatory=True)
+    image = field(mandatory=True)
+    dataset_id = field(type=UUID, mandatory=True)
+    mountpoint = field(type=unicode, mandatory=True)
+
+    @classmethod
+    def setup(
+        cls, reactor, control_service, name, image, volume_size, mountpoint
+    ):
+        """
+        Create a probe.
+
+        :param IReactorTime reactor: Twisted Reactor.
+        :param IFlockerAPIV1Client control_service: Benchmark control service.
+        :param unicode name: Name for created container.
+        :param DockerImage image: Docker image for the container.
+        :param int volume_size: Size of created volume, in bytes.
+        :param unicode mountpoint: Mountpoint for created volume.
+        :return: Deferred firing with a new probe.
+        """
+        d = control_service.list_nodes()
+
+        # Select an arbitrary node on which to create the container.
+        def select_node(nodes):
+            if nodes:
+                return random.choice(nodes)
+            else:
+                # Cannot proceed if there arbitraryre no nodes in the cluster!
+                raise EmptyClusterError("Cluster contains no nodes.")
+        d.addCallback(select_node)
+
+        def parallel_setup(node):
+            # Ensure the Docker image is cached by starting and stopping a
+            # container.
+            name = unicode(uuid4())
+            container_setup = create_container(
+                reactor, control_service, node.uuid, name, image
+            )
+            container_setup.addCallback(
+                partial(delete_container, reactor, control_service)
+            )
+
+            # Create the dataset
+            dataset_id = uuid4()
+            dataset_setup = create_dataset(
+                reactor, control_service, node.uuid, dataset_id, volume_size
+            )
+
+            d = gather_deferreds((container_setup, dataset_setup))
+
+            # Return only the dataset state
+            d.addCallback(lambda results: results[1])
+
+            return d
+        d.addCallback(parallel_setup)
+
+        # Create the CreateContainerProbe instance.
+        def create_probe(dataset_state):
+            return cls(
+                reactor=reactor,
+                control_service=control_service,
+                node_uuid=dataset_state.primary,
+                name=name,
+                image=image,
+                dataset_id=dataset_state.dataset_id,
+                mountpoint=mountpoint,
+            )
+        d.addCallback(create_probe)
+
+        return d
+
+    def run(self):
+        """
+        Create a stateful container, and wait for it to be running.
+        """
+        volumes = [
+            MountedDataset(
+                dataset_id=self.dataset_id, mountpoint=self.mountpoint
+            )
+        ]
+
+        d = create_container(
+            self.reactor, self.control_service, self.node_uuid, self.name,
+            self.image, volumes
+        )
+
+        return d
+
+    def cleanup(self):
+        """
+        Delete the container and dataset created by the probe.
+        """
+        d = self.control_service.delete_container(self.name)
+
+        d.addCallback(
+            lambda _ignore: self.control_service.delete_dataset(
+                self.dataset_id
+            )
+        )
+
+        return d
+
+
+@implementer(IOperation)
+class CreateContainer(object):
+
+    def __init__(
+        self, reactor, cluster, image=u'debian', volume_size=None,
+        mountpoint=u'/data'
+    ):
+        self.reactor = reactor
+        self.control_service = cluster.get_control_service(reactor)
+        self.image = DockerImage(repository=image)
+        if volume_size is None:
+            self.volume_size = cluster.default_volume_size()
+        else:
+            self.volume_size = volume_size
+        self.mountpoint = mountpoint
+
+    def get_probe(self):
+        return CreateContainerProbe.setup(
+            self.reactor,
+            self.control_service,
+            unicode(uuid4()),
+            self.image,
+            self.volume_size,
+            self.mountpoint,
+        )

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -192,10 +192,8 @@ class CreateContainerProbe(PClass):
         :param unicode mountpoint: Mountpoint for created volume.
         :return: Deferred firing with a new probe.
         """
-        d = control_service.list_nodes()
-
         # Select an arbitrary node on which to create the container.
-        d.addCallback(select_node)
+        d = control_service.list_nodes().addCallback(select_node)
 
         def parallel_setup(node):
             # Ensure the Docker image is cached by starting and stopping a

--- a/benchmark/operations/create_dataset.py
+++ b/benchmark/operations/create_dataset.py
@@ -38,10 +38,8 @@ class CreateDatasetProbe(PClass):
         :param int volume_size: Size of created volume, in bytes.
         :return: Deferred firing with a new probe.
         """
-        d = control_service.list_nodes()
-
         # Select an arbitrary node to be the primary for the dataset.
-        d.addCallback(select_node)
+        d = control_service.list_nodes().addCallback(select_node)
 
         # Create the CreateDatasetProbe instance.
         def create_probe(node):

--- a/benchmark/operations/create_dataset.py
+++ b/benchmark/operations/create_dataset.py
@@ -4,7 +4,6 @@ Operation to create a dataset.
 """
 
 from functools import partial
-import random
 from uuid import uuid4
 
 from pyrsistent import PClass, field
@@ -12,13 +11,8 @@ from zope.interface import implementer
 
 from flocker.common import loop_until
 
-from .._interfaces import IProbe, IOperation
-
-
-class EmptyClusterError(Exception):
-    """
-    Exception indicating that the cluster contains no nodes.
-    """
+from benchmark._interfaces import IProbe, IOperation
+from benchmark.operations._common import select_node
 
 
 @implementer(IProbe)
@@ -47,13 +41,7 @@ class CreateDatasetProbe(PClass):
         d = control_service.list_nodes()
 
         # Select an arbitrary node to be the primary for the dataset.
-        def pick_primary(nodes):
-            if nodes:
-                return random.choice(nodes)
-            else:
-                # Cannot proceed if there are no nodes in the cluster!
-                raise EmptyClusterError("Cluster contains no nodes.")
-        d.addCallback(pick_primary)
+        d.addCallback(select_node)
 
         # Create the CreateDatasetProbe instance.
         def create_probe(node):

--- a/benchmark/operations/test/test_create_container.py
+++ b/benchmark/operations/test/test_create_container.py
@@ -1,4 +1,4 @@
-# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+# Copyright 2016 ClusterHQ Inc.  See LICENSE file for details.
 """
 Create Container operation tests for the control service benchmarks.
 """

--- a/benchmark/operations/test/test_create_container.py
+++ b/benchmark/operations/test/test_create_container.py
@@ -1,0 +1,100 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+"""
+Create Container operation tests for the control service benchmarks.
+"""
+from uuid import uuid4
+
+from ipaddr import IPAddress
+from zope.interface.verify import verifyClass
+
+from twisted.internet.task import Clock
+from twisted.trial.unittest import SynchronousTestCase
+
+from flocker.apiclient import FakeFlockerClient, Node
+
+from benchmark.cluster import BenchmarkCluster
+from benchmark._interfaces import IOperation, IProbe
+from benchmark.operations.create_container import (
+    CreateContainer, CreateContainerProbe,
+    EmptyClusterError,
+)
+
+
+class CreateContainerTests(SynchronousTestCase):
+    """
+    CreateContainer operation tests.
+    """
+
+    def test_implements_IOperation(self):
+        """
+        CreateContainer provides the IOperation interface.
+        """
+        verifyClass(IOperation, CreateContainer)
+
+    def test_implements_IProbe(self):
+        """
+        CreateContainerProbe provides the IProbe interface.
+        """
+        verifyClass(IProbe, CreateContainerProbe)
+
+    def test_create_container(self):
+        """
+        CreateContainer probe waits for cluster to converge.
+        """
+        clock = Clock()
+
+        node_id = uuid4()
+        node = Node(uuid=node_id, public_address=IPAddress('10.0.0.1'))
+        control_service = FakeFlockerClient([node], node_id)
+
+        cluster = BenchmarkCluster(
+            IPAddress('10.0.0.1'),
+            lambda reactor: control_service,
+            {},
+            None,
+        )
+        operation = CreateContainer(clock, cluster)
+        d = operation.get_probe()
+
+        def run_probe(probe):
+            def cleanup(result):
+                cleaned_up = probe.cleanup()
+                cleaned_up.addCallback(lambda _ignored: result)
+                return cleaned_up
+            d = probe.run()
+            d.addCallback(cleanup)
+            return d
+        d.addCallback(run_probe)
+
+        # Advance the clock because probe periodically polls the state.
+        # Due to multiple steps, need to synchronize state a few times.
+        control_service.synchronize_state()  # creation of pull container
+        clock.advance(1)
+        control_service.synchronize_state()  # deletion of pull container
+        clock.advance(1)
+
+        # The Deferred does not fire before the container has been created.
+        self.assertNoResult(d)
+
+        control_service.synchronize_state()  # creation of test container
+        clock.advance(1)
+
+        # The Deferred fires once the container has been created.
+        self.successResultOf(d)
+
+    def test_empty_cluster(self):
+        """
+        CreateContainer fails if no nodes in cluster.
+        """
+        control_service = FakeFlockerClient()
+
+        cluster = BenchmarkCluster(
+            IPAddress('10.0.0.1'),
+            lambda reactor: control_service,
+            {},
+            None,
+        )
+
+        d = CreateContainer(Clock(), cluster).get_probe()
+
+        self.failureResultOf(d, EmptyClusterError)

--- a/benchmark/operations/test/test_create_container.py
+++ b/benchmark/operations/test/test_create_container.py
@@ -4,13 +4,14 @@ Create Container operation tests for the control service benchmarks.
 """
 from uuid import uuid4
 
+from eliot.testing import capture_logging
 from ipaddr import IPAddress
 from zope.interface.verify import verifyClass
 
 from twisted.internet.task import Clock
-from twisted.trial.unittest import SynchronousTestCase
 
 from flocker.apiclient import FakeFlockerClient, Node
+from flocker.testtools import TestCase
 
 from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IOperation, IProbe
@@ -20,7 +21,7 @@ from benchmark.operations.create_container import (
 )
 
 
-class CreateContainerTests(SynchronousTestCase):
+class CreateContainerTests(TestCase):
     """
     CreateContainer operation tests.
     """
@@ -37,7 +38,8 @@ class CreateContainerTests(SynchronousTestCase):
         """
         verifyClass(IProbe, CreateContainerProbe)
 
-    def test_create_container(self):
+    @capture_logging(None)
+    def test_create_container(self, _logger):
         """
         CreateContainer probe waits for cluster to converge.
         """

--- a/benchmark/operations/test/test_create_container.py
+++ b/benchmark/operations/test/test_create_container.py
@@ -17,8 +17,8 @@ from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IOperation, IProbe
 from benchmark.operations.create_container import (
     CreateContainer, CreateContainerProbe,
-    EmptyClusterError,
 )
+from benchmark.operations._common import EmptyClusterError
 
 
 class CreateContainerTests(TestCase):

--- a/benchmark/operations/test/test_create_dataset.py
+++ b/benchmark/operations/test/test_create_dataset.py
@@ -16,8 +16,9 @@ from flocker.testtools import TestCase
 from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IOperation, IProbe
 from benchmark.operations.create_dataset import (
-    CreateDataset, CreateDatasetProbe, EmptyClusterError,
+    CreateDataset, CreateDatasetProbe
 )
+from benchmark.operations._common import EmptyClusterError
 
 
 class CreateDatasetTests(TestCase):

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -38,6 +38,7 @@ _SCENARIOS = {
 }
 
 _OPERATIONS = {
+    'create-container': operations.CreateContainer,
     'create-dataset': operations.CreateDataset,
     'no-op': operations.NoOperation,
     'read-request': operations.ReadRequest,

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -142,7 +142,9 @@ Operation Types
    Create a stateful container and wait for it to be running.
 
    Specify the container image using an additional ``image`` property.
-   The default is ``clusterhq/mongodb``.
+   The container will be started with the default command line.
+   Hence the image must have a long-lived default command line.
+   The default image is ``clusterhq/mongodb``.
 
    Specify the size of the dataset using an additional ``volume_size`` property.
    If specifying a cluster using environment variables, this defaults to the value of the ``FLOCKER_ACCEPTANCE_DEFAULT_VOLUME_SIZE`` environment variable.

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -142,7 +142,7 @@ Operation Types
    Create a stateful container and wait for it to be running.
 
    Specify the container image using an additional ``image`` property.
-   The default is ``debian``.
+   The default is ``clusterhq/mongodb``.
 
    Specify the size of the dataset using an additional ``volume_size`` property.
    If specifying a cluster using environment variables, this defaults to the value of the ``FLOCKER_ACCEPTANCE_DEFAULT_VOLUME_SIZE`` environment variable.

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -137,6 +137,20 @@ Scenario Types
 Operation Types
 ~~~~~~~~~~~~~~~
 
+.. option:: create-container
+
+   Create a stateful container and wait for it to be running.
+
+   Specify the container image using an additional ``image`` property.
+   The default is ``debian``.
+
+   Specify the size of the dataset using an additional ``volume_size`` property.
+   If specifying a cluster using environment variables, this defaults to the value of the ``FLOCKER_ACCEPTANCE_DEFAULT_VOLUME_SIZE`` environment variable.
+   Otherwise, it defaults to a platform-specific value.
+
+   Specify the volume mountpoint using an additional ``mountpoint`` property.
+   The default is ``/data``.
+
 .. option:: create-dataset
 
    Create a dataset and wait for it to be mounted.

--- a/flocker/apiclient/__init__.py
+++ b/flocker/apiclient/__init__.py
@@ -9,10 +9,10 @@ This may eventually be a standalone package.
 from ._client import (
     IFlockerAPIV1Client, FakeFlockerClient, Dataset, DatasetState,
     DatasetAlreadyExists, FlockerClient, Lease, LeaseAlreadyHeld,
-    conditional_create, DatasetsConfiguration, Node,
+    conditional_create, DatasetsConfiguration, Node, MountedDataset,
 )
 
 __all__ = ["IFlockerAPIV1Client", "FakeFlockerClient", "Dataset",
            "DatasetState", "DatasetAlreadyExists", "FlockerClient",
            "Lease", "LeaseAlreadyHeld", "conditional_create",
-           "DatasetsConfiguration", "Node"]
+           "DatasetsConfiguration", "Node", "MountedDataset", ]


### PR DESCRIPTION
Add a benchmark operation to create a stateful container and wait for it to start.

This performs the following actions:
1. create a container and then delete it, to ensure the image will not need to be pulled later, during the measured part of the benchmark;
2. create a dataset;
3. create a container attached to the dataset;
4. wait for the container to be running;
5. delete the container and dataset.

Steps 3 and 4 are in the `run` method of the probe, and hence are the operations that are measured by the benchmark.

If you have a Flocker cluster handy, and the acceptance test environment variables set, change to the `benchmark` directory and run:
```
./benchmark --operation create-container
```
which creates output like:
```
{
  "scenario": {
    "type": "no-load", 
    "name": "default"
  }, 
  "timestamp": "2016-01-06T12:07:09.795871", 
  "metric": {
    "type": "wallclock", 
    "name": "default"
  }, 
  "client": {
    "username": "jon", 
    "platform": "Linux-3.13.0-74-generic-x86_64-with-Ubuntu-14.04-trusty", 
    "working_directory": "/home/jon/projects/clusterhq/flocker/benchmark", 
    "nodename": "ecuador", 
    "flocker_version": "1.9.0.dev1+877.g40b4a15"
  }, 
  "samples": [
    {
      "value": 1.7430620193481445, 
      "success": true
    }, 
    {
      "value": 1.7483181953430176, 
      "success": true
    }, 
    {
      "value": 16.281208992004395, 
      "success": true
    }
  ], 
  "control_service": {
    "flocker_version": "1.9.0.dev1+945.ga00891e", 
    "host": "52.32.171.65"
  }, 
  "operation": {
    "type": "create-container", 
    "name": "create-container"
  }
}
```

In addition, a problem was fixed where if the `get_probe` operation failed, the benchmarking hung. The handling of errors has been moved around, so that any error in the sampling creates an unsuccessful sample.
