### PR TITLE
[FLOC-3877] Safety net test: check build.yaml lists all packages

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1007,6 +1007,10 @@ run_trial_as_root_modules: &run_trial_as_root_modules
   - flocker.volume
   # flocker.node.agent needs to run as root due to mounting filesystems
   - flocker.node.agents
+run_trial_functional_agent_modules: &run_trial_functional_agent_modules
+  # The modules have appropriate skips so only EBS tests run on EBS environment,
+  # etc.
+  - flocker.node.agents.functional
 
 
 # run_trial_cli contains a list of all the CLI yaml anchors we want to
@@ -1103,8 +1107,7 @@ job_type:
   run_trial_for_storage_driver:
     run_trial_for_ebs_storage_driver_on_CentOS_7:
       on_nodes_with_labels: 'aws-centos-7-SELinux-T2Small'
-      with_modules:
-        - flocker/node/agents/ebs.py
+      with_modules: *run_trial_functional_agent_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1121,8 +1124,7 @@ job_type:
 
     run_trial_for_ebs_storage_driver_on_Ubuntu_trusty:
       on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
-      with_modules:
-        - flocker/node/agents/ebs.py
+      with_modules: *run_trial_functional_agent_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1141,8 +1143,7 @@ job_type:
 
     run_trial_for_cinder_storage_driver_on_CentOS_7:
       on_nodes_with_labels: 'rackspace-jenkins-slave-centos7-selinux-standard-4-dfw'
-      with_modules:
-        - flocker/node/agents/cinder.py
+      with_modules: *run_trial_functional_agent_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1163,8 +1164,7 @@ job_type:
 
     run_trial_for_cinder_storage_driver_on_Ubuntu_trusty:
       on_nodes_with_labels: 'rackspace-jenkins-slave-ubuntu14-standard-4-dfw'
-      with_modules:
-        - flocker/node/agents/cinder.py
+      with_modules: *run_trial_functional_agent_modules
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,

--- a/build.yaml
+++ b/build.yaml
@@ -1040,13 +1040,6 @@ run_trial_cli_as_root: &run_trial_cli_as_root [
   *run_coverage,
   *convert_results_to_junit ]
 
-# run_acceptance_modules contains the list of Flocker modules to be executed
-# during the acceptance tests
-run_acceptance_modules: &run_acceptance_modules
-  - flocker.acceptance.endtoend
-  - flocker.acceptance.integration
-  - flocker.acceptance.obsolete
-
 # When we have acceptance tests that run quickly enough (as they do on loopback)
 # we just run them all in one builder:
 run_full_acceptance_modules: &run_full_acceptance_modules

--- a/build.yaml
+++ b/build.yaml
@@ -989,7 +989,6 @@ run_trial_modules: &run_trial_modules
   - flocker.cli
   - flocker.common
   - flocker.control
-  - flocker.restapi
   - flocker.docs
   - flocker.dockerplugin
   - flocker.node.test

--- a/build.yaml
+++ b/build.yaml
@@ -982,7 +982,7 @@ common_cli:
 run_trial_modules: &run_trial_modules
   - admin
   - benchmark
-  - flocker.acceptance
+  - flocker.acceptance.test
   - flocker.apiclient
   - flocker.ca.functional
   - flocker.ca.test

--- a/flocker/test/test_meta.py
+++ b/flocker/test/test_meta.py
@@ -5,10 +5,11 @@ Tests for the test running process.
 """
 
 from unittest import skipUnless, TestSuite
+from pprint import pformat
 
 from yaml import safe_load
 
-from pyrsistent import pset, thaw
+from pyrsistent import pset
 
 from twisted.python.filepath import FilePath
 from twisted.trial.runner import TestLoader
@@ -75,5 +76,10 @@ class EnsureAllTestsRun(TestCase):
         # around with extra tests from no-longer existent modules. So
         # delete those. Also it implicitly assumes test run environment is
         # the same as the checkout in terms of what tests it has.
-        self.assertItemsEqual(thaw(configured_tests), thaw(expected_tests))
+        self.assertTrue(
+            configured_tests == expected_tests,
+            ("Tests that are unexpected but in build.yaml: {}\n\n"
+             "Tests that are missing from build.yaml: {}\n\n").format(
+                 pformat(list(configured_tests - expected_tests)),
+                 pformat(list(expected_tests - configured_tests))))
 

--- a/flocker/test/test_meta.py
+++ b/flocker/test/test_meta.py
@@ -24,7 +24,7 @@ def get_tests_for(python_name):
     """
     Find all tests for the given ``python_name``.
 
-    :param python_name: Either directory in ``REPISTORY`` or a Python FQPN
+    :param python_name: Either directory in ``REPOSITORY`` or a Python FQPN
         importable from ``REPOSITORY``.
     :return: PSet of test names.
     """

--- a/flocker/test/test_meta.py
+++ b/flocker/test/test_meta.py
@@ -1,0 +1,79 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for the test running process.
+"""
+
+from unittest import skipUnless, TestSuite
+
+from yaml import safe_load
+
+from pyrsistent import pset, thaw
+
+from twisted.python.filepath import FilePath
+from twisted.trial.runner import TestLoader
+
+from flocker.testtools import TestCase
+
+
+REPOSITORY = FilePath(__file__).parent().parent().parent()
+
+
+def get_tests_for(python_name):
+    """
+    Find all tests for the given ``python_name``.
+
+    :param python_name: Either directory in ``REPISTORY`` or a Python FQPN
+        importable from ``REPOSITORY``.
+    :return: PSet of test names.
+    """
+    def _extract_ids(t):
+        if isinstance(t, TestSuite):
+            result = pset()
+            for sub_tests in t:
+                result = result | _extract_ids(sub_tests)
+            return result
+        else:
+            return pset([t.id()])
+
+    loader = TestLoader()
+    tests = loader.loadByName(python_name, recurse=True)
+    return _extract_ids(tests)
+
+
+class EnsureAllTestsRun(TestCase):
+    """
+    Safety net tests: make sure our Jenkins config is running all tests.
+
+    There is an obvious problem that if ``flocker.test`` tests aren't
+    being run then this won't be caught!
+    """
+    @skipUnless(b".git" in REPOSITORY.listdir(),
+                "Need to run out of git checkout.")
+    def test_build_yaml_includes_all_repository_tests(self):
+        """
+        Ensure that the split-up test structure of ``build.yaml`` covers all
+        code in the Flocker repository.
+
+        This only makes sense when running out of a git checkout.
+        """
+        build_config = safe_load(REPOSITORY.child(b"build.yaml").getContent())
+        configured_tests = pset()
+
+        for jobs in build_config[u"job_type"].values():
+            for job in jobs.values():
+                for module in job.get(u"with_modules", []):
+                    configured_tests = configured_tests | get_tests_for(module)
+
+        expected_tests = pset()
+        for child in REPOSITORY.children():
+            if child.isdir() and b"__init__.py" in child.listdir():
+                expected_tests = expected_tests | get_tests_for(
+                    child.basename())
+
+        # This test may fail erroneously if you have .pyc files lying
+        # around with extra tests from no-longer existent modules. So
+        # delete those. Also it implicitly assumes test run environment is
+        # the same as the checkout in terms of what tests it has.
+        self.assertItemsEqual(thaw(configured_tests), thaw(expected_tests))
+

--- a/flocker/test/test_meta.py
+++ b/flocker/test/test_meta.py
@@ -57,6 +57,14 @@ class EnsureAllTestsRun(TestCase):
         code in the Flocker repository.
 
         This only makes sense when running out of a git checkout.
+
+        Caveats:
+        * This has no idea whether tests are actually being run in an
+          appropriate environment. E.g. maybe we're only running tests
+          that require root in non-root environment, and so they are
+          always skipped.
+        * Acceptance tests are run using different mechanism that
+          isn't well covered by this check.
         """
         build_config = safe_load(REPOSITORY.child(b"build.yaml").getContent())
         configured_tests = pset()

--- a/flocker/test/test_meta.py
+++ b/flocker/test/test_meta.py
@@ -90,4 +90,3 @@ class EnsureAllTestsRun(TestCase):
              "Tests that are missing from build.yaml: {}\n\n").format(
                  pformat(list(configured_tests - expected_tests)),
                  pformat(list(expected_tests - configured_tests))))
-


### PR DESCRIPTION
This will catch some mistakes, e.g. completely omitting a new package from test run. There are many cases it won't catch, see code for caveats.

```
$ git diff
diff --git a/build.yaml b/build.yaml
index 168eeef..65cebe1 100644
--- a/build.yaml
+++ b/build.yaml
@@ -995,7 +995,7 @@ run_trial_modules: &run_trial_modules
   - flocker.node.functional.test_docker
   - flocker.node.functional.test_script
   - flocker.node.functional.test_deploy
-  - flocker.provision
+#  - flocker.provision
   - flocker.restapi
   - flocker.route
   - flocker.test
$ trial flocker.test.test_meta
...
Traceback (most recent call last):
  File "/home/itamarst/ClusterHQ/flocker/flocker/test/test_meta.py", line 92, in test_build_yaml_includes_all_repository_tests
    pformat(list(expected_tests - configured_tests))))
  File "/home/itamarst/ClusterHQ/flocker/.tox/py27/local/lib/python2.7/site-packages/unittest2/case.py", line 702, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true : Tests that are unexpected but in build.yaml: []

Tests that are missing from build.yaml: ['flocker.provision.test.test_install.GetRepoOptionsTests.test_development_release',
 'flocker.provision.test.test_ssh_conch.Tests.test_run_logs_stderr',
 'flocker.provision.test.test_install.PrivateKeyLoggingTest.test_no_end_key_removed',
 'flocker.provision.test.test_install.PrivateKeyLoggingTest.test_non_key_kept',
 'flocker.provision.test.test_install.EnableFlockerAgentTests.test_ubuntu_sequence',
...
```