### PR TITLE
[FLOC-3842] Remove unnecessary git pull from initialize-release script

### DIFF
--- a/admin/release.py
+++ b/admin/release.py
@@ -886,7 +886,6 @@ def initialize_release(version, path, top_level):
     release_repo = Repo.init(release_path.path)
     release_origin = release_repo.create_remote('origin', REMOTE_URL)
     release_origin.fetch()
-    release_origin.pull(release_origin.refs[0].remote_head)
 
     sys.stdout.write("Checking out master...\n")
     release_repo.git.checkout("master")


### PR DESCRIPTION
Fixes [FLOC-3842](https://clusterhq.atlassian.net/browse/FLOC-3842).

After initialising the release flocker repository, the remote refs are fetched. The first available ref is pulled and the local `master` branch is updated to this point. If the first available ref is not `master`, this can result in a merge conflict when `origin master` is pulled later. The first pull is not necessary. We can simply fetch, checkout `master` and then pull `origin master`.