### PR TITLE
[FLOC-3891] Helpers for making files and directories 

### DIFF
--- a/flocker/common/__init__.py
+++ b/flocker/common/__init__.py
@@ -14,7 +14,7 @@ from bitmath import GiB as _GiB
 from ._ipc import INode, FakeNode, ProcessNode
 from ._defer import gather_deferreds
 from ._thread import auto_threaded
-from ._filepath import make_file
+from ._filepath import make_directory, make_file
 from ._interface import interface_decorator, provides
 from ._net import get_all_ips, ipaddress_from_string
 from ._retry import (
@@ -36,7 +36,7 @@ __all__ = [
     'RACKSPACE_MINIMUM_VOLUME_SIZE',
     'DEVICEMAPPER_LOOPBACK_SIZE',
 
-    'make_file',
+    'make_directory', 'make_file',
 ]
 
 # This is currently set to the minimum size for a SATA based Rackspace Cloud

--- a/flocker/common/__init__.py
+++ b/flocker/common/__init__.py
@@ -14,6 +14,7 @@ from bitmath import GiB as _GiB
 from ._ipc import INode, FakeNode, ProcessNode
 from ._defer import gather_deferreds
 from ._thread import auto_threaded
+from ._filepath import make_file
 from ._interface import interface_decorator, provides
 from ._net import get_all_ips, ipaddress_from_string
 from ._retry import (
@@ -34,6 +35,8 @@ __all__ = [
 
     'RACKSPACE_MINIMUM_VOLUME_SIZE',
     'DEVICEMAPPER_LOOPBACK_SIZE',
+
+    'make_file',
 ]
 
 # This is currently set to the minimum size for a SATA based Rackspace Cloud

--- a/flocker/common/_filepath.py
+++ b/flocker/common/_filepath.py
@@ -16,3 +16,13 @@ def make_file(path, content='', permissions=None):
     path.setContent(content)
     if permissions is not None:
         path.chmod(permissions)
+
+
+def make_directory(path):
+    """
+    Create a directory at ``path``.
+
+    :param FilePath path: The place to create a directory.
+    """
+    if not path.isdir():
+        path.makedirs()

--- a/flocker/common/_filepath.py
+++ b/flocker/common/_filepath.py
@@ -5,6 +5,14 @@ Helpers for :py:class:`~twisted.python.filepath.FilePath`.
 """
 
 
-def make_file(path, content, permissions):
+def make_file(path, content='', permissions=None):
+    """
+    Create a file with given content and permissions.
+
+    :param FilePath path: Path to create the file.
+    :param str content: Content to write to the file. If not specified,
+    :param int permissions: Unix file permissions to be passed to ``chmod``.
+    """
     path.setContent(content)
-    path.chmod(permissions)
+    if permissions is not None:
+        path.chmod(permissions)

--- a/flocker/common/_filepath.py
+++ b/flocker/common/_filepath.py
@@ -1,0 +1,10 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Helpers for :py:class:`~twisted.python.filepath.FilePath`.
+"""
+
+
+def make_file(path, content, permissions):
+    path.setContent(content)
+    path.chmod(permissions)

--- a/flocker/common/_filepath.py
+++ b/flocker/common/_filepath.py
@@ -9,13 +9,20 @@ def make_file(path, content='', permissions=None):
     """
     Create a file with given content and permissions.
 
+    Don't use this for sensitive content, as the permissions are applied
+    *after* the data is written to the filesystem.
+
     :param FilePath path: Path to create the file.
     :param str content: Content to write to the file. If not specified,
     :param int permissions: Unix file permissions to be passed to ``chmod``.
+
+    :return: ``path``, unmodified.
+    :rtype: :py:class:`twisted.python.filepath.FilePath`
     """
     path.setContent(content)
     if permissions is not None:
         path.chmod(permissions)
+    return path
 
 
 def make_directory(path):
@@ -23,6 +30,11 @@ def make_directory(path):
     Create a directory at ``path``.
 
     :param FilePath path: The place to create a directory.
+
+    :raise OSError: If path already exists and is not a directory.
+    :return: ``path``, unmodified.
+    :rtype: :py:class:`twisted.python.filepath.FilePath`
     """
     if not path.isdir():
         path.makedirs()
+    return path

--- a/flocker/common/test/test_filepath.py
+++ b/flocker/common/test/test_filepath.py
@@ -26,14 +26,23 @@ class MakeFileTests(TestCase):
     Tests for :py:func:`make_file`.
     """
 
-    @given(content=binary(average_size=20), permissions=permissions)
-    def test_make_file(self, content, permissions):
+    @given(content=binary(average_size=20), perms=permissions)
+    def test_make_file(self, content, perms):
         """
         ``make_file`` creates a file with the given content and permissions.
         """
         path = self.make_temporary_path()
-        make_file(path, content, permissions)
+        make_file(path, content, perms)
         self.addCleanup(path.remove)
-        self.expectThat(path, with_permissions(Equals(permissions)))
+        self.expectThat(path, with_permissions(Equals(perms)))
         path.chmod(0600)
         self.assertThat(path, file_contents(Equals(content)))
+
+    def test_make_file_defaults(self):
+        """
+        By default, ``make_file`` creates an empty file.
+        """
+        path = self.make_temporary_path()
+        make_file(path)
+        self.addCleanup(path.remove)
+        self.assertThat(path, file_contents(Equals('')))

--- a/flocker/common/test/test_filepath.py
+++ b/flocker/common/test/test_filepath.py
@@ -1,0 +1,39 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for :py:class:`~twisted.python.FilePath` helpers.
+"""
+
+import stat
+
+from hypothesis import given
+from hypothesis.strategies import binary
+from testtools.matchers import Equals
+
+from ...testtools import TestCase
+from ...testtools.matchers import file_contents, with_permissions
+from ...testtools.strategies import permissions
+
+from .. import make_file
+
+
+user_rw = stat.S_IRUSR | stat.S_IWUSR
+user_rw_perms = permissions.filter(lambda x: x & user_rw == user_rw)
+
+
+class MakeFileTests(TestCase):
+    """
+    Tests for :py:func:`make_file`.
+    """
+
+    @given(content=binary(average_size=20), permissions=permissions)
+    def test_make_file(self, content, permissions):
+        """
+        ``make_file`` creates a file with the given content and permissions.
+        """
+        path = self.make_temporary_path()
+        make_file(path, content, permissions)
+        self.addCleanup(path.remove)
+        self.expectThat(path, with_permissions(Equals(permissions)))
+        path.chmod(0600)
+        self.assertThat(path, file_contents(Equals(content)))

--- a/flocker/common/test/test_filepath.py
+++ b/flocker/common/test/test_filepath.py
@@ -35,8 +35,10 @@ class MakeFileTests(TestCase):
         path = self.make_temporary_path()
         make_file(path, content, perms)
         self.addCleanup(path.remove)
-        self.expectThat(path, with_permissions(Equals(perms)))
-        path.chmod(0600)
+        try:
+            self.assertThat(path, with_permissions(Equals(perms)))
+        finally:
+            path.chmod(0600)
         self.assertThat(path, file_contents(Equals(content)))
 
     def test_make_file_defaults(self):
@@ -72,7 +74,10 @@ class MakeDirectoryTests(TestCase):
 
     def test_make_directory_file_exists(self):
         """
-        If the file exists, ``make_directory`` does something.
+        If the file exists, ``make_directory`` raises an OSError with EEXIST.
+
+        There is no particular reason for this exception rather than any
+        other.
         """
         path = self.make_temporary_file()
         error = self.assertRaises(OSError, make_directory, path)

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -81,9 +81,7 @@ class _MktempMixin(object):
         :return: Path to file.
         :rtype: FilePath
         """
-        path = self.make_temporary_path()
-        make_file(path, content, permissions)
-        return path
+        return make_file(self.make_temporary_path(), content, permissions)
 
 
 class _DeferredAssertionMixin(object):

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -35,6 +35,7 @@ from twisted.python import log
 from twisted.python.filepath import FilePath
 from twisted.trial import unittest
 
+from ..common import make_file
 from ._flaky import retry_flaky
 
 
@@ -71,16 +72,17 @@ class _MktempMixin(object):
         """
         return make_temporary_directory(_path_for_test(self))
 
-    def make_temporary_file(self, content=''):
+    def make_temporary_file(self, content='', permissions=None):
         """
         Create a temporary file for use in tests.
 
         :param str content: Content to write to the file.
+        :param int permissions: The permissions for the file
         :return: Path to file.
         :rtype: FilePath
         """
         path = self.make_temporary_path()
-        path.setContent(content)
+        make_file(path, content, permissions)
         return path
 
 

--- a/flocker/testtools/matchers.py
+++ b/flocker/testtools/matchers.py
@@ -4,6 +4,9 @@
 testtools matchers used in Flocker tests.
 """
 
+from functools import partial
+import os
+
 from pyrsistent import PClass, field, pmap_field
 from testtools.content import Content
 from testtools.matchers import (
@@ -201,3 +204,11 @@ def file_contents(matcher):
             AfterPreprocessing(get_content, matcher, annotate=False)),
         first_only=True,
     )
+
+
+with_permissions = partial(
+    AfterPreprocessing,
+    lambda filepath: os.stat(filepath.path).st_mode & 07777)
+"""
+Match if path has the given permissions.
+"""

--- a/flocker/testtools/strategies.py
+++ b/flocker/testtools/strategies.py
@@ -2,7 +2,7 @@
 
 import string
 
-from hypothesis.strategies import lists, text
+from hypothesis.strategies import integers, lists, text
 from twisted.python.filepath import FilePath
 
 
@@ -46,4 +46,10 @@ fqpns = lists(
 Fully-qualified Python names.
 
 e.g. ``twisted.internet.defer.Deferred``, ``foo.bar.baz_qux``.
+"""
+
+
+permissions = integers(min_value=0, max_value=07777)
+"""
+Unix file permissions.
 """


### PR DESCRIPTION
Adds new helpers in `flocker.common`:

* `make_file` – create a file with content and permissions
* `make_directory` – create a directory, or do nothing when a directory already exists

Similar code is repeated a lot throughout the code base, so I thought it might be nice to have something more intent-revealing.

Further:

* generators for Unix permissions
* matcher for Unix permissions
* `make_temporary_file` now takes optional permissions

This answers an in-person question asked by @avg-I.
