### PR TITLE
[FLOC-3839] AWS session token support for acceptance and benchmark tests

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -959,6 +959,7 @@ class CommonOptions(Options):
                  zone: <aws zone, e.g. "us-west-2a">
                  access_key: <aws access key>
                  secret_access_token: <aws secret access token>
+                 session_token: <optional session token>
                  keyname: <ssh-key-name>
                  security_groups: ["<permissive security group>"]
                  instance_type: m3.large

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -153,6 +153,7 @@ To run the acceptance tests on AWS, you need:
      zone: <aws zone, e.g. "us-west-2a">
      access_key: <aws access key>
      secret_access_token: <aws secret access token>
+     session_token: <optional aws session token>
      keyname: <ssh-key-name>
      security_groups: ["<permissive security group>"]
      instance_type: <instance type, e.g. "m3.large">

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -356,7 +356,7 @@ class AWSProvisioner(PClass):
 
 def aws_provisioner(
     access_key, secret_access_token, keyname, region, zone, security_groups,
-    instance_type=b"m3.large"
+    instance_type=b"m3.large", session_token=None,
 ):
     """
     Create an IProvisioner for provisioning nodes on AWS EC2.
@@ -371,11 +371,14 @@ def aws_provisioner(
     :param list security_groups: List of security groups to put created nodes
         in.
     :param bytes instance_type: AWS instance type for cluster nodes.
+    :param bytes session_token: The optional session token, if required
+        for connection.
     """
     conn = connect_to_region(
         region,
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_access_token,
+        security_token=session_token,
     )
     return AWSProvisioner(
         _connection=conn,


### PR DESCRIPTION
The AWS benchmarking account uses roles to allow main account users access.  Roles use temporary credentials, which are like normal credentials, but add a session token.

This PR allows the session token to be provided as an additional property in the YAML configuration file for acceptance and benchmark tests.

The token is optional. If not supplied in the YAML file, it defaults to `None`, which indicates that no session token is being provided.

