### PR TITLE
[FLOC-3869] Fix lint problems

### DIFF
--- a/benchmark/_interfaces.py
+++ b/benchmark/_interfaces.py
@@ -117,4 +117,3 @@ class IRequestScenarioSetup(Interface):
         :return: ``Deferred`` that fires when the REST request has been
             completed, and returns the results of the request.
         """
-

--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -5,6 +5,8 @@ Flocker is an open-source container data volume manager for your
 Dockerized applications.
 """
 
+from ._version import get_versions
+
 # Default port for REST API:
 REST_API_PORT = 4523
 
@@ -43,7 +45,6 @@ _suppress_warnings()
 del _suppress_warnings
 
 
-from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 

--- a/flocker/ca/__init__.py
+++ b/flocker/ca/__init__.py
@@ -4,15 +4,6 @@
 A minimal certificate authority.
 """
 
-__all__ = [
-    "RootCredential", "ControlCredential", "NodeCredential", "UserCredential",
-    "ComparableKeyPair", "PathError", "CertificateAlreadyExistsError",
-    "KeyAlreadyExistsError", "EXPIRY_20_YEARS",
-    "AUTHORITY_CERTIFICATE_FILENAME", "AUTHORITY_KEY_FILENAME",
-    "amp_server_context_factory", "rest_api_context_factory",
-    "ControlServicePolicy", "treq_with_authentication",
-]
-
 from ._ca import (
     RootCredential, ControlCredential, NodeCredential, UserCredential,
     ComparableKeyPair, PathError, CertificateAlreadyExistsError,
@@ -24,3 +15,12 @@ from ._validation import (
     amp_server_context_factory, rest_api_context_factory, ControlServicePolicy,
     treq_with_authentication,
 )
+
+__all__ = [
+    "RootCredential", "ControlCredential", "NodeCredential", "UserCredential",
+    "ComparableKeyPair", "PathError", "CertificateAlreadyExistsError",
+    "KeyAlreadyExistsError", "EXPIRY_20_YEARS",
+    "AUTHORITY_CERTIFICATE_FILENAME", "AUTHORITY_KEY_FILENAME",
+    "amp_server_context_factory", "rest_api_context_factory",
+    "ControlServicePolicy", "treq_with_authentication",
+]

--- a/flocker/ca/_script.py
+++ b/flocker/ca/_script.py
@@ -91,8 +91,7 @@ class PrettyOptions(Options):
         usage = base
         if self.subCommand is not None:
             subUsage = (
-                "Run flocker-ca "
-                + self.subCommand +
+                "Run flocker-ca " + self.subCommand +
                 " --help for command usage and help."
             )
             usage = usage + "\n\n" + subUsage + "\n\n"

--- a/flocker/cli/__init__.py
+++ b/flocker/cli/__init__.py
@@ -4,6 +4,6 @@
 The Flocker command line interface.
 """
 
-__all__ = ["configure_ssh"]
-
 from ._sshconfig import configure_ssh
+
+__all__ = ["configure_ssh"]

--- a/flocker/common/__init__.py
+++ b/flocker/common/__init__.py
@@ -9,6 +9,19 @@ Shared flocker components.
     device used by the Docker devicemapper storage driver.
 """
 
+from bitmath import GiB as _GiB
+
+from ._ipc import INode, FakeNode, ProcessNode
+from ._defer import gather_deferreds
+from ._thread import auto_threaded
+from ._interface import interface_decorator, provides
+from ._net import get_all_ips, ipaddress_from_string
+from ._retry import (
+    loop_until, timeout, poll_until, retry_failure, retry_effect_with_timeout,
+    get_default_retry_steps,
+    retry_if, decorate_methods, with_retry,
+)
+
 __all__ = [
     'INode', 'FakeNode', 'ProcessNode', 'gather_deferreds',
     'auto_threaded', 'interface_decorator', 'provides',
@@ -22,19 +35,6 @@ __all__ = [
     'RACKSPACE_MINIMUM_VOLUME_SIZE',
     'DEVICEMAPPER_LOOPBACK_SIZE',
 ]
-
-from bitmath import GiB as _GiB
-
-from ._ipc import INode, FakeNode, ProcessNode
-from ._defer import gather_deferreds
-from ._thread import auto_threaded
-from ._interface import interface_decorator, provides
-from ._net import get_all_ips, ipaddress_from_string
-from ._retry import (
-    loop_until, timeout, poll_until, retry_failure, retry_effect_with_timeout,
-    get_default_retry_steps,
-    retry_if, decorate_methods, with_retry,
-)
 
 # This is currently set to the minimum size for a SATA based Rackspace Cloud
 # Block Storage volume. See:

--- a/flocker/common/algebraic.py
+++ b/flocker/common/algebraic.py
@@ -148,8 +148,10 @@ def tagged_union_strategy(type, attr_strategies):
         args.update({
             attribute: strategy
             for attribute, strategy in attr_strategies.items()
-            if attribute in invariant.attributes_for_tag[tag]
-            or attribute not in invariant._all_attributes
+            if (
+              attribute in invariant.attributes_for_tag[tag] or
+              attribute not in invariant._all_attributes
+            )
         })
         return fixed_dictionaries(args).map(lambda kwargs: type(**kwargs))
 

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -95,8 +95,10 @@ def flocker_standard_options(cls):
         Log to journald.
         """
         if JournaldDestination is None:
-            raise usage.UsageError("Journald unavailable on this machine: "
-                                   + _missing_journald_reason)
+            raise usage.UsageError(
+                "Journald unavailable on this machine: " +
+                _missing_journald_reason
+            )
         # Log messages are written line by line, so pretend we're a file...
         self['journald'] = True
     cls.opt_journald = opt_journald

--- a/flocker/common/test/test_algebraic.py
+++ b/flocker/common/test/test_algebraic.py
@@ -96,8 +96,7 @@ class TaggedUnionInvariantTests(TestCase):
         state = args['state']
         invariant = AlgebraicType.__invariant__
         extra_attributes = (
-            invariant._all_attributes
-            - invariant.attributes_for_tag[state]
+            invariant._all_attributes - invariant.attributes_for_tag[state]
         )
         assume(extra_attributes)
         extra_attribute = choice(sorted(extra_attributes))
@@ -158,8 +157,8 @@ class TaggedUnionInvariantTests(TestCase):
 
     @given(
         state=st.sampled_from(
-            pset(States.iterconstants())
-            - AlgebraicType.__invariant__._allowed_tags
+            pset(States.iterconstants()) -
+            AlgebraicType.__invariant__._allowed_tags
         ),
         extra_value=st.booleans(),
     )

--- a/flocker/common/version.py
+++ b/flocker/common/version.py
@@ -122,8 +122,10 @@ def get_doc_version(version):
     Get the version string of Flocker to display in documentation.
     """
     parsed_version = _parse_version(version)
-    if (is_release(version)
-            and parsed_version.documentation_revision is not None):
+    if (
+        is_release(version) and
+        parsed_version.documentation_revision is not None
+    ):
         return parsed_version.release
     else:
         return version
@@ -148,10 +150,12 @@ def is_release(version):
         documentation release.
     """
     parsed_version = _parse_version(version)
-    return (parsed_version.commit_count is None
-            and parsed_version.pre_release is None
-            and parsed_version.weekly_release is None
-            and parsed_version.dirty is None)
+    return (
+        parsed_version.commit_count is None and
+        parsed_version.pre_release is None and
+        parsed_version.weekly_release is None and
+        parsed_version.dirty is None
+    )
 
 
 def is_weekly_release(version):
@@ -162,10 +166,12 @@ def is_weekly_release(version):
     :return bool: Whether the version is a weekly release.
     """
     parsed_version = _parse_version(version)
-    return (parsed_version.weekly_release is not None
-            and parsed_version.commit_count is None
-            and parsed_version.pre_release is None
-            and parsed_version.dirty is None)
+    return (
+        parsed_version.weekly_release is not None and
+        parsed_version.commit_count is None and
+        parsed_version.pre_release is None and
+        parsed_version.dirty is None
+    )
 
 
 def is_pre_release(version):
@@ -176,10 +182,12 @@ def is_pre_release(version):
     :return bool: Whether the version is a pre-release.
     """
     parsed_version = _parse_version(version)
-    return (parsed_version.pre_release is not None
-            and parsed_version.weekly_release is None
-            and parsed_version.commit_count is None
-            and parsed_version.dirty is None)
+    return (
+        parsed_version.pre_release is not None and
+        parsed_version.weekly_release is None and
+        parsed_version.commit_count is None and
+        parsed_version.dirty is None
+        )
 
 
 def get_pre_release(version):

--- a/flocker/control/_model.py
+++ b/flocker/control/_model.py
@@ -88,7 +88,8 @@ def pvector_field(item_type, optional=False, initial=()):
                            initial)
 
 
-_valid = lambda item: (True, "")
+def _valid(item):
+    return (True, "")
 
 
 _UNDEFINED = object()
@@ -508,9 +509,12 @@ class LeaseError(Exception):
         :param UUID node_id: The node UUID.
         :param unicode action: The action that failed.
         """
-        message = (u"Cannot " + action + " lease " + unicode(dataset_id)
-                   + u" for node " + unicode(node_id)
-                   + u": Lease already held by another node")
+        message = (
+            u"Cannot {} lease {} for node {}: "
+            u"Lease already held by another node".format(
+                action, unicode(dataset_id), unicode(node_id)
+            )
+        )
         return super(LeaseError, self).__init__(message)
 
 

--- a/flocker/control/test/test_model.py
+++ b/flocker/control/test/test_model.py
@@ -1685,9 +1685,9 @@ class LeaseTests(TestCase):
             self.now, self.dataset_id, node2.uuid
         )
         expected_error = (
-            u"Cannot acquire lease " + unicode(self.dataset_id)
-            + " for node " + unicode(node2.uuid)
-            + u": Lease already held by another node"
+            u"Cannot acquire lease " + unicode(self.dataset_id) +
+            u" for node " + unicode(node2.uuid) +
+            u": Lease already held by another node"
         )
         self.assertEqual(
             exception.message, expected_error

--- a/flocker/control/test/test_model.py
+++ b/flocker/control/test/test_model.py
@@ -1661,9 +1661,10 @@ class LeaseTests(TestCase):
             self.dataset_id, node2.uuid
         )
         expected_error = (
-            u"Cannot release lease " + unicode(self.dataset_id)
-            + " for node " + unicode(node2.uuid)
-            + u": Lease already held by another node"
+            u"Cannot release lease {} for node {}: "
+            u"Lease already held by another node".format(
+                unicode(self.dataset_id), unicode(node2.uuid)
+            )
         )
         self.assertEqual(
             exception.message, expected_error

--- a/flocker/control/test/test_model_change.py
+++ b/flocker/control/test/test_model_change.py
@@ -84,6 +84,16 @@ def _psequence_model(klass):
     return record, further_classes
 
 
+def _default_model(klass):
+    """
+    Default model for unhandled classes.
+
+    :param klass: A class.
+    :return: Tuple of (model dictionary, further classes to process).
+    """
+    return (None, set())
+
+
 def generate_model(root_class=ROOT_CLASS):
     """
     Generate a data-structure that represents the current configuration
@@ -111,7 +121,7 @@ def generate_model(root_class=ROOT_CLASS):
         elif issubclass(klass, (CheckedPSet, CheckedPVector)):
             to_model = _psequence_model
         else:
-            to_model = lambda klass: (None, set())
+            to_model = _default_model
         record, further_classes = to_model(klass)
         classes_result[klass_name] = record
         classes |= further_classes

--- a/flocker/node/_container.py
+++ b/flocker/node/_container.py
@@ -581,7 +581,7 @@ class ApplicationNodeDeployer(object):
         )
 
         return (
-            comparable_state != comparable_configuration
+            comparable_state != comparable_configuration or
 
             # Restart policies were briefly supported but they interact poorly
             # with system restarts.  They're disabled now (except for the
@@ -592,9 +592,9 @@ class ApplicationNodeDeployer(object):
             #
             # Also restart policies don't implement comparison usefully.  See
             # FLOC-2500.
-            or not isinstance(restart_state, RestartNever)
+            not isinstance(restart_state, RestartNever) or
 
-            or self._restart_for_volume_change(
+            self._restart_for_volume_change(
                 node_state, volume_state, volume_configuration
             )
         )

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -434,12 +434,12 @@ def _is_known_retryable(exception):
     # A connection problem coming from the requests library used by docker-py
     if isinstance(exception, ConnectionError):
         if (
-            len(exception.args) > 0
-            and isinstance(exception.args[0], ProtocolError)
+            len(exception.args) > 0 and
+            isinstance(exception.args[0], ProtocolError)
         ):
             if (
-                len(exception.args[0].args) > 1
-                and isinstance(exception.args[0].args[1], socket_error)
+                len(exception.args[0].args) > 1 and
+                isinstance(exception.args[0].args[1], socket_error)
             ):
                 return exception.args[0].args[1].errno in {ECONNREFUSED}
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -776,8 +776,7 @@ def allocated_size(allocation_unit, requested_size):
     requested_size = int(requested_size)
 
     previous_interval_size = (
-        (requested_size // allocation_unit)
-        * allocation_unit
+        (requested_size // allocation_unit) * allocation_unit
     )
     if previous_interval_size < requested_size:
         return previous_interval_size + allocation_unit
@@ -1353,6 +1352,10 @@ class BlockDeviceDeployerLocalState(PClass):
         )
 
 
+def _provides_IDatasetStateChangeFactory(k, v):
+    return provides(IDatasetStateChangeFactory)(v)
+
+
 class TransitionTable(CheckedPMap):
     """
     Mapping from desired and discovered dataset state to
@@ -1362,7 +1365,7 @@ class TransitionTable(CheckedPMap):
 
     class __value_type__(CheckedPMap):
         __key_type__ = NamedConstant
-        __invariant__ = lambda k, v: provides(IDatasetStateChangeFactory)(v)
+        __invariant__ = _provides_IDatasetStateChangeFactory
 
 
 # If we've nothing to do we want to sleep for no more than a minute:

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -43,7 +43,7 @@ from .blockdevice import (
     MandatoryProfiles, ICloudAPI,
 )
 
-from ..script import StorageInitializationError
+from ..exceptions import StorageInitializationError
 
 from ...control import pmap_field
 

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -12,17 +12,12 @@ import time
 import logging
 import itertools
 
-# Don't use pyOpenSSL in urllib3 - it causes an ``OpenSSL.SSL.Error``
-# exception when we try an API call on an idled persistent connection.
-# See https://github.com/boto/boto3/issues/220
-from botocore.vendored.requests.packages.urllib3.contrib.pyopenssl import (
-    extract_from_urllib3,
-)
-extract_from_urllib3()
-
 import boto3
 
 from botocore.exceptions import ClientError, EndpointConnectionError
+from botocore.vendored.requests.packages.urllib3.contrib.pyopenssl import (
+    extract_from_urllib3,
+)
 
 # There is no boto3 equivalent of this yet.
 # See https://github.com/boto/boto3/issues/313
@@ -58,6 +53,11 @@ from ._logging import (
     BOTO_LOG_HEADER, IN_USE_DEVICES, CREATE_VOLUME_FAILURE,
     BOTO_LOG_RESULT, VOLUME_BUSY_MESSAGE,
 )
+
+# Don't use pyOpenSSL in urllib3 - it causes an ``OpenSSL.SSL.Error``
+# exception when we try an API call on an idled persistent connection.
+# See https://github.com/boto/boto3/issues/220
+extract_from_urllib3()
 
 DATASET_ID_LABEL = u'flocker-dataset-id'
 METADATA_VERSION_LABEL = u'flocker-metadata-version'

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -159,9 +159,11 @@ _METADATA_STRATEGY = text(average_size=3, min_size=1, alphabet="CGAT")
 DESIRED_DATASET_ATTRIBUTE_STRATEGIES = {
     'dataset_id': uuids(),
     'maximum_size': integers(min_value=0).map(
-        lambda n:
-        LOOPBACK_MINIMUM_ALLOCATABLE_SIZE
-        + n*LOOPBACK_ALLOCATION_UNIT),
+        lambda n: (
+            LOOPBACK_MINIMUM_ALLOCATABLE_SIZE +
+            n * LOOPBACK_ALLOCATION_UNIT
+        )
+    ),
     'metadata': dictionaries(keys=_METADATA_STRATEGY,
                              values=_METADATA_STRATEGY),
     'mount_point': builds(FilePath, sampled_from([
@@ -1157,8 +1159,10 @@ def compare_dataset_state(discovered_dataset, desired_dataset):
     :return: ``bool`` indicating if the datasets correspond.
     """
     if discovered_dataset is None:
-        return (desired_dataset is None
-                or desired_dataset.state == DatasetStates.DELETED)
+        return (
+            desired_dataset is None or
+            desired_dataset.state == DatasetStates.DELETED
+        )
     if desired_dataset is None:
         return discovered_dataset.state == DatasetStates.NON_MANIFEST
     if discovered_dataset.state != desired_dataset.state:
@@ -1316,8 +1320,8 @@ class BlockDeviceCalculatorTests(TestCase):
             DatasetStates.DELETED,
         ]),
         discovered_state=sampled_from(
-            DiscoveredDataset.__invariant__.attributes_for_tag.keys()
-            + [DatasetStates.NON_EXISTENT]
+            DiscoveredDataset.__invariant__.attributes_for_tag.keys() +
+            [DatasetStates.NON_EXISTENT]
         )
     )
     def test_all_transitions(self, desired_state, discovered_state):

--- a/flocker/node/exceptions.py
+++ b/flocker/node/exceptions.py
@@ -1,0 +1,19 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+from twisted.python.constants import NamedConstant
+
+
+class StorageInitializationError(Exception):
+    """
+    Exception raised by a storage API factory in the event that
+    the backend could not be successfully initialized.
+
+    :param NamedConstant code: The ``StorageInitializationError`` constant
+        indicating the type of failure.
+    """
+    CONFIGURATION_ERROR = NamedConstant()
+    OPERATIVE_ERROR = NamedConstant()
+
+    def __init__(self, code, *args):
+        Exception.__init__(self, *args)
+        self.code = code

--- a/flocker/node/functional/test_docker.py
+++ b/flocker/node/functional/test_docker.py
@@ -6,6 +6,7 @@ Functional tests for :module:`flocker.node._docker`.
 
 from __future__ import absolute_import
 
+from functools import partial
 import time
 import socket
 
@@ -158,7 +159,7 @@ class GenericDockerClientTests(AsyncTestCase):
         client = self.make_client()
 
         if retry_on_port_collision:
-            add = lambda **kw: add_with_port_collision_retry(client, **kw)
+            add = partial(add_with_port_collision_retry, client)
         else:
             add = client.add
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -37,6 +37,7 @@ from ..common.script import (
     flocker_standard_options, FlockerScriptRunner, main_for_service)
 from . import P2PManifestationDeployer, ApplicationNodeDeployer
 from ._loop import AgentLoopService
+from .exceptions import StorageInitializationError
 from .diagnostics import (
     current_distribution, FlockerDebugArchive, DISTRIBUTION_BY_LABEL,
     lookup_distribution,
@@ -57,22 +58,6 @@ __all__ = [
     "flocker_container_agent_main",
     "flocker_diagnostics_main",
 ]
-
-
-class StorageInitializationError(Exception):
-    """
-    Exception raised by a storage API factory in the event that
-    the backend could not be successfully initialized.
-
-    :param NamedConstant code: The ``StorageInitializationError`` constant
-        indicating the type of failure.
-    """
-    CONFIGURATION_ERROR = NamedConstant()
-    OPERATIVE_ERROR = NamedConstant()
-
-    def __init__(self, code, *args):
-        Exception.__init__(self, *args)
-        self.code = code
 
 
 def flocker_dataset_agent_main():

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -47,6 +47,8 @@ from .agents.blockdevice import (
 from .agents.loopback import (
     LoopbackBlockDeviceAPI,
 )
+from .agents.cinder import cinder_from_configuration
+from .agents.ebs import aws_from_configuration
 from ..ca import ControlServicePolicy, NodeCredential
 from ..common._era import get_era
 
@@ -451,9 +453,6 @@ class BackendDescription(PClass):
             value in DeployerType.iterconstants(), "Unknown deployer_type"
         ),
     )
-
-from .agents.cinder import cinder_from_configuration
-from .agents.ebs import aws_from_configuration
 
 # These structures should be created dynamically to handle plug-ins
 _DEFAULT_BACKENDS = [

--- a/flocker/node/test/istatechange.py
+++ b/flocker/node/test/istatechange.py
@@ -4,10 +4,6 @@
 Helpers for tests for implementations of ``IStateChange``.
 """
 
-__all__ = [
-    "make_comparison_tests", "make_istatechange_tests",
-]
-
 from zope.interface.verify import verifyObject
 
 from zope.interface import implementer
@@ -21,6 +17,11 @@ from twisted.internet.defer import succeed
 
 from ...testtools import TestCase
 from .. import IStateChange
+
+
+__all__ = [
+    "make_comparison_tests", "make_istatechange_tests",
+]
 
 
 def make_comparison_tests(klass, kwargs1, kwargs2):

--- a/flocker/restapi/_error.py
+++ b/flocker/restapi/_error.py
@@ -4,6 +4,12 @@ This module defines the presentation of error conditions that can be
 encountered by the implementation of the API.
 """
 
+from inspect import cleandoc
+
+from eliot import register_exception_extractor
+
+from twisted.web.http import BAD_REQUEST, FORBIDDEN, NOT_FOUND
+
 __all__ = [
     "BadRequest", "InvalidRequestJSON", "makeBadRequest",
 
@@ -15,12 +21,6 @@ __all__ = [
 
     "UNPROCESSABLE_REQUEST",
     ]
-
-from inspect import cleandoc
-
-from eliot import register_exception_extractor
-
-from twisted.web.http import BAD_REQUEST, FORBIDDEN, NOT_FOUND
 
 # HTTP response code indicating the request is syntactically correct but
 # semantically wrong, as defined in

--- a/flocker/restapi/_logging.py
+++ b/flocker/restapi/_logging.py
@@ -4,12 +4,12 @@
 This module defines the Eliot log events emitted by the API implementation.
 """
 
+from eliot import Field, ActionType
+
 __all__ = [
     "JSON_REQUEST",
     "REQUEST",
     ]
-
-from eliot import Field, ActionType
 
 LOG_SYSTEM = u"api"
 

--- a/flocker/restapi/_schema.py
+++ b/flocker/restapi/_schema.py
@@ -6,17 +6,17 @@ Helpers for validating API input and output against JSON Schema.
 See https://python-jsonschema.readthedocs.org/en/v2.3.0/.
 """
 
+import copy
+
+from jsonschema.validators import RefResolver, validator_for
+from jsonschema import draft4_format_checker
+
 __all__ = [
     "SchemaNotProvided",
     "LocalRefResolver",
     "getValidator",
     "resolveSchema",
 ]
-
-import copy
-
-from jsonschema.validators import RefResolver, validator_for
-from jsonschema import draft4_format_checker
 
 
 class SchemaNotProvided(Exception):

--- a/flocker/restapi/testtools.py
+++ b/flocker/restapi/testtools.py
@@ -13,14 +13,18 @@ from jsonschema.exceptions import ValidationError
 
 from zope.interface import implementer
 
+from klein.app import KleinRequest
+from klein.interfaces import IKleinRequest
+
+from twisted.python.components import registerAdapter
 from twisted.python.log import err
 from twisted.web.iweb import IAgent, IResponse
 from twisted.internet.endpoints import TCP4ClientEndpoint, UNIXClientEndpoint
 from twisted.internet import defer
 from twisted.web.client import ProxyAgent, readBody, FileBodyProducer
-from twisted.web.server import NOT_DONE_YET, Site
+from twisted.web.server import NOT_DONE_YET, Site, Request
 from twisted.web.resource import getChildForRequest
-from twisted.web.http import urlparse, unquote
+from twisted.web.http import HTTPChannel, urlparse, unquote
 from twisted.internet.address import IPv4Address
 from twisted.test.proto_helpers import StringTransport
 from twisted.web.client import ResponseDone
@@ -252,11 +256,8 @@ def build_UNIX_integration_tests(mixin_class, name, fixture):
     RealTests.__module__ = mixin_class.__module__
     return RealTests
 
-
 # Fakes for testing Twisted Web servers.  Unverified.  Belongs in Twisted.
 # https://twistedmatrix.com/trac/ticket/3274
-from twisted.web.server import Request
-from twisted.web.http import HTTPChannel
 
 
 class EventChannel(object):
@@ -567,9 +568,6 @@ def render(resource, request):
 # exercise Klein-based code without trying to use the real request type.
 #
 # See https://github.com/twisted/klein/issues/31
-from twisted.python.components import registerAdapter
-from klein.app import KleinRequest
-from klein.interfaces import IKleinRequest
 registerAdapter(KleinRequest, _DummyRequest, IKleinRequest)
 
 

--- a/flocker/route/__init__.py
+++ b/flocker/route/__init__.py
@@ -16,13 +16,12 @@ this allows easy, transparent migration of containers between any of the
 cooperating nodes.
 """
 
-__all__ = [
-    "INetwork", "make_host_network", "make_memory_network",
-    "Proxy", "OpenPort",
-]
-
-
 from ._interfaces import INetwork
 from ._iptables import make_host_network
 from ._memory import make_memory_network
 from ._model import Proxy, OpenPort
+
+__all__ = [
+    "INetwork", "make_host_network", "make_memory_network",
+    "Proxy", "OpenPort",
+]

--- a/flocker/route/functional/iptables.py
+++ b/flocker/route/functional/iptables.py
@@ -21,14 +21,16 @@ def get_iptables_rules():
     return [
         rule
         for rule in rules.splitlines()
-        # Comments don't matter.  They always differ because they
-        # include timestamps.
-        if not rule.startswith("#")
-        # Chain data could matter but doesn't.  The implementation
-        # doesn't mess with this stuff.  It typically differs in
-        # uninteresting ways - such as matched packet counters.
-        and not rule.startswith(":")
-        ]
+        if (
+            # Comments don't matter.  They always differ because they
+            # include timestamps.
+            not rule.startswith("#") and
+            # Chain data could matter but doesn't.  The implementation
+            # doesn't mess with this stuff.  It typically differs in
+            # uninteresting ways - such as matched packet counters.
+            not rule.startswith(":")
+        )
+    ]
 
 
 class _Namespace(object):

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -6,36 +6,6 @@ Various utilities to help with unit and functional testing.
 
 from __future__ import absolute_import
 
-__all__ = [
-    'AsyncTestCase',
-    'CustomException',
-    'DockerImageBuilder',
-    'FakeProcessReactor',
-    'FakeSysModule',
-    'FlockerScriptTestsMixin',
-    'MemoryCoreReactor',
-    'REALISTIC_BLOCKDEVICE_SIZE',
-    'make_standard_options_tests',
-    'TestCase',
-    'assertContainsAll',
-    'assertNoFDsLeaked',
-    'assert_equal_comparison',
-    'assert_not_equal_comparison',
-    'async_runner',
-    'attempt_effective_uid',
-    'find_free_port',
-    'flaky',
-    'help_problems',
-    'if_root',
-    'logged_run_process',
-    'make_script_tests',
-    'make_with_init_tests',
-    'not_root',
-    'random_name',
-    'run_process',
-    'skip_on_broken_permissions',
-]
-
 import gc
 import io
 import socket
@@ -80,8 +50,37 @@ from ._base import AsyncTestCase, TestCase, async_runner
 from ._flaky import flaky
 from .. import __version__
 from ..common import RACKSPACE_MINIMUM_VOLUME_SIZE
-from ..common.script import (
-    FlockerScriptRunner, ICommandLineScript)
+from ..common.script import FlockerScriptRunner, ICommandLineScript
+
+__all__ = [
+    'AsyncTestCase',
+    'CustomException',
+    'DockerImageBuilder',
+    'FakeProcessReactor',
+    'FakeSysModule',
+    'FlockerScriptTestsMixin',
+    'MemoryCoreReactor',
+    'REALISTIC_BLOCKDEVICE_SIZE',
+    'make_standard_options_tests',
+    'TestCase',
+    'assertContainsAll',
+    'assertNoFDsLeaked',
+    'assert_equal_comparison',
+    'assert_not_equal_comparison',
+    'async_runner',
+    'attempt_effective_uid',
+    'find_free_port',
+    'flaky',
+    'help_problems',
+    'if_root',
+    'logged_run_process',
+    'make_script_tests',
+    'make_with_init_tests',
+    'not_root',
+    'random_name',
+    'run_process',
+    'skip_on_broken_permissions',
+]
 
 REALISTIC_BLOCKDEVICE_SIZE = RACKSPACE_MINIMUM_VOLUME_SIZE
 

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -36,6 +36,7 @@ from twisted.internet.interfaces import (
     IProcessTransport, IReactorProcess, IReactorCore,
 )
 from twisted.python.filepath import FilePath, Permissions
+from twisted.internet.base import _ThreePhaseEvent
 from twisted.internet.task import Clock
 from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectionDone
@@ -769,7 +770,6 @@ not_root = skipIf(os.getuid() == 0, "Must not run as root.")
 
 # TODO: This should be provided by Twisted (also it should be more complete
 # instead of 1/3rd done).
-from twisted.internet.base import _ThreePhaseEvent
 
 
 @implementer(IReactorCore)

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -77,7 +77,7 @@ def _get_flaky_annotation(case):
     return getattr(method, _FLAKY_ATTRIBUTE, None)
 
 
-def _get_invariants(x):
+def _flaky_invariants(x):
     return (
         (x.max_runs >= x.min_passes, "Can't pass more than we run"),
         (len(x.jira_keys) > 0, "Must provide a jira key"),
@@ -92,7 +92,7 @@ class _FlakyAnnotation(PClass):
                        invariant=lambda x: (x > 0, "must pass at least once"))
     jira_keys = pset_field(unicode, optional=False)
 
-    __invariant__ = _get_invariants
+    __invariant__ = _flaky_invariants
 
     def to_dict(self):
         return {

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -77,6 +77,13 @@ def _get_flaky_annotation(case):
     return getattr(method, _FLAKY_ATTRIBUTE, None)
 
 
+def _get_invariants(x):
+    return (
+        (x.max_runs >= x.min_passes, "Can't pass more than we run"),
+        (len(x.jira_keys) > 0, "Must provide a jira key"),
+    )
+
+
 class _FlakyAnnotation(PClass):
 
     max_runs = field(int, mandatory=True,
@@ -85,10 +92,7 @@ class _FlakyAnnotation(PClass):
                        invariant=lambda x: (x > 0, "must pass at least once"))
     jira_keys = pset_field(unicode, optional=False)
 
-    __invariant__ = lambda x: (
-        (x.max_runs >= x.min_passes, "Can't pass more than we run"),
-        (len(x.jira_keys) > 0, "Must provide a jira key"),
-    )
+    __invariant__ = _get_invariants
 
     def to_dict(self):
         return {


### PR DESCRIPTION
These lint problems are mostly:
1. imports appearing after other code
2. assigned lambdas
3. operators appearing after newline rather than before.

Most of the fixes are to shuffle code around a bit, and convert lambdas to functions.

In `flocker/node`, there was a circular import which worked previously because one of the imports was after the definition of an Exception object.  The exception was moved to its own file to break the circular import.
