### PR TITLE
[FLOC-3920] Increase timeout on node.functional.test_docker tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1062,7 +1062,10 @@ job_type:
       publish_test_results: true
       coverage_report: true
       clean_repo: true
-      timeout: 30
+      # This is larger than we like because of node.functional.test_docker
+      # being quite slow to run. If that is no longer the case then
+      # please reduce this.
+      timeout: 45
 
     run_trial_on_AWS_CentOS_7_as_root:
       on_nodes_with_labels: 'aws-centos-7-SELinux-T2Small'
@@ -1086,7 +1089,10 @@ job_type:
       publish_test_results: true
       coverage_report: true
       clean_repo: true
-      timeout: 30
+      # This is larger than we like because of node.functional.test_docker
+      # being quite slow to run. If that is no longer the case then
+      # please reduce this.
+      timeout: 45
 
     run_trial_on_AWS_Ubuntu_Trusty_as_root:
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'


### PR DESCRIPTION
Unfortunately this means increasing the timeout for
all trial tests, or defining new stanzas for just the
test_docker module.

test_docker is currently timing out fairly frequently
because the tests are slow to run. Increasing the
timeout will allow more green runs to happen (if slower)
while we look in to whether we can speed up the tests,
or parallelise them to get the complete suite faster.