### PR TITLE
[FLOC-3927] Configure dependency logging using agent.yml

### DIFF
--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -103,6 +103,23 @@ The top-level mapping may also contain any number of computer-resource provider 
 These are used to provide required parameters to the cluster runner selected by the ``--provider`` option.
 Configuration is loaded from the item in the top-level mapping with a key matching the value given to ``--provider``.
 
+The top-level mapping may contain a ``logging`` stanza, which must match the format described in `PEP 0391 <https://www.python.org/dev/peps/pep-0391/>`_.
+An example stanza:
+
+.. code-block:: yaml
+
+   logging:
+      version: 1
+      handlers:
+          logfile:
+              class: 'logging.FileHandler'
+              level: 10
+              filename: "/tmp/flocker.log"
+              encoding: 'utf-8'
+      root:
+          handlers: ['logfile']
+          level: 10
+
 .. _acceptance-testing-rackspace-config:
 
 Rackspace

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -113,12 +113,12 @@ An example stanza:
       handlers:
           logfile:
               class: 'logging.FileHandler'
-              level: 10
+              level: DEBUG
               filename: "/tmp/flocker.log"
               encoding: 'utf-8'
       root:
           handlers: ['logfile']
-          level: 10
+          level: DEBUG
 
 .. _acceptance-testing-rackspace-config:
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -212,7 +212,11 @@ def validate_configuration(configuration):
                 "required": [
                     "backend",
                 ],
-            }
+            },
+            "logging": {
+                # Format described at https://www.python.org/dev/peps/pep-0391/
+                "type": "object",
+            },
         }
     }
 
@@ -527,6 +531,10 @@ class AgentService(PClass):
         :return: A new instance of ``cls`` with values loaded from the
             configuration.
         """
+        if 'logging' in configuration:
+            from logging.config import dictConfig
+            dictConfig(configuration['logging'])
+
         host = configuration['control-service']['hostname']
         port = configuration['control-service']['port']
 

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -66,8 +66,7 @@ def setup_config(test, control_address=u"10.0.0.1", control_port=1234,
     if name is None:
         name = random_name(test)
     ca_set = get_credential_sets()[0]
-    scratch_directory = FilePath(test.mktemp())
-    scratch_directory.makedirs()
+    scratch_directory = test.make_temporary_directory()
     contents = {
         u"control-service": {
             u"hostname": control_address,
@@ -269,7 +268,7 @@ class AgentServiceFromConfigurationTests(TestCase):
         host = b"192.0.2.13"
         port = 2314
         name = u"from_config-test"
-        logfile = self.make_temporary_directory().child('logfile')
+        logfile = self.make_temporary_path()
         log_config = {
             'version': 1,
             'handlers': {

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -88,7 +88,6 @@ def setup_config(test, control_address=u"10.0.0.1", control_port=1234,
     test.config.setContent(yaml.safe_dump(contents))
     ca_set.copy_to(scratch_directory, node=True)
     test.ca_set = ca_set
-    test.non_existent_file = scratch_directory.child('missing-config.yml')
 
 deployer = object()
 
@@ -128,18 +127,15 @@ class DatasetServiceFactoryTests(TestCase):
     Generic tests for ``DatasetServiceFactory``, independent of the storage
     driver being used.
     """
-    def setUp(self):
-        super(DatasetServiceFactoryTests, self).setUp()
-        setup_config(self)
 
     def test_config_validated(self):
         """
         ``DatasetServiceFactory.get_service`` validates the configuration file.
         """
-        self.config.setContent(b"INVALID")
+        config = self.make_temporary_file(content=b"INVALID")
 
         options = DatasetAgentOptions()
-        options.parseOptions([b"--agent-config", self.config.path])
+        options.parseOptions([b"--agent-config", config.path])
 
         self.assertRaises(
             ValidationError,
@@ -152,7 +148,9 @@ class DatasetServiceFactoryTests(TestCase):
         given configuration file does not exist.
         """
         options = DatasetAgentOptions()
-        options.parseOptions([b"--agent-config", self.non_existent_file.path])
+        options.parseOptions(
+            [b"--agent-config", self.make_temporary_path().path]
+        )
 
         self.assertRaises(
             IOError,
@@ -716,7 +714,9 @@ class AgentServiceFactoryTests(TestCase):
         """
         reactor = MemoryCoreReactor()
         options = DatasetAgentOptions()
-        options.parseOptions([b"--agent-config", self.non_existent_file.path])
+        options.parseOptions(
+            [b"--agent-config", self.make_temporary_path().path]
+        )
         service_factory = self.service_factory(
             deployer_factory=deployer_factory_stub,
         )

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -1035,8 +1035,10 @@ def _remove_dataset_fields(content):
     return yaml.safe_dump(content)
 
 
-def task_configure_flocker_agent(control_node, dataset_backend,
-                                 dataset_backend_configuration):
+def task_configure_flocker_agent(
+    control_node, dataset_backend, dataset_backend_configuration,
+    logging_config=None,
+):
     """
     Configure the flocker agents by writing out the configuration file.
 
@@ -1045,24 +1047,28 @@ def task_configure_flocker_agent(control_node, dataset_backend,
         configured with.
     :param dict dataset_backend_configuration: The backend specific
         configuration options.
+    :param dict logging_config: A Python logging configuration dictionary,
+        following the structure of PEP 391.
     """
     dataset_backend_configuration = dataset_backend_configuration.copy()
     dataset_backend_configuration.update({
         u"backend": dataset_backend.name,
     })
 
+    content = {
+        "version": 1,
+        "control-service": {
+            "hostname": control_node,
+            "port": 4524,
+        },
+        "dataset": dataset_backend_configuration,
+    }
+    if logging_config is not None:
+        content['logging'] = logging_config
+
     put_config_file = put(
         path='/etc/flocker/agent.yml',
-        content=yaml.safe_dump(
-            {
-                "version": 1,
-                "control-service": {
-                    "hostname": control_node,
-                    "port": 4524,
-                },
-                "dataset": dataset_backend_configuration,
-            },
-        ),
+        content=yaml.safe_dump(content),
         log_content_filter=_remove_dataset_fields
     )
     return sequence([put_config_file])
@@ -1485,7 +1491,9 @@ def install_flocker(nodes, package_source):
     )
 
 
-def configure_cluster(cluster, dataset_backend_configuration, provider):
+def configure_cluster(
+    cluster, dataset_backend_configuration, provider, logging_config=None
+):
     """
     Configure flocker-control, flocker-dataset-agent and
     flocker-container-agent on a collection of nodes.
@@ -1496,6 +1504,9 @@ def configure_cluster(cluster, dataset_backend_configuration, provider):
         supply to the dataset backend.
 
     :param bytes provider: provider of the nodes  - aws. rackspace or managed.
+
+    :param dict logging_config: A Python logging configuration dictionary,
+        following the structure of PEP 391.
     """
     setup_action = 'start'
     if provider == "managed":
@@ -1544,6 +1555,7 @@ def configure_cluster(cluster, dataset_backend_configuration, provider):
                             dataset_backend_configuration=(
                                 dataset_backend_configuration
                             ),
+                            logging_config=logging_config,
                         ),
                         task_enable_docker_plugin(node.distribution),
                         task_enable_flocker_agent(

--- a/flocker/provision/_ssh/_model.py
+++ b/flocker/provision/_ssh/_model.py
@@ -139,6 +139,8 @@ def perform_put(dispatcher, intent):
     Default implementation of `Put`.
     """
     def create_put_command(content, path):
+        # Escape printf format markers
+        content = content.replace('\\', '\\\\').replace('%', '%%')
         return 'printf -- %s > %s' % (shell_quote(content), shell_quote(path))
     return Effect(Run(
         command=create_put_command(intent.content, intent.path),

--- a/flocker/provision/test/test_install.py
+++ b/flocker/provision/test/test_install.py
@@ -36,6 +36,15 @@ BASIC_AGENT_YML = freeze({
     "dataset": {
         "backend": "zfs",
     },
+    "logging": {
+        "version": 1,
+        "formatters": {
+            "timestamped": {
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+                "format": "%(asctime)s %(message)s"
+            },
+        },
+    },
 })
 
 
@@ -57,6 +66,7 @@ class ConfigureFlockerAgentTests(TestCase):
                 BASIC_AGENT_YML["dataset"]["backend"]
             ),
             dataset_backend_configuration=expected_backend_configuration,
+            logging_config=thaw(BASIC_AGENT_YML["logging"]),
         )
         [put_agent_yml] = list(
             effect.intent

--- a/flocker/provision/test/test_ssh_conch.py
+++ b/flocker/provision/test/test_ssh_conch.py
@@ -56,12 +56,12 @@ class Tests(AsyncTestCase):
         """
         The ``Put`` intent puts the provided contents in the specified file.
         """
-
+        content = '\\hell%o'
         command = run_remotely(
             username="root",
             address=str(self.server.ip),
             port=self.server.port,
-            commands=put(content="hello", path="file"),
+            commands=put(content=content, path="file"),
         )
 
         d = perform(
@@ -71,7 +71,7 @@ class Tests(AsyncTestCase):
 
         def check(_):
             self.assertEqual(self.server.home.child('file').getContent(),
-                             "hello")
+                             content)
         d.addCallback(check)
         return d
 


### PR DESCRIPTION
For debugging and benchmarking, it is useful to configure the logging provided by dependencies, which use the standard Python logging rather than Eliot.

This PR adds a `logging` stanza to the `agent.yml` file, which follows the PEP 391 format for specifying logging configuration.

For benchmarking AWS API calls, for example, we can add the following stanza to the YAML configuration file (`acceptance.yml` or equivalent):
```yaml
logging:
   version: 1
   formatters:
      timestamped:
         format: "%(asctime)s %(message)s"
         datefmt: "%Y-%m-%d %H:%M:%S"
   handlers:
      boto2:
         class: logging.handlers.WatchedFileHandler
         level: DEBUG
         filename: /tmp/boto2.log
         encoding: utf-8
         formatter: timestamped
      boto3:
         class: logging.handlers.WatchedFileHandler
         level: DEBUG
         filename: /tmp/boto3.log
         encoding: utf-8
         formatter: timestamped
   loggers:
      boto:
         handlers: ["boto2"]
         level: DEBUG
      boto3:
         handlers: ["boto3"]
         level: DEBUG
```

For ease of review, the changes can be divided into three parts:
1. changes in `flocker.node` which allow the agents to parse the `agent.yml` and setup logging;
2. changes in `flocker.provision` and `admin` which provision nodes with an `agent.yml` generated from a YAML config file;
3. changes in `docs`, which describe the additions in the YAML file.

There is also a fix in `flocker.provision` to the Put effect provider function, to escape backslashes and per-cent symbols correctly.