### PR TITLE
[FLOC-3781] Replace broken ActionNeeded wakeup placeholder with polling

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,6 +9,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+Next Next Release
+=================
+
+* Fixed a regression that caused block device agents to poll backend APIs like EBS too frequently in some circumstances.
+
 Next Release
 ============
 

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -168,13 +168,27 @@ LOG_NOOP = ActionType("flocker:change:noop", [], [], "We've done nothing.")
 
 
 @implementer(IStateChange)
-class NoOp(PClass):
+class Sleep(PClass):
     """
     Do nothing.
     """
+    interval = field(type=timedelta)
+
     @property
     def eliot_action(self):
         return LOG_NOOP()
 
     def run(self, deployer):
         return succeed(None)
+
+def get_sleep_interval(state_change):
+    if isinstance(state_change, Sleep):
+        return state_change.interval
+    if isinstance(state_change, _Sequentially, _InParallel):
+        return min(map(get_sleep_interval, state_change.changes))
+    else:
+        return timedelta(seconds=0)
+
+# BlockDevice does:
+NOTHING_TO_DO = Sleep(interval=timedelta(seconds=60.0))
+WAIT_FOR_REMOTE_DETACH = Sleep(interval=timedelta(seconds=2.0))

--- a/flocker/node/_change.py
+++ b/flocker/node/_change.py
@@ -168,27 +168,13 @@ LOG_NOOP = ActionType("flocker:change:noop", [], [], "We've done nothing.")
 
 
 @implementer(IStateChange)
-class Sleep(PClass):
+class NoOp(PClass):
     """
     Do nothing.
     """
-    interval = field(type=timedelta)
-
     @property
     def eliot_action(self):
         return LOG_NOOP()
 
     def run(self, deployer):
         return succeed(None)
-
-def get_sleep_interval(state_change):
-    if isinstance(state_change, Sleep):
-        return state_change.interval
-    if isinstance(state_change, _Sequentially, _InParallel):
-        return min(map(get_sleep_interval, state_change.changes))
-    else:
-        return timedelta(seconds=0)
-
-# BlockDevice does:
-NOTHING_TO_DO = Sleep(interval=timedelta(seconds=60.0))
-WAIT_FOR_REMOTE_DETACH = Sleep(interval=timedelta(seconds=2.0))

--- a/flocker/node/_container.py
+++ b/flocker/node/_container.py
@@ -16,7 +16,7 @@ from eliot import Message, Logger, start_action
 
 from twisted.internet.defer import fail, succeed
 
-from . import IStateChange, in_parallel, sequentially
+from . import IStateChange, in_parallel, sequentially, NoOp
 from ._docker import DockerClient, PortMap, Environment, Volume as DockerVolume
 
 from ..control._model import (
@@ -238,8 +238,6 @@ class ApplicationNodeDeployer(object):
     :ivar INetwork network: The network routing API to use in
         deployment operations. Default is iptables-based implementation.
     """
-    poll_interval = timedelta(seconds=1.0)
-
     def __init__(self, hostname, docker_client=None, network=None,
                  node_uuid=None):
         if node_uuid is None:
@@ -712,4 +710,6 @@ class ApplicationNodeDeployer(object):
         start_restart = start_containers + restart_containers
         if start_restart:
             phases.append(in_parallel(changes=start_restart))
-        return sequentially(changes=phases)
+
+        return sequentially(changes=phases,
+                            sleep_when_empty=timedelta(seconds=1))

--- a/flocker/node/_container.py
+++ b/flocker/node/_container.py
@@ -16,7 +16,7 @@ from eliot import Message, Logger, start_action
 
 from twisted.internet.defer import fail, succeed
 
-from . import IStateChange, in_parallel, sequentially, NoOp
+from . import IStateChange, in_parallel, sequentially
 from ._docker import DockerClient, PortMap, Environment, Volume as DockerVolume
 
 from ..control._model import (

--- a/flocker/node/_deploy.py
+++ b/flocker/node/_deploy.py
@@ -58,15 +58,9 @@ class IDeployer(Interface):
     :ivar UUID node_uuid: The UUID of the node this deployer is running.
     :ivar unicode hostname: The hostname (really, IP) of the node this
         deployer is managing.
-    :ivar float poll_interval: Number of seconds to delay between
-        iterations of convergence loop that call ``discover_state()``, to
-        reduce impact of polling external resources. The actual delay may
-        be smaller if the convergence loop decides more work is necessary
-        in order to converge.
     """
     node_uuid = Attribute("")
     hostname = Attribute("")
-    poll_interval = Attribute("")
 
     def discover_state(local_state):
         """
@@ -91,13 +85,22 @@ class IDeployer(Interface):
         Calculate the state changes necessary to make the local state match the
         desired cluster configuration.
 
+        This is called in two situations:
+
+        1. A real convergence iteration, in which case the local state is
+           the immediately returned result of ``discover_state``.
+        2. To discover whether to wake up the loop when it is sleeping if
+           a new configuration or cluster state is received.
+
         Returning ``flocker.node.NoOp`` will result in the convergence
-        loop sleeping for the duration of ``poll_interval``. The sleep
-        will only be interrupted by a new configuration/cluster state
-        update from control service which would result in need to run some
-        ``IStateChange``. Thus even if no immediate changes are needed if
-        you want ``discover_state`` to be called more frequently than
-        ``poll_interval`` you should not return ``NoOp``.
+        loop sleeping for the duration of the specified sleep. If a new
+        cluster state or configuration are recieved by the loop then it
+        runs ``calculate_changes`` with cached local state and new
+        configuration and cluster state in order to figure out whether it
+        should interrupt the sleep. If this results in a ``IStateChange``
+        or a ``NoOp`` with a shorter sleep duration then the sleep is
+        appropriately curtailed (waking up immediately or with shorter
+        delay respectively) and a real convergence iteration is run.
 
         :param Deployment configuration: The intended configuration of all
             nodes.

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -409,8 +409,13 @@ class ConvergenceLoop(object):
             changes = None
         if not isinstance(changes, NoOp):
             self.fsm.receive(ConvergenceLoopInputs.WAKEUP)
-        # XXX else reset wakeup delay to lowest of calculated sleep
-        # interval and existing delay
+        else:
+            # Check if the calculated NoOp suggests an earlier wakeup than
+            # currently planned:
+            remaining = self._sleep_timeout.getTime() - self.reactor.seconds()
+            calculated = changes.sleep.total_seconds()
+            if calculated < remaining:
+                self._sleep_timeout.reset(calculated)
 
     def _send_state_to_control_service(self, state_changes):
         context = LOG_SEND_TO_CONTROL_SERVICE(

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -264,6 +264,11 @@ class _Sleep(trivialInput(ConvergenceLoopInputs.SLEEP)):
         return cls(delay_seconds=delay_seconds*jitter)
 
 
+# How many seconds to sleep between iterations when we may yet not be
+# converged so want to do another iteration again soon:
+_UNCONVERGED_DELAY = _Sleep(delay_seconds=0.1)
+
+
 class ConvergenceLoopStates(Names):
     """
     Convergence loop FSM states.
@@ -402,9 +407,6 @@ class ConvergenceLoop(object):
             # responsive.
             write_traceback()
             changes = None
-        # XXX need to decide whether to wakeup based on sleep interval!
-        # Wake up if not infinite?  Or preserve NoOp compression, turn it
-        # into Sleep compression, and then check for not being Sleep?
         if changes != NoOp():
             self.fsm.receive(ConvergenceLoopInputs.WAKEUP)
 
@@ -483,10 +485,16 @@ class ConvergenceLoop(object):
             action = self.deployer.calculate_changes(
                 self.configuration, self.cluster_state, local_state
             )
-            sleep_seconds = get_sleep_interval(action).total_seconds()
-            if sleep_seconds == 0:
-                sleep_seconds = 0.1
-            sleep_duration = _Sleep.with_jitter(sleep_seconds)
+            if action == NoOp():
+                # We've converged, we can sleep for deployer poll
+                # interval. We add some jitter so not all agents wake up
+                # at exactly the same time, to reduce load on system:
+                sleep_duration = _Sleep.with_jitter(
+                    self.deployer.poll_interval.total_seconds())
+            else:
+                # We're going to do some work, we should do another
+                # iteration quickly in case there's followup work:
+                sleep_duration = _UNCONVERGED_DELAY
 
             LOG_CALCULATED_ACTIONS(calculated_actions=action).write(
                 self.fsm.logger)
@@ -506,7 +514,7 @@ class ConvergenceLoop(object):
         def error(failure):
             writeFailure(failure, self.fsm.logger)
             # We should retry quickly to redo the failed work:
-            return _Sleep(delay_seconds=0.1)
+            return _UNCONVERGED_DELAY
         d.addErrback(error)
 
         # We're done with the iteration:

--- a/flocker/node/_p2p.py
+++ b/flocker/node/_p2p.py
@@ -20,7 +20,7 @@ from eliot import write_failure, Logger, start_action
 
 from twisted.internet.defer import gatherResults
 
-from . import IStateChange, in_parallel, sequentially, NoOp
+from . import IStateChange, in_parallel, sequentially
 
 from ..control._model import (
     DatasetChanges, DatasetHandoff, NodeState, Manifestation, Dataset,

--- a/flocker/node/_p2p.py
+++ b/flocker/node/_p2p.py
@@ -20,7 +20,7 @@ from eliot import write_failure, Logger, start_action
 
 from twisted.internet.defer import gatherResults
 
-from . import IStateChange, in_parallel, sequentially
+from . import IStateChange, in_parallel, sequentially, NoOp
 
 from ..control._model import (
     DatasetChanges, DatasetHandoff, NodeState, Manifestation, Dataset,
@@ -208,8 +208,6 @@ class P2PManifestationDeployer(object):
     :ivar unicode hostname: The hostname of the node that this is running on.
     :ivar VolumeService volume_service: The volume manager for this node.
     """
-    poll_interval = timedelta(seconds=1.0)
-
     def __init__(self, hostname, volume_service, node_uuid=None):
         if node_uuid is None:
             # To be removed in https://clusterhq.atlassian.net/browse/FLOC-1795
@@ -318,7 +316,9 @@ class P2PManifestationDeployer(object):
                 DeleteDataset(dataset=dataset)
                 for dataset in deleting
                 ]))
-        return sequentially(changes=phases)
+
+        return sequentially(changes=phases,
+                            sleep_when_empty=timedelta(seconds=1))
 
 
 def find_dataset_changes(uuid, current_state, desired_state):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1422,7 +1422,7 @@ Desired = Discovered = DatasetStates
 DATASET_TRANSITIONS = TransitionTable.create({
     Desired.MOUNTED: {
         Discovered.NON_EXISTENT: CreateBlockDeviceDataset,
-        # Other node will need to deatch first, but we we need to
+        # Other node will need to detach first, but we we need to
         # wake up to notice that it has detached.
         Discovered.ATTACHED_ELSEWHERE: ActionNeeded,
         Discovered.ATTACHED_NO_FILESYSTEM: CreateFilesystem,
@@ -1433,7 +1433,7 @@ DATASET_TRANSITIONS = TransitionTable.create({
         # XXX FLOC-2206
         # Can't create non-manifest datasets yet.
         Discovered.NON_EXISTENT: CreateBlockDeviceDataset,
-        # Other node will deatch
+        # Other node will detach
         Discovered.ATTACHED_ELSEWHERE: DoNothing,
         Discovered.ATTACHED_NO_FILESYSTEM: DetachVolume,
         Discovered.ATTACHED: DetachVolume,

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -702,6 +702,13 @@ class AttachVolume(PClass):
         return attaching
 
 
+ACTION_NEEDED = ActionType(
+    u"agent:blockdevice:action_needed:BUGGY_CODE",
+    [DATASET_ID], [],
+    u"If you see this logged that means an ActionNeeded was run, which in"
+    u"theory should never happen.")
+
+
 @implementer(IStateChange)
 @provider(IDatasetStateChangeFactory)
 class ActionNeeded(PClass):
@@ -718,9 +725,9 @@ class ActionNeeded(PClass):
     """
     dataset_id = field(type=UUID, mandatory=True)
 
-    # Nominal interface compliance; we don't expect this to be ever run,
-    # it's just a marker object basically.
-    eliot_action = None
+    @property
+    def eliot_action(self):
+        return ACTION_NEEDED(_logger, dataset_id=self.dataset_id)
 
     @classmethod
     def from_state_and_config(cls, discovered_dataset, desired_dataset):

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1399,6 +1399,10 @@ class TransitionTable(CheckedPMap):
         __invariant__ = lambda k, v: provides(IDatasetStateChangeFactory)(v)
 
 
+# If we've nothing to do we want to sleep for no more than a minute:
+NOTHING_TO_DO = NoOp(sleep=timedelta(seconds=60))
+
+
 @provider(IDatasetStateChangeFactory)
 class DoNothing(PClass):
     """
@@ -1406,7 +1410,7 @@ class DoNothing(PClass):
     """
     @staticmethod
     def from_state_and_config(discovered_dataset, desired_dataset):
-        return NoOp()
+        return NOTHING_TO_DO
 
 # Mapping from desired and discovered dataset state to
 # IStateChange factory. (The factory is expected to take
@@ -1485,7 +1489,7 @@ class BlockDeviceCalculator(PClass):
                 desired_dataset=desired_dataset,
             )
         else:
-            return NoOp()
+            return NOTHING_TO_DO
 
     def calculate_changes_for_datasets(
         self, discovered_datasets, desired_datasets
@@ -1531,7 +1535,6 @@ class BlockDeviceDeployer(PClass):
     _profiled_blockdevice_api = field(mandatory=True, initial=None)
     _async_block_device_api = field(mandatory=True, initial=None)
     mountroot = field(type=FilePath, initial=FilePath(b"/flocker"))
-    poll_interval = timedelta(seconds=60.0)
     block_device_manager = field(initial=BlockDeviceManager())
     calculator = field(
         invariant=provides(ICalculator),
@@ -1798,7 +1801,7 @@ class BlockDeviceDeployer(PClass):
         # deletion or handoffs. Eventually this will rely on leases instead.
         # https://clusterhq.atlassian.net/browse/FLOC-1425.
         if local_node_state.applications is None:
-            return NoOp()
+            return NOTHING_TO_DO
 
         desired_datasets = self._calculate_desired_state(
             configuration=configuration,

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -702,13 +702,6 @@ class AttachVolume(PClass):
         return attaching
 
 
-ACTION_NEEDED = ActionType(
-    u"agent:blockdevice:action_needed:BUGGY_CODE",
-    [DATASET_ID], [],
-    u"If you see this logged that means an ActionNeeded was run, which in"
-    u"theory should never happen.")
-
-
 @implementer(IStateChange)
 @provider(IDatasetStateChangeFactory)
 class ActionNeeded(PClass):
@@ -725,9 +718,9 @@ class ActionNeeded(PClass):
     """
     dataset_id = field(type=UUID, mandatory=True)
 
-    @property
-    def eliot_action(self):
-        return ACTION_NEEDED(_logger, dataset_id=self.dataset_id)
+    # Nominal interface compliance; we don't expect this to be ever run,
+    # it's just a marker object basically.
+    eliot_action = None
 
     @classmethod
     def from_state_and_config(cls, discovered_dataset, desired_dataset):
@@ -1422,7 +1415,7 @@ Desired = Discovered = DatasetStates
 DATASET_TRANSITIONS = TransitionTable.create({
     Desired.MOUNTED: {
         Discovered.NON_EXISTENT: CreateBlockDeviceDataset,
-        # Other node will need to detach first, but we we need to
+        # Other node will need to deatch first, but we we need to
         # wake up to notice that it has detached.
         Discovered.ATTACHED_ELSEWHERE: ActionNeeded,
         Discovered.ATTACHED_NO_FILESYSTEM: CreateFilesystem,
@@ -1433,7 +1426,7 @@ DATASET_TRANSITIONS = TransitionTable.create({
         # XXX FLOC-2206
         # Can't create non-manifest datasets yet.
         Discovered.NON_EXISTENT: CreateBlockDeviceDataset,
-        # Other node will detach
+        # Other node will deatch
         Discovered.ATTACHED_ELSEWHERE: DoNothing,
         Discovered.ATTACHED_NO_FILESYSTEM: DetachVolume,
         Discovered.ATTACHED: DetachVolume,

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -5067,16 +5067,6 @@ class ActionNeededTests(
     """
     Tests for ``ActionNeeded``\ 's ``IStateChange`` implementation.
     """
-    def test_run(self):
-        """
-        If run, ``ActionNeeded`` fails with a ``NotImplementedError``.
-
-        It's never supposed to run, but if it does it should fail with an
-        appropriate meaningful error, thus this test.
-        """
-        action = ActionNeeded(dataset_id=uuid4())
-        self.failureResultOf(run_state_change(action, None),
-                             NotImplementedError)
 
 
 class AllocatedSizeTypeTests(TestCase):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -11,7 +11,7 @@ import time
 from uuid import UUID, uuid4
 from subprocess import STDOUT, PIPE, Popen, check_output, check_call
 from stat import S_IRWXU
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from bitmath import Byte, MB, MiB, GB, GiB
 
@@ -61,7 +61,7 @@ from ..blockdevice import (
     BlockDeviceVolume, UnknownVolume, AlreadyAttachedVolume,
     CreateBlockDeviceDataset, UnattachedVolume, DatasetExists,
     UnmountBlockDevice, DetachVolume, AttachVolume,
-    CreateFilesystem, DestroyVolume, MountBlockDevice, ActionNeeded,
+    CreateFilesystem, DestroyVolume, MountBlockDevice,
 
     DATASET_TRANSITIONS, IDatasetStateChangeFactory,
     ICalculator, NOTHING_TO_DO,
@@ -99,7 +99,7 @@ from ..loopback import (
 from ....common.algebraic import tagged_union_strategy
 
 
-from ... import run_state_change, in_parallel, ILocalState, IStateChange
+from ... import run_state_change, in_parallel, ILocalState, IStateChange, NoOp
 from ...testtools import (
     ideployer_tests_factory, to_node, assert_calculated_changes_for_deployer,
     compute_cluster_state,
@@ -2671,7 +2671,7 @@ class BlockDeviceDeployerCreationCalculateChangesTests(
         )
         changes = deployer.calculate_changes(configuration, state, local_state)
         self.assertEqual(
-            in_parallel(changes=[ActionNeeded(dataset_id=dataset_id)]),
+            in_parallel(changes=[NoOp(sleep=timedelta(seconds=3))]),
             changes
         )
 
@@ -5043,30 +5043,6 @@ class AttachVolumeTests(
         self.assertEqual(
             bad_blockdevice_id, failure.value.blockdevice_id
         )
-
-
-class ActionNeededInitTests(
-    make_with_init_tests(
-        record_type=ActionNeeded,
-        kwargs=dict(dataset_id=uuid4()),
-        expected_defaults=dict(),
-    )
-):
-    """
-    Tests for ``ActionNeeded`` initialization.
-    """
-
-
-class ActionNeededTests(
-    make_istatechange_tests(
-        ActionNeeded,
-        dict(dataset_id=uuid4()),
-        dict(dataset_id=uuid4()),
-    )
-):
-    """
-    Tests for ``ActionNeeded``\ 's ``IStateChange`` implementation.
-    """
 
 
 class AllocatedSizeTypeTests(TestCase):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -5067,6 +5067,16 @@ class ActionNeededTests(
     """
     Tests for ``ActionNeeded``\ 's ``IStateChange`` implementation.
     """
+    def test_run(self):
+        """
+        If run, ``ActionNeeded`` fails with a ``NotImplementedError``.
+
+        It's never supposed to run, but if it does it should fail with an
+        appropriate meaningful error, thus this test.
+        """
+        action = ActionNeeded(dataset_id=uuid4())
+        self.failureResultOf(run_state_change(action, None),
+                             NotImplementedError)
 
 
 class AllocatedSizeTypeTests(TestCase):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -64,7 +64,7 @@ from ..blockdevice import (
     CreateFilesystem, DestroyVolume, MountBlockDevice, ActionNeeded,
 
     DATASET_TRANSITIONS, IDatasetStateChangeFactory,
-    ICalculator,
+    ICalculator, NOTHING_TO_DO,
 
     DiscoveredDataset, DesiredDataset, DatasetStates,
 
@@ -99,7 +99,7 @@ from ..loopback import (
 from ....common.algebraic import tagged_union_strategy
 
 
-from ... import run_state_change, in_parallel, ILocalState, NoOp, IStateChange
+from ... import run_state_change, in_parallel, ILocalState, IStateChange
 from ...testtools import (
     ideployer_tests_factory, to_node, assert_calculated_changes_for_deployer,
     compute_cluster_state,
@@ -1140,7 +1140,7 @@ class BlockDeviceCalculatorInterfaceTests(
 
 
 class RecordingCalculatorInterfaceTests(
-    make_icalculator_tests(lambda: RecordingCalculator(NoOp()))
+    make_icalculator_tests(lambda: RecordingCalculator(NOTHING_TO_DO))
 ):
     """
     Tests for ``RecordingCalculator``'s implementation of ``ICalculator``.
@@ -1361,7 +1361,7 @@ def assert_desired_datasets(
     :type additional_node_config: ``set`` of ``Node``s
     :param Leases leases: Leases to include in the cluster configration.
     """
-    calculator = RecordingCalculator(NoOp())
+    calculator = RecordingCalculator(NOTHING_TO_DO)
     deployer = deployer.set(calculator=calculator)
     cluster_configuration = Deployment(
         nodes={
@@ -1908,7 +1908,7 @@ class BlockDeviceDeployerAlreadyConvergedCalculateChangesTests(
 
         assert_calculated_changes(
             self, local_state, local_config, set(),
-            NoOp(),
+            NOTHING_TO_DO,
         )
 
     def test_deleted_ignored(self):
@@ -3075,7 +3075,7 @@ class BlockDeviceDeployerCalculateChangesTests(
             nonmanifest_datasets=[],
             additional_node_states=set(),
             additional_node_config=set(),
-            expected_changes=NoOp(),
+            expected_changes=NOTHING_TO_DO,
             local_state=self.local_state,
         )
 

--- a/flocker/node/test/test_container.py
+++ b/flocker/node/test/test_container.py
@@ -1111,7 +1111,7 @@ class ApplicationNodeDeployerCalculateChangesTests(TestCase):
         """
         assert_application_calculated_changes(
             self, EMPTY_NODESTATE, to_node(EMPTY_NODESTATE), set(),
-            sequentially(changes=[]),
+            NoOp(sleep=timedelta(seconds=1)),
         )
 
     def test_proxy_needs_creating(self):
@@ -1382,7 +1382,7 @@ class ApplicationNodeDeployerCalculateChangesTests(TestCase):
             desired_configuration=desired,
             current_cluster_state=DeploymentState(nodes=[node_state]),
             local_state=NodeLocalState(node_state=node_state))
-        expected = sequentially(changes=[])
+        expected = NoOp(sleep=timedelta(seconds=1))
         self.assertEqual(expected, result)
 
     def test_node_not_described(self):

--- a/flocker/node/test/test_container.py
+++ b/flocker/node/test/test_container.py
@@ -5,6 +5,7 @@ Tests for ``flocker.node._container``.
 """
 
 from uuid import UUID, uuid4
+from datetime import timedelta
 
 from ipaddr import IPAddress
 
@@ -873,7 +874,7 @@ def no_change():
     Construct the exact ``IStateChange`` that ``ApplicationNodeDeployer``
     returns when it doesn't want to make any changes.
     """
-    return NoOp()
+    return NoOp(sleep=timedelta(seconds=1))
 
 
 class ApplicationNodeDeployerCalculateVolumeChangesTests(TestCase):

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -46,6 +46,9 @@ from ...control.test.test_protocol import iconvergence_agent_tests_factory
 from .. import NoOp
 
 
+NO_OP = NoOp(sleep=timedelta(seconds=300))
+
+
 class StubFSM(object):
     """
     A finite state machine look-alike that just records inputs.
@@ -668,7 +671,6 @@ class ConvergenceLoopFSMTests(TestCase):
         self.deployer = deployer = ControllableDeployer(
             local_state.hostname, [succeed(local_state), succeed(local_state)],
             [initial_action] + later_actions,
-            poll_interval=timedelta(seconds=300),
         )
         client = self.make_amp_client([local_state])
         self.reactor = reactor = Clock()
@@ -717,7 +719,7 @@ class ConvergenceLoopFSMTests(TestCase):
         """
         # Later calculations will return a NoOp(), indicating no need to
         # wake up:
-        loop = self.convergence_iteration(later_actions=[NoOp(), NoOp()])
+        loop = self.convergence_iteration(later_actions=[NO_OP, NO_OP])
         node_state = NodeState(hostname=u'192.0.3.5')
         changed_configuration = Deployment(
             nodes=frozenset([to_node(node_state)]))
@@ -749,7 +751,7 @@ class ConvergenceLoopFSMTests(TestCase):
         """
         # Later calculations will return a NoOp(), indicating no need to
         # wake up:
-        loop = self.convergence_iteration(later_actions=[NoOp(), NoOp()])
+        loop = self.convergence_iteration(later_actions=[NO_OP, NO_OP])
         remaining_discover_calls = len(self.deployer.local_states)
 
         # An update received while sleeping:
@@ -764,10 +766,10 @@ class ConvergenceLoopFSMTests(TestCase):
     def test_longer_sleep_when_converged(self):
         """
         When a convergence loop results in a ``NoOp`` the sleep is based on
-        that configured on the ``Deployer``.
+        that configured in the returned NoOp.
         """
-        loop = self.convergence_iteration(initial_action=NoOp(),
-                                          later_actions=[NoOp(), NoOp()])
+        loop = self.convergence_iteration(initial_action=NO_OP,
+                                          later_actions=[NO_OP, NO_OP])
 
         # An update received while sleeping:
         loop.receive(_ClientStatusUpdate(
@@ -793,7 +795,7 @@ class ConvergenceLoopFSMTests(TestCase):
         self.assertEqual(
             dict(long_enough=(delay > 200),
                  pre=pre_sleep, mid=mid_sleep, post=post_sleep),
-            dict(long_enough=True,  # deployer has 300s sleep with jitter added
+            dict(long_enough=True,  # NO_OP has 300s sleep with jitter added
                  pre=1,  # no new iteration yet
                  mid=1,  # slept not quite enough, so still no new iteration
                  post=0),  # slept full poll interval, new iteration

--- a/flocker/node/test/test_p2p.py
+++ b/flocker/node/test/test_p2p.py
@@ -16,7 +16,7 @@ from twisted.internet.defer import fail, Deferred
 from twisted.python.filepath import FilePath
 
 from .. import (
-    P2PManifestationDeployer,
+    P2PManifestationDeployer, NoOp,
 )
 from ...control import (
     Application, DockerImage, Deployment, Node,
@@ -239,6 +239,9 @@ class P2PManifestationDeployerDiscoveryTests(TestCase):
             manifestation)
 
 
+NO_CHANGES = NoOp(sleep=timedelta(seconds=1))
+
+
 class P2PManifestationDeployerLeaseTests(TestCase):
     """
     Tests for impact of leases on
@@ -301,7 +304,7 @@ class P2PManifestationDeployerLeaseTests(TestCase):
         changes = self.changes_when_leased(
             MANIFESTATION.transform(("dataset", "deleted"), True),
             MANIFESTATION)
-        self.assertEqual(sequentially(changes=[]), changes)
+        self.assertEqual(NO_CHANGES, changes)
 
     def test_no_resize_if_leased(self):
         """
@@ -310,7 +313,7 @@ class P2PManifestationDeployerLeaseTests(TestCase):
         """
         changes = self.changes_when_leased(
             MANIFESTATION_WITH_SIZE, MANIFESTATION)
-        self.assertEqual(sequentially(changes=[]), changes)
+        self.assertEqual(NO_CHANGES, changes)
 
     def test_no_handoff_if_leased_on_different_node(self):
         """
@@ -322,7 +325,7 @@ class P2PManifestationDeployerLeaseTests(TestCase):
             MANIFESTATION, MANIFESTATION,
             # lease:       destination:  origin:
             self.NODE_ID2, self.NODE_ID, self.NODE_ID2)
-        self.assertEqual(sequentially(changes=[]), changes)
+        self.assertEqual(NO_CHANGES, changes)
 
     def test_handoff_if_leased_on_destination_node(self):
         """
@@ -412,7 +415,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
         )
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        self.assertEqual(sequentially(changes=[]), changes)
+        self.assertEqual(NO_CHANGES, changes)
 
     def test_no_resize_if_in_use(self):
         """
@@ -443,7 +446,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
         changes = api.calculate_changes(
             desired, current, NodeLocalState(node_state=current_node))
 
-        expected = sequentially(changes=[])
+        expected = NO_CHANGES
         self.assertEqual(expected, changes)
 
     def test_no_handoff_if_in_use(self):
@@ -480,7 +483,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        self.assertEqual(sequentially(changes=[]), changes)
+        self.assertEqual(NO_CHANGES, changes)
 
     def test_no_handoff_if_destination_unknown(self):
         """
@@ -508,7 +511,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        self.assertEqual(sequentially(changes=[]), changes)
+        self.assertEqual(NO_CHANGES, changes)
 
     def test_volume_handoff(self):
         """
@@ -577,7 +580,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(
             desired, current, NodeLocalState(node_state=current_node))
-        expected = sequentially(changes=[])
+        expected = NO_CHANGES
         self.assertEqual(expected, changes)
 
     def test_metadata_does_not_cause_changes(self):
@@ -621,7 +624,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        self.assertEqual(changes, sequentially(changes=[]))
+        self.assertEqual(changes, NO_CHANGES)
 
     def test_dataset_created(self):
         """
@@ -773,7 +776,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        expected = sequentially(changes=[])
+        expected = NO_CHANGES
         self.assertEqual(expected, changes)
 
     def test_different_node_is_ignorant(self):

--- a/flocker/node/test/test_p2p.py
+++ b/flocker/node/test/test_p2p.py
@@ -6,7 +6,7 @@ Tests for ``flocker.node._p2p``.
 
 
 from uuid import UUID, uuid4
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from pytz import UTC
 
@@ -511,7 +511,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        self.assertEqual(NO_CHANGES, changes)
+        self.assertEqual(NoOp(sleep=timedelta(seconds=60)), changes)
 
     def test_volume_handoff(self):
         """
@@ -776,7 +776,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        expected = NO_CHANGES
+        expected = NoOp(sleep=timedelta(seconds=60))
         self.assertEqual(expected, changes)
 
     def test_different_node_is_ignorant(self):

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -9,7 +9,6 @@ import os
 import pwd
 from unittest import skipIf, SkipTest
 from uuid import uuid4
-from datetime import timedelta
 from distutils.version import LooseVersion
 
 import psutil

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -166,7 +166,6 @@ class DummyDeployer(object):
     """
     hostname = u"127.0.0.1"
     node_uuid = uuid4()
-    poll_interval = timedelta(seconds=1.0)
 
     def discover_state(self, node_state):
         return succeed(DummyLocalState())
@@ -181,8 +180,7 @@ class ControllableDeployer(object):
     """
     ``IDeployer`` whose results can be controlled for any ``NodeLocalState``.
     """
-    def __init__(self, hostname, local_states, calculated_actions,
-                 poll_interval=timedelta(seconds=1.0)):
+    def __init__(self, hostname, local_states, calculated_actions):
         """
         :param list local_states: A list of results to produce from
             ``discover_state``.  Each call to ``discover_state`` pops the first
@@ -190,14 +188,12 @@ class ControllableDeployer(object):
             is an exception, it is raised.  Otherwise it must be a
             ``Deferred`` that resolves to a ``NodeState``. This ``IDeployer``
             always returns a ``NodeLocalState`` from ``discover_state``.
-        :param poll_interval: How many seconds to sleep between iterations.
         """
         self.node_uuid = ip_to_uuid(hostname)
         self.hostname = hostname
         self.local_states = local_states
         self.calculated_actions = calculated_actions
         self.calculate_inputs = []
-        self.poll_interval = poll_interval
 
     def discover_state(self, node_state):
         state = self.local_states.pop(0)


### PR DESCRIPTION
*How we got here:*

When the convergence loop is sleeping and gets an update of configuration or cluster state it runs calculate_changes on the deployer with cached local state to see if it should wake up. If a remote node has a volume we want attached, we would return ActionNeeded to indicate we wanted to wake up. Originally ActionNeeded was never run.

After Tom refactored the block device deployer, ActionNeeded ended up actually being run, which resulted in an exception in the logs. Moreover, the ability to sleep until the remote node detached volume we're supposed to move locally went away (temporarily, it'll return eventually). So the choices were either "sleep for 60 seconds, then check if remote detached" or "poll every 0.1 seconds" which hits the cloud API pretty hard. The latter was what was happening in practice.

Thus we were getting exceptions in logs and polling the cloud API 10x a second while waiting for remote volumes to detach.

*My solution:*

1. Refactor convergence loop/IDeployer interaction so the sleep time is determined by a returned `NoOp`, rather than being a binary "sleep for fixed amount / wake up real soon". This is a generally useful change since it allows deployers more flexibility.
2. For BlockDevice deployer specifically, return a longer sleep for the general "nothing to do", and a shorter sleep for the situation where we want to poll more frequently to see if volume is now attachable (replacing the need for ActionNeeded). This bit is an expedient fix until we split up the block device agent into a local agent and a cloud-interaction agent.