### PR TITLE
[FLOC-3933] Use testtools 1.9.0 

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,7 +42,7 @@ sphinx-prompt==1.0.0
 sphinx-rtd-theme==0.1.8
 sphinxcontrib-httpdomain==1.3.0
 sphinxcontrib-spelling==2.1.2
-testtools==1.8.2chq2
+testtools==1.9.0chq3
 tox==2.1.1
 troposphere==1.3.0
 versioneer==0.15

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -34,7 +34,7 @@ from hypothesis.strategies import (
     dictionaries, tuples
 )
 
-from testtools.deferredruntest import SynchronousDeferredRunTest
+from testtools.twistedsupport import SynchronousDeferredRunTest
 from testtools.matchers import Equals
 
 from twisted.internet import reactor

--- a/flocker/node/test/test_testtools.py
+++ b/flocker/node/test/test_testtools.py
@@ -4,7 +4,7 @@
 Tests for ``flocker.node.testtools``.
 """
 
-from testtools.deferredruntest import SynchronousDeferredRunTest
+from testtools.twistedsupport import SynchronousDeferredRunTest
 from twisted.internet.defer import succeed
 
 from .. import sequentially

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -20,7 +20,7 @@ from testtools.twistedsupport import (
 )
 
 try:
-    from testtools.twistedsupport import CaptureTwistedLogs
+    from testtools.deferredruntest import CaptureTwistedLogs
 except ImportError:
     # We are using a fork of testtools, which unfortunately means that we need
     # to do special things to make sure we're using the latest version. Raise

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -15,12 +15,12 @@ from fixtures import Fixture
 import testtools
 from testtools.content import Content, text_content
 from testtools.content_type import UTF8_TEXT
-from testtools.deferredruntest import (
+from testtools.twistedsupport import (
     AsynchronousDeferredRunTestForBrokenTwisted, assert_fails_with,
 )
 
 try:
-    from testtools.deferredruntest import CaptureTwistedLogs
+    from testtools.twistedsupport import CaptureTwistedLogs
 except ImportError:
     # We are using a fork of testtools, which unfortunately means that we need
     # to do special things to make sure we're using the latest version. Raise
@@ -112,13 +112,6 @@ class TestCase(testtools.TestCase, _MktempMixin, _DeferredAssertionMixin):
     # exception that signals skipping.
     skipException = SkipTest
 
-    def __init__(self, *args, **kwargs):
-        super(TestCase, self).__init__(*args, **kwargs)
-        # XXX: Work around testing-cabal/unittest-ext#60. Delete after
-        # https://github.com/testing-cabal/testtools/pull/189 lands, is
-        # released, and we use it.
-        self.exception_handlers.insert(-1, (unittest.SkipTest, _test_skipped))
-
     def setUp(self):
         log.msg("--> Begin: %s <--" % (self.id()))
         super(TestCase, self).setUp()
@@ -163,13 +156,6 @@ class AsyncTestCase(testtools.TestCase, _MktempMixin, _DeferredAssertionMixin):
     run_tests_with = async_runner(timeout=DEFAULT_ASYNC_TIMEOUT)
     # See comment on TestCase.skipException.
     skipException = SkipTest
-
-    def __init__(self, *args, **kwargs):
-        super(AsyncTestCase, self).__init__(*args, **kwargs)
-        # XXX: Work around testing-cabal/unittest-ext#60. Delete after
-        # https://github.com/testing-cabal/testtools/pull/189 lands, is
-        # released, and we use it.
-        self.exception_handlers.insert(-1, (unittest.SkipTest, _test_skipped))
 
     def setUp(self):
         log.msg("--> Begin: %s <--" % (self.id()))

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
         # "git+https" weirdness is due to setuptools expecting:
         #     vcs+proto://host/path@revision#egg=project-version
         # See https://setuptools.readthedocs.org/en/latest/setuptools.html
-        "git+https://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools-1.8.2chq2",  # noqa
+        "git+https://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools-1.9.0chq3",  # noqa
     ],
 
     # Some "trove classifiers" which are relevant.


### PR DESCRIPTION
Increments the version of testtools that we use.

Practical benefits:

* `expectThat` will actually fail async tests
* new matchers for Deferreds (see http://testtools.readthedocs.org/en/latest/twisted-support.html)
* `testtools.twistedsupport` new namespace for Twisted stuff
* less weird interaction with tests in case of timeout
* slightly less boilerplate in our base cases