### PR TITLE
[FLOC-3865] Configure Jenkins cron jobs with publishers as well

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -726,6 +726,7 @@ for (job_type_entry in GLOBAL_CONFIG.job_type) {
                 triggers build_triggers('cron', job_values.at, "${branchName}")
                 scm build_scm("${git_url}", "${branchName}")
                 steps build_steps(dashProject, dashBranchName, _job_name, job_values)
+                publishers build_publishers(job_values)
             }
         }
     }


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3865
Follow-up for apparently incomplete https://clusterhq.atlassian.net/browse/FLOC-3799

Co-testing with https://clusterhq.atlassian.net/browse/FLOC-3199 / https://github.com/ClusterHQ/flocker/pull/2191 - http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/better-random-port-assignment-FLOC-3199/view/cron/