### PR TITLE
[FLOC-3895] Count timeout for effect retry from the first effect failure

### DIFF
--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -252,7 +252,8 @@ def retry_effect_with_timeout(effect, timeout, retry_wait=timedelta(seconds=1),
     algorithm by default, waiting double the time between each retry.
 
     :param Effect effect: The Effect to retry.
-    :param int timeout: Keep retrying until timeout.
+    :param int timeout: Keep retrying until timeout.  This is measured from the
+        time of the first failure of ``effect``.
     :param timedelta retry_wait: The wait time between retries
     :param bool backoff: Whether we should use exponential backoff
     :param callable time: A nullary callable that returns a UNIX timestamp.


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3895