### PR TITLE
[FLOC-3854] AWS session token support for backend

### DIFF
--- a/docs/config/aws-configuration.rst
+++ b/docs/config/aws-configuration.rst
@@ -20,6 +20,20 @@ The configuration item to use AWS should look like:
 Make sure that the ``region`` and ``zone`` match each other and that both match the region and zone where the Flocker agent nodes run.
 AWS must be able to attach volumes created in that availability zone to your Flocker nodes.
 
+In addition to the mandatory properties shown, there are some optional properties:
+
+.. option:: session_token
+
+   An AWS session token.
+   This allows cross-account access.
+   It is mainly useful for testing since session tokens only last for a short time.
+
+.. option:: validate_region
+
+   Boolean indicating whether to validate the supplied region.
+   This defaults to True.
+   It is set to False for testing purposes.
+
 The Amazon AWS / EBS driver maintained by ClusterHQ provides :ref:`storage-profiles`.
 The three available profiles are:
 
@@ -28,7 +42,7 @@ The three available profiles are:
 * **Silver**: EBS General Purpose SSD / API named ``gp2``.
 * **Bronze**: EBS Magnetic / API named ``standard``.
 
-If no profile is specified, then a bronze volume is created, which is consistent with previous behavior. 
+If no profile is specified, then a bronze volume is created, which is consistent with previous behavior.
 
 .. note::
 	After configuration you are subject to the normal performance guarantees that EBS provides.

--- a/docs/config/aws-configuration.rst
+++ b/docs/config/aws-configuration.rst
@@ -27,12 +27,13 @@ In addition to the mandatory properties shown, there are some optional propertie
    An AWS session token.
    This allows cross-account access.
    It is mainly useful for testing since session tokens only last for a short time.
+   See http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html for more information on when session tokens are required.
 
 .. option:: validate_region
 
    Boolean indicating whether to validate the supplied region.
    This defaults to True.
-   It is set to False for testing purposes.
+   It is set to False for internal testing.
 
 The Amazon AWS / EBS driver maintained by ClusterHQ provides :ref:`storage-profiles`.
 The three available profiles are:


### PR DESCRIPTION
In FLOC-3839, support for AWS session tokens was added to the `aws` stanza used to start cluster nodes.

However, the nodes themselves use AWS for managing volumes, so the AWS backend also needs to use session tokens where appropriate.

Session tokens typically only last for an hour, but Flocker agents are likely to last longer than that. So, under the circumstances where they are needed, session tokens will need to be generated by the backend.  FLOC-3857 has been created to solve this.

In the meantime, this PR uses the same solution from FLOC-3839 for short-lived tests.