### PR TITLE
[FLOC-3980] Release Flocker 1.10

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,16 +9,24 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
-Next Release
+This Release
 ============
+
+v1.10.0
+-------
 
 * The :ref:`Flocker documentation <supported-orchestration-frameworks>` has been re-designed to better reflect that Flocker now integrates with Cluster Managers, rather than providing its own container management features.
 * The new :ref:`CloudFormation installer <cloudformation>` has been made available, to provide a far simpler installation experience for users on AWS.
 * The :ref:`Flocker plugin for Docker <plugin>` should support the direct volume listing and inspection functionality added to Docker 1.10.
 * Fixed a regression that caused block device agents to poll backend APIs like EBS too frequently in some circumstances.
 
-This Release
-============
+Previous Releases
+=================
+
+.. contents::
+   :local:
+   :backlinks: none
+   :depth: 2
 
 v1.9.0
 ------
@@ -38,13 +46,6 @@ v1.9.0
 * The :ref:`Flocker plugin for Docker<plugin>` now supports specifying the size during volume creation.
 * Fixed a bug where Flocker would fail to service requests that had an unexpected format.
 
-Previous Releases
-=================
-
-.. contents::
-   :local:
-   :backlinks: none
-   :depth: 2
 
 v1.8.0
 ------

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -765,7 +765,7 @@ branches.each { branchName ->
     println("iterating over branch... ${branchName}")
     dashBranchName = escape_name(branchName)
     // our convention for release branches is release/flocker-<version>
-    isReleaseBuild = branchName.startsWith("release/*")
+    isReleaseBuild = branchName.startsWith("release/")
 
     generate_jobs_for_branch(dashProject, dashBranchName, branchName, false)
 

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -721,12 +721,13 @@ def build_multijob(dashProject, dashBranchName, branchName, isReleaseBuild) {
 }
 
 
-def generate_jobs_for_branch(dashProject, dashBranchName, branchName, isReleaseBuild) {
+def generate_jobs_for_branch(dashProject, dashBranchName, displayFolderName, branchName, isReleaseBuild) {
     /*
         Generate all the jobs for the specific branch.
 
         :param unicode dashProject: the project name escaped with dashes
         :param unicode dashBranchName: the branch name escaped with dashes
+        :param unicode displayFolderName: The display name of the folder.
         :param unicode branchName: the name of the branch for display - spaces
              etc. allowed
         :param bool isReleaseBuild: whether to generate a release build that
@@ -735,7 +736,7 @@ def generate_jobs_for_branch(dashProject, dashBranchName, branchName, isReleaseB
 
     // create a folder for every branch: /git-username/git-repo/branch
     folder(folder_name(dashProject, dashBranchName)) {
-        displayName(branchName)
+        displayName(displayFolderName)
     }
 
     // create tabs
@@ -767,12 +768,12 @@ branches.each { branchName ->
     // our convention for release branches is release/flocker-<version>
     isReleaseBuild = branchName.startsWith("release/")
 
-    generate_jobs_for_branch(dashProject, dashBranchName, branchName, false)
+    generate_jobs_for_branch(dashProject, dashBranchName, branchName, branchName, false)
 
     if (isReleaseBuild) {
         generate_jobs_for_branch(
             dashProject, "release-" + dashBranchName, "Release " + branchName,
-            true
+            branchName, true
         )
     }
 


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3980

Using the [instructions](http://clusterhq-staging-docs.s3.amazonaws.com/release-process-docs-jenkins-buildbot-FLOC-3964/gettinginvolved/infrastructure/release-process.html) from [FLOC-3964][https://clusterhq.atlassian.net/browse/FLOC-3964].