### PR TITLE
[FLOC-3972] Ensure icloudapis have unicode lists.

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1121,8 +1121,8 @@ class ICloudAPI(Interface):
         This is used to figure out which nodes are dead, so that other
         nodes can do the detach.
 
-        :returns: A collection of compute instance IDs, compatible with
-            those returned by ``IBlockDeviceAPI.compute_instance_id``.
+        :returns: A collection of ``unicode`` compute instance IDs, compatible
+            with those returned by ``IBlockDeviceAPI.compute_instance_id``.
         """
 
     def start_node(node_id):

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -1363,7 +1363,7 @@ class EBSBlockDeviceAPI(object):
     def list_live_nodes(self):
         instances = self.connection.instances.filter(
             Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
-        return list(instance.id for instance in instances)
+        return list(unicode(instance.id) for instance in instances)
 
     @boto3_log
     def start_node(self, node_id):

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -425,17 +425,6 @@ class EBSProfiledBlockDeviceAPIInterfaceTests(
     pass
 
 
-class EBSCloudAPIInterfaceTests(
-        make_icloudapi_tests(
-            cloud_api_factory=ebsblockdeviceapi_for_test,
-        )
-):
-    """
-    Interface adherence tests for ``ICloudAPI``.
-    """
-    pass
-
-
 class VolumeStub(object):
     """
     Stub object to represent properties found on the immutable

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -425,6 +425,17 @@ class EBSProfiledBlockDeviceAPIInterfaceTests(
     pass
 
 
+class EBSCloudAPIInterfaceTests(
+        make_icloudapi_tests(
+            cloud_api_factory=ebsblockdeviceapi_for_test,
+        )
+):
+    """
+    Interface adherence tests for ``ICloudAPI``.
+    """
+    pass
+
+
 class VolumeStub(object):
     """
     Stub object to represent properties found on the immutable

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -5505,8 +5505,8 @@ def make_icloudapi_tests(
             """
             ``list_live_nodes`` returns an iterable of unicode values.
             """
-            result = self.api.list_live_nodes()
-            for x in result:
+            live_nodes = self.api.list_live_nodes()
+            for x in live_nodes:
                 self.expectThat(type(x), Is(unicode))
 
     return Tests

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -35,7 +35,7 @@ from hypothesis.strategies import (
 )
 
 from testtools.deferredruntest import SynchronousDeferredRunTest
-from testtools.matchers import Equals
+from testtools.matchers import Equals, Is
 
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
@@ -3921,6 +3921,45 @@ def make_iprofiledblockdeviceapi_tests(profiled_blockdevice_api_factory,
             super(Tests, self).setUp()
             self.api = profiled_blockdevice_api_factory(self)
             self.dataset_size = dataset_size
+
+    return Tests
+
+
+class ICloudAPITestsMixin(object):
+    """
+    Tests to perform on ``ICloudAPI`` providers.
+    """
+    def test_interface(self):
+        """
+        The API object provides ``IProfiledBlockDeviceAPI``.
+        """
+        self.assertTrue(
+            verifyObject(ICloudAPI, self.api)
+        )
+
+    def test_list_live_nodes(self):
+        """
+        ``list_live_nodes`` returns an iterable of unicode values.
+        """
+        result = self.api.list_live_nodes()
+        for x in result:
+            self.expectThat(type(x), Is(unicode))
+
+
+def make_icloudapi_tests(cloud_api_factory):
+    """
+    Create tests for classes that implement ``ICloudAPI``.
+
+    :param cloud_api_factory: A factory that generates the ``ICloudAPI``
+        provider to test.
+
+    :returns: A ``TestCase`` with tests that will be performed on the
+       supplied ``IProfiledBlockDeviceAPI`` provider.
+    """
+    class Tests(ICloudAPITestsMixin, TestCase):
+        def setUp(self):
+            super(Tests, self).setUp()
+            self.api = cloud_api_factory(self)
 
     return Tests
 

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -3925,45 +3925,6 @@ def make_iprofiledblockdeviceapi_tests(profiled_blockdevice_api_factory,
     return Tests
 
 
-class ICloudAPITestsMixin(object):
-    """
-    Tests to perform on ``ICloudAPI`` providers.
-    """
-    def test_interface(self):
-        """
-        The API object provides ``IProfiledBlockDeviceAPI``.
-        """
-        self.assertTrue(
-            verifyObject(ICloudAPI, self.api)
-        )
-
-    def test_list_live_nodes(self):
-        """
-        ``list_live_nodes`` returns an iterable of unicode values.
-        """
-        result = self.api.list_live_nodes()
-        for x in result:
-            self.expectThat(type(x), Is(unicode))
-
-
-def make_icloudapi_tests(cloud_api_factory):
-    """
-    Create tests for classes that implement ``ICloudAPI``.
-
-    :param cloud_api_factory: A factory that generates the ``ICloudAPI``
-        provider to test.
-
-    :returns: A ``TestCase`` with tests that will be performed on the
-       supplied ``IProfiledBlockDeviceAPI`` provider.
-    """
-    class Tests(ICloudAPITestsMixin, TestCase):
-        def setUp(self):
-            super(Tests, self).setUp()
-            self.api = cloud_api_factory(self)
-
-    return Tests
-
-
 class IBlockDeviceAsyncAPITestsMixin(object):
     """
     Tests to perform on ``IBlockDeviceAsyncAPI`` providers.
@@ -5539,6 +5500,15 @@ def make_icloudapi_tests(
             d.addCallback(lambda live:
                           self.assertIn(self.api.compute_instance_id(), live))
             return d
+
+        def test_list_live_nodes(self):
+            """
+            ``list_live_nodes`` returns an iterable of unicode values.
+            """
+            result = self.api.list_live_nodes()
+            for x in result:
+                self.expectThat(type(x), Is(unicode))
+
     return Tests
 
 


### PR DESCRIPTION
The EBS driver was returning non-unicode compute IDs for live nodes. This resulted in pyrsistent type errors during raw state discovery and ultimately non-convergence.

Added a functional test so we don't have to rely on acceptance tests to catch this issue in the future.