### PR TITLE
[FLOC 3837] Fix broken EMC links

### DIFF
--- a/docs/config/emc-configuration.rst
+++ b/docs/config/emc-configuration.rst
@@ -16,6 +16,6 @@ For more information, including installation, testing and usage instructions, vi
 .. _ScaleIO: https://www.emc.com/storage/scaleio/index.htm
 .. _XtremIO: https://www.emc.com/storage/xtremio/overview.htm
 .. _VMAX: https://www.emc.com/en-us/storage/vmax.htm
-.. _EMC ScaleIO Flocker driver on GitHub: https://github.com/emccorp/scaleio-flocker-driver
-.. _EMC XtremIO Flocker driver on GitHub: https://github.com/emccorp/xtremio-flocker-driver
-.. _EMC VMAX Flocker driver on GitHub: https://github.com/emccorp/vmax-flocker-driver
+.. _EMC ScaleIO Flocker driver on GitHub: https://github.com/emccode/flocker-drivers/tree/master/scaleio
+.. _EMC XtremIO Flocker driver on GitHub: https://github.com/emccode/flocker-drivers/tree/master/xtremio
+.. _EMC VMAX Flocker driver on GitHub: https://github.com/emccode/flocker-drivers/tree/master/vmax


### PR DESCRIPTION
EMC recently changed the URLs for their backend storage drivers.

This PR updates our documentation to point at the right GitHub repositories.