### PR TITLE
[FLOC-3958] Remove --testmodule from storage driver tests.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -428,7 +428,7 @@ common_cli:
     # Consume the MODULE parameter set in the job configuration
     sudo -E ${venv}/bin/coverage run ${venv}/bin/trial \
       --debug-stacktraces --reporter=subunit \
-      --testmodule ${MODULE} 2>&1 | tee trial.log
+      ${MODULE} 2>&1 | tee trial.log
 
   setup_authentication: &setup_authentication |
     # acceptance tests rely on this file existing


### PR DESCRIPTION
The test definitions for those tests now specify the test module
directly, so don't try and use --testmodule to find it.