### PR TITLE
[FLOC-3977] Fixup labs admonition image and padding.

### DIFF
--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -394,9 +394,13 @@ Legacy
 }
 
 .admonition.labs {
-    background: url(../images/experimental.png) no-repeat #BCED91;
+    background: url(../images/icon-labs2x.png) no-repeat #BCED91;
     background-size:30px; background-position: 30px 20px;
     padding-right:20px;
+}
+
+.admonition.labs p {
+    padding-bottom:1em;
 }
 
 /* Nav Style from website */


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3977

While I was there, fixed bottom padding for these admonitions on low width displays.