### PR TITLE
[FLOC-3760] Benchmark userdata option

### DIFF
--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -206,12 +206,12 @@ def get_cluster(options, env):
     return cluster
 
 
-def add_userdata(options, result):
+def parse_userdata(options):
     """
     Parse the userdata option and add to result.
 
     :param BenchmarkOptions options: Script options.
-    :param dict result: Result dictionary.
+    :return: Parsed user data.
     """
     userdata = options['userdata']
     if userdata:
@@ -219,16 +219,17 @@ def add_userdata(options, result):
             if userdata.startswith('@'):
                 try:
                     with open(userdata[1:]) as f:
-                        result['userdata'] = json.load(f)
+                        return json.load(f)
                 except IOError as e:
                     usage(
                         options,
                         'Invalid user data file: {}'.format(e.strerror)
                     )
             else:
-                result['userdata'] = json.loads(userdata)
+                return json.loads(userdata)
         except ValueError as e:
             usage(options, 'Invalid user data: {}'.format(e.args[0]))
+    return None
 
 
 def main():
@@ -295,7 +296,9 @@ def main():
         metric=metric_config,
     )
 
-    add_userdata(options, result)
+    userdata = parse_userdata(options)
+    if userdata:
+        result['userdata'] = userdata
 
     react(
         driver, (

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -84,6 +84,7 @@ class BenchmarkOptions(Options):
          'Environmental scenario under which to perform test.'],
         ['operation', None, 'default', 'Operation to measure.'],
         ['metric', None, 'default', 'Quantity to benchmark.'],
+        ['userdata', None, None, 'JSON data to add to output.']
     ]
 
 
@@ -205,6 +206,31 @@ def get_cluster(options, env):
     return cluster
 
 
+def add_userdata(options, result):
+    """
+    Parse the userdata option and add to result.
+
+    :param BenchmarkOptions options: Script options.
+    :param dict result: Result dictionary.
+    """
+    userdata = options['userdata']
+    if userdata:
+        try:
+            if userdata.startswith('@'):
+                try:
+                    with open(userdata[1:]) as f:
+                        result['userdata'] = json.load(f)
+                except IOError as e:
+                    usage(
+                        options,
+                        'Invalid user data file: {}'.format(e.strerror)
+                    )
+            else:
+                result['userdata'] = json.loads(userdata)
+        except ValueError as e:
+            usage(options, 'Invalid user data: {}'.format(e.args[0]))
+
+
 def main():
     options = BenchmarkOptions()
 
@@ -268,6 +294,8 @@ def main():
         operation=operation_config,
         metric=metric_config,
     )
+
+    add_userdata(options, result)
 
     react(
         driver, (

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -10,10 +10,13 @@ import tempfile
 from ipaddr import IPAddress
 from jsonschema.exceptions import ValidationError
 
+from twisted.python.filepath import FilePath
+
 from flocker.testtools import TestCase
 
 from benchmark.script import (
-    BenchmarkOptions, get_cluster, validate_configuration, get_config_by_name
+    BenchmarkOptions, get_cluster, validate_configuration, get_config_by_name,
+    add_userdata,
 )
 
 
@@ -424,3 +427,101 @@ class SubConfigurationTests(TestCase):
         """
         config = get_config_by_name(self.config['metrics'], 'default')
         self.assertEqual(config['name'], 'default')
+
+
+class UserDataTests(TestCase):
+    """
+    Test --userdata option.
+    """
+
+    def test_no_userdata(self):
+        """
+        Missing option adds nothing to result.
+        """
+        options = BenchmarkOptions()
+        options.parseOptions([])
+        result = {}
+        add_userdata(options, result)
+        self.assertEqual(result, {})
+
+    def test_empty_userdata(self):
+        """
+        Empty option adds nothing to result.
+        """
+        options = BenchmarkOptions()
+        options.parseOptions(['--userdata', ''])
+        result = {}
+        add_userdata(options, result)
+        self.assertEqual(result, {})
+
+    def test_json_userdata(self):
+        """
+        JSON string adds to result.
+        """
+        options = BenchmarkOptions()
+        options.parseOptions(['--userdata', '{"branch": "master"}'])
+        result = {}
+        add_userdata(options, result)
+        self.assertEqual(result, {"userdata": {"branch": "master"}})
+
+    def test_json_file_userdata(self):
+        """
+        JSON file adds to result.
+        """
+        json_file = FilePath(self.mktemp())
+        with json_file.open('w') as f:
+            f.write('{"branch": "master"}\n')
+        options = BenchmarkOptions()
+        options.parseOptions(['--userdata', '@{}'.format(json_file.path)])
+        result = {}
+        add_userdata(options, result)
+        self.assertEqual(result, {"userdata": {"branch": "master"}})
+
+    def test_invalid_json(self):
+        """
+        Invalid JSON string handled.
+        """
+        options = BenchmarkOptions()
+        options.parseOptions(['--userdata', '"branch": "master"'])
+        with capture_stderr() as captured_stderr:
+            exception = self.assertRaises(
+                SystemExit, add_userdata, options, {},
+            )
+            self.assertIn(
+                'Invalid user data', exception.args[0]
+            )
+            self.assertIn(options.getUsage(), captured_stderr())
+
+    def test_invalid_path(self):
+        """
+        Non-existent file handled.
+        """
+        no_file = FilePath(self.mktemp())
+        options = BenchmarkOptions()
+        options.parseOptions(['--userdata', '@{}'.format(no_file.path)])
+        with capture_stderr() as captured_stderr:
+            exception = self.assertRaises(
+                SystemExit, add_userdata, options, {},
+            )
+            self.assertIn(
+                'Invalid user data file', exception.args[0]
+            )
+            self.assertIn(options.getUsage(), captured_stderr())
+
+    def test_invalid_file_data(self):
+        """
+        Invalid file data handled.
+        """
+        invalid_file = FilePath(self.mktemp())
+        with invalid_file.open('w') as f:
+            f.write('hello\n')
+        options = BenchmarkOptions()
+        options.parseOptions(['--userdata', '@{}'.format(invalid_file.path)])
+        with capture_stderr() as captured_stderr:
+            exception = self.assertRaises(
+                SystemExit, add_userdata, options, {},
+            )
+            self.assertIn(
+                'Invalid user data', exception.args[0]
+            )
+            self.assertIn(options.getUsage(), captured_stderr())

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -16,7 +16,7 @@ from flocker.testtools import TestCase
 
 from benchmark.script import (
     BenchmarkOptions, get_cluster, validate_configuration, get_config_by_name,
-    add_userdata,
+    parse_userdata,
 )
 
 
@@ -440,9 +440,7 @@ class UserDataTests(TestCase):
         """
         options = BenchmarkOptions()
         options.parseOptions([])
-        result = {}
-        add_userdata(options, result)
-        self.assertEqual(result, {})
+        self.assertIs(parse_userdata(options), None)
 
     def test_empty_userdata(self):
         """
@@ -450,9 +448,7 @@ class UserDataTests(TestCase):
         """
         options = BenchmarkOptions()
         options.parseOptions(['--userdata', ''])
-        result = {}
-        add_userdata(options, result)
-        self.assertEqual(result, {})
+        self.assertIs(parse_userdata(options), None)
 
     def test_json_userdata(self):
         """
@@ -460,9 +456,7 @@ class UserDataTests(TestCase):
         """
         options = BenchmarkOptions()
         options.parseOptions(['--userdata', '{"branch": "master"}'])
-        result = {}
-        add_userdata(options, result)
-        self.assertEqual(result, {"userdata": {"branch": "master"}})
+        self.assertEqual(parse_userdata(options), {"branch": "master"})
 
     def test_json_file_userdata(self):
         """
@@ -473,9 +467,7 @@ class UserDataTests(TestCase):
             f.write('{"branch": "master"}\n')
         options = BenchmarkOptions()
         options.parseOptions(['--userdata', '@{}'.format(json_file.path)])
-        result = {}
-        add_userdata(options, result)
-        self.assertEqual(result, {"userdata": {"branch": "master"}})
+        self.assertEqual(parse_userdata(options), {"branch": "master"})
 
     def test_invalid_json(self):
         """
@@ -485,7 +477,7 @@ class UserDataTests(TestCase):
         options.parseOptions(['--userdata', '"branch": "master"'])
         with capture_stderr() as captured_stderr:
             exception = self.assertRaises(
-                SystemExit, add_userdata, options, {},
+                SystemExit, parse_userdata, options
             )
             self.assertIn(
                 'Invalid user data', exception.args[0]
@@ -501,7 +493,7 @@ class UserDataTests(TestCase):
         options.parseOptions(['--userdata', '@{}'.format(no_file.path)])
         with capture_stderr() as captured_stderr:
             exception = self.assertRaises(
-                SystemExit, add_userdata, options, {},
+                SystemExit, parse_userdata, options
             )
             self.assertIn(
                 'Invalid user data file', exception.args[0]
@@ -519,7 +511,7 @@ class UserDataTests(TestCase):
         options.parseOptions(['--userdata', '@{}'.format(invalid_file.path)])
         with capture_stderr() as captured_stderr:
             exception = self.assertRaises(
-                SystemExit, add_userdata, options, {},
+                SystemExit, parse_userdata, options
             )
             self.assertIn(
                 'Invalid user data', exception.args[0]

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -28,9 +28,11 @@ def capture_stderr():
     Call the returned context variable to obtain captured output.
     """
     s = StringIO()
-    out, sys.stderr = sys.stderr, s
-    yield s.getvalue
-    sys.stderr = out
+    saved, sys.stderr = sys.stderr, s
+    try:
+        yield s.getvalue
+    finally:
+        sys.stderr = saved
 
 # Addresses must be different, to check that environment is not used
 # during YAML tests.

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -53,6 +53,13 @@ The :program:`benchmark` script has the following command line options:
    This is the ``name`` of a metric in the configuration file.
    Defaults to the name ``default``.
 
+.. option:: --userdata <json-data>
+
+   Specifies JSON data to be added to the result JSON.
+   If the value starts with ``@`` the remainder of the value is the name of a file containing JSON data.
+   Otherwise, the value must be a valid JSON structure.
+   The supplied data is added as the ``userdata`` property of the output result.
+
 
 .. _benchmarking-cluster-description:
 


### PR DESCRIPTION
Provide the ability to supply additional data for the JSON output of the benchmark script.  This is useful to provide data about the benchmark run that cannot easily be determined automatically by the script.

The particular use-case is to supply the Git branch for the benchmark cluster. While the Git SHA is easily obtained through the version number, it is difficult (and, in general, impossible) to determine the intended branch name.  This PR allows that information to be provided by the caller of the benchmark script, who has more information about the cluster, including which branch they deployed.
