### PR TITLE
[FLOC-3983] Acceptance tests prep for node shutdown

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -94,11 +94,6 @@ def get_trial_environment(cluster):
         'FLOCKER_ACCEPTANCE_VOLUME_BACKEND': cluster.dataset_backend.name,
         'FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH':
             cluster.certificates_path.path,
-        'FLOCKER_ACCEPTANCE_HOSTNAME_TO_PUBLIC_ADDRESS': json.dumps({
-            node.private_address: node.address
-            for node in cluster.agent_nodes
-            if node.private_address is not None
-        }),
         'FLOCKER_ACCEPTANCE_DEFAULT_VOLUME_SIZE': bytes(
             cluster.default_volume_size
         ),

--- a/flocker/acceptance/endtoend/test_installer.py
+++ b/flocker/acceptance/endtoend/test_installer.py
@@ -326,7 +326,6 @@ class DockerComposeTests(AsyncTestCase):
             control_node=self.control_node_ip.encode('ascii'),
             certificates_path=local_certs_path,
             num_agent_nodes=2,
-            hostname_to_public_address={},
             username='user1',
         )
         d.addCallback(

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1121,8 +1121,10 @@ class ICloudAPI(Interface):
         This is used to figure out which nodes are dead, so that other
         nodes can do the detach.
 
-        :returns: A collection of ``unicode`` compute instance IDs, compatible
-            with those returned by ``IBlockDeviceAPI.compute_instance_id``.
+        :returns: A mapping of ``unicode`` compute instance IDs
+            (compatible with those returned by
+            ``IBlockDeviceAPI.compute_instance_id``) to IPs of those
+            nodes, also as unicode..
         """
 
     def start_node(node_id):
@@ -1647,7 +1649,8 @@ class BlockDeviceDeployer(PClass):
                     pass
 
         if ICloudAPI.providedBy(self._underlying_blockdevice_api):
-            live_instances = self._underlying_blockdevice_api.list_live_nodes()
+            live_instances = list(
+                self._underlying_blockdevice_api.list_live_nodes())
         else:
             # Can't know accurately who is alive and who is dead:
             live_instances = None

--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -689,8 +689,11 @@ class CinderBlockDeviceAPI(object):
 
     # ICloudAPI:
     def list_live_nodes(self):
-        return list(server.id for server in self.nova_server_manager.list()
-                    if server.status == u'ACTIVE')
+        return {server.id:
+                list(map(
+                    unicode, _extract_nova_server_addresses(server.addresses)))
+                for server in self.nova_server_manager.list()
+                if server.status == u'ACTIVE'}
 
     def start_node(self, node_id):
         server = self.nova_server_manager.get(node_id)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -719,7 +719,7 @@ def _wait_for_volume_state_change(operation,
     start_time = time.time()
     poll_until(
         lambda: _reached_end_state(
-           operation, volume, update, time.time() - start_time, timeout
+            operation, volume, update, time.time() - start_time, timeout
         ),
         itertools.repeat(1)
     )

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -1363,7 +1363,10 @@ class EBSBlockDeviceAPI(object):
     def list_live_nodes(self):
         instances = self.connection.instances.filter(
             Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
-        return list(unicode(instance.id) for instance in instances)
+        return {unicode(instance.id):
+                [unicode(instance.public_ip_address),
+                 unicode(instance.private_ip_address)]
+                for instance in instances}
 
     @boto3_log
     def start_node(self, node_id):

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -754,7 +754,9 @@ class FakeCloudAPI(proxyForInterface(IBlockDeviceAPI)):
         self.live_nodes = live_nodes
 
     def list_live_nodes(self):
-        return [self.compute_instance_id()] + list(self.live_nodes)
+        return {node: [u"10.1.1.{}".format(i)]
+                for i, node in enumerate(
+                        [self.compute_instance_id()] + list(self.live_nodes))}
 
     def start_node(self, node_id):
         return
@@ -5501,11 +5503,17 @@ def make_icloudapi_tests(
                           self.assertIn(self.api.compute_instance_id(), live))
             return d
 
+        def test_current_machine_has_appropriate_ip(self):
+            """
+            The machine's known IP is set for the current node.
+            """
+            # XXX ...
+
         def test_list_live_nodes(self):
             """
             ``list_live_nodes`` returns an iterable of unicode values.
             """
-            live_nodes = self.api.list_live_nodes()
+            live_nodes = list(self.api.list_live_nodes())
             self.assertThat(live_nodes, AllMatch(IsInstance(unicode)))
 
     return Tests

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -97,7 +97,7 @@ from ..loopback import (
     _backing_file_name,
 )
 from ....common.algebraic import tagged_union_strategy
-
+from ....common import get_all_ips
 
 from ... import run_state_change, in_parallel, ILocalState, IStateChange, NoOp
 from ...testtools import (
@@ -754,9 +754,12 @@ class FakeCloudAPI(proxyForInterface(IBlockDeviceAPI)):
         self.live_nodes = live_nodes
 
     def list_live_nodes(self):
-        return {node: [u"10.1.1.{}".format(i)]
-                for i, node in enumerate(
-                        [self.compute_instance_id()] + list(self.live_nodes))}
+        result = {self.compute_instance_id():
+                  set(unicode(i) for i in get_all_ips()
+                      if i != b"127.0.0.1")}
+        result.update({node: [u"10.1.1.{}".format(i)]
+                       for i, node in enumerate(self.live_nodes)})
+        return result
 
     def start_node(self, node_id):
         return
@@ -5507,7 +5510,15 @@ def make_icloudapi_tests(
             """
             The machine's known IP is set for the current node.
             """
-            # XXX ...
+            local_addresses = set(unicode(i) for i in get_all_ips()
+                                  if i != b"127.0.0.1")
+            d = self.async_cloud_api.list_live_nodes()
+            d.addCallback(
+                lambda live:
+                self.assertTrue(
+                    set(live[self.api.compute_instance_id()]).intersection(
+                        local_addresses)))
+            return d
 
         def test_list_live_nodes(self):
             """


### PR DESCRIPTION
When a node is shutdown and later started its public IP may have changed. We want to have an acceptance test that shuts down a node, to test moving datasets off dead nodes. We can therefore not rely on a fixed public IP for all tests.

Did so by trusting Flocker's reported IPs for nodes by default. However, if the backend provides `ICloudAPI` we use that to figure out public IP for each node.