### PR TITLE
[FLOC-3832] Add flaky decorator for affected test

### DIFF
--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -155,6 +155,7 @@ class EBSBlockDeviceAPIInterfaceTests(
             bad_instance_id
         )
 
+    @flaky(u"FLOC-3832")
     def test_attach_when_foreign_device_has_next_device(self):
         """
         ``attach_volume`` does not attempt to use device paths that are already


### PR DESCRIPTION
The build failures we're seeing for this test are most likely AWS' eventual consistency biting us - the logs for the test indicate Flocker is attempting to do the right things it's supposed to be doing, but not getting the expected volume states from EC2. So this PR just adds the flaky decorator to allow us to accept at least 1 out of 3 runs passing.