### PR TITLE
[FLOC-3885] generate and save managed config for a newly created cluster

### DIFF
--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -171,10 +171,15 @@ def main(reactor, args, base_path, top_level):
     try:
         yield runner.ensure_keys(reactor)
         cluster = yield runner.start_cluster(reactor)
-        managed_config = options['cert-directory'].child("managed.yaml")
-        managed_config.setContent(
-            yaml.safe_dump(generate_managed_config(cluster))
+
+        managed_config_file = options['cert-directory'].child("managed.yaml")
+        managed_config = dict()
+        managed_config.update(options['config'])
+        managed_config.update(generate_managed_config(cluster))
+        managed_config_file.setContent(
+            yaml.safe_dump(managed_config, default_flow_style=False)
         )
+
         if options['distribution'] in ('centos-7',):
             remote_logs_file = open("remote_logs.log", "a")
             for node in cluster.all_nodes:

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -3,6 +3,7 @@
 Set up a Flocker cluster.
 """
 
+import stat
 import string
 import sys
 import yaml
@@ -117,6 +118,7 @@ def _ensure_empty_directory(path):
 
     try:
         path.makedirs()
+        path.chmod(stat.S_IRWXU)
     except OSError as e:
         raise UsageError(
             "Can not create {}. {}: {}.".format(path.path, e.filename,

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -207,14 +207,25 @@ def main(reactor, args, base_path, top_level):
                 print("Didn't finish creating the cluster.")
                 runner.stop_cluster(reactor)
             else:
-                print("The following variables describe the cluster:")
                 environment_variables = get_trial_environment(cluster)
+                environment_strings = list()
                 for environment_variable in environment_variables:
-                    print("export {name}={value};".format(
-                        name=environment_variable,
-                        value=shell_quote(
-                            environment_variables[environment_variable]),
-                    ))
+                    environment_strings.append(
+                        "export {name}={value};\n".format(
+                            name=environment_variable,
+                            value=shell_quote(
+                                environment_variables[environment_variable]
+                            ),
+                        )
+                    )
+                environment = ''.join(environment_strings)
+                print("The following variables describe the cluster:")
+                print(environment)
+                env_file = options['cert-directory'].child("environment.env")
+                env_file.setContent(environment)
+                print("The variables are also saved in {}".format(
+                    env_file.path
+                ))
                 print("Be sure to preserve the required files.")
 
     raise SystemExit(result)

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -133,7 +133,10 @@ def generate_managed_config(cluster):
             addresses.append([node.private_address, node.address])
         else:
             addresses.append(node.address)
-    return {"managed": {"addresses": addresses}}
+    config = dict()
+    config["addresses"] = addresses
+    config["upgrade"] = True
+    return {"managed": config}
 
 
 @inlineCallbacks


### PR DESCRIPTION
This is useful for the easy re-use of the cluster nodes for a new cluster.
Along with `managed.yaml` we also now save a `environment.env` file that contains all the
environment variables needed for running acceptance tests on the cluster
(and potentially interacting with it in other useful ways).