### PR TITLE
[FLOC-3500] Disable timeout for Mongo tests

### DIFF
--- a/flocker/acceptance/integration/test_mongodb.py
+++ b/flocker/acceptance/integration/test_mongodb.py
@@ -4,10 +4,14 @@
 Tests for interoperability between MongoDB and Flocker datasets.
 """
 
+from datetime import timedelta
+
 from twisted.python.filepath import FilePath
 
 from ..testtools import get_mongo_client, require_mongo
 from .testtools import make_dataset_integration_testcase
+
+from ...testtools import async_runner
 
 
 def insert_data(test_case, host, port):
@@ -57,6 +61,10 @@ class MongoIntegrationTests(make_dataset_integration_testcase(
     """
     Integration tests for MongoDB.
     """
+
+    # Disable timeout for MongoDB integration tests.
+    run_tests_with = async_runner(timeout=timedelta(hours=1))
+
     @require_mongo
     def setUp(self):
         super(MongoIntegrationTests, self).setUp()


### PR DESCRIPTION
Should fix https://clusterhq.atlassian.net/browse/FLOC-3500

The code for the integration tests is about as broadly reliable as it's going to get; failures are typically due to these tests having only 2 minutes to run.