### PR TITLE
[FLOC-3763] Remove the jobs.groovy.j2 symlink.

### DIFF
--- a/jobs.groovy.j2
+++ b/jobs.groovy.j2
@@ -1,1 +1,0 @@
-jobs.groovy


### PR DESCRIPTION
Jenkins no longer uses the file, so we can remove the compatibility
symlink.