### PR TITLE
[FLOC-3882] Docker plugin: add support for VolumeDriver.List and VolumeDriver.Get

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -12,6 +12,7 @@ You can learn more about where we might be going with future releases by:
 Next Next Release
 =================
 
+* The :ref:`Flocker Plugin for Docker<docker-plugin>` should support the direct volume listing and inspection functionality added to Docker 1.10.
 * Fixed a regression that caused block device agents to poll backend APIs like EBS too frequently in some circumstances.
 
 Next Release

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -446,3 +446,47 @@ class DockerPluginTests(AsyncTestCase):
         volume on a different machine.
         """
         return self._test_move(cluster, cluster.nodes[0], cluster.nodes[1])
+
+    @require_cluster(1)
+    def test_inspect(self, cluster):
+        """
+        A volume created outside of Docker can be inspected via the Docker
+        Volume API.
+
+        :param cluster: Flocker cluster.
+        """
+        self.require_docker('1.10.0', cluster)
+        name = random_name(self)
+
+        d = create_dataset(self, cluster, metadata={u"name": name})
+
+        def created(_):
+            client = get_docker_client(
+                cluster, cluster.nodes[0].public_address)
+            info = client.inspect_volume(name)
+            self.assertEqual((info[u"Driver"], info[u"Name"]),
+                             (u"flocker", name))
+        d.addCallback(created)
+        return d
+
+    @require_cluster(1)
+    def test_listed(self, cluster):
+        """
+        A volume created outside of Docker can be listed via the Docker
+        Volume API.
+
+        :param cluster: Flocker cluster.
+        """
+        self.require_docker('1.10.0', cluster)
+        name = random_name(self)
+
+        d = create_dataset(self, cluster, metadata={u"name": name})
+
+        def created(_):
+            client = get_docker_client(
+                cluster, cluster.nodes[0].public_address)
+            our_volume = [v[u"Driver"] for v in client.volumes()
+                          if v[u"Name"] == name]
+            self.assertEqual(our_volume, [u"flocker"])
+        d.addCallback(created)
+        return d

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -485,7 +485,7 @@ class DockerPluginTests(AsyncTestCase):
         def created(_):
             client = get_docker_client(
                 cluster, cluster.nodes[0].public_address)
-            our_volume = [v[u"Driver"] for v in client.volumes()
+            our_volume = [v[u"Driver"] for v in client.volumes()[u"Volumes"]
                           if v[u"Name"] == name]
             self.assertEqual(our_volume, [u"flocker"])
         d.addCallback(created)

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -371,3 +371,28 @@ class VolumePlugin(object):
                         u"Mountpoint": path.path}
         d.addCallback(got_path)
         return d.result
+
+    @app.route("/VolumeDriver.Get", methods=["POST"])
+    @_endpoint(u"Get")
+    def volumedriver_get(self, Name):
+        """
+        Return information about the current state of a particular volume.
+
+        :param unicode Name: The name of the volume.
+
+        :return: Result indicating success.
+        """
+        d = DeferredContext(self._dataset_id_for_name(Name))
+        d.addCallback(self._get_path_from_dataset_id)
+
+        def got_path(path):
+            if path is None:
+                path = u""
+            else:
+                path = path.path
+            return {u"Err": u"",
+                    u"Volume": {
+                        u"Name": Name,
+                        u"Mountpoint": path}}
+        d.addCallback(got_path)
+        return d.result

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -41,7 +41,8 @@ SCHEMAS = {
     b'/endpoints.json': yaml.safe_load(
         SCHEMA_BASE.child(b'endpoints.yml').getContent()),
     }
-
+# Metadata field we use to store volume names:
+NAME_FIELD = u"name"
 
 # The default size of a created volume. Pick a number that isn't the same
 # as devicemapper loopback size (100GiB) so we don't trigger
@@ -227,7 +228,7 @@ class VolumePlugin(object):
 
         def got_configured(configured):
             for dataset in configured:
-                if dataset.metadata.get(u"name") == name:
+                if dataset.metadata.get(NAME_FIELD) == name:
                     return dataset.dataset_id
             raise NOT_FOUND_RESPONSE
 
@@ -263,7 +264,7 @@ class VolumePlugin(object):
 
         :return: Result indicating success.
         """
-        metadata = {u"name": Name}
+        metadata = {NAME_FIELD: Name}
         opts = Opts or {}
         profile = opts.get(u"profile")
         if profile:
@@ -278,7 +279,7 @@ class VolumePlugin(object):
 
         def ensure_unique_name(configured):
             for dataset in configured:
-                if dataset.metadata.get(u"name") == Name:
+                if dataset.metadata.get(NAME_FIELD) == Name:
                     raise DatasetAlreadyExists
 
         creating = conditional_create(
@@ -411,9 +412,9 @@ class VolumePlugin(object):
             results = []
             for dataset in configured:
                 # Datasets without a name can't be used by the Docker plugin:
-                if u"name" not in dataset.metadata:
+                if NAME_FIELD not in dataset.metadata:
                     continue
-                name = dataset.metadata[u"name"]
+                name = dataset.metadata[NAME_FIELD]
                 d = self._get_path_from_dataset_id(dataset.dataset_id)
                 d.addCallback(lambda path: (path, name))
                 results.append(d)

--- a/flocker/dockerplugin/schema/endpoints.yml
+++ b/flocker/dockerplugin/schema/endpoints.yml
@@ -69,3 +69,24 @@ definitions:
     required:
       - "Err"
     additionalProperties: false
+
+  Get:
+    description: "Get response."
+    type: object
+    properties:
+      Err:
+        '$ref': 'types.json#/definitions/Err'
+      Volume:
+        type: object
+        properties:
+          Mountpoint:
+            type: string
+          Name:
+            type: string
+        required:
+          - "Mountpoint"
+          - "Name"
+        additionalProperties: false
+    required:
+      - "Err"
+    additionalProperties: false

--- a/flocker/dockerplugin/schema/endpoints.yml
+++ b/flocker/dockerplugin/schema/endpoints.yml
@@ -77,16 +77,21 @@ definitions:
       Err:
         '$ref': 'types.json#/definitions/Err'
       Volume:
-        type: object
-        properties:
-          Mountpoint:
-            type: string
-          Name:
-            type: string
-        required:
-          - "Mountpoint"
-          - "Name"
-        additionalProperties: false
+        '$ref': 'types.json#/definitions/VolumeInspect'
+    required:
+      - "Err"
+    additionalProperties: false
+
+  List:
+    description: "List response."
+    type: object
+    properties:
+      Err:
+        '$ref': 'types.json#/definitions/Err'
+      Volumes:
+        type: array
+        items:
+          '$ref': 'types.json#/definitions/VolumeInspect'
     required:
       - "Err"
     additionalProperties: false

--- a/flocker/dockerplugin/schema/types.yml
+++ b/flocker/dockerplugin/schema/types.yml
@@ -7,3 +7,17 @@ definitions:
     type:
       - "string"
       - "null"
+
+  VolumeInspect:
+    title: "Volume info"
+    description: "Volume information for Get and List."
+    type: object
+    properties:
+      Mountpoint:
+        type: string
+      Name:
+        type: string
+    required:
+      - "Mountpoint"
+      - "Name"
+    additionalProperties: false

--- a/flocker/dockerplugin/schema/types.yml
+++ b/flocker/dockerplugin/schema/types.yml
@@ -3,7 +3,7 @@ id: http://api.clusterhq.com/dockerplugin/types.json
 definitions:
   Err:
     title: "Error response"
-    description: "Null indicates success, string indicates error."
+    description: "Null indicates success, non-empty string indicates error."
     type:
       - "string"
       - "null"

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -21,7 +21,7 @@ from pyrsistent import pmap
 
 from eliot.testing import capture_logging
 
-from .._api import VolumePlugin, DEFAULT_SIZE, parse_num
+from .._api import VolumePlugin, DEFAULT_SIZE, parse_num, NAME_FIELD
 from ...apiclient import FakeFlockerClient, Dataset, DatasetsConfiguration
 from ...testtools import CustomException, random_name
 
@@ -138,7 +138,7 @@ class APITestsMixin(APIAssertionsMixin):
                               Dataset(dataset_id=result[0].dataset_id,
                                       primary=self.NODE_A,
                                       maximum_size=int(DEFAULT_SIZE.to_Byte()),
-                                      metadata={u"name": name,
+                                      metadata={NAME_FIELD: name,
                                                 u"clusterhq:flocker:profile":
                                                 unicode(profile)})]))
         return d
@@ -167,7 +167,7 @@ class APITestsMixin(APIAssertionsMixin):
                               Dataset(dataset_id=result[0].dataset_id,
                                       primary=self.NODE_A,
                                       maximum_size=real_size,
-                                      metadata={u"name": name,
+                                      metadata={NAME_FIELD: name,
                                                 u"maximum_size":
                                                 unicode(real_size)})]))
         return d
@@ -248,7 +248,7 @@ class APITestsMixin(APIAssertionsMixin):
                               Dataset(dataset_id=result[0].dataset_id,
                                       primary=self.NODE_A,
                                       maximum_size=int(DEFAULT_SIZE.to_Byte()),
-                                      metadata={u"name": name})]))
+                                      metadata={NAME_FIELD: name})]))
         return d
 
     def test_create_duplicate_name(self):
@@ -260,7 +260,8 @@ class APITestsMixin(APIAssertionsMixin):
         # Create a dataset out-of-band with matching name but non-matching
         # dataset ID:
         d = self.flocker_client.create_dataset(
-            self.NODE_A, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name})
+            self.NODE_A, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name})
         d.addCallback(lambda _: self.create(name))
         d.addCallback(
             lambda _: self.flocker_client.list_datasets_configuration())
@@ -284,7 +285,7 @@ class APITestsMixin(APIAssertionsMixin):
             # its existence:
             d = self.flocker_client.create_dataset(
                 self.NODE_A, int(DEFAULT_SIZE.to_Byte()),
-                metadata={u"name": name})
+                metadata={NAME_FIELD: name})
             d.addCallback(lambda _: DatasetsConfiguration(
                 tag=u"1234", datasets={}))
             return d
@@ -322,7 +323,8 @@ class APITestsMixin(APIAssertionsMixin):
 
         # Create dataset on a different node:
         d = self.flocker_client.create_dataset(
-            self.NODE_B, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name},
+            self.NODE_B, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name},
             dataset_id=dataset_id)
 
         self._flush_volume_plugin_reactor_on_endpoint_render()
@@ -363,7 +365,8 @@ class APITestsMixin(APIAssertionsMixin):
         dataset_id = uuid4()
         # Create dataset on a different node:
         d = self.flocker_client.create_dataset(
-            self.NODE_B, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name},
+            self.NODE_B, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name},
             dataset_id=dataset_id)
 
         self._flush_volume_plugin_reactor_on_endpoint_render()
@@ -391,7 +394,8 @@ class APITestsMixin(APIAssertionsMixin):
         name = u"myvol"
 
         d = self.flocker_client.create_dataset(
-            self.NODE_A, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name})
+            self.NODE_A, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name})
 
         def created(dataset):
             self.flocker_client.synchronize_state()
@@ -454,7 +458,8 @@ class APITestsMixin(APIAssertionsMixin):
         name = u"myvol"
 
         d = self.flocker_client.create_dataset(
-            self.NODE_A, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name})
+            self.NODE_A, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name})
 
         def created(dataset):
             self.flocker_client.synchronize_state()
@@ -493,7 +498,8 @@ class APITestsMixin(APIAssertionsMixin):
 
         # Create dataset on node B:
         d = self.flocker_client.create_dataset(
-            self.NODE_B, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name},
+            self.NODE_B, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name},
             dataset_id=dataset_id)
         d.addCallback(lambda _: self.flocker_client.synchronize_state())
 
@@ -598,7 +604,8 @@ class APITestsMixin(APIAssertionsMixin):
         name = u"myvol"
 
         d = self.flocker_client.create_dataset(
-            self.NODE_A, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name})
+            self.NODE_A, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name})
 
         def created(dataset):
             self.flocker_client.synchronize_state()
@@ -634,7 +641,8 @@ class APITestsMixin(APIAssertionsMixin):
 
         # Create dataset on node B:
         d = self.flocker_client.create_dataset(
-            self.NODE_B, int(DEFAULT_SIZE.to_Byte()), metadata={u"name": name},
+            self.NODE_B, int(DEFAULT_SIZE.to_Byte()),
+            metadata={NAME_FIELD: name},
             dataset_id=dataset_id)
         d.addCallback(lambda _: self.flocker_client.synchronize_state())
 
@@ -661,10 +669,10 @@ class APITestsMixin(APIAssertionsMixin):
         d = gatherResults([
             self.flocker_client.create_dataset(
                 self.NODE_A, int(DEFAULT_SIZE.to_Byte()),
-                metadata={u"name": name}),
+                metadata={NAME_FIELD: name}),
             self.flocker_client.create_dataset(
                 self.NODE_B, int(DEFAULT_SIZE.to_Byte()),
-                metadata={u"name": remote_name})])
+                metadata={NAME_FIELD: remote_name})])
 
         # The datasets arrive as state:
         d.addCallback(lambda _: self.flocker_client.synchronize_state())

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -123,3 +123,37 @@ GetTests = build_schema_test(
                 "Name": "x",
                 "Mountpoint": "/x/"}},
         ])
+
+
+ListTests = build_schema_test(
+        name=str("GetTests"),
+        schema={"$ref": "/endpoints.json#/definitions/List"},
+        schema_store=SCHEMAS,
+        failing_instances=[
+            # Wrong types:
+            [], "", None,
+            # Missing field:
+            {}, {"Volumes": []},
+            # Wrong fields:
+            {"Result": "hello"},
+            # Extra field:
+            {"Err": "", "Volumes": [], "extra": "y"},
+            # Missing field:
+            {"Err": "", "Volumes": [{"Mountpoint": "/y"}]},
+            {"Err": "", "Volumes": [{"Name": "/x"}]},
+            # Extra field:
+            {"Err": "", "Volumes": [{"Name": "/x",
+                                     "Mountpoint": "y",
+                                     "extra": "r"}]},
+        ],
+        passing_instances=[
+            {"Err": "Something went wrong."},
+            {"Err": "", "Volumes": [
+                {"Name": "x",
+                 "Mountpoint": "/x/"}]},
+            {"Err": "", "Volumes": [
+                {"Name": "y",
+                 "Mountpoint": "/y/"},
+                {"Name": "x",
+                 "Mountpoint": "/x/"}]},
+        ])

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -93,3 +93,33 @@ def build_path_result_tests(name):
 
 MountTests = build_path_result_tests("Mount")
 PathTests = build_path_result_tests("Path")
+
+
+GetTests = build_schema_test(
+        name=str("GetTests"),
+        schema={"$ref": "/endpoints.json#/definitions/Get"},
+        schema_store=SCHEMAS,
+        failing_instances=[
+            # Wrong types:
+            [], "", None,
+            # Missing field:
+            {}, {"Volume": "/x"},
+            # Wrong fields:
+            {"Result": "hello"},
+            # Extra field:
+            {"Err": "", "Volume": {"Name": "x",
+                                   "Mountpoint": "/y"}, "extra": "y"},
+            # Missing field:
+            {"Err": "", "Volume": {"Mountpoint": "/y"}},
+            {"Err": "", "Volume": {"Name": "/x"}},
+            # Extra field:
+            {"Err": "", "Volume": {"Name": "/x",
+                                   "Mountpoint": "y",
+                                   "extra": "r"}},
+        ],
+        passing_instances=[
+            {"Err": "Something went wrong."},
+            {"Err": "", "Volume": {
+                "Name": "x",
+                "Mountpoint": "/x/"}},
+        ])

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -96,64 +96,64 @@ PathTests = build_path_result_tests("Path")
 
 
 GetTests = build_schema_test(
-        name=str("GetTests"),
-        schema={"$ref": "/endpoints.json#/definitions/Get"},
-        schema_store=SCHEMAS,
-        failing_instances=[
-            # Wrong types:
-            [], "", None,
-            # Missing field:
-            {}, {"Volume": "/x"},
-            # Wrong fields:
-            {"Result": "hello"},
-            # Extra field:
-            {"Err": "", "Volume": {"Name": "x",
-                                   "Mountpoint": "/y"}, "extra": "y"},
-            # Missing field:
-            {"Err": "", "Volume": {"Mountpoint": "/y"}},
-            {"Err": "", "Volume": {"Name": "/x"}},
-            # Extra field:
-            {"Err": "", "Volume": {"Name": "/x",
-                                   "Mountpoint": "y",
-                                   "extra": "r"}},
-        ],
-        passing_instances=[
-            {"Err": "Something went wrong."},
-            {"Err": "", "Volume": {
-                "Name": "x",
-                "Mountpoint": "/x/"}},
-        ])
+    name=str("GetTests"),
+    schema={"$ref": "/endpoints.json#/definitions/Get"},
+    schema_store=SCHEMAS,
+    failing_instances=[
+        # Wrong types:
+        [], "", None,
+        # Missing field:
+        {}, {"Volume": "/x"},
+        # Wrong fields:
+        {"Result": "hello"},
+        # Extra field:
+        {"Err": "", "Volume": {"Name": "x",
+                               "Mountpoint": "/y"}, "extra": "y"},
+        # Missing field:
+        {"Err": "", "Volume": {"Mountpoint": "/y"}},
+        {"Err": "", "Volume": {"Name": "/x"}},
+        # Extra field:
+        {"Err": "", "Volume": {"Name": "/x",
+                               "Mountpoint": "y",
+                               "extra": "r"}},
+    ],
+    passing_instances=[
+        {"Err": "Something went wrong."},
+        {"Err": "", "Volume": {
+            "Name": "x",
+            "Mountpoint": "/x/"}},
+    ])
 
 
 ListTests = build_schema_test(
-        name=str("GetTests"),
-        schema={"$ref": "/endpoints.json#/definitions/List"},
-        schema_store=SCHEMAS,
-        failing_instances=[
-            # Wrong types:
-            [], "", None,
-            # Missing field:
-            {}, {"Volumes": []},
-            # Wrong fields:
-            {"Result": "hello"},
-            # Extra field:
-            {"Err": "", "Volumes": [], "extra": "y"},
-            # Missing field:
-            {"Err": "", "Volumes": [{"Mountpoint": "/y"}]},
-            {"Err": "", "Volumes": [{"Name": "/x"}]},
-            # Extra field:
-            {"Err": "", "Volumes": [{"Name": "/x",
-                                     "Mountpoint": "y",
-                                     "extra": "r"}]},
-        ],
-        passing_instances=[
-            {"Err": "Something went wrong."},
-            {"Err": "", "Volumes": [
-                {"Name": "x",
-                 "Mountpoint": "/x/"}]},
-            {"Err": "", "Volumes": [
-                {"Name": "y",
-                 "Mountpoint": "/y/"},
-                {"Name": "x",
-                 "Mountpoint": "/x/"}]},
-        ])
+    name=str("GetTests"),
+    schema={"$ref": "/endpoints.json#/definitions/List"},
+    schema_store=SCHEMAS,
+    failing_instances=[
+        # Wrong types:
+        [], "", None,
+        # Missing field:
+        {}, {"Volumes": []},
+        # Wrong fields:
+        {"Result": "hello"},
+        # Extra field:
+        {"Err": "", "Volumes": [], "extra": "y"},
+        # Missing field:
+        {"Err": "", "Volumes": [{"Mountpoint": "/y"}]},
+        {"Err": "", "Volumes": [{"Name": "/x"}]},
+        # Extra field:
+        {"Err": "", "Volumes": [{"Name": "/x",
+                                 "Mountpoint": "y",
+                                 "extra": "r"}]},
+    ],
+    passing_instances=[
+        {"Err": "Something went wrong."},
+        {"Err": "", "Volumes": [
+            {"Name": "x",
+             "Mountpoint": "/x/"}]},
+        {"Err": "", "Volumes": [
+            {"Name": "y",
+             "Mountpoint": "/y/"},
+            {"Name": "x",
+             "Mountpoint": "/x/"}]},
+    ])


### PR DESCRIPTION
`docker volume ls` and `docker volume inspect` now use the Docker volume plugin API.

This adds support for the two new calls:
https://github.com/docker/docker/blob/master/docs/extend/plugins_volume.md#volumedriverget

Note that at some point Docker changed their docs to say one should return `"Err": ""` for non-errors; it used to say `"Err": null`. I will do follow up branch to address this for existing commands, but did the new way for the new commands.

I ran the new acceptance tests with an experimental Docker build (`1.10.0-dev`):

```
$ trial flocker.acceptance.endtoend.test_dockerplugin.DockerPluginTests.test_{listed,inspect}
flocker.acceptance.endtoend.test_dockerplugin
  DockerPluginTests
    test_listed ...                                                        [OK]
    test_inspect ...                                                       [OK]

-------------------------------------------------------------------------------
Ran 2 tests in 84.871s

PASSED (successes=2)
```