### PR TITLE
[FLOC 3809] add EMC VMAX driver to configuration doc

### DIFF
--- a/docs/config/emc-configuration.rst
+++ b/docs/config/emc-configuration.rst
@@ -4,15 +4,18 @@
 EMC Block Device Backend Configuration
 ======================================
 
-EMC provide plugins for Flocker integration with `ScaleIO`_ and `XtremIO`_.
+EMC provide plugins for Flocker integration with `ScaleIO`_, `XtremIO`_ and `VMAX`_.
 For more information, including installation, testing and usage instructions, visit the following links to their GitHub repositories:
 
 * `EMC ScaleIO Flocker driver on GitHub`_
 * `EMC XtremIO Flocker driver on GitHub`_
+* `EMC VMAX Flocker driver on GitHub`_
 
 .. XXX FLOC 2443 to expand this EMC/Backend storage section
 
 .. _ScaleIO: https://www.emc.com/storage/scaleio/index.htm
 .. _XtremIO: https://www.emc.com/storage/xtremio/overview.htm
+.. _VMAX: https://www.emc.com/en-us/storage/vmax.htm
 .. _EMC ScaleIO Flocker driver on GitHub: https://github.com/emccorp/scaleio-flocker-driver
 .. _EMC XtremIO Flocker driver on GitHub: https://github.com/emccorp/xtremio-flocker-driver
+.. _EMC VMAX Flocker driver on GitHub: https://github.com/emccorp/vmax-flocker-driver

--- a/docs/introduction/flocker-supports.rst
+++ b/docs/introduction/flocker-supports.rst
@@ -42,6 +42,7 @@ Community supported drivers:
 * Dell SC Series
 * EMC ScaleIO
 * EMC XtremIO
+* EMC VMAX
 * Hedvig
 * Huawei
 * NetApp OnTap

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -16,8 +16,8 @@ Next Release
 * The :ref:`Flocker Plugin for Docker<docker-plugin>` now solely relies on the metadata key ``"name"`` to find datasets.
 * Now supporting Ubuntu-15.10 instead of Ubuntu-15.04 for the flocker client.
   See :ref:`installing-flocker-cli-ubuntu-15.10`.
-* Test being skipped (2 of them) in ``admin/test/test_release.py`` - once we have released the changes for ``15.10``, they
-  don't need to be skipped anymore.
+* Test being skipped (2 of them) in ``admin/test/test_release.py`` - once we have released the changes for ``15.10``, they don't need to be skipped anymore.
+* Added documentation for the :ref:`EMC VMAX <emc-dataset-backend>` driver.
 
 This Release
 ============


### PR DESCRIPTION
Fixes 3809

EMC have provided a flocker driver for VMAX. This PR adds the link to our list of community provided backends.