### PR TITLE
[FLOC-3840] Add `--process-dependency-links` to the release `pip install` step

### DIFF
--- a/admin/release.py
+++ b/admin/release.py
@@ -916,7 +916,8 @@ def initialize_release(version, path, top_level):
         os.environ["LDFLAGS"] = '-L{}/lib" CFLAGS="-I{}/include'.format(
             brew_openssl, brew_openssl)
     check_call(
-        ["pip install -e .[dev]"], shell=True, stdout=open(os.devnull, 'w'))
+        ["pip install --process-dependency-links -e .[dev]"], shell=True,
+        stdout=open(os.devnull, 'w'))
 
     sys.stdout.write("Updating LICENSE file...\n")
     update_license_file(list(), top_level)


### PR DESCRIPTION
To install our forked version of testtools, we need to specify `--process-dependency-links` when performing `pip install`. This flag was missing from the script which sets up the release environment.