### PR TITLE
[FLOC-3889] Benchmark - remove use of compose 

### DIFF
--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -48,9 +48,9 @@ class ContainerOptions(usage.Options):
          'Location of the user and control certificates and user key'],
         ['max-size', None, 1,
          'Size of the volume, in gigabytes. One GB by default'],
-        ['wait', None, 72000,
+        ['wait', None, 7200,
          "The timeout in seconds for waiting until the operation is complete. "
-         "No waiting is done by default."],
+         "Waits two hours by default."],
         ['wait-interval', None, 4,
          "How often are we going to check if the creation of containers and "
          "datasets has finished, in second"],
@@ -150,14 +150,14 @@ class ClusterContainerDeployment(object):
 
     :ivar options: ``ContainerOptions`` with the options passed to the script
     :ivar image: ``DockerImage`` for the containers.
-    :ivar max_size: maximum volume (dataset) size.
+    :ivar max_size: maximum volume (dataset) size in bytes.
     :ivar mountpoint: unicode string containing the absolute path of the
         mountpoint.
     :ivar timeout: total time to wait for the containers and datasets
         to be created.
     :ivar wait_interval: how much to wait between list calls when waiting for
         the containers and datasets to be created.
-    :ivar _num_loops: numer of times to repeat the looping call based on the
+    :ivar _num_loops: number of times to repeat the looping call based on the
         ``tiemeout`` and the ``wait_interval``.
     :ivar per_node: number of containers and dataset per node.
     :ivar control_node_address: public ip address of the control node.
@@ -191,7 +191,7 @@ class ClusterContainerDeployment(object):
             if self.timeout is None:
                 # Wait two hours by default
                 self.timeout = 72000
-            self._num_loops = 10
+            self._num_loops = 1
             if self.wait_interval < self.timeout:
                 self._num_loops = self.timeout / self.wait_interval
 
@@ -381,7 +381,6 @@ class ClusterContainerDeployment(object):
         """
         deferred_list = []
         for node in self.nodes:
-            # Todo create a partial with the node info
             create_container_in_node = partial(self.create_container,
                                                node=node)
             for i in range(self.per_node):

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -257,6 +257,17 @@ class ClusterContainerDeployment(object):
         datasets = []
         containers = []
 
+        # Listing datasets and containers to know the initial number of
+        # datasets and containers, so we know the total number of them
+        # we are expecting to have.
+        # XXX please note that, if some of those initial datasets or containers
+        # are being deleted, the output of this script won't be as expected,
+        # and it will end up timing out waiting for all the containers and
+        # datasets to be ready. This is a possible future improvement (bear
+        # it in mind if reusing the code), but it is not needed by benchmarking
+        # as it is not an scenario we will have, and even if we had it, we
+        # still can re-run this script to create the extra datasets and
+        # containers we may need, or even cleanup the cluster and start again.
         def list_datasets(ignored):
             return client.list_datasets_state()
 

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -1,22 +1,20 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
-import yaml
 import sys
-from copy import deepcopy
-from json import dumps
 from itertools import repeat
 from ipaddr import IPAddress
+from functools import partial
+from uuid import uuid4
+from bitmath import GiB
 
-from treq import json_content
 from eliot import add_destination, Message
 from twisted.internet.defer import inlineCallbacks
 from twisted.python.filepath import FilePath
 from twisted.python import usage
-from twisted.web.http import OK
 
-from flocker.common import loop_until
+from flocker.common import loop_until, gather_deferreds
 from flocker.control.httpapi import REST_API_PORT
-from flocker.apiclient import FlockerClient
-from flocker.ca import treq_with_authentication
+from flocker.control import DockerImage
+from flocker.apiclient import FlockerClient, MountedDataset
 
 
 def eliot_output(message):
@@ -40,33 +38,48 @@ class ContainerOptions(usage.Options):
     optParameters = [
         ['apps-per-node', None, 1, 'Number of application containers per node',
          int],
-        ['app-template', None, None,
-         'Configuration to use for each application container'],
+        ['image', None, None,
+         'Docker image to deploy'],
+        ['mountpoint', None, None,
+         'Location of the mountpoint of the datasets'],
         ['control-node', None, None,
          'Public IP address of the control node'],
         ['cert-directory', None, None,
          'Location of the user and control certificates and user key'],
-        ['wait', None, None,
+        ['max-size', None, 1,
+         'Size of the volume, in gigabytes. One GB by default'],
+        ['wait', None, 72000,
          "The timeout in seconds for waiting until the operation is complete. "
          "No waiting is done by default."],
+        ['wait-interval', None, 4,
+         "How often are we going to check if the creation of containers and "
+         "datasets has finished, in second"],
     ]
 
     synopsis = ('Usage: setup-cluster-containers --app-per-node <containers '
-                'per node> --app-template <name of the file> '
+                'per node> --image<DockerImage> '
+                '--mountpoint <path to the mountpoint> '
                 '--control-node <IPAddress> '
                 '--cert-directory <path where all the certificates are> '
-                '[--wait <seconds to wait>]')
+                '[--max-size <volume size in GB>] '
+                '[--wait <total seconds to wait>]'
+                '[--wait-interval <seconds to wait between list calls]')
 
     def postOptions(self):
         # Mandatory parameters
-        # Validate template
-        if self['app-template'] is not None:
-            template_file = FilePath(self['app-template'])
-            self['template'] = yaml.safe_load(template_file.getContent())
-        else:
+        # Validate image
+        if self['image'] is None:
             raise usage.UsageError(
-                "app-template parameter must be provided"
+                "image parameter must be provided"
             )
+        # Validate mountpoint
+        if self['mountpoint'] is None:
+            raise usage.UsageError("mountpoint is a mandatory parameter")
+        else:
+            try:
+                FilePath(self['mountpoint'])
+            except ValueError:
+                raise usage.UsageError("mountpoint has to be an absolute path")
         # Validate app per node
         if self['apps-per-node'] is None:
             raise usage.UsageError("apps-per-node is a mandatory parameter")
@@ -85,17 +98,33 @@ class ContainerOptions(usage.Options):
                 raise usage.UsageError("control-node has to be an IP address")
         # Validate certificate directory
         if self['cert-directory'] is None:
-            raise usage.UsageError("'cert-directory is a mandatory parameter")
+            raise usage.UsageError("cert-directory is a mandatory parameter")
 
         # Validate optional parameters
-        if self['wait'] is not None:
-            try:
-                self['wait'] = int(self['wait'])
-            except ValueError:
-                raise usage.UsageError("The wait timeout must be an integer.")
+        # Note that we don't check if those parameters are None, because
+        # all of them have default value and can't be none. If they are,
+        # and exception will be raised
+        try:
+            self['max-size'] = int(self['max-size'])
+        except ValueError:
+            raise usage.UsageError(
+                "The max-size timeout must be an integer.")
+
+        try:
+            self['wait'] = int(self['wait'])
+        except ValueError:
+            raise usage.UsageError("The wait timeout must be an integer.")
+
+        try:
+            self['wait-interval'] = int(self['wait-interval'])
+        except ValueError:
+            raise usage.UsageError(
+                "The wait-interval must be an integer.")
 
 
 def main(reactor, argv, environ):
+    # Setup eliot to print better human-readable output to standard
+    # output
     add_destination(eliot_output)
 
     try:
@@ -114,23 +143,22 @@ def main(reactor, argv, environ):
     return container_deployment.deploy_and_wait_for_creation()
 
 
-class ResponseError(Exception):
-    """
-    An unexpected response from the REST API.
-    """
-    def __init__(self, code, message):
-        Exception.__init__(self, "Unexpected response code {}:\n{}\n".format(
-            code, message))
-        self.code = code
-
-
 class ClusterContainerDeployment(object):
     """
     Class that contains all the methods needed to deploy a new config in a
     cluster.
 
     :ivar options: ``ContainerOptions`` with the options passed to the script
-    :ivar application_template: template of the containers to deploy.
+    :ivar image: ``DockerImage`` for the containers.
+    :ivar max_size: maximum volume (dataset) size.
+    :ivar mountpoint: unicode string containing the absolute path of the
+        mountpoint.
+    :ivar timeout: total time to wait for the containers and datasets
+        to be created.
+    :ivar wait_interval: how much to wait between list calls when waiting for
+        the containers and datasets to be created.
+    :ivar _num_loops: numer of times to repeat the looping call based on the
+        ``tiemeout`` and the ``wait_interval``.
     :ivar per_node: number of containers and dataset per node.
     :ivar control_node_address: public ip address of the control node.
     :ivar cluster_cert: ``FilePath`` of the cluster certificate.
@@ -153,13 +181,20 @@ class ClusterContainerDeployment(object):
         """
         self.options = options
         try:
-            self.application_template = self.options['template']
+            self.image = DockerImage(repository=self.options['image'])
+            self.max_size = int(GiB(self.options['max-size']).to_Byte().value)
+            self.mountpoint = unicode(self.options['mountpoint'])
             self.per_node = self.options['apps-per-node']
             self.control_node_address = self.options['control-node']
             self.timeout = self.options['wait']
+            self.wait_interval = self.options['wait-interval']
             if self.timeout is None:
                 # Wait two hours by default
                 self.timeout = 72000
+            self._num_loops = 10
+            if self.wait_interval < self.timeout:
+                self._num_loops = self.timeout / self.wait_interval
+
         except Exception as e:
             sys.stderr.write("%s: %s\n" % ("Missing or wrong arguments", e))
             sys.stderr.write(e.args[0])
@@ -173,6 +208,8 @@ class ClusterContainerDeployment(object):
         self.cluster_cert = certificates_path.child(b"cluster.crt")
         self.user_cert = certificates_path.child(b"user.crt")
         self.user_key = certificates_path.child(b"user.key")
+        self._initial_num_datasets = 0
+        self._initial_num_containers = 0
         self.client = None
         self.reactor = reactor
         self.nodes = []
@@ -191,9 +228,29 @@ class ClusterContainerDeployment(object):
             self.user_key
         )
 
+    def _dataset_to_volume(self, dataset):
+        """
+        Given a ``Dataset``, returns a ``MountedDataset`` populated with
+        the information from the dataset and the mountpoint.
+
+        :param dataset: ``Dataset`` containing the dataset_id of an
+            existent dataset.
+
+        :return MountedDataset: with the datset id and the mountpoint
+            populated.
+        """
+        if dataset is not None:
+            return MountedDataset(dataset_id=dataset.dataset_id,
+                                  mountpoint=self.mountpoint)
+        else:
+            return None
+
     def _set_nodes(self, nodes):
         """
         Set the list of the nodes in the cluster.
+
+        :param nodes: list of ``Node`` containing all the nodes in the
+            cluster.
         """
         self.nodes = nodes
 
@@ -208,9 +265,35 @@ class ClusterContainerDeployment(object):
         Message.log(action="Listing current nodes")
         d = self.client.list_nodes()
         d.addCallback(self._set_nodes)
-        d.addCallback(self._build_config)
-        d.addCallback(self._configure)
+        d.addCallback(self._set_current_number_of_datasets_and_containers)
+        d.addCallback(self.create_datasets_and_containers)
         return d
+
+    def _set_current_number_of_datasets_and_containers(self, ignored):
+        """
+        Populates the ``self._initial_num_containers`` with the current
+        number of containers in the cluster. It is intended to be used
+        before requesting the creation of any containers or datasets so
+        we can know the total number of datasets and containers to expect.
+
+        :return Deferred: that will fire once the ``_initial_num_datasets``
+            and ``_initial_num_containers`` are populated.
+        """
+        d1 = self.client.list_containers_state()
+
+        def set_initial_num_containers(containers):
+            self._initial_num_containers = len(containers)
+
+        d1.addCallback(set_initial_num_containers)
+
+        d2 = self.client.list_datasets_state()
+
+        def set_initial_num_datasets(datasets):
+            self._initial_num_datasets = len(datasets)
+
+        d2.addCallback(set_initial_num_datasets)
+
+        return gather_deferreds([d1, d2])
 
     def is_datasets_deployment_complete(self):
         """
@@ -225,17 +308,20 @@ class ClusterContainerDeployment(object):
         d = self.client.list_datasets_state()
 
         def do_we_have_enough_datasets(datasets):
+            created_datasets = len(datasets) - self._initial_num_datasets
             msg = (
                 "Waiting for the datasets to be ready..."
-                "Created {current_datasets} of {total_datasets}"
+                "Created {current_datasets} of {datasets_to_create} "
+                "(Total = {total_datasets})"
 
             ).format(
-                current_datasets=len(datasets),
-                total_datasets=number_of_datasets,
+                current_datasets=created_datasets,
+                datasets_to_create=number_of_datasets,
+                total_datasets=len(datasets),
             )
             Message.log(action=msg)
 
-            return (len(datasets) >= number_of_datasets)
+            return (created_datasets >= number_of_datasets)
 
         d.addCallback(do_we_have_enough_datasets)
         return d
@@ -253,16 +339,19 @@ class ClusterContainerDeployment(object):
         d = self.client.list_containers_state()
 
         def do_we_have_enough_containers(containers):
+            created_containers = len(containers) - self._initial_num_containers
             msg = (
                 "Waiting for the containers to be ready..."
-                "Created {current_containers} of {total_containers}"
+                "Created {current_containers} of {containers_to_create} "
+                "(Total = {total_containers})"
 
             ).format(
-                current_containers=len(containers),
-                total_containers=number_of_containers,
+                current_containers=created_containers,
+                containers_to_create=number_of_containers,
+                total_containers=len(containers),
             )
             Message.log(action=msg)
-            return (len(containers) >= number_of_containers)
+            return (created_containers >= number_of_containers)
 
         d.addCallback(do_we_have_enough_containers)
         return d
@@ -277,87 +366,63 @@ class ClusterContainerDeployment(object):
         yield self.deploy()
         yield loop_until(self.reactor,
                          self.is_datasets_deployment_complete,
-                         repeat(1, self.timeout))
+                         repeat(self.wait_interval, self._num_loops))
         yield loop_until(self.reactor,
                          self.is_container_deployment_complete,
-                         repeat(1, self.timeout))
+                         repeat(self.wait_interval, self._num_loops))
 
-    def _build_config(self, ignored):
+    def create_datasets_and_containers(self, ignored=None):
         """
-        Build a Flocker deployment configuration for the given cluster
-        and parameters.
-        The configuration consists of identically configured applications
-        (containers) uniformly spread over all cluster nodes.
+        Create ``per_node`` containers and datasets in each node of the
+        cluster.
 
-        :return dict: containing the json we need to send to compose to
-            create the datasets and containers we want.
+        :return Deferred: once all the requests to create the datasets and
+            containers are made.
         """
-        Message.log(action="Building config")
-        application_root = {}
-        applications = {}
-        application_root["version"] = 1
-        application_root["applications"] = applications
+        deferred_list = []
         for node in self.nodes:
+            # Todo create a partial with the node info
+            create_container_in_node = partial(self.create_container,
+                                               node=node)
             for i in range(self.per_node):
-                name = "app_%s_%d" % (node.public_address, i)
-                applications[name] = deepcopy(self.application_template)
+                msg = (
+                    "Creating dataset {num_dataset} in node {node_uuid}"
 
-        deployment_root = {}
-        nodes = {}
-        deployment_root["nodes"] = nodes
-        deployment_root["version"] = 1
-        for node in self.nodes:
-            addr = "%s" % node.public_address
-            nodes[addr] = []
-            for i in range(self.per_node):
-                name = "app_%s_%d" % (node.public_address, i)
-                nodes[addr].append(name)
+                ).format(
+                    num_dataset=i+1,
+                    node_uuid=node.uuid,
+                )
+                Message.log(action=msg)
 
-        return {"applications": application_root,
-                "deployment": deployment_root}
+                d = self.client.create_dataset(node.uuid,
+                                               maximum_size=self.max_size)
+                d.addCallback(create_container_in_node)
+                deferred_list.append(d)
 
-    def _configure(self, configuration):
+        return gather_deferreds(deferred_list)
+
+    def create_container(self, dataset, node):
         """
-        Configure the cluster with the given deployment configuration.
+        Create a container in the given node with the give dataset attached.
 
-        :param dict configuration: dictionary with the configuration
-            to deploy.
-        :return Deferred: Deferred that fires when the configuration is pushed
-                          to the cluster's control agent.
+        :param dataset: ``Dataset`` to attach to the container.
+        :param node: ``Node`` where to create the container.
+
+        :return Deferred: that will fire once the request to create the
+            container is made.
         """
-        Message.log(action="Deploying new config")
-        base_url = b"https://{}:{}/v1".format(
-            self.control_node_address, REST_API_PORT
+        msg = (
+            "Creating container in node {node_uuid} with attached "
+            "dataset {dataset_id}"
+
+        ).format(
+            node_uuid=node.uuid,
+            dataset_id=dataset.dataset_id
         )
-        cluster_cert = self.cluster_cert
-        user_cert = self.user_cert
-        user_key = self.user_key
-        body = dumps(configuration)
-        treq_client = treq_with_authentication(
-            self.reactor, cluster_cert, user_cert, user_key)
+        Message.log(action=msg)
 
-        def do_configure():
-            posted = treq_client.post(
-                base_url + b"/configuration/_compose", data=body,
-                headers={b"content-type": b"application/json"},
-                persistent=False
-            )
-
-            def got_response(response):
-                if response.code != OK:
-                    d = json_content(response)
-
-                    def got_error(error):
-                        if isinstance(error, dict):
-                            error = error[u"description"] + u"\n"
-                        else:
-                            error = u"Unknown error: " + unicode(error) + "\n"
-                        raise ResponseError(response.code, error)
-
-                    d.addCallback(got_error)
-                    return d
-
-            posted.addCallback(got_response)
-            return posted
-
-        return do_configure()
+        return self.client.create_container(node.uuid,
+                                            unicode(uuid4()),
+                                            self.image,
+                                            volumes=[self._dataset_to_volume
+                                                     (dataset)])

--- a/docs/gettinginvolved/cluster-setup.rst
+++ b/docs/gettinginvolved/cluster-setup.rst
@@ -185,19 +185,22 @@ The :program:`setup-cluster-containers` script has the following command line op
 
 .. program:: setup-cluster-containers`
 
-.. option:: --app-template <application-template-file>
+.. option:: --image <docker image>
 
-   Specifies a YAML file that describes a single application.
-   It must include a name of a Docker image to use as an application container and may include other parameters.
+   Specifies the docker image to use to create the containers.
+
+.. option:: --mountpoint <mountpoint path>
+
+    Path of the mountpoint where the dataset should be mounted in the containers.
+
+.. option:: --control-node <ip-address>
+
+    Public IP address of the control node.
 
 .. option:: --apps-per-node <number>
 
    Specifies the number of applications (containers) to start on each cluster node.
    If this is not specified, one container and dataset per node will be created.
-
-.. option:: --control-node <ip-address>
-
-    Public IP address of the control node.
 
 .. option:: --cert-directory <certificates-directory>
 
@@ -207,36 +210,43 @@ The :program:`setup-cluster-containers` script has the following command line op
    - ``user.crt`` - a user certificate file; and
    - ``user.key`` - a user private key file.
 
+.. option:: --max-size <GB>
+    
+    Maximum size of the datasets specified in gigabytes. This parameter is optional. By default it will
+    be 1GB.
+
 .. option:: --wait <seconds>
 
    Specifies the timeout of waiting for the configuration changes to take effect
    or, in other words, for the cluster to converge.
    If this parameter is not set, then the program will wait up to two hours.
 
+.. option:: --wait-interval <seconds>
+    
+    The duration of the waiting intervals can be set as a parameter. It will determine how long the
+    program will wait between list calls when waiting for the containers and datasets to be created.
+    It is four seconds by default.
+
+If :option:`--max-size` is used the script will create volumes with the given maximum
+size (GB).
+If :option:`--max-size` is not specified, then the script will create volumes of 1GB.
+
 If :option:`--wait` is used the script waits for the deletions to take effect.
 After the script successfully finishes the cluster should be in a converged state
 with the requested containers and datasets.
 If :option:`--wait` is not specified, then the script will wait for up to two hours.
 
-Application Template
---------------------
+If :option:`--wait-interval` is used the script waits the specified number of seconds between
+list calls when waiting for the containers and datasets to be created.
+If :option:`--wait-interval` is not specified, then the script will wait for four seconds.
 
-The configuration file given for the ``--app-template`` parameter describes a single application.
-At the very least it should specify a name of a Docker image to use for an application container.
-
-.. code-block:: yaml
-
-  image: "clusterhq/mongodb"
-  volume:
-    mountpoint: "/data/db"
-
-See :ref:application-configuration for more details.
-The ``--apps-per-node`` parameter specifies how many applications to start on each cluster node.
+An example of how to use it, without specifying any optional argument would be:
 
 .. prompt:: bash $
 
   admin/setup-cluster-containers \
-    --app-template $PWD/application.yml \
+    --image "clusterhq/mongodb" \
+    --mountpoint "/data/db" \
     --apps-per-node 5 \
     --control-node 52.52.52.52 \
     --cert-directory /etc/flocker/test_cluster1/


### PR DESCRIPTION
Compose was used in the container setup script to create datasets and containers in a cluster. As it is deprecated, I have refactored the code to use the flocker client instead. That means that:
* app-template yaml file is no longer used: we only needed to know the Docker image, mountpoint, and we could specify the maximum size of the dataset. Anything else in the yaml file would be ignored, plus it didn't make sense to use a format that doesn't match with what we need to call create_dataset and create_container.
* The options that we do need have been added as command line arguments. That will, in addition, make it easier to integrate this script with the other ones, as we are aiming to have one single script that will do the benchmarking, including creating the cluster and setting up the containers. The parameters added are the docker image and the mountpoint (and an optional volume size)
* An extra improvement has been made to the way the scripts wait until the containers are created. In order to avoid overloading the control service with list calls while looping, instead of listing every second, now we list every four seconds. That waiting time can also be changed passing the new value as a command line argument