### PR TITLE
[FLOC-3820] Benchmark latency count

### DIFF
--- a/benchmark/_driver.py
+++ b/benchmark/_driver.py
@@ -70,12 +70,11 @@ def benchmark(scenario, operation, metric, num_samples=3):
     :param IOperation operation: An operation to perform.
     :param IMetric metric: A quantity to measure.
     :param int num_samples: Number of samples to take.
-    XXX - modify docstring
-    :return: Deferred firing with a list of samples. Each sample is a
-        dictionary containing a ``success`` boolean. If ``success is True``,
-        the dictionary also contains a ``value`` for the sample measurement.
-        If ``success is False``, the dictionary also contains a ``reason`` for
-        failure.
+    :return: Deferred firing with a tuple containing one list of
+        benchmark samples and one scenario metrics result. See the
+        ``sample`` function for the structure of the samples.  The
+        scenario metrics are a dictionary containing information about
+        the scenario.
     """
     scenario_established = scenario.start()
 
@@ -110,7 +109,10 @@ def benchmark(scenario, operation, metric, num_samples=3):
         d.addCallback(combine_results)
 
         return d
-    benchmarking.addBoth(stop_scenario)
+    benchmarking.addCallbacks(
+        stop_scenario,
+        bypass, errbackArgs=[scenario.stop]
+    )
 
     return benchmarking
 

--- a/benchmark/_interfaces.py
+++ b/benchmark/_interfaces.py
@@ -34,7 +34,7 @@ class IScenario(Interface):
         """
         Stop the scenario from being maintained.
 
-        :return: A Deferred that fires when the desired scenario is stopped.
+        :return Deferred[Optional[Dict[unicode, Any]]]: Scenario metrics.
         """
 
 

--- a/benchmark/scenarios/_rate_measurer.py
+++ b/benchmark/scenarios/_rate_measurer.py
@@ -23,6 +23,7 @@ class RateMeasurer(object):
         self._received = 0
         self._errors = 0
         self._rate = 0
+        self._count = {}  # XXX - count of calltimes
 
     def request_sent(self):
         """
@@ -30,14 +31,15 @@ class RateMeasurer(object):
         """
         self._sent += 1
 
-    def response_received(self, ignored):
+    def response_received(self, calltime):
         """
         Increase the number of received requests.
 
-        :param ignored: The result of a callback. This parameter is
-            not used.
+        :param calltime: Time to perform call
         """
         self._received += 1
+        # XXX - need to handle non-existent key
+        self.count[int(calltime)] += 1
 
     def request_failed(self, ignored):
         """

--- a/benchmark/scenarios/_rate_measurer.py
+++ b/benchmark/scenarios/_rate_measurer.py
@@ -15,7 +15,7 @@ class RateMeasurer(object):
     :ivar _error_count: The number of failed requests recorded.
     :ivar _rate: The current rate.
     :ivar Mapping[int, int] _call_durations: The number of times a call took
-        the given time (rounded down to whole seconds).
+        the given time (rounded to 1 decimal place).
     :ivar Mapping[str, int] _errors: The number of times the given error
         message was received.
     """
@@ -43,8 +43,8 @@ class RateMeasurer(object):
         :param float duration: Time taken to perform call
         """
         self._received += 1
-        duration = int(duration)
-        self._call_durations[duration] = self._call_durations.get(duration, 0) + 1
+        key = round(duration, 1)
+        self._call_durations[key] = self._call_durations.get(key, 0) + 1
 
     def request_failed(self, failure):
         """

--- a/benchmark/scenarios/_rate_measurer.py
+++ b/benchmark/scenarios/_rate_measurer.py
@@ -12,11 +12,12 @@ class RateMeasurer(object):
     :ivar _samples: The recorded samples.
     :ivar _sent: The number of sent requests recorded.
     :ivar _received: The number of received requests recorded.
-    :ivar _errors: The number of failed requests recorded.
+    :ivar _error_count: The number of failed requests recorded.
     :ivar _rate: The current rate.
-    :ivar Mapping[int, int] _calltimes: Value is the number of requests
-        that took the amount of time (rounded down to nearest integer)
-        indicated by the key.
+    :ivar Mapping[int, int] _calltimes: The number of times a call took
+        the given time (rounded down to whole seconds).
+    :ivar Mapping[str, int] _errors: The number of times the given error
+        message was received.
     """
 
     def __init__(self, sample_size=DEFAULT_SAMPLE_SIZE):
@@ -77,6 +78,9 @@ class RateMeasurer(object):
         return self._rate
 
     def get_metrics(self):
+        """
+        Return the collected metrics.
+        """
         return {
             'calltimes': self._calltimes,
             'errors': self._errors,

--- a/benchmark/scenarios/_rate_measurer.py
+++ b/benchmark/scenarios/_rate_measurer.py
@@ -14,7 +14,7 @@ class RateMeasurer(object):
     :ivar _received: The number of received requests recorded.
     :ivar _error_count: The number of failed requests recorded.
     :ivar _rate: The current rate.
-    :ivar Mapping[int, int] _calltimes: The number of times a call took
+    :ivar Mapping[int, int] _call_durations: The number of times a call took
         the given time (rounded down to whole seconds).
     :ivar Mapping[str, int] _errors: The number of times the given error
         message was received.
@@ -27,7 +27,7 @@ class RateMeasurer(object):
         self._received = 0
         self._error_count = 0
         self._rate = 0
-        self._calltimes = {}
+        self._call_durations = {}
         self._errors = {}
 
     def request_sent(self):
@@ -36,15 +36,15 @@ class RateMeasurer(object):
         """
         self._sent += 1
 
-    def response_received(self, calltime):
+    def response_received(self, duration):
         """
         Increase the number of received requests.
 
-        :param float calltime: Time to perform call
+        :param float duration: Time taken to perform call
         """
         self._received += 1
-        calltime = int(calltime)
-        self._calltimes[calltime] = self._calltimes.get(calltime, 0) + 1
+        duration = int(duration)
+        self._call_durations[duration] = self._call_durations.get(duration, 0) + 1
 
     def request_failed(self, failure):
         """
@@ -82,7 +82,7 @@ class RateMeasurer(object):
         Return the collected metrics.
         """
         return {
-            'calltimes': self._calltimes,
+            'call_durations': self._call_durations,
             'errors': self._errors,
             'ok_count': self._received,
             'err_count': self._error_count,

--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -110,6 +110,8 @@ class RequestLoadScenario(object):
         for i in range(self.request_rate):
             d = self.scenario_setup.make_request()
             self.rate_measurer.request_sent()
+            # XXX - make_request modified to return time for call
+            # XXX - pass to rate_measurer.response_received
             d.addCallbacks(self.rate_measurer.response_received,
                            errback=handle_request_error)
 
@@ -205,6 +207,7 @@ class RequestLoadScenario(object):
 
         :return: A ``Deferred`` that fires when the scenario has stopped.
         """
+        # XXX - get calltimes from rate_measurer, to return as result of deferred
         self.is_started = False
         if self.monitor_loop.running:
             self.monitor_loop.stop()

--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -3,7 +3,6 @@
 Request load scenario for the control service benchmarks.
 """
 from itertools import repeat
-from time import time
 
 from zope.interface import implementer
 from eliot import start_action, write_failure, Message
@@ -109,12 +108,12 @@ class RequestLoadScenario(object):
             write_failure(result)
 
         for i in range(self.request_rate):
-            t0 = time()
+            t0 = self.reactor.seconds()
 
             d = self.scenario_setup.make_request()
 
             def get_time(_ignore):
-                return time() - t0
+                return self.reactor.seconds() - t0
             d.addCallback(get_time)
 
             self.rate_measurer.request_sent()

--- a/benchmark/scenarios/no_load.py
+++ b/benchmark/scenarios/no_load.py
@@ -38,7 +38,6 @@ class NoLoadScenario(object):
         """
         Stop the scenario from being maintained.
 
-        :return: A Deferred that fires when the desired scenario is
-            stopped.
+        :return Deferred[None]: No scenario metrics.
         """
-        return succeed(self)
+        return succeed(None)

--- a/benchmark/scenarios/read_request_load.py
+++ b/benchmark/scenarios/read_request_load.py
@@ -30,10 +30,7 @@ class ReadRequest(object):
 
         :return: A ``Deferred`` that fires when the nodes have been listed.
         """
-        # XXX - get time at start
         return self.control_service.list_nodes()
-        # XXX - get time at end
-        # XXX - return Deferred firing with time difference
 
     def run_setup(self):
         """

--- a/benchmark/scenarios/read_request_load.py
+++ b/benchmark/scenarios/read_request_load.py
@@ -30,7 +30,10 @@ class ReadRequest(object):
 
         :return: A ``Deferred`` that fires when the nodes have been listed.
         """
+        # XXX - get time at start
         return self.control_service.list_nodes()
+        # XXX - get time at end
+        # XXX - return Deferred firing with time difference
 
     def run_setup(self):
         """

--- a/benchmark/scenarios/test/test_rate_measurer.py
+++ b/benchmark/scenarios/test/test_rate_measurer.py
@@ -149,3 +149,27 @@ class RateMeasurerTest(TestCase):
 
         self.assertEqual(0, r.outstanding())
 
+    def test_calltime_stats(self):
+        """
+        Calltime stats reflect response calls.
+        """
+        r = RateMeasurer()
+
+        # Send 25 requests
+        self.send_requests(r, 5, r.sample_size)
+
+        # Receive successful responses for 20 of those requests
+        self.receive_requests(r, 4, r.sample_size)
+
+        # Mark 5 of the requests as failed
+        self.failed_requests(r, 1, r.sample_size)
+
+        self.assertEqual(
+            r.get_metrics(),
+            {
+                'calltimes': {5: 20},
+                'errors': {'fail': 5},
+                'ok_count': 20,
+                'err_count': 5,
+            }
+        )

--- a/benchmark/scenarios/test/test_rate_measurer.py
+++ b/benchmark/scenarios/test/test_rate_measurer.py
@@ -31,10 +31,10 @@ class RateMeasurerTest(TestCase):
         :param num_requests: The number of request we want to receive.
         :param num_samples: The number of samples to collect.
         """
-        calltime = 5
+        call_duration = 5
         for i in range(num_samples):
             for i in range(num_requests):
-                rate_measurer.response_received(calltime)
+                rate_measurer.response_received(call_duration)
             rate_measurer.update_rate()
 
     def failed_requests(self, rate_measurer, num_failures, num_samples):
@@ -149,7 +149,7 @@ class RateMeasurerTest(TestCase):
 
         self.assertEqual(0, r.outstanding())
 
-    def test_calltime_stats(self):
+    def test_call_duration_stats(self):
         """
         Calltime stats reflect response calls.
         """
@@ -167,7 +167,7 @@ class RateMeasurerTest(TestCase):
         self.assertEqual(
             r.get_metrics(),
             {
-                'calltimes': {5: 20},
+                'call_durations': {5: 20},
                 'errors': {'fail': 5},
                 'ok_count': 20,
                 'err_count': 5,

--- a/benchmark/scenarios/test/test_rate_measurer.py
+++ b/benchmark/scenarios/test/test_rate_measurer.py
@@ -31,7 +31,7 @@ class RateMeasurerTest(TestCase):
         :param num_requests: The number of request we want to receive.
         :param num_samples: The number of samples to collect.
         """
-        call_duration = 5
+        call_duration = 4.567
         for i in range(num_samples):
             for i in range(num_requests):
                 rate_measurer.response_received(call_duration)
@@ -167,7 +167,7 @@ class RateMeasurerTest(TestCase):
         self.assertEqual(
             r.get_metrics(),
             {
-                'call_durations': {5: 20},
+                'call_durations': {4.6: 20},
                 'errors': {'fail': 5},
                 'ok_count': 20,
                 'err_count': 5,

--- a/benchmark/scenarios/test/test_rate_measurer.py
+++ b/benchmark/scenarios/test/test_rate_measurer.py
@@ -1,4 +1,7 @@
-# copyright 2016 clusterhq inc.  see license file for details.
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+from twisted.python.failure import Failure
+
 from flocker.testtools import TestCase
 
 from .._rate_measurer import RateMeasurer
@@ -28,10 +31,10 @@ class RateMeasurerTest(TestCase):
         :param num_requests: The number of request we want to receive.
         :param num_samples: The number of samples to collect.
         """
-        ignored = u""
+        calltime = 5
         for i in range(num_samples):
             for i in range(num_requests):
-                rate_measurer.response_received(ignored)
+                rate_measurer.response_received(calltime)
             rate_measurer.update_rate()
 
     def failed_requests(self, rate_measurer, num_failures, num_samples):
@@ -43,7 +46,7 @@ class RateMeasurerTest(TestCase):
         :param num_failures: The number of requests we want to fail.
         :param num_samples: The number of samples to collect.
         """
-        result = None
+        result = Failure(RuntimeError('fail'))
         for i in range(num_samples):
             for i in range(num_failures):
                 rate_measurer.request_failed(result)

--- a/benchmark/scenarios/test/test_read_request_load.py
+++ b/benchmark/scenarios/test/test_read_request_load.py
@@ -287,7 +287,9 @@ class read_request_load_scenarioTest(TestCase):
         cluster = self.make_cluster(RequestErrorFakeFlockerClient)
         delay = 1
 
-        cluster.get_control_service(c).delay = delay
+        control_service = cluster.get_control_service(c)
+
+        control_service.delay = delay
         sample_size = 5
         s = read_request_load_scenario(
             c, cluster, request_rate=10, sample_size=sample_size
@@ -303,9 +305,9 @@ class read_request_load_scenarioTest(TestCase):
         # Force the control service to fail requests for one second.
         # These requests will fail after the delay period set in the
         # control service.
-        cluster.get_control_service(c).fail_requests = True
+        control_service.fail_requests = True
         c.advance(1)
-        cluster.get_control_service(c).fail_requests = False
+        control_service.fail_requests = False
 
         d.addCallback(lambda ignored: s.stop())
 
@@ -323,8 +325,7 @@ class read_request_load_scenarioTest(TestCase):
     def test_scenario_timeouts_if_requests_not_completed(self, _logger):
         """
         ``read_request_load_scenario`` should timeout if the outstanding
-        requests for the scenarion do not complete within the specified
-        time.
+        requests for the scenario do not complete within the specified time.
         """
         c = Clock()
 
@@ -334,9 +335,11 @@ class read_request_load_scenarioTest(TestCase):
             c, cluster, request_rate=10, sample_size=sample_size
         )
 
+        control_service = cluster.get_control_service(c)
+
         # Set the delay for the requests to be longer than the scenario
         # timeout
-        cluster.get_control_service(c).delay = s.timeout + 10
+        control_service.delay = s.timeout + 10
 
         d = s.start()
         s.maintained().addBoth(lambda x: self.fail())
@@ -345,9 +348,9 @@ class read_request_load_scenarioTest(TestCase):
         # requested rate.
         c.pump(repeat(1, sample_size))
 
-        cluster.get_control_service(c).fail_requests = True
+        control_service.fail_requests = True
         c.advance(1)
-        cluster.get_control_service(c).fail_requests = False
+        control_service.fail_requests = False
 
         d.addCallback(lambda ignored: s.stop())
 

--- a/benchmark/test/test_driver.py
+++ b/benchmark/test/test_driver.py
@@ -160,9 +160,10 @@ class BenchmarkTest(AsyncTestCase):
             FakeMetric(count(5)),
             3)
 
-        def check(samples):
+        def check(outputs):
             self.assertEqual(
-                samples, [{'success': True, 'value': x} for x in [5, 6, 7]])
+                outputs,
+                ([{'success': True, 'value': x} for x in [5, 6, 7]], None))
         samples_ready.addCallback(check)
         return samples_ready
 
@@ -177,14 +178,17 @@ class BenchmarkTest(AsyncTestCase):
             FakeMetric(count(5)),
             3)
 
-        def check(samples):
+        def check(outputs):
             # We don't care about the actual value for reason.
-            for s in samples:
+            for s in outputs[0]:
                 if 'reason' in s:
                     s['reason'] = None
             self.assertEqual(
-                samples,
-                [{'success': False, 'reason': None} for x in [5, 6, 7]])
+                outputs,
+                (
+                    [{'success': False, 'reason': None} for x in [5, 6, 7]],
+                    None)
+                )
         samples_ready.addCallback(check)
         return samples_ready
 

--- a/benchmark/test/test_driver.py
+++ b/benchmark/test/test_driver.py
@@ -214,7 +214,8 @@ class BenchmarkTest(AsyncTestCase):
             FakeMetric(count(5)),
             5)
 
-        def check(samples):
+        def check(outputs):
+            samples, scenario_metrics = outputs
             self.assertEqual(len(samples), 5)
         samples_ready.addCallback(check)
         return samples_ready


### PR DESCRIPTION
Add benchmark to provide statistics for request time for the read and write request load scenarios.  This is the final benchmark required for January/March benchmark tests.

The statistics for these benchmarks were already being generated in the `RateMeasurer` object used for the scenarios that generate requests, so this PR focusses on extracting the information and providing them to the user.

Normally a benchmark measures a specific operation, with a scenario running outside the measurement to provide the required load. Since the metric, which measures the operation, does not even know about the scenario, the PR adds a `scenario_metrics` output to the usual measured samples.  This keeps the scenario and metric independent of each other.

The output for the scenario now contains additional values, which can be used to calculate the percentage of requests completing within a time limit.  The `calltimes` dictionary indicates the number of times the request took the specified seconds (i.e. the dictionary key is the seconds required for the request, the dictionary value is the number of occurrences of a request taking that many seconds).  

Seconds are integers, and are rounded down from actual value (e.g. 1.9 seconds increments the "1" key).  Since we're looking for calls that take longer than 30 seconds, this rounding is unlikely to significantly affect the results.

```
$  ./benchmark --scenario read-request-5 --operation wait-10
{
  "scenario": {
    "metrics": {
      "ok_count": 185, 
      "calltimes": {
        "0": 1, 
        "1": 169, 
        "2": 15
      }, 
      "err_count": 0, 
      "errors": {}
    }, 
    "type": "read-request-load", 
    "request_rate": 5, 
    "name": "read-request-5"
  }, 
  "samples": [
    {
      "value": 10.000745058059692, 
      "success": true
    }, 
    {
      "value": 10.000056982040405, 
      "success": true
    }, 
    {
      "value": 10.00004506111145, 
      "success": true
    }
  ], 
...
}
```