### PR TITLE
[FLOC-3873] Generate a second set of jobs for release builds that don't merge master.

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -714,7 +714,8 @@ branches.each {
     println("iterating over branch... ${it}")
     branchName = it
     dashBranchName = branchName.replace("/","-")
-    isReleaseBuild = branchName.startsWith("target-branch-")
+    // our convention for release branches is release/flocker-<version>
+    isReleaseBuild = branchName.startsWith("release/*")
 
     generate_jobs_for_branch(dashProject, dashBranchName, branchName, false)
 


### PR DESCRIPTION
Release builds shouldn't merge in to master before running. Firstly
this will sometimes fail for good reason, but more importantly
the merge isn't the code we want to test.

Any branch that named release/* will get a second set of jobs
generated that don't do the merge.