### PR TITLE
[FLOC 3948] simplify setup cluster

### DIFF
--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -208,6 +208,9 @@ def main(reactor, args, base_path, top_level):
                                            node.address,
                                            remote_logs_file)
                            )
+    # gather_deferreds() below does more than just creating a DeferredList.
+    # So, while we are not using its result in any way, it is still useful
+    # because it logs any failures coming from the gathered deferreds.
     gather_deferreds(results)
 
     if options['no-keep']:

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -177,66 +177,61 @@ def main(reactor, args, base_path, top_level):
     reactor.addSystemEventTrigger(
         'before', 'shutdown', log_writer.stopService)
 
-    cluster = None
+    def cluster_cleanup():
+        print("stopping cluster")
+        return runner.stop_cluster(reactor)
+
+    cleanup_trigger_id = reactor.addSystemEventTrigger('before', 'shutdown',
+                                                       cluster_cleanup)
+
     results = []
-    try:
-        yield runner.ensure_keys(reactor)
-        cluster = yield runner.start_cluster(reactor)
+    yield runner.ensure_keys(reactor)
+    cluster = yield runner.start_cluster(reactor)
 
-        managed_config_file = options['cert-directory'].child("managed.yaml")
-        managed_config = create_managed_config(options['config'], cluster)
-        managed_config_file.setContent(
-            yaml.safe_dump(managed_config, default_flow_style=False)
-        )
+    managed_config_file = options['cert-directory'].child("managed.yaml")
+    managed_config = create_managed_config(options['config'], cluster)
+    managed_config_file.setContent(
+        yaml.safe_dump(managed_config, default_flow_style=False)
+    )
 
-        if options['distribution'] in ('centos-7',):
-            remote_logs_file = open("remote_logs.log", "a")
-            for node in cluster.all_nodes:
-                results.append(capture_journal(reactor,
-                                               node.address,
-                                               remote_logs_file)
-                               )
-        elif options['distribution'] in ('ubuntu-14.04', 'ubuntu-15.10'):
-            remote_logs_file = open("remote_logs.log", "a")
-            for node in cluster.all_nodes:
-                results.append(capture_upstart(reactor,
-                                               node.address,
-                                               remote_logs_file)
-                               )
-        gather_deferreds(results)
+    if options['distribution'] in ('centos-7',):
+        remote_logs_file = open("remote_logs.log", "a")
+        for node in cluster.all_nodes:
+            results.append(capture_journal(reactor,
+                                           node.address,
+                                           remote_logs_file)
+                           )
+    elif options['distribution'] in ('ubuntu-14.04', 'ubuntu-15.10'):
+        remote_logs_file = open("remote_logs.log", "a")
+        for node in cluster.all_nodes:
+            results.append(capture_upstart(reactor,
+                                           node.address,
+                                           remote_logs_file)
+                           )
+    gather_deferreds(results)
 
-        result = 0
+    if options['no-keep']:
+        print("not keeping cluster")
+    else:
+        environment_variables = get_trial_environment(cluster)
+        environment_strings = list()
+        for environment_variable in environment_variables:
+            environment_strings.append(
+                "export {name}={value};\n".format(
+                    name=environment_variable,
+                    value=shell_quote(
+                        environment_variables[environment_variable]
+                    ),
+                )
+            )
+        environment = ''.join(environment_strings)
+        print("The following variables describe the cluster:")
+        print(environment)
+        env_file = options['cert-directory'].child("environment.env")
+        env_file.setContent(environment)
+        print("The variables are also saved in {}".format(
+            env_file.path
+        ))
+        print("Be sure to preserve the required files.")
 
-    except BaseException:
-        result = 1
-        raise
-    finally:
-        if options['no-keep'] or result == 1:
-            runner.stop_cluster(reactor)
-        else:
-            if cluster is None:
-                print("Didn't finish creating the cluster.")
-                runner.stop_cluster(reactor)
-            else:
-                environment_variables = get_trial_environment(cluster)
-                environment_strings = list()
-                for environment_variable in environment_variables:
-                    environment_strings.append(
-                        "export {name}={value};\n".format(
-                            name=environment_variable,
-                            value=shell_quote(
-                                environment_variables[environment_variable]
-                            ),
-                        )
-                    )
-                environment = ''.join(environment_strings)
-                print("The following variables describe the cluster:")
-                print(environment)
-                env_file = options['cert-directory'].child("environment.env")
-                env_file.setContent(environment)
-                print("The variables are also saved in {}".format(
-                    env_file.path
-                ))
-                print("Be sure to preserve the required files.")
-
-    raise SystemExit(result)
+        reactor.removeSystemEventTrigger(cleanup_trigger_id)

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -166,6 +166,13 @@ def main(reactor, args, base_path, top_level):
 
     runner = options.runner
 
+    def cluster_cleanup():
+        print("stopping cluster")
+        return runner.stop_cluster(reactor)
+
+    cleanup_trigger_id = reactor.addSystemEventTrigger('before', 'shutdown',
+                                                       cluster_cleanup)
+
     from flocker.common.script import eliot_logging_service
     log_writer = eliot_logging_service(
         destination=FileDestination(
@@ -176,13 +183,6 @@ def main(reactor, args, base_path, top_level):
     log_writer.startService()
     reactor.addSystemEventTrigger(
         'before', 'shutdown', log_writer.stopService)
-
-    def cluster_cleanup():
-        print("stopping cluster")
-        return runner.stop_cluster(reactor)
-
-    cleanup_trigger_id = reactor.addSystemEventTrigger('before', 'shutdown',
-                                                       cluster_cleanup)
 
     results = []
     yield runner.ensure_keys(reactor)


### PR DESCRIPTION
Because main() is decorated with @inlineCallbacks there is no guarantee
that the control flow always returns to it after a yield statement.
In particular, that's the case if the reactor is stopped.
And that could happen, for instance, if a user presses Ctrl-C because
twisted installs a SIGINT handler which stops the reactor.

Thus, to improve the chances of the cluster clean-up being executed
the clean-up code is moved to a before-shutdown system event trigger.

Also, there is no reason now to have except and finally clauses as
(a) there is no guarantee that they are executed, (b) all the except
block did was to re-raise an exception, so no reason to capture it
at all, (c) the finally block would contain only actions that should
be executed on success after the clean-up code was moved to the
shutdown handler.