### PR TITLE
[FLOC-3930] Flaky audit script

### DIFF
--- a/admin/find-flaky-tests
+++ b/admin/find-flaky-tests
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Find and report on tests marked as flaky.
+"""
+
+from _preamble import TOPLEVEL, BASEPATH
+
+import sys
+
+if __name__ == '__main__':
+    from admin.flaky import find_flaky_tests_main as main
+    main(sys.argv[1:], top_level=TOPLEVEL, base_path=BASEPATH)

--- a/admin/flaky.py
+++ b/admin/flaky.py
@@ -66,9 +66,9 @@ def report_flaky_tests(output, flaky_tests):
         output.write('{}\n'.format(test))
 
 
-def report_bugs(output, flaky_tests):
+def report_issues(output, flaky_tests):
     """
-    Print all bugs for flaky tests.
+    Print all issues for flaky tests.
     """
     jira_keys = frozenset().union(
         *(flaky.jira_keys for (_, flaky) in flaky_tests))
@@ -99,7 +99,7 @@ def report_test_tree(output, flaky_tests):
 
 
 _REPORTS = {
-    'bugs': report_bugs,
+    'issues': report_issues,
     'tests': report_tests,
     'tree': report_test_tree,
 }

--- a/admin/flaky.py
+++ b/admin/flaky.py
@@ -5,7 +5,11 @@ Find and report on tests marked as flaky.
 """
 
 import sys
+
+from testtools import iterate_tests
+from twisted.python.reflect import namedAny
 from twisted.python.usage import Options, UsageError
+from twisted.trial.runner import TestLoader
 
 
 class FindFlakyTestsOptions(Options):
@@ -21,11 +25,33 @@ class FindFlakyTestsOptions(Options):
         self['suites'] = suites
 
 
+def _load_tests(name):
+    """
+    Find all the tests under ``name``.
+
+    :param str name: The fully-qualified Python name of an object.
+    :return: A ``TestSuite`` or ``TestCase`` containing all the tests.
+    """
+    loader = TestLoader()
+    thing = namedAny(name)
+    return loader.loadAnything(thing, recurse=True)
+
+
+def _iter_tests(names):
+    """
+    Given a list of names, iterate through all the tests in them.
+    """
+    for name in names:
+        suite = _load_tests(name)
+        for test in iterate_tests(suite):
+            yield test
+
+
 def find_flaky_tests(suites):
     """
     Find all flaky tests in the given suites.
     """
-    return []
+    return _iter_tests(suites)
 
 
 def report_flaky_tests(output, flaky_tests):

--- a/admin/flaky.py
+++ b/admin/flaky.py
@@ -1,0 +1,56 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Find and report on tests marked as flaky.
+"""
+
+import sys
+from twisted.python.usage import Options, UsageError
+
+
+class FindFlakyTestsOptions(Options):
+    """
+    Options for finding flaky tests.
+    """
+
+    def parseArgs(self, *suites):
+        """
+        Accept an arbitrary number of suites, specified as fully-qualified
+        Python names.
+        """
+        self['suites'] = suites
+
+
+def find_flaky_tests(suites):
+    """
+    Find all flaky tests in the given suites.
+    """
+    return []
+
+
+def report_flaky_tests(output, flaky_tests):
+    """
+    Report on flaky tests.
+    """
+    for test in flaky_tests:
+        output.write('{}\n'.format(test))
+
+
+def find_flaky_tests_main(args, base_path, top_level, stdout=None,
+                          stderr=None):
+    """
+    Find and report on tests marked as flaky.
+    """
+    stdout = sys.stdout if stdout is None else stdout
+    stderr = sys.stderr if stderr is None else stderr
+    # XXX: Boilerplate copied from release.py, very similar (but not similar
+    # enough!) to boilerplate in flocker.common.script.
+    options = FindFlakyTestsOptions()
+    try:
+        options.parseOptions(args)
+    except UsageError as e:
+        stderr.write("{}: {}\n".format(base_path.basename(), e))
+        sys.exit(1)
+
+    flaky_tests = find_flaky_tests(options['suites'])
+    report_flaky_tests(stdout, flaky_tests)

--- a/admin/flaky.py
+++ b/admin/flaky.py
@@ -128,11 +128,18 @@ class FindFlakyTestsOptions(Options):
         ['report', 'r', 'tree', 'The report to use', _to_report]
     ]
 
+    def __init__(self, name, *args, **kwargs):
+        super(FindFlakyTestsOptions, self).__init__(*args, **kwargs)
+        self._name = name
+        self.synopsis = "{} [options] [TEST...]".format(name)
+
     def parseArgs(self, *suites):
         """
         Accept an arbitrary number of suites, specified as fully-qualified
         Python names.
         """
+        if not suites:
+            raise UsageError('Must provide name of at least one test suite')
         self['suites'] = suites
 
 
@@ -145,10 +152,12 @@ def find_flaky_tests_main(args, base_path, top_level, stdout=None,
     stderr = sys.stderr if stderr is None else stderr
     # XXX: Boilerplate copied from release.py, very similar (but not similar
     # enough!) to boilerplate in flocker.common.script.
-    options = FindFlakyTestsOptions()
+    options = FindFlakyTestsOptions(base_path.basename())
     try:
         options.parseOptions(args)
     except UsageError as e:
+        stdout.write(str(options))
+        stdout.write("\n")
         stderr.write("{}: {}\n".format(base_path.basename(), e))
         sys.exit(1)
 


### PR DESCRIPTION
New script to dump all of the flaky tests in Flocker.

```
find-flaky-tests --report=tree flocker
```

Will show the flaky tests as a trial output tree. --bugs and --tests will show only bugs or only tests.