### PR TITLE
[FLOC-3883] FilePath matchers and temporary helpers

### DIFF
--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -1,10 +1,10 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
+from __future__ import absolute_import
+
 """
 Various utilities to help with unit and functional testing.
 """
-
-from __future__ import absolute_import
 
 import gc
 import io
@@ -59,10 +59,9 @@ __all__ = [
     'DockerImageBuilder',
     'FakeProcessReactor',
     'FakeSysModule',
-    'FlockerScriptTestsMixin',
     'MemoryCoreReactor',
     'REALISTIC_BLOCKDEVICE_SIZE',
-    'make_standard_options_tests',
+    'make_standard_options_test',
     'TestCase',
     'assertContainsAll',
     'assertNoFDsLeaked',

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -51,17 +51,25 @@ class _MktempMixin(object):
 
         :return: Path to non-existent file or directory.
         """
-        # XXX: Should we provide a cleaner interface for people to use? One
-        # that returns FilePath? One that returns a directory?
-        return make_temporary_directory(self).child('temp').path
+        return self.make_temporary_path().path
 
     def make_temporary_path(self):
         """
         Create a temporary path for use in tests.
 
         :return: Path to non-existent file or directory.
+        :rtype: FilePath
         """
-        return make_temporary_directory(self).child('temp')
+        return self.make_temporary_directory().child('temp')
+
+    def make_temporary_directory(self):
+        """
+        Create a temporary directory for use in tests.
+
+        :return: Path to directory.
+        :rtype: FilePath
+        """
+        return make_temporary_directory(_path_for_test(self))
 
 
 class _DeferredAssertionMixin(object):
@@ -330,16 +338,25 @@ def _path_for_test_id(test_id, max_segment_length=32):
         segment[:max_segment_length] for segment in test_id.rsplit('.', 2))
 
 
-def make_temporary_directory(test):
+def _path_for_test(test):
     """
-    Create a temporary directory for use in ``test``.
+    Get the temporary directory path for a test.
+    """
+    return FilePath(_path_for_test_id(test.id()))
 
-    :param TestCase test: A TestCase
+
+def make_temporary_directory(base_path):
+    """
+    Create a temporary directory beneath ``base_path``.
+
+    It is the responsibility of the caller to delete the temporary directory.
+
+    :param FilePath base_path: Base directory for the temporary directory.
+        Will be created if it does not exist.
     :return: The FilePath to a newly-created temporary directory, created
         beneath the current working directory.
     """
-    path = FilePath(_path_for_test_id(test.id()))
-    if not path.exists():
-        path.makedirs()
-    temp_dir = tempfile.mkdtemp(dir=path.path)
+    if not base_path.exists():
+        base_path.makedirs()
+    temp_dir = tempfile.mkdtemp(dir=base_path.path)
     return FilePath(temp_dir)

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -45,15 +45,23 @@ class _MktempMixin(object):
 
     def mktemp(self):
         """
-        Create a temporary directory that will be deleted on test completion.
+        Create a temporary path for use in tests.
 
         Provided for compatibility with Twisted's ``TestCase``.
 
-        :return: Path to the newly-created temporary directory.
+        :return: Path to non-existent file or directory.
         """
         # XXX: Should we provide a cleaner interface for people to use? One
         # that returns FilePath? One that returns a directory?
         return make_temporary_directory(self).child('temp').path
+
+    def make_temporary_path(self):
+        """
+        Create a temporary path for use in tests.
+
+        :return: Path to non-existent file or directory.
+        """
+        return make_temporary_directory(self).child('temp')
 
 
 class _DeferredAssertionMixin(object):

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -71,6 +71,18 @@ class _MktempMixin(object):
         """
         return make_temporary_directory(_path_for_test(self))
 
+    def make_temporary_file(self, content=''):
+        """
+        Create a temporary file for use in tests.
+
+        :param str content: Content to write to the file.
+        :return: Path to file.
+        :rtype: FilePath
+        """
+        path = self.make_temporary_path()
+        path.setContent(content)
+        return path
+
 
 class _DeferredAssertionMixin(object):
     """

--- a/flocker/testtools/_testhelpers.py
+++ b/flocker/testtools/_testhelpers.py
@@ -78,3 +78,19 @@ def run_test(case):
     result = unittest.TestResult()
     case.run(result)
     return result
+
+
+def make_test_case(base_case, behavior=lambda case: None):
+    """
+    Make a single test subclasses ``base_case`` and does ``behavior``.
+
+    :param type base_case: A ``TestCase`` class.
+    :param (TestCase -> A) behavior: The contents of the test. If not
+        specified, defaults to a passing test.
+
+    :rtype: ``base_case``
+    """
+    class FooTests(base_case):
+        def test_something(self):
+            pass
+    return FooTests('test_something')

--- a/flocker/testtools/_testhelpers.py
+++ b/flocker/testtools/_testhelpers.py
@@ -80,13 +80,11 @@ def run_test(case):
     return result
 
 
-def make_test_case(base_case, behavior=lambda case: None):
+def make_test_case(base_case):
     """
-    Make a single test subclasses ``base_case`` and does ``behavior``.
+    Make a single test that subclasses ``base_case`` and passes.
 
     :param type base_case: A ``TestCase`` class.
-    :param (TestCase -> A) behavior: The contents of the test. If not
-        specified, defaults to a passing test.
 
     :rtype: ``base_case``
     """

--- a/flocker/testtools/matchers.py
+++ b/flocker/testtools/matchers.py
@@ -172,11 +172,13 @@ Match if a file exists on disk.
 
 def file_contents(matcher):
     """
-    Match if a files contents match ``matcher``.
+    Match if a file's contents match ``matcher``.
 
     For example::
 
-        self.assertThat('/foo/bar/baz', file_contents(Equals('hello world')))
+        self.assertThat(
+            FilePath('/foo/bar/baz'),
+            file_contents(Equals('hello world')))
 
     Will match if there is a file ``/foo/bar/baz`` and if its contents are
     exactly ``hello world``.

--- a/flocker/testtools/matchers.py
+++ b/flocker/testtools/matchers.py
@@ -6,6 +6,7 @@ testtools matchers used in Flocker tests.
 
 from testtools.matchers import (
     AfterPreprocessing,
+    DirExists,
     PathExists,
 )
 
@@ -22,3 +23,10 @@ def path_exists():
     Match if a path exists on disk.
     """
     return AfterPreprocessing(_filepath_to_path, PathExists(), annotate=False)
+
+
+def dir_exists():
+    """
+    Match if a directory exists on disk.
+    """
+    return AfterPreprocessing(_filepath_to_path, DirExists(), annotate=False)

--- a/flocker/testtools/matchers.py
+++ b/flocker/testtools/matchers.py
@@ -8,6 +8,7 @@ from testtools.matchers import (
     AfterPreprocessing,
     DirExists,
     FileExists,
+    MatchesAll,
     PathExists,
 )
 
@@ -38,3 +39,30 @@ def file_exists():
     Match if a file exists on disk.
     """
     return AfterPreprocessing(_filepath_to_path, FileExists(), annotate=False)
+
+
+def _get_content(file_path):
+    """
+    Get content for ``file_path``.
+    """
+    return file_path.getContent()
+
+
+def file_contents(matcher):
+    """
+    Match if a files contents match ``matcher``.
+
+    For example::
+
+        self.assertThat('/foo/bar/baz', file_contents(Equals('hello world')))
+
+    Will match if there is a file ``/foo/bar/baz`` and if its contents are
+    exactly ``hello world``.
+    """
+    # We don't use ``FileContains``, as that raises an IOError if the path is
+    # for an existing directory.
+    return MatchesAll(
+        file_exists(),
+        AfterPreprocessing(_get_content, matcher, annotate=False),
+        first_only=True,
+    )

--- a/flocker/testtools/matchers.py
+++ b/flocker/testtools/matchers.py
@@ -1,0 +1,24 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+testtools matchers used in Flocker tests.
+"""
+
+from testtools.matchers import (
+    AfterPreprocessing,
+    PathExists,
+)
+
+
+def _filepath_to_path(filepath):
+    """
+    Convert FilePath to a regular path.
+    """
+    return filepath.path
+
+
+def path_exists():
+    """
+    Match if a path exists on disk.
+    """
+    return AfterPreprocessing(_filepath_to_path, PathExists(), annotate=False)

--- a/flocker/testtools/matchers.py
+++ b/flocker/testtools/matchers.py
@@ -4,6 +4,8 @@
 testtools matchers used in Flocker tests.
 """
 
+from pyrsistent import PClass, field, pmap_field
+from testtools.content import Content
 from testtools.matchers import (
     AfterPreprocessing,
     DirExists,
@@ -29,10 +31,99 @@ def after(function, annotate=False):
     :return: New matcher factory.
     :rtype: (*a -> **kw -> Matcher[A]) -> (*args -> **kwargs -> Matcher[B])
     """
+    # XXX: Probably should be part of upstream testtools.
     def decorated(matcher):
         def make_matcher(*args, **kwargs):
             return AfterPreprocessing(
                 function, matcher(*args, **kwargs), annotate=annotate)
+
+        return make_matcher
+    return decorated
+
+
+class _Mismatch(PClass):
+    """
+    Immutable Mismatch that also stores the mismatched object.
+
+    :ivar mismatched: The object that failed to match.
+    """
+
+    # XXX: No direct tests.
+
+    # XXX: jml thinks the base testtools mismatch should be extended to
+    # include the mismatched object.
+
+    mismatched = field(object)
+    _description = field((str, unicode))
+    _details = pmap_field((str, unicode), Content)
+
+    def describe(self):
+        return self._description
+
+    def get_details(self):
+        return self._details
+
+
+def mismatch(mismatched, description, details):
+    """
+    Create an immutable Mismatch that also stores the mismatched object.
+    """
+    return _Mismatch(
+        mismatched=mismatched, _description=description, _details=details)
+
+
+def _adapt_mismatch(original, matchee):
+    """
+    If ``original`` doesn't already store ``matchee`` then return a new
+    one that has it stored.
+    """
+    # XXX: No direct tests.
+    marker = object()
+    if getattr(original, 'mismatched', marker) is marker:
+        return mismatch(matchee, original.describe(), original.get_details())
+    return original
+
+
+class _OnMismatch(PClass):
+    """
+    Decorate a matcher with a function that is run on mismatch.
+    """
+
+    _function = field()
+    _matcher = field()
+
+    def match(self, matchee):
+        """
+        Match if ``matchee`` matches the wrapped matcher.
+
+        If it does not match, apply the given function to the mismatch, first
+        ensuring that the mismatch has ``mismatched`` set.
+        """
+        mismatch = self._matcher.match(matchee)
+        if mismatch is None:
+            return
+        return self._function(_adapt_mismatch(mismatch, matchee))
+
+
+def OnMismatch(function, matcher):
+    """
+    Decorate ``matcher`` such that ``function`` is called on mismatches.
+    """
+    return _OnMismatch(_function=function, _matcher=matcher)
+
+
+def on_mismatch(function):
+    """
+    Return a function that maps matcher factories to new matcher factories,
+    such that the matchers returned by the new factories have ``function``
+    applied to any mismatch they receive.
+
+    :param (_Mismatch[A] -> _Mismatch[B]) function: Applied to any mismatch.
+    :return: A function that operates on matcher factories.
+    """
+    def decorated(matcher):
+        def make_matcher(*args, **kwargs):
+            return _OnMismatch(function, matcher(*args, **kwargs))
 
         return make_matcher
     return decorated
@@ -46,6 +137,9 @@ def _filepath_to_path(filepath):
 
 
 _on_filepath = after(_filepath_to_path)
+"""
+Lift regular path matchers to be FilePath matchers.
+"""
 
 
 path_exists = _on_filepath(PathExists)
@@ -76,13 +170,6 @@ Match if a file exists on disk.
 """
 
 
-def _get_content(file_path):
-    """
-    Get content for ``file_path``.
-    """
-    return file_path.getContent()
-
-
 def file_contents(matcher):
     """
     Match if a files contents match ``matcher``.
@@ -94,10 +181,23 @@ def file_contents(matcher):
     Will match if there is a file ``/foo/bar/baz`` and if its contents are
     exactly ``hello world``.
     """
+
+    def get_content(file_path):
+        return file_path.getContent()
+
+    def content_mismatches(original):
+        return mismatch(
+            original.mismatched,
+            '%s has unexpected contents:\n%s' % (
+                original.mismatched.path, original.describe()),
+            original.get_details(),
+        )
     # We don't use ``FileContains``, as that raises an IOError if the path is
     # for an existing directory.
     return MatchesAll(
         file_exists(),
-        AfterPreprocessing(_get_content, matcher, annotate=False),
+        OnMismatch(
+            content_mismatches,
+            AfterPreprocessing(get_content, matcher, annotate=False)),
         first_only=True,
     )

--- a/flocker/testtools/matchers.py
+++ b/flocker/testtools/matchers.py
@@ -7,6 +7,7 @@ testtools matchers used in Flocker tests.
 from testtools.matchers import (
     AfterPreprocessing,
     DirExists,
+    FileExists,
     PathExists,
 )
 
@@ -30,3 +31,10 @@ def dir_exists():
     Match if a directory exists on disk.
     """
     return AfterPreprocessing(_filepath_to_path, DirExists(), annotate=False)
+
+
+def file_exists():
+    """
+    Match if a file exists on disk.
+    """
+    return AfterPreprocessing(_filepath_to_path, FileExists(), annotate=False)

--- a/flocker/testtools/strategies.py
+++ b/flocker/testtools/strategies.py
@@ -1,5 +1,7 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
+import string
+
 from hypothesis.strategies import lists, text
 from twisted.python.filepath import FilePath
 
@@ -23,4 +25,25 @@ paths = lists(path_segments).map(lambda ps: FilePath('/'.join(ps)))
 Paths
 
 e.g. '/usr/local', 'foo/bar/bar'.
+"""
+
+
+_identifier_characters = string.ascii_letters + string.digits + '_'
+
+
+identifiers = text(
+    average_size=20, min_size=1, alphabet=_identifier_characters)
+"""
+Python identifiers.
+
+e.g. ``Foo``, ``bar``.
+"""
+
+
+fqpns = lists(
+    identifiers, min_size=1, average_size=5).map(lambda xs: '.'.join(xs))
+"""
+Fully-qualified Python names.
+
+e.g. ``twisted.internet.defer.Deferred``, ``foo.bar.baz_qux``.
 """

--- a/flocker/testtools/strategies.py
+++ b/flocker/testtools/strategies.py
@@ -24,7 +24,7 @@ paths = lists(path_segments).map(lambda ps: FilePath('/'.join(ps)))
 """
 Paths
 
-e.g. '/usr/local', 'foo/bar/bar'.
+e.g. ``FilePath('/usr/local')``, ``FilePath('foo/bar/bar')``.
 """
 
 

--- a/flocker/testtools/strategies.py
+++ b/flocker/testtools/strategies.py
@@ -1,0 +1,26 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+from hypothesis.strategies import lists, text
+from twisted.python.filepath import FilePath
+
+
+path_segments = (
+    text().
+    filter(lambda x: '/' not in x).
+    map(lambda x: x.encode('utf8')).
+    filter(lambda x: '\0' not in x))
+"""
+Individual path segments.
+
+These are UTF-8 encoded segments that contain neither '/' nor NULL.
+
+e.g. 'foo', 'rc.local'.
+"""
+
+
+paths = lists(path_segments).map(lambda ps: FilePath('/'.join(ps)))
+"""
+Paths
+
+e.g. '/usr/local', 'foo/bar/bar'.
+"""

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -56,6 +56,7 @@ from ..strategies import fqpns
 from .._testhelpers import (
     base_test_cases,
     has_results,
+    make_test_case,
     only_skips,
     run_test,
 )
@@ -81,18 +82,12 @@ class BaseTestCaseTests(TesttoolsTestCase):
         result = run_test(test)
         self.assertThat(result, only_skips(1, [reason]))
 
-    @given(base_test_cases)
-    def test_mktemp_doesnt_exist(self, base_test_case):
+    @given(base_test_cases.map(make_test_case))
+    def test_mktemp_doesnt_exist(self, test):
         """
         ``mktemp`` returns a path that doesn't exist inside a directory that
         does.
         """
-
-        class SomeTest(base_test_case):
-            def test_pass(self):
-                pass
-
-        test = SomeTest('test_pass')
         temp_path = FilePath(test.mktemp())
         self.addCleanup(_remove_dir, temp_path.parent())
 
@@ -118,18 +113,12 @@ class BaseTestCaseTests(TesttoolsTestCase):
         self.addCleanup(os.unlink, path)
         self.assertThat(path, FileContains('hello'))
 
-    @given(base_test_cases)
-    def test_make_temporary_path_doesnt_exist(self, base_test_case):
+    @given(base_test_cases.map(make_test_case))
+    def test_make_temporary_path_doesnt_exist(self, test):
         """
         ``make_temporary_path`` returns a path that doesn't exist inside a
         directory that does.
         """
-
-        class SomeTest(base_test_case):
-            def test_pass(self):
-                pass
-
-        test = SomeTest('test_pass')
         temp_path = test.make_temporary_path()
         self.addCleanup(_remove_dir, temp_path.parent())
 
@@ -156,55 +145,36 @@ class BaseTestCaseTests(TesttoolsTestCase):
         self.addCleanup(path.remove)
         self.assertThat(path.path, FileContains('hello'))
 
-    @given(base_test_cases)
-    def test_make_temporary_directory_exists(self, base_test_case):
+    @given(base_test_cases.map(make_test_case))
+    def test_make_temporary_directory_exists(self, test):
         """
         ``make_temporary_directory`` returns a path to a directory.
         """
-
-        class SomeTest(base_test_case):
-            def test_pass(self):
-                pass
-
-        test = SomeTest('test_pass')
         temp_dir = test.make_temporary_directory()
         self.addCleanup(_remove_dir, temp_dir)
-
         self.assertThat(temp_dir, dir_exists())
 
-    @given(base_test_cases, binary(average_size=20))
-    def test_make_temporary_file_with_content(self, base_test_case, content):
+    @given(base_test_cases.map(make_test_case), binary(average_size=20))
+    def test_make_temporary_file_with_content(self, test, content):
         """
         ``make_temporary_file`` returns a path to an existing file.
         """
-        class SomeTest(base_test_case):
-            def test_pass(self):
-                pass
-
-        test = SomeTest('test_pass')
         temp_file = test.make_temporary_file(content)
         self.addCleanup(temp_file.remove)
-
         self.assertThat(temp_file, file_contents(Equals(content)))
 
-    @given(base_test_cases)
-    def test_make_temporary_file(self, base_test_case):
+    @given(base_test_cases.map(make_test_case))
+    def test_make_temporary_file(self, test):
         """
         ``make_temporary_file`` returns a path to an existing file. If no
         content is provided, defaults to an empty file.
         """
-        class SomeTest(base_test_case):
-            def test_pass(self):
-                pass
-
-        test = SomeTest('test_pass')
         temp_file = test.make_temporary_file()
         self.addCleanup(temp_file.remove)
-
         self.assertThat(temp_file, file_contents(Equals('')))
 
-    @given(base_test_cases)
-    def test_run_twice(self, base_test_case):
+    @given(base_test_cases.map(make_test_case))
+    def test_run_twice(self, test):
         """
         Tests can be run twice without errors.
 
@@ -213,12 +183,6 @@ class BaseTestCaseTests(TesttoolsTestCase):
         coverage is inadequate for a thorough fix. However, this will be
         enough to let us use ``trial -u`` (see FLOC-3462).
         """
-
-        class SomeTest(base_test_case):
-            def test_something(self):
-                pass
-
-        test = SomeTest('test_something')
         result = TestResult()
         test.run(result)
         test.run(result)

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -51,7 +51,7 @@ from .._base import (
     _iter_lines,
     _path_for_test_id,
 )
-from ..matchers import dir_exists
+from ..matchers import dir_exists, file_contents
 from ..strategies import fqpns
 from .._testhelpers import (
     base_test_cases,
@@ -171,6 +171,37 @@ class BaseTestCaseTests(TesttoolsTestCase):
         self.addCleanup(_remove_dir, temp_dir)
 
         self.assertThat(temp_dir, dir_exists())
+
+    @given(base_test_cases, binary(average_size=20))
+    def test_make_temporary_file_with_content(self, base_test_case, content):
+        """
+        ``make_temporary_file`` returns a path to an existing file.
+        """
+        class SomeTest(base_test_case):
+            def test_pass(self):
+                pass
+
+        test = SomeTest('test_pass')
+        temp_file = test.make_temporary_file(content)
+        self.addCleanup(temp_file.remove)
+
+        self.assertThat(temp_file, file_contents(Equals(content)))
+
+    @given(base_test_cases)
+    def test_make_temporary_file(self, base_test_case):
+        """
+        ``make_temporary_file`` returns a path to an existing file. If no
+        content is provided, defaults to an empty file.
+        """
+        class SomeTest(base_test_case):
+            def test_pass(self):
+                pass
+
+        test = SomeTest('test_pass')
+        temp_file = test.make_temporary_file()
+        self.addCleanup(temp_file.remove)
+
+        self.assertThat(temp_file, file_contents(Equals('')))
 
     @given(base_test_cases)
     def test_run_twice(self, base_test_case):

--- a/flocker/testtools/test/test_base.py
+++ b/flocker/testtools/test/test_base.py
@@ -7,7 +7,6 @@ Tests for flocker base test cases.
 import errno
 import os
 import shutil
-import string
 import unittest
 
 from eliot import MessageType, fields
@@ -40,7 +39,6 @@ from testtools.matchers import (
     StartsWith,
     IsInstance,
 )
-
 from twisted.internet.defer import Deferred, succeed, fail
 from twisted.python.filepath import FilePath
 from twisted.python.failure import Failure
@@ -53,6 +51,7 @@ from .._base import (
     _iter_lines,
     _path_for_test_id,
 )
+from ..strategies import fqpns, identifiers
 from .._testhelpers import (
     base_test_cases,
     has_results,
@@ -307,10 +306,6 @@ class GetEliotDataTests(TesttoolsTestCase):
         self.assertThat(_get_eliot_data(logged_line), Equals(expected))
 
 
-identifier_characters = string.ascii_letters + string.digits + '_'
-identifiers = text(average_size=20, min_size=1, alphabet=identifier_characters)
-fqpns = lists(
-    identifiers, min_size=1, average_size=5).map(lambda xs: '.'.join(xs))
 tests = lists(identifiers, min_size=3, average_size=5).map(
     lambda xs: PlaceHolder('.'.join(xs)))
 

--- a/flocker/testtools/test/test_matchers.py
+++ b/flocker/testtools/test/test_matchers.py
@@ -1,12 +1,20 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 from hypothesis import given
-from testtools.matchers import AfterPreprocessing, Equals, Is, Not, PathExists
+from testtools.matchers import (
+    AfterPreprocessing,
+    DirExists,
+    Equals,
+    Is,
+    Not,
+    PathExists,
+)
 
 
 from .. import TestCase
 from ..strategies import paths
 from ..matchers import (
+    dir_exists,
     path_exists,
 )
 
@@ -67,4 +75,43 @@ class PathExistsTests(TestCase):
         self.assertThat(
             path_exists().match(path),
             is_equivalent_mismatch(PathExists().match(path.path)),
+        )
+
+
+class DirExistsTests(TestCase):
+    """
+    Tests for :py:func:`dir_exists`.
+    """
+
+    def test_does_not_exist(self):
+        """
+        If the path does not exist, dir_exists does not match.
+        """
+        path = self.make_temporary_path()
+        self.assertThat(path, Not(dir_exists()))
+
+    def test_file_exists(self):
+        """
+        If there is a file at path, dir_exists does not match.
+        """
+        path = self.make_temporary_path()
+        path.setContent('foo')
+        self.assertThat(path, Not(dir_exists()))
+
+    def test_dir_exists(self):
+        """
+        If there is a directory at path, dir_exists matches.
+        """
+        path = self.make_temporary_path()
+        path.makedirs()
+        self.assertThat(path, dir_exists())
+
+    @given(paths)
+    def test_equivalent_to_standard_dir_exists(self, path):
+        """
+        dir_exists is to FilePaths what DirExists is to normal paths.
+        """
+        self.assertThat(
+            dir_exists().match(path),
+            is_equivalent_mismatch(DirExists().match(path.path)),
         )

--- a/flocker/testtools/test/test_matchers.py
+++ b/flocker/testtools/test/test_matchers.py
@@ -2,7 +2,6 @@
 
 from hypothesis import given
 from testtools.matchers import AfterPreprocessing, Equals, Is, Not, PathExists
-from twisted.python.filepath import FilePath
 
 
 from .. import TestCase
@@ -41,14 +40,14 @@ class PathExistsTests(TestCase):
         """
         If the path does not exist, path_exists does not match.
         """
-        path = FilePath(self.mktemp())
+        path = self.make_temporary_path()
         self.assertThat(path, Not(path_exists()))
 
     def test_file_exists(self):
         """
         If there is a file at path, path_exists matches.
         """
-        path = FilePath(self.mktemp())
+        path = self.make_temporary_path()
         path.setContent('foo')
         self.assertThat(path, path_exists())
 
@@ -56,12 +55,15 @@ class PathExistsTests(TestCase):
         """
         If there is a directory at path, path_exists matches.
         """
-        path = FilePath(self.mktemp())
+        path = self.make_temporary_path()
         path.makedirs()
         self.assertThat(path, path_exists())
 
     @given(paths)
     def test_equivalent_to_standard_path_exists(self, path):
+        """
+        path_exists is to FilePaths what PathExists is to normal paths.
+        """
         self.assertThat(
             path_exists().match(path),
             is_equivalent_mismatch(PathExists().match(path.path)),

--- a/flocker/testtools/test/test_matchers.py
+++ b/flocker/testtools/test/test_matchers.py
@@ -5,6 +5,7 @@ from testtools.matchers import (
     AfterPreprocessing,
     DirExists,
     Equals,
+    FileExists,
     Is,
     Not,
     PathExists,
@@ -15,6 +16,7 @@ from .. import TestCase
 from ..strategies import paths
 from ..matchers import (
     dir_exists,
+    file_exists,
     path_exists,
 )
 
@@ -114,4 +116,42 @@ class DirExistsTests(TestCase):
         self.assertThat(
             dir_exists().match(path),
             is_equivalent_mismatch(DirExists().match(path.path)),
+        )
+
+
+class FileExistsTests(TestCase):
+    """
+    Tests for :py:func:`file_exists`.
+    """
+
+    def test_does_not_exist(self):
+        """
+        If the path does not exist, file_exists does not match.
+        """
+        path = self.make_temporary_path()
+        self.assertThat(path, Not(file_exists()))
+
+    def test_file_exists(self):
+        """
+        If there is a file at path, file_exists matches.
+        """
+        path = self.make_temporary_path()
+        path.setContent('foo')
+        self.assertThat(path, file_exists())
+
+    def test_dir_exists(self):
+        """
+        If there is a directory at path, file_exists does not match.
+        """
+        path = self.make_temporary_directory()
+        self.assertThat(path, Not(file_exists()))
+
+    @given(paths)
+    def test_equivalent_to_standard_file_exists(self, path):
+        """
+        file_exists is to FilePaths what FileExists is to normal paths.
+        """
+        self.assertThat(
+            file_exists().match(path),
+            is_equivalent_mismatch(FileExists().match(path.path)),
         )

--- a/flocker/testtools/test/test_matchers.py
+++ b/flocker/testtools/test/test_matchers.py
@@ -1,16 +1,41 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
+from hypothesis import given
+from testtools.matchers import AfterPreprocessing, Equals, Is, Not, PathExists
 from twisted.python.filepath import FilePath
 
-from testtools.matchers import Not
 
 from .. import TestCase
+from ..strategies import paths
 from ..matchers import (
     path_exists,
 )
 
 
+def is_equivalent_mismatch(expected):
+    """
+    Matches another mismatch.
+
+    :param Optional[Mismatch] expected: If None, then match None,
+        otherwise, match a mismatch that has the same description and details.
+    :rtype: Matcher
+    """
+    def to_dict(mismatch):
+        return {
+            'details': mismatch.get_details(),
+            'description': mismatch.describe(),
+        }
+    if expected is None:
+        return Is(None)
+    # XXX: This should really be a standard combinator.
+    return AfterPreprocessing(
+        to_dict, Equals(to_dict(expected)), annotate=False)
+
+
 class PathExistsTests(TestCase):
+    """
+    Tests for :py:func:`path_exists`.
+    """
 
     def test_does_not_exist(self):
         """
@@ -34,3 +59,10 @@ class PathExistsTests(TestCase):
         path = FilePath(self.mktemp())
         path.makedirs()
         self.assertThat(path, path_exists())
+
+    @given(paths)
+    def test_equivalent_to_standard_path_exists(self, path):
+        self.assertThat(
+            path_exists().match(path),
+            is_equivalent_mismatch(PathExists().match(path.path)),
+        )

--- a/flocker/testtools/test/test_matchers.py
+++ b/flocker/testtools/test/test_matchers.py
@@ -1,0 +1,36 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+from twisted.python.filepath import FilePath
+
+from testtools.matchers import Not
+
+from .. import TestCase
+from ..matchers import (
+    path_exists,
+)
+
+
+class PathExistsTests(TestCase):
+
+    def test_does_not_exist(self):
+        """
+        If the path does not exist, path_exists does not match.
+        """
+        path = FilePath(self.mktemp())
+        self.assertThat(path, Not(path_exists()))
+
+    def test_file_exists(self):
+        """
+        If there is a file at path, path_exists matches.
+        """
+        path = FilePath(self.mktemp())
+        path.setContent('foo')
+        self.assertThat(path, path_exists())
+
+    def test_dir_exists(self):
+        """
+        If there is a directory at path, path_exists matches.
+        """
+        path = FilePath(self.mktemp())
+        path.makedirs()
+        self.assertThat(path, path_exists())

--- a/flocker/testtools/test/test_matchers.py
+++ b/flocker/testtools/test/test_matchers.py
@@ -185,6 +185,11 @@ class FileContainsTests(TestCase):
 
     @given(observed=binary(average_size=10), expected=binary(average_size=10))
     def test_file_exists_content_mismatch(self, observed, expected):
+        """
+        If the file exists, the content is matched against the given matcher.
+        If it mismatches, the message includes both the filename and the
+        message from the underlying matcher.
+        """
         assume(observed != expected)
         matcher = Equals(expected)
         path = self.make_temporary_path()
@@ -198,6 +203,10 @@ class FileContainsTests(TestCase):
 
     @given(content=binary(average_size=10))
     def test_file_exists_content_match(self, content):
+        """
+        If the file exists, the content is matched against the given matcher.
+        If it matches, then the overall matcher also matches.
+        """
         path = self.make_temporary_path()
         path.setContent(content)
         self.assertThat(path, file_contents(Equals(content)))


### PR DESCRIPTION
Adds new helper methods to our base test cases:

* `make_temporary_path` – like `mktemp`, but returns a `FilePath`
* `make_temporary_directory` – returns a temporary directory as a `FilePath`
* `make_temporary_file` – returns a temporary file, with optional content

Adds a new `flocker.testtools.matchers` module that provides `FilePath`-related matchers:

* `path_exists` – matches if a `FilePath` exists on disk
* `dir_exists` – matches if a `FilePath` exists and is a directory
* `file_exists` – matches if a `FilePath` exists and is a file
* `file_contents` – matches on the contents of a file if it exists

Note that `file_contents` is analogous to `testtools.matchers.FileContains` but different in that it _always_ takes a matcher and has a name that reflects this.

In order to make writing the above matchers easier, I added:

* `after` – a thing like `AfterPreprocessing` that operates on Matcher factories
* `on_mismatch` – like `after`, but applies to mismatches
* `OnMismatch` – life `AfterPreprocessing`, but applies to mismatches
* A new `_Mismatch` type that also stores the mismatched object, to allow for better composition

None of these have direct tests, as they came out of refactoring efforts.

In order to make _testing_ these changes easier, I added a `flocker.testtools.strategies` module that collates existing strategies and adds a couple for file paths. I also added a helper for creating simple test cases.

There are also unrelated lint fixes to `flocker/testtools/__init__.py`.

Apologies for the size of this PR. I was originally going to focus on the matchers, but found that doing the temp helpers was a natural pair.