### PR TITLE
[FLOC-3947] Tool for adding new nodes to an existing Flocker cluster

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -458,7 +458,7 @@ def make_managed_nodes(addresses, distribution):
 
 def get_default_volume_size(dataset_backend_configuration):
     """
-    Calcuate the default volume size for the given dataset backend
+    Calculate the default volume size for the given dataset backend
     configuration.
 
     :param dataset_backend_configuration: The backend configuration.
@@ -649,7 +649,7 @@ class LibcloudRunner(object):
                     self._destroy_node(node)
                     return failure
 
-                # Make sure too return the node.
+                # Make sure to return the node.
                 d.addCallbacks(lambda _: node, errback=provisioning_failed)
                 return d
 

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -705,11 +705,11 @@ class LibcloudRunner(object):
         :return: Deferred that fires with the :param:`node` when it is
             configured.
         """
-        node_certnkey = cluster.certificates.add_node(index)
+        node_cert_and_key = cluster.certificates.add_node(index)
         commands = configure_node(
             cluster,
             node,
-            node_certnkey,
+            node_cert_and_key,
             self.dataset_backend_configuration,
             'libcloud',
             logging_config=self.config.get('logging'),

--- a/admin/add-cluster-nodes
+++ b/admin/add-cluster-nodes
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Add a new node to a cluster.
+"""
+
+from _preamble import TOPLEVEL, BASEPATH
+
+import sys
+
+from twisted.internet.task import react
+
+from admin.cluster_add_nodes import main
+
+if __name__ == '__main__':
+    react(main, (sys.argv[1:], BASEPATH, TOPLEVEL))

--- a/admin/add-cluster-nodes
+++ b/admin/add-cluster-nodes
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 """
-Add a new node to a cluster.
+Provision new nodes and add them to an existing cluster
 """
 
 from _preamble import TOPLEVEL, BASEPATH

--- a/admin/cluster_add_nodes.py
+++ b/admin/cluster_add_nodes.py
@@ -106,6 +106,8 @@ def main(reactor, args, base_path, top_level):
         options.parseOptions(args)
     except UsageError as e:
         sys.stderr.write("%s: %s\n" % (base_path.basename(), e))
+        sys.stderr.write("\n")
+        sys.stderr.write(str(options))
         raise SystemExit(1)
 
     # Existing nodes must be described in a managed section

--- a/admin/cluster_add_nodes.py
+++ b/admin/cluster_add_nodes.py
@@ -190,10 +190,7 @@ def main(reactor, args, base_path, top_level):
         if not success:
             failed_count = failed_count + 1
     if failed_count:
-        print "Failed to create {} nodes, see log.".format(failed_count)
-
-    for n in cluster.agent_nodes:
-        print "agent node:", n
+        print "Failed to create {} nodes, see logs.".format(failed_count)
 
     yield wait_for_nodes(
         reactor,

--- a/admin/cluster_add_nodes.py
+++ b/admin/cluster_add_nodes.py
@@ -1,0 +1,204 @@
+# Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
+"""
+Provision a new node and add it to an existing cluster.
+"""
+
+import sys
+
+from eliot import FileDestination, add_destination
+
+from twisted.internet.defer import DeferredList, inlineCallbacks
+from twisted.python.usage import UsageError
+from twisted.python.filepath import FilePath
+
+from flocker.provision._ca import Certificates
+from flocker.provision._common import Cluster
+
+from .acceptance import (
+    capture_journal,
+    capture_upstart,
+    eliot_output,
+    get_default_volume_size,
+    make_managed_nodes,
+    save_backend_configuration,
+)
+from .cluster_setup import (
+    RunOptions as SetupOptions,
+    make_client,
+    save_environment,
+    save_managed_config,
+    wait_for_nodes,
+)
+
+
+class RunOptions(SetupOptions):
+    optParameters = [
+        ['purpose', None, 'testing',
+         "Purpose of the cluster recorded in its metadata where possible."],
+        ['tag', None, None,
+         "Tag used in names of the existing cluster nodes."],
+        ['control-node', None, None,
+         "The address of the cluster's control node."],
+        ['cert-directory', None, None,
+         "Directory with the cluster certificates. "],
+        ['number-of-nodes', None, 1,
+         "Number of new nodes to create.", int],
+        ['starting-index', None, None,
+         "Starting index to use in names of new nodes.", int],
+    ]
+
+    def __init__(self, top_level):
+        """
+        :param FilePath top_level: The top-level of the Flocker repository.
+        :param reactor: The reactor.
+        :param Deferred ready: A deferred to fire...
+        """
+        super(RunOptions, self).__init__(top_level)
+        self._remove_options(['no-keep'])
+
+    def _remove_options(self, to_remove):
+        """
+        Remove the given options that are defined in the parent classes.
+
+        :param to_remove: The options to rmeove.
+        :type to_remove: list of str
+
+        .. note::
+            Option names should be given as is,
+            parameter names should have '=' suffix.
+        """
+        self.longOpt = [opt for opt in self.longOpt if opt not in to_remove]
+
+    def postOptions(self):
+        if not self['control-node']:
+            raise UsageError("Control node address must be provided.")
+        if self.get('cert-directory') is None:
+            raise UsageError("Certificate directory must be set.")
+        if self.get('tag') is None:
+            raise UsageError("Tag must be specified.")
+
+        # This is run last as it creates the actual "runner" object
+        # based on the provided parameters.
+        super(RunOptions, self).postOptions()
+
+    def _check_cert_directory(self):
+        cert_path = FilePath(self['cert-directory'])
+        self['cert-directory'] = cert_path
+        if not cert_path.exists():
+            raise UsageError("{} does not exist".format(cert_path.path))
+        if not cert_path.isdir():
+            raise UsageError("{} is not a directory".format(cert_path.path))
+
+
+@inlineCallbacks
+def main(reactor, args, base_path, top_level):
+    """
+    :param reactor: Reactor to use.
+    :param list args: The arguments passed to the script.
+    :param FilePath base_path: The executable being run.
+    :param FilePath top_level: The top-level of the Flocker repository.
+    """
+    add_destination(eliot_output)
+    options = RunOptions(top_level=top_level)
+    try:
+        options.parseOptions(args)
+    except UsageError as e:
+        sys.stderr.write("%s: %s\n" % (base_path.basename(), e))
+        raise SystemExit(1)
+
+    # Existing nodes must be described in a managed section
+    # of the configuration.
+    existing_nodes = make_managed_nodes(
+        options['config']['managed']['addresses'],
+        options['distribution'],
+    )
+    # The following code assumes that one of the managed nodes
+    # is both a control node and an agent node.
+    [control_node] = [
+        node for node in existing_nodes
+        if node.address == options['control-node']
+    ]
+    dataset_backend_config_file = save_backend_configuration(
+        options.dataset_backend(),
+        options.dataset_backend_configuration(),
+    )
+    cluster = Cluster(
+        all_nodes=list(existing_nodes),
+        control_node=control_node,
+        agent_nodes=list(existing_nodes),
+        dataset_backend=options.dataset_backend(),
+        default_volume_size=get_default_volume_size(
+            options.dataset_backend_configuration()
+        ),
+        certificates=Certificates(options['cert-directory']),
+        dataset_backend_config_file=dataset_backend_config_file,
+    )
+
+    flocker_client = make_client(reactor, cluster)
+    existing_count = len(existing_nodes)
+    yield wait_for_nodes(reactor, flocker_client, existing_count)
+    if options['starting-index'] is None:
+        options['starting-index'] = existing_count
+
+    print(
+        "Adding {} node(s) to the cluster of {} nodes "
+        "starting at index {}".format(
+            options['number-of-nodes'],
+            existing_count,
+            options['starting-index'],
+        )
+    )
+
+    runner = options.runner
+    cleanup_id = reactor.addSystemEventTrigger('before', 'shutdown',
+                                               runner.stop_cluster, reactor)
+
+    from flocker.common.script import eliot_logging_service
+    log_writer = eliot_logging_service(
+        destination=FileDestination(
+            file=open("%s.log" % (base_path.basename(),), "a")
+        ),
+        reactor=reactor,
+        capture_stdout=False)
+    log_writer.startService()
+    reactor.addSystemEventTrigger(
+        'before', 'shutdown', log_writer.stopService)
+
+    control_node = options['control-node']
+    if options['distribution'] in ('centos-7',):
+        remote_logs_file = open("remote_logs.log", "a")
+        capture_journal(reactor, control_node, remote_logs_file)
+    elif options['distribution'] in ('ubuntu-14.04', 'ubuntu-15.10'):
+        remote_logs_file = open("remote_logs.log", "a")
+        capture_upstart(reactor, control_node, remote_logs_file)
+
+    yield runner.ensure_keys(reactor)
+
+    deferreds = runner.extend_cluster(
+        reactor,
+        cluster,
+        options['number-of-nodes'],
+        options['tag'],
+        options['starting-index'],
+    )
+    results = yield DeferredList(deferreds)
+
+    failed_count = 0
+    for (success, value) in results:
+        if not success:
+            failed_count = failed_count + 1
+    if failed_count:
+        print "Failed to create {} nodes, see log.".format(failed_count)
+
+    for n in cluster.agent_nodes:
+        print "agent node:", n
+
+    yield wait_for_nodes(
+        reactor,
+        flocker_client,
+        len(cluster.agent_nodes),
+    )
+
+    save_managed_config(options['cert-directory'], options['config'], cluster)
+    save_environment(options['cert-directory'], cluster)
+    reactor.removeSystemEventTrigger(cleanup_id)

--- a/admin/cluster_add_nodes.py
+++ b/admin/cluster_add_nodes.py
@@ -1,6 +1,6 @@
 # Copyright 2015 ClusterHQ Inc.  See LICENSE file for details.
 """
-Provision a new node and add it to an existing cluster.
+Provision new nodes and add them to an existing cluster.
 """
 
 import sys
@@ -46,6 +46,8 @@ class RunOptions(SetupOptions):
         ['starting-index', None, None,
          "Starting index to use in names of new nodes.", int],
     ]
+
+    synopsis = 'Usage: add-cluster-nodes [options]'
 
     def __init__(self, top_level):
         """

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -272,7 +272,7 @@ def _wait_for_nodes(reactor, client, count):
         def check_node_count(nodes):
             print("Waiting for nodes, "
                   "got {} out of {}".format(len(nodes), count))
-            return len(nodes) == count
+            return len(nodes) >= count
 
         d.addCallback(check_node_count)
         return d

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -48,9 +48,9 @@ class LibcloudRunner(OldLibcloudRunner):
     def _setup_control_node(self, reactor, node, index):
         print "Selecting node {} for control service".format(node.name)
         certificates = Certificates.generate(
-            self.cert_path,
-            node.address,
-            0,
+            directory=self.cert_path,
+            control_hostname=node.address,
+            num_nodes=0,
             cluster_name=self.identity.name,
             cluster_id=self.identity.id,
         )

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -75,21 +75,21 @@ class LibcloudRunner(OldLibcloudRunner):
         )
         d = perform(make_dispatcher(reactor), commands)
 
-        def error(failure):
+        def configure_failed(failure):
             print "Failed to configure control node"
             write_failure(failure)
             return failure
 
-        d.addErrback(error)
-
         # It should be sufficient to configure just the control service here,
         # but there is an assumption that the control node is both a control
         # node and an agent node.
-        d.addCallback(
+        d.addCallbacks(
             lambda _: self._add_node_to_cluster(
                 reactor, cluster, node, index
-            )
+            ),
+            errback=configure_failed,
         )
+        # Return the cluster.
         d.addCallback(lambda _: cluster)
         return d
 

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -94,11 +94,8 @@ class LibcloudRunner(OldLibcloudRunner):
         return d
 
     def _add_nodes_to_cluster(self, reactor, cluster, results):
-        print "_add_nodes_to_cluster called"
-
         def add_node(node, index):
             # The control should be already fully configured.
-            print "add_node called for node #{} {}".format(index, node.name)
             if node is not cluster.control_node:
                 return self._add_node_to_cluster(reactor, cluster, node, index)
 

--- a/docs/gettinginvolved/cluster-setup.rst
+++ b/docs/gettinginvolved/cluster-setup.rst
@@ -68,6 +68,13 @@ The :program:`admin/setup-cluster` script has several options:
    Specifies the number of nodes (machines) to create for use in the cluster.
    This option is only applicable if the nodes are created dynamically.
 
+.. option:: --cert-directory <directory>
+
+   If this option is used then the generated cluster certificate files will be stored
+   in the directory specified.
+   Otherwise a random temporary directory will be used.
+   The specified directory must not exist or it must be an empty directory.
+
 To see the supported values for each option, run:
 
 .. prompt:: bash $
@@ -83,6 +90,17 @@ An example of how to run :program:`setup-cluster` would be:
     --provider rackspace \
     --config-file $PWD/cluster.yml \
     --number-of-nodes 2 
+
+The :program:`setup-cluster` script also creates the following files in the directory
+specified by :option:`--cert-directory`:
+
+    :file:`environment.env`
+        contains definitions of the environment variables that are needed to run the
+        acceptance tests on the cluster.
+
+    :file:`managed.yaml`
+        a YAML configuration file based on the file specified with :option:`--config-file` that
+        in addition contains a ``managed`` section describing the newly created cluster nodes.
 
 Configuration File
 ==================
@@ -170,6 +188,119 @@ Or you can run, for example, the acceptance tests against the created cluster:
      --branch=master \
      --flocker-version='' \
      flocker.acceptance.obsolete.test_containers.ContainerAPITests.test_create_container_with_ports
+
+=========================
+Extending a Cluster
+=========================
+
+It is possible to add more nodes to an existing Flocker cluster.
+
+.. prompt:: bash $
+
+   admin/add-cluster-nodes <options>
+
+
+The :program:`admin/add-cluster-nodes` script has several options,
+some of them the same as for :program:`admin/setup-cluster`:
+
+.. program:: admin/add-cluster-nodes
+
+.. option:: --distribution <distribution>
+
+   See :program:`admin/setup-cluster`.
+   Typically this would be the same distribution as for the existing cluster nodes,
+   however that's not required.
+
+.. option:: --provider <provider>
+
+   See :program:`admin/setup-cluster`.
+   This should be the same provider as for the existing nodes.
+   The new nodes may fail to work properly otherwise.
+   At present ``rackspace`` and ``aws`` providers are supported.
+
+.. option:: --dataset-backend <dataset-backend>
+
+   See :program:`admin/setup-cluster`.
+
+.. option:: --branch <branch>
+
+   See :program:`admin/setup-cluster`.
+   Different Flocker versions might fail to inter-operate.
+
+.. option:: --flocker-version <version>
+
+   See :program:`admin/setup-cluster`.
+   Different Flocker versions might fail to inter-operate.
+
+.. option:: --build-server <buildserver>
+
+   See :program:`admin/setup-cluster`.
+
+.. option:: --config-file <config-file>
+
+   See :program:`admin/setup-cluster`.
+   The configuration file must include a ``managed`` section that describes the existing nodes.
+   Typically this would be :file:`managed.yaml` file from the certificates directory
+   of the cluster.  See :option:`--cert-directory`.
+
+.. option:: --purpose <purpose>
+
+   See :program:`admin/setup-cluster`.
+   The purpose should be the same as used when creating the existing node.
+   That makes the administration of the nodes easier.
+
+.. option:: --tag <tag>
+
+   :program:`admin/setup-cluster` generates a random tag that is added to names
+   of the cluster nodes.
+   This option allows to use the same tag for the new nodes.
+   That makes the administration of the nodes easier.
+
+.. option:: --number-of-nodes <number>
+
+   Specifies the number of additional nodes to add to the cluster.
+
+.. option:: --cert-directory <directory>
+
+   This mandatory option specifies a directory with the cluster certificate files.
+   Certificate files for the new nodes will also be added to this directory.
+   The :file:`environment.env` and :file:`managed.yaml` files in this directory will
+   be updated in place.
+
+.. option:: --control-node <IP address>
+
+   IP address of the cluster's control node.
+
+.. option:: --starting-index <number>
+
+   A starting index to use when naming the new nodes.
+   If not specified then the number of the existing nodes will be used as the starting index.
+   The indexes of nodes are reflected in their names and in file names of node certificates.
+
+
+:program:`add-cluster-nodes` may create fewer nodes than requested with :option:`--number-of-nodes`,
+the partial success is still considered as a success.
+A diagnostic message will be printed in such a case.
+
+To see the supported values for each option, run:
+
+.. prompt:: bash $
+
+   admin/add-cluster-nodes --help
+
+An example of how to run :program:`add-cluster-nodes` would be:
+
+.. prompt:: bash $
+
+  admin/add-cluster-node \
+    --distribution centos-7 \
+    --branch master \
+    --config-file ~/clusters/test0/managed.yaml \
+    --purpose FLOC-3947 \
+    --tag '4S4Av0gRJ9c' \
+    --cert-directory ~/clusters/test0 \
+    --control-node 52.33.228.33 \
+    --number-of-nodes 3
 
 Adding Containers and Datasets
 ==============================

--- a/flocker/provision/_ca.py
+++ b/flocker/provision/_ca.py
@@ -93,3 +93,25 @@ class Certificates(object):
             child.moveTo(directory.child(b"node-%d.crt" % (i,)))
             sibling.moveTo(directory.child(b"node-%d.key" % (i,)))
         return cls(directory)
+
+    def add_node(self, index):
+        """
+        Generate another node certificate.
+
+        :rtype: CertAndKey
+        :return: The newly created node certificate.
+        """
+        def run(*arguments):
+            check_call([b"flocker-ca"] + list(arguments),
+                       cwd=self.directory.path)
+
+        run(b"create-node-certificate")
+        tmp_crt = self.directory.globChildren(b"????????-????-*.crt")[0]
+        tmp_key = FilePath(tmp_crt.path[:-3] + b"key")
+        crt = self.directory.child(b"node-%d.crt" % (index,))
+        key = self.directory.child(b"node-%d.key" % (index,))
+        tmp_crt.moveTo(crt)
+        tmp_key.moveTo(key)
+        cert = CertAndKey(crt, key)
+        self.nodes.append(cert)
+        return cert

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -1508,63 +1508,116 @@ def configure_cluster(
     :param dict logging_config: A Python logging configuration dictionary,
         following the structure of PEP 391.
     """
-    setup_action = 'start'
-    if provider == "managed":
-        setup_action = 'restart'
-
     return sequence([
-        run_remotely(
-            username='root',
-            address=cluster.control_node.address,
-            commands=sequence([
-                task_install_control_certificates(
-                    cluster.certificates.cluster.certificate,
-                    cluster.certificates.control.certificate,
-                    cluster.certificates.control.key),
-                task_enable_flocker_control(cluster.control_node.distribution,
-                                            setup_action),
-                if_firewall_available(
-                    cluster.control_node.distribution,
-                    task_open_control_firewall(
-                        cluster.control_node.distribution
-                    )
-                ),
-                ]),
+        configure_control_node(
+            cluster,
+            provider,
+            logging_config,
         ),
         parallel([
             sequence([
-                run_remotely(
-                    username='root',
-                    address=node.address,
-                    commands=sequence([
-                        task_install_node_certificates(
-                            cluster.certificates.cluster.certificate,
-                            certnkey.certificate,
-                            certnkey.key),
-                        task_install_api_certificates(
-                            cluster.certificates.user.certificate,
-                            cluster.certificates.user.key),
-                        task_enable_docker(node.distribution),
-                        if_firewall_available(
-                            node.distribution,
-                            open_firewall_for_docker_api(node.distribution),
-                        ),
-                        task_configure_flocker_agent(
-                            control_node=cluster.control_node.address,
-                            dataset_backend=cluster.dataset_backend,
-                            dataset_backend_configuration=(
-                                dataset_backend_configuration
-                            ),
-                            logging_config=logging_config,
-                        ),
-                        task_enable_docker_plugin(node.distribution),
-                        task_enable_flocker_agent(
-                            distribution=node.distribution,
-                            action=setup_action,
-                        ),
-                    ]),
+                configure_node(
+                    cluster,
+                    node,
+                    certnkey,
+                    dataset_backend_configuration,
+                    provider,
+                    logging_config,
                 ),
             ]) for certnkey, node
             in zip(cluster.certificates.nodes, cluster.agent_nodes)
         ])
     ])
+
+
+def configure_control_node(
+    cluster,
+    provider,
+    logging_config=None
+):
+    """
+    Configure Flocker control service on the given node.
+
+    :param Cluster cluster: Description of the cluster.
+    :param bytes provider: provider of the nodes  - aws. rackspace or managed.
+    :param dict logging_config: A Python logging configuration dictionary,
+        following the structure of PEP 391.
+    """
+    setup_action = 'start'
+    if provider == "managed":
+        setup_action = 'restart'
+
+    return run_remotely(
+        username='root',
+        address=cluster.control_node.address,
+        commands=sequence([
+            task_install_control_certificates(
+                cluster.certificates.cluster.certificate,
+                cluster.certificates.control.certificate,
+                cluster.certificates.control.key),
+            task_enable_flocker_control(cluster.control_node.distribution,
+                                        setup_action),
+            if_firewall_available(
+                cluster.control_node.distribution,
+                task_open_control_firewall(
+                    cluster.control_node.distribution
+                )
+            ),
+        ]),
+    )
+
+
+def configure_node(
+    cluster,
+    node,
+    certnkey,
+    dataset_backend_configuration,
+    provider,
+    logging_config=None
+):
+    """
+    Configure flocker-dataset-agent and flocker-container-agent on a node,
+    so that it could join an existing Flocker cluster.
+
+    :param Cluster cluster: Description of the cluster.
+    :param Node node: The node to configure.
+    :param CertAndKey certnkey: The node's certificate and key.
+    :param bytes provider: provider of the nodes  - aws. rackspace or managed.
+    :param dict logging_config: A Python logging configuration dictionary,
+        following the structure of PEP 391.
+    """
+    setup_action = 'start'
+    if provider == "managed":
+        setup_action = 'restart'
+
+    return run_remotely(
+        username='root',
+        address=node.address,
+        commands=sequence([
+            task_install_node_certificates(
+                cluster.certificates.cluster.certificate,
+                certnkey.certificate,
+                certnkey.key),
+            task_install_api_certificates(
+                cluster.certificates.user.certificate,
+                cluster.certificates.user.key),
+            task_enable_docker(node.distribution),
+            if_firewall_available(
+                node.distribution,
+                open_firewall_for_docker_api(node.distribution),
+            ),
+            task_configure_flocker_agent(
+                control_node=cluster.control_node.address,
+                dataset_backend=cluster.dataset_backend,
+                dataset_backend_configuration=(
+                    dataset_backend_configuration
+                ),
+                logging_config=logging_config,
+            ),
+            task_enable_docker_plugin(node.distribution),
+            task_enable_flocker_agent(
+                distribution=node.distribution,
+                action=setup_action,
+            ),
+        ]),
+    )

--- a/flocker/provision/test/test_ca.py
+++ b/flocker/provision/test/test_ca.py
@@ -39,3 +39,26 @@ class CertificatesGenerateTests(TestCase):
             },
             set(output.children()),
         )
+
+    @skipUnless(which(b"flocker-ca"), b"flocker-ca not installed (FLOC-2600)")
+    def test_add_node(self):
+        """
+        ``Certificates.add_node`` generates another node certificate.
+        """
+        output = FilePath(self.mktemp())
+        output.makedirs()
+        certificates = Certificates.generate(output, b"some-service", 2,
+                                             b"test-cluster")
+        certificates.add_node(3)
+        self.assertEqual(
+            {
+                output.child(b"cluster.crt"), output.child(b"cluster.key"),
+                output.child(b"control-some-service.crt"),
+                output.child(b"control-some-service.key"),
+                output.child(b"user.crt"), output.child(b"user.key"),
+                output.child(b"node-0.crt"), output.child(b"node-0.key"),
+                output.child(b"node-1.crt"), output.child(b"node-1.key"),
+                output.child(b"node-3.crt"), output.child(b"node-3.key"),
+            },
+            set(output.children()),
+        )


### PR DESCRIPTION
Also, `setup-cluster` now uses alternative implementation of `LibcloudRunner.start_cluster`.
The alternative implementation should be faster as it creates cloud nodes
in parallel.  Also it should be more robust as it does not fail as long
as it is able to create at least a control node for the cluster.
