### PR TITLE
[FLOC-3904] Match Docker plugin API docs

### DIFF
--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -193,7 +193,7 @@ class VolumePlugin(object):
 
         :return: Result indicating success.
         """
-        return {u"Err": None}
+        return {u"Err": u""}
 
     @app.route("/VolumeDriver.Unmount", methods=["POST"])
     @_endpoint(u"Unmount")
@@ -209,7 +209,7 @@ class VolumePlugin(object):
 
         :return: Result indicating success.
         """
-        return {u"Err": None}
+        return {u"Err": u""}
 
     def _dataset_id_for_name(self, name):
         """
@@ -286,7 +286,7 @@ class VolumePlugin(object):
             self._flocker_client, self._reactor, ensure_unique_name,
             self._node_id, int(size.to_Byte()), metadata=metadata)
         creating.addErrback(lambda reason: reason.trap(DatasetAlreadyExists))
-        creating.addCallback(lambda _: {u"Err": None})
+        creating.addCallback(lambda _: {u"Err": u""})
         return creating
 
     def _get_path_from_dataset_id(self, dataset_id):
@@ -334,7 +334,7 @@ class VolumePlugin(object):
             self._reactor,
             lambda: self._get_path_from_dataset_id(dataset_id),
             repeat(self._POLL_INTERVAL)))
-        d.addCallback(lambda p: {u"Err": None, u"Mountpoint": p.path})
+        d.addCallback(lambda p: {u"Err": u"", u"Mountpoint": p.path})
 
         timeout(self._reactor, d.result, self._MOUNT_TIMEOUT)
 
@@ -367,7 +367,7 @@ class VolumePlugin(object):
                 return {u"Err": u"Volume not available.",
                         u"Mountpoint": u""}
             else:
-                return {u"Err": None,
+                return {u"Err": u"",
                         u"Mountpoint": path.path}
         d.addCallback(got_path)
         return d.result

--- a/flocker/dockerplugin/schema/types.yml
+++ b/flocker/dockerplugin/schema/types.yml
@@ -3,7 +3,6 @@ id: http://api.clusterhq.com/dockerplugin/types.json
 definitions:
   Err:
     title: "Error response"
-    description: "Null indicates success, string indicates error."
+    description: "Non-emptry string indicates error."
     type:
       - "string"
-      - "null"

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -108,14 +108,14 @@ class APITestsMixin(APIAssertionsMixin):
         ``/VolumeDriver.Remove`` returns a successful result.
         """
         return self.assertResult(b"POST", b"/VolumeDriver.Remove",
-                                 {u"Name": u"vol"}, OK, {u"Err": None})
+                                 {u"Name": u"vol"}, OK, {u"Err": u""})
 
     def test_unmount(self):
         """
         ``/VolumeDriver.Unmount`` returns a successful result.
         """
         return self.assertResult(b"POST", b"/VolumeDriver.Unmount",
-                                 {u"Name": u"vol"}, OK, {u"Err": None})
+                                 {u"Name": u"vol"}, OK, {u"Err": u""})
 
     def test_create_with_profile(self):
         """
@@ -127,7 +127,7 @@ class APITestsMixin(APIAssertionsMixin):
         name = random_name(self)
         d = self.assertResult(b"POST", b"/VolumeDriver.Create",
                               {u"Name": name, 'Opts': {u"profile": profile}},
-                              OK, {u"Err": None})
+                              OK, {u"Err": u""})
         d.addCallback(
             lambda _: self.flocker_client.list_datasets_configuration())
         d.addCallback(list)
@@ -154,7 +154,7 @@ class APITestsMixin(APIAssertionsMixin):
         size_opt = "".join(str(size))+expression
         d = self.assertResult(b"POST", b"/VolumeDriver.Create",
                               {u"Name": name, 'Opts': {u"size": size_opt}},
-                              OK, {u"Err": None})
+                              OK, {u"Err": u""})
 
         real_size = int(parse_num(size_opt).to_Byte())
         d.addCallback(
@@ -230,7 +230,7 @@ class APITestsMixin(APIAssertionsMixin):
         :return: ``Deferred`` that fires when the volume that was created.
         """
         return self.assertResult(b"POST", b"/VolumeDriver.Create",
-                                 {u"Name": name}, OK, {u"Err": None})
+                                 {u"Name": name}, OK, {u"Err": u""})
 
     def test_create_creates(self):
         """
@@ -335,7 +335,7 @@ class APITestsMixin(APIAssertionsMixin):
                       self.assertResult(
                           b"POST", b"/VolumeDriver.Mount",
                           {u"Name": name}, OK,
-                          {u"Err": None,
+                          {u"Err": u"",
                            u"Mountpoint": u"/flocker/{}".format(dataset_id)}))
         d.addCallback(lambda _: self.flocker_client.list_datasets_state())
 
@@ -397,7 +397,7 @@ class APITestsMixin(APIAssertionsMixin):
             result = self.assertResult(
                 b"POST", b"/VolumeDriver.Mount",
                 {u"Name": name}, OK,
-                {u"Err": None,
+                {u"Err": u"",
                  u"Mountpoint": u"/flocker/{}".format(
                      dataset.dataset_id)})
             result.addCallback(lambda _:
@@ -439,7 +439,7 @@ class APITestsMixin(APIAssertionsMixin):
                       self.assertResult(
                           b"POST", b"/VolumeDriver.Path",
                           {u"Name": name}, OK,
-                          {u"Err": None,
+                          {u"Err": u"",
                            u"Mountpoint": u"/flocker/{}".format(
                                datasets_config.datasets.keys()[0])}))
         return d
@@ -460,7 +460,7 @@ class APITestsMixin(APIAssertionsMixin):
             return self.assertResult(
                 b"POST", b"/VolumeDriver.Path",
                 {u"Name": name}, OK,
-                {u"Err": None,
+                {u"Err": u"",
                  u"Mountpoint": u"/flocker/{}".format(dataset.dataset_id)})
         d.addCallback(created)
         return d

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -32,10 +32,10 @@ def build_simple_test(command_name):
             # Wrong Err types:
             {"Err": 1}, {"Err": {}},
             # Extra field:
-            {"Err": None, "Extra": ""},
+            {"Err": "", "Extra": ""},
         ],
         passing_instances=[
-            {"Err": None},
+            {"Err": ""},
             {"Err": "Something went wrong!"},
         ])
 
@@ -84,11 +84,11 @@ def build_path_result_tests(name):
             # Wrong fields:
             {"Result": "hello"},
             # Extra field:
-            {"Err": None, "Mountpoint": "/x", "extra": "y"},
+            {"Err": "", "Mountpoint": "/x", "extra": "y"},
         ],
         passing_instances=[
             {"Err": "Something went wrong."},
-            {"Err": None, "Mountpoint": "/x/"},
+            {"Err": "", "Mountpoint": "/x/"},
         ])
 
 MountTests = build_path_result_tests("Mount")

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -30,7 +30,7 @@ def build_simple_test(command_name):
             # Wrong fields:
             {"Result": "hello"},
             # Wrong Err types:
-            {"Err": 1}, {"Err": {}},
+            {"Err": 1}, {"Err": {}}, {"Err": None},
             # Extra field:
             {"Err": "", "Extra": ""},
         ],


### PR DESCRIPTION
`Err` in success cases is supposed to be empty string, not null/None.

https://github.com/docker/docker/commit/cc62a88524b623c8f86075d9ed220196cf5e92da