### PR TITLE
Report to github the status of individual jobs rather than the multijob.

### DIFF
--- a/jobs.groovy
+++ b/jobs.groovy
@@ -740,7 +740,7 @@ def build_multijob(dashProject, dashBranchName, branchName, isReleaseBuild) {
                Skip the cron jobs as they don't run from this multijob,
                so the copied artifacts could be from a build of a previous
                revision, which may confuse things. */
-            list_jobs(dashProject, dashBranchName).findAll { it.job_type != 'cronly_jobs' }.each {
+            list_jobs(dashProject, dashBranchName).findAll { it.type != 'cronly_jobs' }.each {
                 if (it.values.archive_artifacts) {
                     copy_artifacts_from(
                         delegate, it.full_name,

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -575,7 +575,7 @@ def define_job(dashProject, dashBranchName, branchName, job_type, job_name,
             wrappers build_wrappers(job_values, directories_to_delete)
             scm build_scm(git_url, branchName, isReleaseBuild)
             steps build_steps(job_values)
-            publishers build_publishers(job_values, branchName, dashProject, dashBranchName, _job_name)
+            publishers build_publishers(job_values, branchName, dashProject, dashBranchName, job_name)
         }
     } else if (job_type == 'run_sphinx') {
         assert module == null


### PR DESCRIPTION
Report to github the status of individual jobs rather than the multijob.
    
This means that the information on the github page will be more useful,
as you can see which tests failed without clicking through and
searching. In addition, when a job is retried it will update its status
again, so a passing run will show all green on github even if it
required a job to be retried.
   
This commit changes the "pending" notifications to be for each test
we intend to run, and then each job does the successful/failing
notifications itself.
    
The github_status.sh script with the auth details isn't available
on the slaves, so this now embeds it in the script step.
