### PR TITLE
[FLOC-3975] Add counts of the most commonly called AWS API calls.

### DIFF
--- a/flocker/node/agents/_logging.py
+++ b/flocker/node/agents/_logging.py
@@ -8,10 +8,15 @@ for consolidation opportunities.
 """
 
 from eliot import Field, ActionType, MessageType
-from .blockdevice import DATASET_ID
 
 # Begin: Common structures used by all (AWS, OpenStack)
 # storage drivers.
+
+DATASET_ID = Field(
+    u"dataset_id",
+    lambda dataset_id: unicode(dataset_id),
+    u"The unique identifier of a dataset."
+)
 
 # An OPERATION is a list of:
 # IBlockDeviceAPI name, positional arguments, keyword arguments.

--- a/flocker/node/agents/_logging.py
+++ b/flocker/node/agents/_logging.py
@@ -20,6 +20,10 @@ OPERATION = Field.for_types(
     u"The IBlockDeviceAPI operation being executed,"
     u"along with positional and keyword arguments.")
 
+COUNT = Field.for_types(
+    u"count", [int],
+    u"Count of operation calls.")
+
 # End: Common structures used by all storage drivers.
 
 # Begin: Helper datastructures to log IBlockDeviceAPI calls
@@ -28,7 +32,7 @@ OPERATION = Field.for_types(
 # ActionType used by AWS storage driver.
 AWS_ACTION = ActionType(
     u"flocker:node:agents:blockdevice:aws",
-    [OPERATION],
+    [OPERATION, COUNT],
     [],
     u"An IBlockDeviceAPI operation is executing using AWS storage driver.")
 

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -420,6 +420,15 @@ DISCOVERED_RAW_STATE = MessageType(
     [Field(u"raw_state", safe_repr)],
     u"The discovered raw state of the node's block device volumes.")
 
+FUNCTION_NAME = Field.for_types(
+    "function", [bytes, unicode],
+    u"The name of the function.")
+
+CALL_LIST_VOLUMES = MessageType(
+    u"flocker:node:agents:blockdevice:list_volumes",
+    [FUNCTION_NAME, COUNT],
+    u"list_volumes called.",)
+
 
 def _volume_field():
     """
@@ -1228,12 +1237,6 @@ class _SyncToThreadedAsyncAPIAdapter(PClass):
     _threadpool = field()
 
 
-CALL_LIST_VOLUMES = MessageType(
-    u"flocker:node:agents:blockdevice:list_volumes",
-    [OPERATION, COUNT],
-    u"list_volumes called.",)
-
-
 def log_list_volumes(function):
     """
     Decorator to count calls to list_volumes.
@@ -1250,8 +1253,7 @@ def log_list_volumes(function):
         Run given function with count.
         """
         CALL_LIST_VOLUMES(
-            operation=[function.__name__, args[1:], kwargs],
-            count=next(counter)
+            function=function.__name__, count=next(counter)
         ).write()
         return function(*args, **kwargs)
     return _count_calls

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -32,7 +32,7 @@ from twisted.python.constants import (
 )
 
 from .blockdevice_manager import BlockDeviceManager
-from ._logging import DATASET_ID, OPERATION, COUNT
+from ._logging import DATASET_ID, COUNT
 
 from .. import (
     IDeployer, ILocalState, IStateChange, in_parallel, NoOp,

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -32,7 +32,7 @@ from twisted.python.constants import (
 )
 
 from .blockdevice_manager import BlockDeviceManager
-from ._logging import OPERATION, COUNT
+from ._logging import DATASET_ID, OPERATION, COUNT
 
 from .. import (
     IDeployer, ILocalState, IStateChange, in_parallel, NoOp,
@@ -272,12 +272,6 @@ FILESYSTEM_TYPE = Field.forTypes(
     u"filesystem_type",
     [unicode],
     u"The name of a filesystem."
-)
-
-DATASET_ID = Field(
-    u"dataset_id",
-    lambda dataset_id: unicode(dataset_id),
-    u"The unique identifier of a dataset."
 )
 
 MOUNTPOINT = Field(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -7,6 +7,7 @@ convergence agent that can be re-used against many different kinds of block
 devices.
 """
 
+import itertools
 from uuid import UUID
 from stat import S_IRWXU, S_IRWXG, S_IRWXO
 from errno import EEXIST
@@ -31,6 +32,7 @@ from twisted.python.constants import (
 )
 
 from .blockdevice_manager import BlockDeviceManager
+from ._logging import OPERATION, COUNT
 
 from .. import (
     IDeployer, ILocalState, IStateChange, in_parallel, NoOp,
@@ -1232,6 +1234,36 @@ class _SyncToThreadedAsyncAPIAdapter(PClass):
     _threadpool = field()
 
 
+CALL_LIST_VOLUMES = MessageType(
+    u"flocker:node:agents:blockdevice:list_volumes",
+    [OPERATION, COUNT],
+    u"list_volumes called.",)
+
+
+def log_list_volumes(function):
+    """
+    Decorator to count calls to list_volumes.
+
+    :param func function: The function to call.
+
+    :return: A function which will call the method and do
+        the extra logging.
+    """
+    counter = itertools.count(1)
+
+    def _count_calls(*args, **kwargs):
+        """
+        Run given function with count.
+        """
+        CALL_LIST_VOLUMES(
+            operation=[function.__name__, args[1:], kwargs],
+            count=next(counter)
+        ).write()
+        return function(*args, **kwargs)
+    return _count_calls
+
+
+@log_list_volumes
 def check_for_existing_dataset(api, dataset_id):
     """
     :param IBlockDeviceAPI api: The ``api`` for listing the existing volumes.
@@ -1246,6 +1278,7 @@ def check_for_existing_dataset(api, dataset_id):
             raise DatasetExists(volume)
 
 
+@log_list_volumes
 def get_blockdevice_volume(api, blockdevice_id):
     """
     Find a ``BlockDeviceVolume`` matching the given identifier.
@@ -1607,6 +1640,7 @@ class BlockDeviceDeployer(PClass):
             )
         return self._async_block_device_api
 
+    @log_list_volumes
     def _discover_raw_state(self):
         """
         Find the state of this node that is relevant to determining which

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -540,7 +540,7 @@ def boto3_log(method):
     :return: A function which will call the method and do
         the extra exception logging.
     """
-    counter = itertools.count()
+    counter = itertools.count(1)
 
     def _run_with_logging(*args, **kwargs):
         """

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -540,12 +540,17 @@ def boto3_log(method):
     :return: A function which will call the method and do
         the extra exception logging.
     """
+    counter = itertools.count()
+
     def _run_with_logging(*args, **kwargs):
         """
         Run given boto3.ec2.ServiceResource method with exception
         logging for ``ClientError``.
         """
-        with AWS_ACTION(operation=[method.__name__, args[1:], kwargs]):
+        with AWS_ACTION(
+            operation=[method.__name__, args[1:], kwargs],
+            count=next(counter)
+        ):
             return method(*args, **kwargs)
     return _run_with_logging
 
@@ -601,6 +606,7 @@ def _blockdevicevolume_from_ebs_volume(ebs_volume):
     )
 
 
+@boto3_log
 def _get_ebs_volume_state(volume):
     """
     Fetch input EBS volume's latest state from backend.

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -46,7 +46,7 @@ from twisted.python.filepath import FilePath
 from eliot import start_action, write_traceback, Message, Logger
 from eliot.testing import (
     validate_logging, capture_logging,
-    LoggedAction, assertHasMessage, assertHasAction
+    LoggedAction, LoggedMessage, assertHasMessage, assertHasAction
 )
 
 from .strategies import blockdevice_volumes
@@ -87,6 +87,8 @@ from ..blockdevice import (
 
     ICloudAPI,
     _SyncToThreadedAsyncCloudAPIAdapter,
+
+    log_list_volumes, CALL_LIST_VOLUMES,
 )
 
 from ..loopback import (
@@ -5533,3 +5535,41 @@ class BlockDeviceVolumeTests(TestCase):
                 ),
             ))
         )
+
+
+class LogListVolumesTest(TestCase):
+    """
+    Tests for ``log_list_volumes``
+    """
+
+    @capture_logging(lambda self, logger: None)
+    def test_generates_log_with_incrementing_count(self, logger):
+        """
+        ``log_list_volumes`` increments the count field of log messages.
+        """
+        @log_list_volumes
+        def wrapped():
+            pass
+
+        wrapped()
+        wrapped()
+        wrapped()
+
+        counts = [
+            logged.message['count'] for logged in LoggedMessage.of_type(
+                logger.messages, CALL_LIST_VOLUMES
+            )
+        ]
+
+        self.assertEqual(counts, [1, 2, 3])
+
+    def test_args_passed(self):
+        """
+        Arguments and result passed to/from wrapped function.
+        """
+        @log_list_volumes
+        def wrapped(x, y, z):
+            return (x, y, z)
+
+        result = wrapped(3, 5, z=7)
+        self.assertEqual(result, (3, 5, 7))


### PR DESCRIPTION
We often get `RequestLimitExceeded` errors on AWS.  This PR adds a count field to the logs of functions performing `boto` calls to show how often that operation has been called.  In addition, calls to the higher-level `list_volumes` function are counted, to isolate where they are coming from.

Sample log output:
```json
{"timestamp": 1453822992.761821, "task_uuid": "2e129379-1515-411c-9007-798c8aa27fe0", "action_type": "flocker:agent:discovery", "action_status": "started", "task_level": [2, 2, 1]}
{"count": 406, "task_uuid": "2e129379-1515-411c-9007-798c8aa27fe0", "timestamp": 1453822992.762302, "operation": ["_discover_raw_state", [], {}], "message_type": "flocker:node:agents:blockdevice:list_volumes", "task_level": [2, 2, 2]}
{"count": 406, "task_uuid": "2e129379-1515-411c-9007-798c8aa27fe0", "task_level": [2, 2, 3, 1], "action_type": "flocker:node:agents:blockdevice:aws", "timestamp": 1453822992.763307, "operation": ["_list_ebs_volumes", [], {}], "action_status": "started"}
```