### PR TITLE
[FLOC-3799] Collect artifacts (logs) from cron-triggered acceptance test jobs

### DIFF
--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -6,6 +6,24 @@
   required views, folders, and jobs for a particular project in the Jenkins
   interface.
 
+  The easiest way to debug or experiment with changes to this is:
+    * check them in to a branch
+    * trigger a build of that branch on the setup_ClusterHQ-flocker job
+    * ssh into the master (same hostname as the web ui)
+    * compare the master configuration xml with the branch configuration xml:
+
+        BASE=/var/lib/jenkins/jobs/ClusterHQ-flocker/jobs/
+        A=master
+        B=copy-artifacts-for-all-jobs-FLOC-3799
+        for config in $(find ${BASE}/${A} -name config.xml | cut -d '/' -f 10- | sort); do
+            if [ -e ${BASE}/${A}/${config} ] && [ -e ${BASE}/${B}/${config} ]; then
+                diff -u ${BASE}/${A}/${config} <(sed -e "s,${B},${A}," ${BASE}/${B}/${config})
+            fi
+        done | less
+
+      Certain changes will always be present.  For example, triggers for the
+      cron-style jobs are only created for the master branch.
+
   The full Jenkins job DSL reference can be found on the URL below:
   https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-reference
 

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -289,10 +289,10 @@ def build_publishers(v) {
     ( 'shell', others )
     currently only shell has been implemented.
 
-    params v: dictionary containing the job values */
-def build_steps(v) {
+    params job: dictionary the job steps (``with_steps``) */
+def build_steps(job_name, job) {
     return {
-        for (_step in v) {
+        for (_step in job.with_steps) {
             if (_step.type == 'shell') {
                 shell(_step.cli.join("\n") + "\n")
             }
@@ -366,7 +366,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
                                          '${WORKSPACE}/.hypothesis']
                 wrappers build_wrappers(job_values, directories_to_delete)
                 scm build_scm(git_url, branchName)
-                steps build_steps(job_values.with_steps)
+                steps build_steps(_job_name, job_values)
                 publishers build_publishers(job_values)
             }
         }
@@ -391,7 +391,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
                                          '${WORKSPACE}/.hypothesis']
                 wrappers build_wrappers(job_values, directories_to_delete)
                 scm build_scm(git_url, branchName)
-                steps build_steps(job_values.with_steps)
+                steps build_steps(_job_name, job_values)
                 publishers build_publishers(job_values)
             }
         }
@@ -408,7 +408,9 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             label(job_values.on_nodes_with_labels)
             wrappers build_wrappers(job_values, [])
             scm build_scm(git_url, branchName)
-            steps build_steps(job_values.with_steps)
+            // There is no module part for sphinx jobs so we can use job_name
+            // unmodified.
+            steps build_steps(job_name, job_values)
         }
     }
 
@@ -435,7 +437,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
                 directories_to_delete = ['${WORKSPACE}/repo' ]
                 wrappers build_wrappers(job_values, directories_to_delete)
                 scm build_scm(git_url, branchName)
-                steps build_steps(job_values.with_steps)
+                steps build_steps(_job_name, job_values)
                 publishers build_publishers(job_values)
             }
         }
@@ -460,7 +462,9 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             directories_to_delete = ['${WORKSPACE}/repo']
             wrappers build_wrappers(job_values, directories_to_delete)
             scm build_scm(git_url, branchName)
-            steps build_steps(job_values.with_steps)
+            // There is no module for run_client jobs so we can use job_name
+            // unmodified.
+            steps build_steps(job_name, job_values)
             publishers build_publishers(job_values)
         }
     }
@@ -473,7 +477,9 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             label(job_values.on_nodes_with_labels)
             wrappers build_wrappers(job_values, [])
             scm build_scm("${git_url}", "${branchName}")
-            steps build_steps(job_values.with_steps)
+            // There is no module for omnibus jobs so we can use job_name
+            // unmodified.
+            steps build_steps(job_name, job_values)
         }
     }
 
@@ -486,7 +492,9 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             label(job_values.on_nodes_with_labels)
             wrappers build_wrappers(job_values, [])
             scm build_scm(git_url, branchName)
-            steps build_steps(job_values.with_steps)
+            // There is no module for lint jobs so we can use job_name
+            // unmodified.
+            steps build_steps(job_name, job_values)
         }
     }
 }
@@ -706,7 +714,8 @@ for (job_type_entry in GLOBAL_CONFIG.job_type) {
         job_values = job_entry.value
         /* apply config related to 'cronly_jobs' jobs */
         if (job_type == 'cronly_jobs') {
-            job("${dashProject}/${dashBranchName}/_${job_entry.key}") {
+            _job_name = "_${job_entry.key}"
+            job("${dashProject}/${dashBranchName}/${_job_name}") {
                 parameters {
                     textParam("TRIGGERED_BRANCH", "${branchName}",
                               "Branch that triggered this job" )
@@ -715,7 +724,7 @@ for (job_type_entry in GLOBAL_CONFIG.job_type) {
                 wrappers build_wrappers(job_values, [])
                 triggers build_triggers('cron', job_values.at, "${branchName}")
                 scm build_scm("${git_url}", "${branchName}")
-                steps build_steps(job_values.with_steps)
+                steps build_steps(_job_name, job_values)
             }
         }
     }

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -297,6 +297,28 @@ def build_steps(dash_project, dash_branch_name, job_name, job) {
                 shell(_step.cli.join("\n") + "\n")
             }
         }
+
+        /* not every job produces an artifact, so make sure we
+           don't try to fetch artifacts for jobs that don't
+           produce them */
+        if (job.archive_artifacts) {
+            for (artifact in job.archive_artifacts) {
+                copyArtifacts(
+                    "${dash_project}/${dash_branch_name}/${job_name}") {
+
+                    optional(true)
+                    includePatterns(artifact)
+                    /* and place them under 'job name'/artifact on
+                       the multijob workspace, so that we don't
+                       overwrite them.  */
+                    targetDirectory(job_name)
+                    fingerprintArtifacts(true)
+                    buildSelector {
+                        workspace()
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -576,39 +598,6 @@ def build_multijob(dashBranchName, branchName) {
                     }
                 }
             } /* ends parallel phase */
-
-            /* we've added the jobs to the multijob, we now need to fetch and
-               archive all the artifacts produced by the different jobs */
-            for (job_type_entry in GLOBAL_CONFIG.job_type) {
-                job_type = job_type_entry.key
-                for (job_entry in job_type_entry.value) {
-                    job_name = job_entry.key
-                    job_values = job_entry.value
-                    for (_module in job_values.with_modules) {
-                        _job_name = job_name + '_' + _module.replace('/', '_')
-                        /* no every job produces an artifact, so make sure wew
-                           don't try to fetch artifacts for jobs that don't
-                           produce them */
-                        if (job_values.archive_artifacts) {
-                            for (artifact in job_values.archive_artifacts) {
-                                copyArtifacts(
-                                    "${dashProject}/${dashBranchName}/${_job_name}") {
-                                    optional(true)
-                                    includePatterns(artifact)
-                                    /* and place them under 'job name'/artifact on
-                                       the multijob workspace, so that we don't
-                                       overwrite them.  */
-                                    targetDirectory(_job_name)
-                                    fingerprintArtifacts(true)
-                                    buildSelector {
-                                        workspace()
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         }
 
         /* do an aggregation of all the test results */

--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -290,7 +290,7 @@ def build_publishers(v) {
     currently only shell has been implemented.
 
     params job: dictionary the job steps (``with_steps``) */
-def build_steps(job_name, job) {
+def build_steps(dash_project, dash_branch_name, job_name, job) {
     return {
         for (_step in job.with_steps) {
             if (_step.type == 'shell') {
@@ -366,7 +366,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
                                          '${WORKSPACE}/.hypothesis']
                 wrappers build_wrappers(job_values, directories_to_delete)
                 scm build_scm(git_url, branchName)
-                steps build_steps(_job_name, job_values)
+                steps build_steps(dashProject, dashBranchName, _job_name, job_values)
                 publishers build_publishers(job_values)
             }
         }
@@ -391,7 +391,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
                                          '${WORKSPACE}/.hypothesis']
                 wrappers build_wrappers(job_values, directories_to_delete)
                 scm build_scm(git_url, branchName)
-                steps build_steps(_job_name, job_values)
+                steps build_steps(dashProject, dashBranchName, _job_name, job_values)
                 publishers build_publishers(job_values)
             }
         }
@@ -410,7 +410,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             scm build_scm(git_url, branchName)
             // There is no module part for sphinx jobs so we can use job_name
             // unmodified.
-            steps build_steps(job_name, job_values)
+            steps build_steps(dashProject, dashBranchName, job_name, job_values)
         }
     }
 
@@ -437,7 +437,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
                 directories_to_delete = ['${WORKSPACE}/repo' ]
                 wrappers build_wrappers(job_values, directories_to_delete)
                 scm build_scm(git_url, branchName)
-                steps build_steps(_job_name, job_values)
+                steps build_steps(dashProject, dashBranchName, _job_name, job_values)
                 publishers build_publishers(job_values)
             }
         }
@@ -464,7 +464,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             scm build_scm(git_url, branchName)
             // There is no module for run_client jobs so we can use job_name
             // unmodified.
-            steps build_steps(job_name, job_values)
+            steps build_steps(dashProject, dashBranchName, job_name, job_values)
             publishers build_publishers(job_values)
         }
     }
@@ -479,7 +479,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             scm build_scm("${git_url}", "${branchName}")
             // There is no module for omnibus jobs so we can use job_name
             // unmodified.
-            steps build_steps(job_name, job_values)
+            steps build_steps(dashProject, dashBranchName, job_name, job_values)
         }
     }
 
@@ -494,7 +494,7 @@ def define_job(dashBranchName, branchName, job_type, job_name, job_values) {
             scm build_scm(git_url, branchName)
             // There is no module for lint jobs so we can use job_name
             // unmodified.
-            steps build_steps(job_name, job_values)
+            steps build_steps(dashProject, dashBranchName, job_name, job_values)
         }
     }
 }
@@ -724,7 +724,7 @@ for (job_type_entry in GLOBAL_CONFIG.job_type) {
                 wrappers build_wrappers(job_values, [])
                 triggers build_triggers('cron', job_values.at, "${branchName}")
                 scm build_scm("${git_url}", "${branchName}")
-                steps build_steps(_job_name, job_values)
+                steps build_steps(dashProject, dashBranchName, _job_name, job_values)
             }
         }
     }


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3799

This removes the separate `copyArtifact`-calling loop over some of the jobs (all except the cron jobs) and replaces it with a `copyArtifact` call in the `build_steps` method that is called for every job.

This has two consequences:
  * The `CopyArtifact` configuration is now part of each job rather than all of the `CopyArtifact` configuration being part of the main multijob (incidental but, I think, an improvement).
  * Cron-style jobs now have `CopyArtifact` configuration if they define artifacts that should be copied (the actual point of this PR).

Visual inspection of the generated configuration xml suggest these are actually the consequences achieved by this PR.