### PR TITLE
[FLOC-3841] Add timeout to benchmark container and dataset creation.

### DIFF
--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -4,6 +4,7 @@ Operation to create a container.
 """
 
 from functools import partial
+from datetime import timedelta
 from uuid import UUID, uuid4
 
 from pyrsistent import PClass, field
@@ -17,7 +18,7 @@ from benchmark._interfaces import IProbe, IOperation
 from benchmark.operations._common import select_node
 
 
-DEFAULT_TIMEOUT = 600
+DEFAULT_TIMEOUT = timedelta(minutes=10)
 
 
 def loop_until_state_found(reactor, get_states, state_matches, timeout):
@@ -28,7 +29,7 @@ def loop_until_state_found(reactor, get_states, state_matches, timeout):
         of states.
     :param state_matches: Callable that accepts a state parameter, and
         returns a boolean indicating whether the state matches.
-    :param int timeout: Maximum seconds to wait for state to be found.
+    :param timedelta timeout: Maximum time to wait for state to be found.
     :return Deferred[Any]: The matching state.
     """
     def state_reached():
@@ -44,7 +45,7 @@ def loop_until_state_found(reactor, get_states, state_matches, timeout):
         return d
 
     d = loop_until(reactor, state_reached)
-    _timeout(reactor, d, timeout)
+    _timeout(reactor, d, timeout.total_seconds())
     return d
 
 
@@ -61,7 +62,8 @@ def create_dataset(
     :param UUID node_uuid: Node on which to create dataset.
     :param UUID dataset_id: ID for created dataset.
     :param int volume_size: Size of volume in bytes.
-    :param int timeout: Maximum seconds to wait for dataset to be mounted.
+    :param timedelta timeout: Maximum time to wait for dataset to be
+        mounted.
     :return Deferred[DatasetState]: The state of the created dataset.
     """
 
@@ -103,7 +105,8 @@ def create_container(
     :param DockerImage image: Docker image for the container.
     :param Optional[Sequence[MountedDataset]] volumes: Volumes to attach
         to the container.
-    :param int timeout: Maximum seconds to wait for container to be created.
+    :param timedelta timeout: Maximum time to wait for container to be
+        created.
     :return Deferred[ContainerState]: The state of the created container.
     """
 

--- a/benchmark/operations/test/test_create_container.py
+++ b/benchmark/operations/test/test_create_container.py
@@ -113,7 +113,7 @@ class CreateContainerTests(TestCase):
             return d
         d.addCallback(run_probe)
 
-        clock.advance(DEFAULT_TIMEOUT)
+        clock.advance(DEFAULT_TIMEOUT.total_seconds())
 
         # No control_service.synchronize_state() call, so cluster state
         # never shows container is created.

--- a/benchmark/operations/test/test_create_container.py
+++ b/benchmark/operations/test/test_create_container.py
@@ -136,11 +136,9 @@ class CreateContainerTests(TestCase):
         clock.advance(1)
 
         # get_probe has completed successfully
-        self.successResultOf(d)
+        probe = self.successResultOf(d)
 
-        def run_probe(probe):
-            return probe.run()
-        d.addCallback(run_probe)
+        d = probe.run()
 
         clock.advance(DEFAULT_TIMEOUT.total_seconds())
 


### PR DESCRIPTION
The benchmark script waits for datasets and containers to be created. Occasionally, this may fail, either due to incorrect configuration or Docker getting into a bad state.  Rather than have the benchmark script hang indefinitely, have it timeout.

The timeout is set to 10 minutes, which is a reasonable first guess for a liveable value.  It is not configurable at this stage.