### PR TITLE
[FLOC-3832] EBS flaky test

### DIFF
--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -29,7 +29,7 @@ from ..ebs import (
     EBSMandatoryProfileAttributes, _get_volume_tag,
     AttachUnexpectedInstance, VolumeBusy,
 )
-from ....testtools import AsyncTestCase, flaky, async_runner
+from ....testtools import AsyncTestCase, async_runner
 
 from .._logging import (
     AWS_CODE, AWS_MESSAGE, AWS_REQUEST_ID, BOTO_LOG_HEADER,

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -159,7 +159,6 @@ class EBSBlockDeviceAPIInterfaceTests(
             bad_instance_id
         )
 
-    @flaky(u"FLOC-3832")
     def test_attach_when_foreign_device_has_next_device(self):
         """
         ``attach_volume`` does not attempt to use device paths that are already

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -8,6 +8,8 @@ import time
 from uuid import uuid4
 from bitmath import Byte, GiB
 
+from datetime import timedelta
+
 from botocore.exceptions import ClientError
 
 from testtools.matchers import AllMatch, ContainsAll
@@ -27,7 +29,7 @@ from ..ebs import (
     EBSMandatoryProfileAttributes, _get_volume_tag,
     AttachUnexpectedInstance, VolumeBusy,
 )
-from ....testtools import AsyncTestCase, flaky
+from ....testtools import AsyncTestCase, flaky, async_runner
 
 from .._logging import (
     AWS_CODE, AWS_MESSAGE, AWS_REQUEST_ID, BOTO_LOG_HEADER,
@@ -67,6 +69,8 @@ class EBSBlockDeviceAPIInterfaceTests(
             unknown_blockdevice_id_factory=lambda test: u"vol-00000000",
         )
 ):
+
+    run_tests_with = async_runner(timeout=timedelta(hours=1))
 
     """
     Interface adherence Tests for ``EBSBlockDeviceAPI``.

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -70,6 +70,14 @@ class EBSBlockDeviceAPIInterfaceTests(
         )
 ):
 
+    """
+    Due to AWS eventual consistency sometimes taking too long, give
+    these tests some extra time, such that they are limited only by
+    the CI system max time.
+
+    We are addressing eventual consistency issues; see
+    https://clusterhq.atlassian.net/browse/FLOC-3219
+    """
     run_tests_with = async_runner(timeout=timedelta(hours=1))
 
     """


### PR DESCRIPTION
The problem reported on this issue seems to be a result of AWS eventual consistency sometimes biting us. Not sure what else we can realistically do except give the tests more time to run and therefore hopefully encounter the volume state they expect to be able to proceed. There is (I think) some planned work around solving eventual consistency problems more broadly in Flocker by keeping track of state locally. See FLOC-3219