### PR TITLE
[FLOC-3893] Add a cleanup of the bind mount.

### DIFF
--- a/flocker/node/agents/test/test_blockdevice_manager.py
+++ b/flocker/node/agents/test/test_blockdevice_manager.py
@@ -174,6 +174,7 @@ class BlockDeviceManagerTests(TestCase):
         src_directory = self._get_directory_for_mount()
         target_directory = self._get_directory_for_mount()
         self.manager_under_test.bind_mount(src_directory, target_directory)
+        self.addCleanup(self.manager_under_test.unmount, target_directory)
         for create, view in [(target_directory, src_directory),
                              (src_directory, target_directory)]:
             filename = str(uuid4())


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3893

Unfortunately I had could only reproduce the issue on an AWS Ubuntu instance. See the following gist for the logs of my run of the test that convinced me the issue is fixed:

https://gist.github.com/sarum90/db5e48b613f07678d887