### PR TITLE
[FLOC-3833] Allow the method used by read request scenario to be set as a parameter.

### DIFF
--- a/benchmark/_method.py
+++ b/benchmark/_method.py
@@ -1,0 +1,31 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Functions for checking a method name provided by the user.
+"""
+
+
+class InvalidMethod(Exception):
+    """
+    Method not meeting requested criteria.
+    """
+
+
+def validate_no_arg_method(interface, method_name):
+    """
+    Check that method name exists in interface and requires no parameters.
+
+    :param zope.interface.Interface interface: Interface to validate against.
+    :param str method_name: Method name to validate.
+    :raise InvalidMethod: if name is not valid or requires parameters.
+    """
+    for name, method in interface.namesAndDescriptions():
+        if name == method_name:
+            if len(method.getSignatureInfo()['required']) > 0:
+                raise InvalidMethod(
+                    'Method {!r} requires parameters'.format(method_name)
+                )
+            return
+    raise InvalidMethod(
+        'Method {!r} not found in interface {}'.format(
+            method_name, interface.__name__)
+    )

--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -6,6 +6,11 @@ scenarios:
     type: read-request-load
     request_rate: 5
 
+  - name: list-container-state-4
+    type: read-request-load
+    method: list_containers_state
+    request_rate: 4
+
   - name: write-request-5
     type: write-request-load
     request_rate: 5

--- a/benchmark/operations/read_request.py
+++ b/benchmark/operations/read_request.py
@@ -5,36 +5,7 @@ from twisted.internet.defer import succeed
 from flocker.apiclient import IFlockerAPIV1Client
 
 from .._interfaces import IProbe, IOperation
-
-
-class InvalidMethod(Exception):
-    """
-    Method not suitable for use with ReadRequest operation.
-
-    The method must be provided by the IFlockerAPIV1Client interface,
-    and require no parameters.
-    """
-
-
-def validate_method_name(interface, method_name):
-    """
-    Check that method name exists in interface and requires no parameters.
-
-    :param zope.interface.Interface interface: Interface to validate against.
-    :param str method_name: Method name to validate.
-    :raise InvalidMethod: if name is not valid or requires parameters.
-    """
-    for name, method in interface.namesAndDescriptions():
-        if name == method_name:
-            if len(method.getSignatureInfo()['required']) > 0:
-                raise InvalidMethod(
-                    'Method {!r} requires parameters'.format(method_name)
-                )
-            return
-    raise InvalidMethod(
-        'Method {!r} not found in interface {}'.format(
-            method_name, interface.__name__)
-    )
+from .._method import validate_no_arg_method
 
 
 @implementer(IProbe)
@@ -60,7 +31,7 @@ class ReadRequest(object):
     """
 
     def __init__(self, reactor, cluster, method='version'):
-        validate_method_name(IFlockerAPIV1Client, method)
+        validate_no_arg_method(IFlockerAPIV1Client, method)
         self.request = getattr(cluster.get_control_service(reactor), method)
 
     def get_probe(self):

--- a/benchmark/operations/test/test_read_request.py
+++ b/benchmark/operations/test/test_read_request.py
@@ -15,9 +15,7 @@ from flocker.testtools import TestCase
 
 from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IOperation
-from benchmark.operations.read_request import (
-    ReadRequest, InvalidMethod, validate_method_name
-)
+from benchmark.operations.read_request import ReadRequest
 
 
 class FastConvergingFakeFlockerClient(
@@ -51,41 +49,6 @@ class FastConvergingFakeFlockerClient(
         result = self.original.delete_container(*a, **kw)
         self.original.synchronize_state()
         return result
-
-
-class ValidMethodNameTests(TestCase):
-    """
-    Check that method name validation works.
-    """
-
-    def test_no_parameter_method(self):
-        name = 'version'
-        self.assertIn(name, IFlockerAPIV1Client.names())
-        validate_method_name(IFlockerAPIV1Client, name)
-
-    def test_method_with_parameters(self):
-        """
-        Rejects method that requires parameters.
-        """
-        name = 'create_dataset'
-        self.assertIn(name, IFlockerAPIV1Client.names())
-        self.assertRaises(
-            InvalidMethod,
-            validate_method_name,
-            IFlockerAPIV1Client, name,
-        )
-
-    def test_not_found_method(self):
-        """
-        Rejects name not found in interface.
-        """
-        name = 'non_existent'
-        self.assertNotIn(name, IFlockerAPIV1Client.names())
-        self.assertRaises(
-            InvalidMethod,
-            validate_method_name,
-            IFlockerAPIV1Client, name,
-        )
 
 
 class ReadRequestTests(TestCase):

--- a/benchmark/scenarios/read_request_load.py
+++ b/benchmark/scenarios/read_request_load.py
@@ -56,6 +56,7 @@ def read_request_load_scenario(
 
     :param reactor: Reactor to use.
     :param cluster: ``BenchmarkCluster`` containing the control service.
+    :param method: Method of ``IFlockerAPIV1Client`` to call.
     :param request_rate: The target number of requests per second.
     :param sample_size: The number of samples to collect when measuring
         the rate.

--- a/benchmark/scenarios/read_request_load.py
+++ b/benchmark/scenarios/read_request_load.py
@@ -7,7 +7,10 @@ from zope.interface import implementer
 
 from twisted.internet.defer import succeed
 
+from flocker.apiclient import IFlockerAPIV1Client
+
 from .._interfaces import IRequestScenarioSetup
+from .._method import validate_no_arg_method
 from ._request_load import RequestLoadScenario, DEFAULT_SAMPLE_SIZE
 
 
@@ -16,11 +19,12 @@ class ReadRequest(object):
     """
     Implementation of the setup and request maker for the read load
     scenario.
-    :ivar reactor: Reactor to use.
-    :ivar cluster: ``BenchmarkCluster`` containing the control service.
+
+    :ivar Callable[[], Deferred[Any]] request: Callable to perform the
+        read request.
     """
-    def __init__(self, reactor, cluster):
-        self.control_service = cluster.get_control_service(reactor)
+    def __init__(self, request):
+        self._request = request
 
     def make_request(self):
         """
@@ -28,9 +32,9 @@ class ReadRequest(object):
         It will list the nodes on the cluster given when initialising
         the ``ReadRequest`` class
 
-        :return: A ``Deferred`` that fires when the nodes have been listed.
+        :return: A ``Deferred`` that fires when the request has been performed.
         """
-        return self.control_service.list_nodes()
+        return self._request()
 
     def run_setup(self):
         """
@@ -42,8 +46,10 @@ class ReadRequest(object):
         return succeed(None)
 
 
-def read_request_load_scenario(reactor, cluster, request_rate=10,
-                               sample_size=DEFAULT_SAMPLE_SIZE, timeout=45):
+def read_request_load_scenario(
+    reactor, cluster, method='version', request_rate=10,
+    sample_size=DEFAULT_SAMPLE_SIZE, timeout=45
+):
     """
     Factory that will initialise and return an excenario that places
     load on the cluster by performing read requests at a specified rate.
@@ -59,9 +65,11 @@ def read_request_load_scenario(reactor, cluster, request_rate=10,
     :return: a ``RequestLoadScenario`` initialised to be a read load
         scenario.
     """
+    validate_no_arg_method(IFlockerAPIV1Client, method)
+    request = getattr(cluster.get_control_service(reactor), method)
     return RequestLoadScenario(
         reactor,
-        ReadRequest(reactor, cluster),
+        ReadRequest(request),
         request_rate=request_rate,
         sample_size=sample_size,
         timeout=timeout,

--- a/benchmark/test/test_method.py
+++ b/benchmark/test/test_method.py
@@ -1,0 +1,53 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Method tests for the control service benchmarks.
+"""
+
+from zope.interface import Interface
+
+from flocker.testtools import TestCase
+
+from benchmark._method import validate_no_arg_method, InvalidMethod
+
+
+class ITest(Interface):
+    """
+    An interface for testing.
+    """
+
+    def noargs():
+        """
+        Method that takes no arguments.
+        """
+
+    def hasargs(a, b, c):
+        """
+        Method that takes arguments.
+        """
+
+
+class MethodTests(TestCase):
+
+    def noargs_is_noargs_method(self):
+        """
+        A no-argument method validates as no-arg method.
+        """
+        validate_no_arg_method(ITest, 'noargs')
+
+    def hasargs_fails_noargs_method(self):
+        """
+        An argument-taking method fails to validate as no-arg method.
+        """
+        exception = self.assertRaises(
+            InvalidMethod, validate_no_arg_method, ITest, 'hasargs'
+        )
+        self.assertIn('requires parameters', str(exception))
+
+    def not_present_fails_noargs_method(self):
+        """
+        A non-present method fails to validate as no-arg method.
+        """
+        exception = self.assertRaises(
+            InvalidMethod, validate_no_arg_method, ITest, 'notpresent'
+        )
+        self.assertIn('not found in interface', str(exception))

--- a/benchmark/test/test_method.py
+++ b/benchmark/test/test_method.py
@@ -28,13 +28,13 @@ class ITest(Interface):
 
 class MethodTests(TestCase):
 
-    def noargs_is_noargs_method(self):
+    def test_noargs_is_noargs_method(self):
         """
         A no-argument method validates as no-arg method.
         """
         validate_no_arg_method(ITest, 'noargs')
 
-    def hasargs_fails_noargs_method(self):
+    def test_hasargs_fails_noargs_method(self):
         """
         An argument-taking method fails to validate as no-arg method.
         """
@@ -43,7 +43,7 @@ class MethodTests(TestCase):
         )
         self.assertIn('requires parameters', str(exception))
 
-    def not_present_fails_noargs_method(self):
+    def test_not_present_fails_noargs_method(self):
         """
         A non-present method fails to validate as no-arg method.
         """

--- a/docs/gettinginvolved/benchmarking.rst
+++ b/docs/gettinginvolved/benchmarking.rst
@@ -132,6 +132,10 @@ Scenario Types
 .. option:: read-request-load
 
    Create additional load on the system by performing read requests.
+
+   Specify the operation to be performed using an additional ``method`` property.
+   The value must be the name of a zero-parameter method in the ``flocker.apiclient.IFlockerAPIV1Client`` interface, and defaults to ``version``.
+
    Specify the rate of requests to perform per second using an additional ``request_rate`` property.
    The default is 10 requests per second.
 
@@ -140,6 +144,20 @@ Scenario Types
 
    Specify a timeout for establishing the scenario using an additional ``timeout`` property.
    The default is 45 seconds.
+
+.. option:: write-request-load
+
+   Create additional load on the system by performing write requests, specifically a dataset move that has no real effect (target = source).
+
+   Specify the rate of requests to perform per second using an additional ``request_rate`` property.
+   The default is 10 requests per second.
+
+   Specify the number of samples to be collected when sampling the request rate using an additional ``sample_size`` property.
+   The default is 5 samples.
+
+   Specify a timeout for establishing the scenario using an additional ``timeout`` property.
+   The default is 45 seconds.
+
 
 Operation Types
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Allow the operation used in the benchmarking read load scenario to be set as a parameter.

FLOC-3399 specifies a particular operation to be used for benchmarking, which was different to the existing operation.  The read request /operation/ already allowed the method to be specified as a parameter.

This PR adds the same ability to the read load scenario. Major changes include the extraction of common code for validating the method name into a separate file, and modifying the fake benchmark clients for testing to handle any method, not just the original one.

Also, there was no documentation for the write load scenario, so this was added while updating the read load scenario docs.