### PR TITLE
Also publish test results from run_trial_for_ebs_storage_driver_on_CentOS_7

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1163,6 +1163,7 @@ job_type:
                    *convert_results_to_junit ]
           }
       archive_artifacts: *flocker_artifacts
+      publish_test_results: true
       coverage_report: true
       clean_repo: true
       timeout: 45


### PR DESCRIPTION
The other similar jobs have publish_test_results: true, but it
was apparently missed for this one. This will mean that Jenkins
will show the tests that failed for this job like the other jobs.