### PR TITLE
[FLOC-3812] Allow specification of AWS instance type for acceptance/benchmark tests

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -961,6 +961,7 @@ class CommonOptions(Options):
                  secret_access_token: <aws secret access token>
                  keyname: <ssh-key-name>
                  security_groups: ["<permissive security group>"]
+                 instance_type: m3.large
 
         :see: :ref:`acceptance-testing-aws-config`
         """

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -155,6 +155,7 @@ To run the acceptance tests on AWS, you need:
      secret_access_token: <aws secret access token>
      keyname: <ssh-key-name>
      security_groups: ["<permissive security group>"]
+     instance_type: <instance type, e.g. "m3.large">
 
 You will need a ssh agent running with access to the corresponding private key.
 

--- a/docs/gettinginvolved/example-acceptance.yml
+++ b/docs/gettinginvolved/example-acceptance.yml
@@ -8,6 +8,7 @@ aws:
   region: us-east-1
   zone: us-east-1d
   security_groups: ['acceptance']
+  instance_type: m3.large
 
 rackspace:
   region: "dfw"

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -354,8 +354,10 @@ class AWSProvisioner(PClass):
         return False
 
 
-def aws_provisioner(access_key, secret_access_token, keyname,
-                    region, zone, security_groups):
+def aws_provisioner(
+    access_key, secret_access_token, keyname, region, zone, security_groups,
+    instance_type=b"m3.large"
+):
     """
     Create an IProvisioner for provisioning nodes on AWS EC2.
 
@@ -379,5 +381,5 @@ def aws_provisioner(access_key, secret_access_token, keyname,
         _keyname=keyname,
         _security_groups=security_groups,
         _zone=zone,
-        _default_size=b"m3.large",
+        _default_size=instance_type,
     )

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -370,6 +370,7 @@ def aws_provisioner(
        available from an agent.
     :param list security_groups: List of security groups to put created nodes
         in.
+    :param bytes instance_type: AWS instance type for cluster nodes.
     """
     conn = connect_to_region(
         region,


### PR DESCRIPTION
AWS acceptance and benchmark tests always use an `m3.large` instance.  This patch allows the `aws` configuration stanza to contain an `instance_type` entry to override this.

The field is optional. If missing, it default to the current behavior.

To test, add `instance_type: m3.xlarge` (or any other AWS instance type) to your acceptance testing configuration file and start a cluster using `admin/run-acceptance-tests` or `admin/setup-cluster`. Using the AWS console, you can see the instance types for the cluster nodes.