### PR TITLE
[FLOC-3950] Fix attribute error in ManagedRunner

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -234,10 +234,12 @@ class ManagedRunner(object):
     :ivar ClusterIdentity identity: The identity information of the cluster.
     :ivar FilePath cert_path: The directory where the cluster certificate
         files will be placed.
+    :ivar dict logging_config: A Python logging configuration dictionary,
+        following the structure of PEP 391.
     """
     def __init__(self, node_addresses, package_source, distribution,
                  dataset_backend, dataset_backend_configuration, identity,
-                 cert_path):
+                 cert_path, logging_config):
         """
         :param list: A ``list`` of public IP addresses or
             ``[private_address, public_address]`` lists.
@@ -268,6 +270,7 @@ class ManagedRunner(object):
         self.dataset_backend_configuration = dataset_backend_configuration
         self.identity = identity
         self.cert_path = cert_path
+        self.logging_config = logging_config
 
     def _upgrade_flocker(self, reactor, nodes, package_source):
         """
@@ -337,7 +340,7 @@ class ManagedRunner(object):
                     self.dataset_backend_configuration
                 ),
                 provider="managed",
-                logging_config=self.config.get('logging'),
+                logging_config=self.logging_config,
             )
         configuring = upgrading.addCallback(configure)
         return configuring
@@ -911,6 +914,7 @@ class CommonOptions(Options):
             dataset_backend_configuration=self.dataset_backend_configuration(),
             identity=self._make_cluster_identity(dataset_backend),
             cert_path=self['cert-directory'],
+            logging_config=self['config'].get('logging'),
         )
 
     def _libcloud_runner(self, package_source, dataset_backend,

--- a/admin/test/test_acceptance.py
+++ b/admin/test/test_acceptance.py
@@ -49,6 +49,7 @@ class ManagedRunnerTests(TestCase):
                 prefix=u'test',
             ),
             cert_path=FilePath(mkdtemp()),
+            logging_config=None,
         )
         self.assertTrue(
             verifyObject(IClusterRunner, runner)


### PR DESCRIPTION
FLOC-3927 #2498 unfortunately assumed that `ManagedRunner` followed the structure of `LibcloudRunner`, and used `self.config`, which is not a valid attribute for `ManagedRunner`. @avg-I spotted that this caused an `AttributeError`

This PR changes the `ManagedRunner` class to receive the `logging_config` dictionary directly.  It's use has now been independently tested by both @avg-I and me.
