### PR TITLE
[FLOC-3965] Ensure log message is written if EBS volume is not ready

### DIFF
--- a/flocker/node/agents/_logging.py
+++ b/flocker/node/agents/_logging.py
@@ -88,12 +88,9 @@ TARGET_STATUS = Field.for_types(
 WAIT_TIME = Field.for_types(
     u"wait_time", [int, float],
     u"Time, in seconds, system waited for the volume to reach target status.")
-NEEDS_ATTACH_DATA = Field.for_types(
-    u"needs_attach_data", [bool],
-    u"True if target volume status leads to non-empty EBS Volume attach data.")
 WAITING_FOR_VOLUME_STATUS_CHANGE = MessageType(
     u"flocker:node:agents:blockdevice:aws:volume_status_change_wait",
-    [VOLUME_ID, STATUS, TARGET_STATUS, NEEDS_ATTACH_DATA, WAIT_TIME],
+    [VOLUME_ID, STATUS, TARGET_STATUS, WAIT_TIME],
     u"Waiting for a volume to reach target status.",)
 
 CREATE_VOLUME_FAILURE = MessageType(

--- a/flocker/node/agents/_logging.py
+++ b/flocker/node/agents/_logging.py
@@ -88,9 +88,12 @@ TARGET_STATUS = Field.for_types(
 WAIT_TIME = Field.for_types(
     u"wait_time", [int, float],
     u"Time, in seconds, system waited for the volume to reach target status.")
+NEEDS_ATTACH_DATA = Field.for_types(
+    u"needs_attach_data", [bool],
+    u"True if target volume status leads to non-empty EBS Volume attach data.")
 WAITING_FOR_VOLUME_STATUS_CHANGE = MessageType(
     u"flocker:node:agents:blockdevice:aws:volume_status_change_wait",
-    [VOLUME_ID, STATUS, TARGET_STATUS, WAIT_TIME],
+    [VOLUME_ID, STATUS, TARGET_STATUS, NEEDS_ATTACH_DATA, WAIT_TIME],
     u"Waiting for a volume to reach target status.",)
 
 CREATE_VOLUME_FAILURE = MessageType(

--- a/flocker/node/agents/_logging.py
+++ b/flocker/node/agents/_logging.py
@@ -86,7 +86,7 @@ TARGET_STATUS = Field.for_types(
     u"target_status", [bytes, unicode],
     u"Expected target status of the volume, as a result of an AWS API call.")
 WAIT_TIME = Field.for_types(
-    u"wait_time", [int],
+    u"wait_time", [int, float],
     u"Time, in seconds, system waited for the volume to reach target status.")
 NEEDS_ATTACH_DATA = Field.for_types(
     u"needs_attach_data", [bool],

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -710,9 +710,10 @@ def _wait_for_volume_state_change(operation,
     start_time = time.time()
     while not _should_finish(operation, volume, update, start_time, timeout):
         time.sleep(1.0)
-        WAITING_FOR_VOLUME_STATUS_CHANGE(volume_id=volume.id,
-                                         status=volume.state,
-                                         wait_time=(time.time() - start_time))
+        WAITING_FOR_VOLUME_STATUS_CHANGE(
+            volume_id=volume.id, status=volume.state,
+            wait_time=(time.time() - start_time)
+        ).write()
 
 
 def _get_device_size(device):

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -613,8 +613,10 @@ def _get_ebs_volume_state(volume):
     return volume
 
 
-def _should_finish(operation, volume, update, elapsed_time,
-                   timeout=VOLUME_STATE_CHANGE_TIMEOUT):
+def _reached_end_state(
+    operation, volume, update, elapsed_time,
+    timeout=VOLUME_STATE_CHANGE_TIMEOUT
+):
     """
     Helper function to determine if wait for volume's state transition
     resulting from given operation is over.
@@ -713,7 +715,7 @@ def _wait_for_volume_state_change(operation,
     # volume status to transition from
     # start_status -> transient_status -> end_status.
     start_time = time.time()
-    while not _should_finish(
+    while not _reached_end_state(
         operation, volume, update, (time.time() - start_time), timeout
     ):
         time.sleep(1.0)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -43,6 +43,8 @@ from .blockdevice import (
     MandatoryProfiles, ICloudAPI,
 )
 
+from flocker.common import poll_until
+
 from ..exceptions import StorageInitializationError
 
 from ...control import pmap_field
@@ -715,10 +717,12 @@ def _wait_for_volume_state_change(operation,
     # volume status to transition from
     # start_status -> transient_status -> end_status.
     start_time = time.time()
-    while not _reached_end_state(
-        operation, volume, update, (time.time() - start_time), timeout
-    ):
-        time.sleep(1.0)
+    poll_until(
+        lambda: _reached_end_state(
+           operation, volume, update, time.time() - start_time, timeout
+        ),
+        itertools.repeat(1)
+    )
 
 
 def _get_device_size(device):

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -657,6 +657,11 @@ def _should_finish(operation, volume, update, start_time,
         if e.response['Error']['Code'] == NOT_FOUND:
             raise UnknownVolume(volume.id)
 
+    WAITING_FOR_VOLUME_STATUS_CHANGE(
+        volume_id=volume.id, status=volume.state, target_status=end_state,
+        wait_time=(time.time() - start_time)
+    ).write()
+
     if volume.state not in [start_state, transient_state, end_state]:
         raise UnexpectedStateException(unicode(volume.id), operation,
                                        start_state, transient_state, end_state,
@@ -710,10 +715,6 @@ def _wait_for_volume_state_change(operation,
     start_time = time.time()
     while not _should_finish(operation, volume, update, start_time, timeout):
         time.sleep(1.0)
-        WAITING_FOR_VOLUME_STATUS_CHANGE(
-            volume_id=volume.id, status=volume.state,
-            wait_time=(time.time() - start_time)
-        ).write()
 
 
 def _get_device_size(device):

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -659,7 +659,7 @@ def _should_finish(operation, volume, update, start_time,
 
     WAITING_FOR_VOLUME_STATUS_CHANGE(
         volume_id=volume.id, status=volume.state, target_status=end_state,
-        wait_time=(time.time() - start_time)
+        needs_attach_data=sets_attach, wait_time=(time.time() - start_time)
     ).write()
 
     if volume.state not in [start_state, transient_state, end_state]:

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -4,7 +4,6 @@
 Functional tests for ``flocker.node.agents.ebs`` using an EC2 cluster.
 """
 
-import time
 from uuid import uuid4
 from bitmath import Byte, GiB
 
@@ -598,9 +597,8 @@ class VolumeStateTransitionTests(AsyncTestCase):
         volume = self._create_template_ebs_volume(operation)
         update = self._custom_update(operation, volume_end_state_type,
                                      attach_type)
-        start_time = time.time()
         self.assertRaises(UnexpectedStateException, _should_finish,
-                          operation, volume, update, start_time, TIMEOUT)
+                          operation, volume, update, 0, TIMEOUT)
 
     def _assert_fail(self, operation, volume_end_state_type,
                      attach_data_type=A.MISSING_ATTACH_DATA):
@@ -611,8 +609,7 @@ class VolumeStateTransitionTests(AsyncTestCase):
         volume = self._create_template_ebs_volume(operation)
         update = self._custom_update(operation, volume_end_state_type,
                                      attach_data_type)
-        start_time = time.time()
-        finish_result = _should_finish(operation, volume, update, start_time)
+        finish_result = _should_finish(operation, volume, update, 0)
         self.assertEqual(False, finish_result)
 
     def _assert_timeout(self, operation, testcase,
@@ -624,10 +621,8 @@ class VolumeStateTransitionTests(AsyncTestCase):
         volume = self._create_template_ebs_volume(operation)
         update = self._custom_update(operation, testcase, attach_data_type)
 
-        start_time = time.time()
-        time.sleep(TIMEOUT)
         self.assertRaises(TimeoutException, _should_finish,
-                          operation, volume, update, start_time, TIMEOUT)
+                          operation, volume, update, TIMEOUT + 1, TIMEOUT)
 
     def _process_volume(self, operation, testcase,
                         attach_data_type=A.ATTACH_SUCCESS):

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -22,7 +22,7 @@ from ..blockdevice import MandatoryProfiles
 from ..ebs import (
     _wait_for_volume_state_change,
     VolumeOperations, VolumeStateTable, VolumeStates,
-    TimeoutException, _should_finish, UnexpectedStateException,
+    TimeoutException, _reached_end_state, UnexpectedStateException,
     EBSMandatoryProfileAttributes, _get_volume_tag,
     AttachUnexpectedInstance, VolumeBusy,
 )
@@ -597,7 +597,7 @@ class VolumeStateTransitionTests(AsyncTestCase):
         volume = self._create_template_ebs_volume(operation)
         update = self._custom_update(operation, volume_end_state_type,
                                      attach_type)
-        self.assertRaises(UnexpectedStateException, _should_finish,
+        self.assertRaises(UnexpectedStateException, _reached_end_state,
                           operation, volume, update, 0, TIMEOUT)
 
     def _assert_fail(self, operation, volume_end_state_type,
@@ -609,7 +609,7 @@ class VolumeStateTransitionTests(AsyncTestCase):
         volume = self._create_template_ebs_volume(operation)
         update = self._custom_update(operation, volume_end_state_type,
                                      attach_data_type)
-        finish_result = _should_finish(operation, volume, update, 0)
+        finish_result = _reached_end_state(operation, volume, update, 0)
         self.assertEqual(False, finish_result)
 
     def _assert_timeout(self, operation, testcase,
@@ -621,7 +621,7 @@ class VolumeStateTransitionTests(AsyncTestCase):
         volume = self._create_template_ebs_volume(operation)
         update = self._custom_update(operation, testcase, attach_data_type)
 
-        self.assertRaises(TimeoutException, _should_finish,
+        self.assertRaises(TimeoutException, _reached_end_state,
                           operation, volume, update, TIMEOUT + 1, TIMEOUT)
 
     def _process_volume(self, operation, testcase,


### PR DESCRIPTION
Line to log a message is missing the `write()` method.

This is amongst the reasons it was difficult to see what is generating the AWS RequestLimitExceeded errors.