### PR TITLE
[FLOC-3823] Parametrize number of benchmark samples to take

### DIFF
--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -62,7 +62,7 @@ def sample(operation, metric, name):
         return sampling.addActionFinish()
 
 
-def benchmark(scenario, operation, metric, num_samples=3):
+def benchmark(scenario, operation, metric, num_samples):
     """
     Perform benchmarking of the operation within a scenario.
 
@@ -108,7 +108,7 @@ def benchmark(scenario, operation, metric, num_samples=3):
 
 def driver(
     reactor, cluster, scenario_factory, operation_factory, metric_factory,
-    result, output
+    num_samples, result, output
 ):
     """
     :param reactor: Reactor to use.
@@ -116,6 +116,7 @@ def driver(
     :param callable scenario_factory: A load scenario factory.
     :param callable operation_factory: An operation factory.
     :param callable metric_factory: A metric factory.
+    :param int num_samples: Number of samples to take.
     :param result: A dictionary which will be updated with values to
         create a JSON result.
     :param output: A callable to receive the JSON structure, for
@@ -137,6 +138,7 @@ def driver(
             scenario_factory(reactor, cluster),
             operation_factory(reactor, cluster),
             metric_factory(reactor, cluster),
+            num_samples,
         )
 
     d.addCallback(run_benchmark)

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -80,6 +80,7 @@ class BenchmarkOptions(Options):
          'If not set, use acceptance test environment variables.'],
         ['config', None, 'benchmark.yml',
          'YAML file describing benchmark options.'],
+        ['samples', None, 3, 'Number of samples to take.'],
         ['scenario', None, 'default',
          'Environmental scenario under which to perform test.'],
         ['operation', None, 'default', 'Operation to measure.'],
@@ -280,6 +281,8 @@ def main():
             options, 'Invalid metric type: {!r}'.format(metric_config['type'])
         )
 
+    num_samples = int(options['samples'])
+
     timestamp = datetime.now().isoformat()
 
     result = dict(
@@ -303,7 +306,7 @@ def main():
     react(
         driver, (
             cluster, scenario_factory, operation_factory, metric_factory,
-            result, partial(json.dump, fp=sys.stdout, indent=2)
+            num_samples, result, partial(json.dump, fp=sys.stdout, indent=2)
         )
     )
 

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -233,15 +233,15 @@ def parse_userdata(options):
     return None
 
 
-def main():
+def main(argv, environ, react=react):
     options = BenchmarkOptions()
 
     try:
-        options.parseOptions()
+        options.parseOptions(argv[1:])
     except UsageError as e:
         usage(options, e.args[0])
 
-    cluster = get_cluster(options, os.environ)
+    cluster = get_cluster(options, environ)
 
     with open(options['config'], 'rt') as f:
         config = yaml.safe_load(f)
@@ -281,7 +281,10 @@ def main():
             options, 'Invalid metric type: {!r}'.format(metric_config['type'])
         )
 
-    num_samples = int(options['samples'])
+    try:
+        num_samples = int(options['samples'])
+    except ValueError:
+        usage(options, 'Invalid sample count: {!r}'.format(options['samples']))
 
     timestamp = datetime.now().isoformat()
 
@@ -290,7 +293,7 @@ def main():
         client=dict(
             flocker_version=flocker_client_version,
             working_directory=os.getcwd(),
-            username=os.environ[b"USER"],
+            username=environ[b"USER"],
             nodename=node(),
             platform=platform(),
         ),
@@ -311,4 +314,4 @@ def main():
     )
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv, os.environ)

--- a/benchmark/test/test_driver.py
+++ b/benchmark/test/test_driver.py
@@ -198,3 +198,19 @@ class BenchmarkTest(AsyncTestCase):
             FakeMetric(count(5)),
             3)
         self.assertFailure(samples_ready, RuntimeError)
+
+    @capture_logging(None)
+    def test_sample_count(self, _logger):
+        """
+        The sample count determines the number of samples.
+        """
+        samples_ready = benchmark(
+            FakeScenario(),
+            FakeOperation(repeat(True)),
+            FakeMetric(count(5)),
+            5)
+
+        def check(samples):
+            self.assertEqual(len(samples), 5)
+        samples_ready.addCallback(check)
+        return samples_ready

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -34,6 +34,11 @@ The :program:`benchmark` script has the following command line options:
    The format of this file is specified in the :ref:`benchmarking-configuration-file` section below.
    Defaults to the file ``./benchmark.yml``.
 
+.. option:: --samples <integer>
+
+   Specifies the number of times to run the benchmark measurements.
+   Defaults to 3.
+
 .. option:: --scenario <scenario>
 
    Specifies the scenario to run the benchmark under.


### PR DESCRIPTION
Allow the number of benchmarking samples to be provided as a command line parameter, rather than fixed at 3.

A particular use case is to help with generating benchmarks that are specified as meeting a limit in X% of cases. Running 100 samples can generate results to easily check such benchmarks.