### PR TITLE
[FLOC-3996] Improve signposting on docs.

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -114,14 +114,17 @@
                 </div>
                 <!-- Menu area start -->
 
+                {%- if pagename == "index" %}
+                <h3><a href="{{ pathto('index') }}">Install &amp; Docs</a></h3>
                 <ul class="navbar-prelude">
-                    {%- if pagename == "index" %}
-                        <li class="toctree-l1 current"><a class="reference internal current" href="{{ pathto('index') }}">Installing Flocker</a></li>
-                    {%- else %}
-                        <li class="toctree-l1"><a class="reference internal" href="{{ pathto('index') }}">Installing Flocker</a></li>
-                    {%- endif %}
+                    <li class="toctree-l1 current"><a class="reference internal current" href="{{ pathto('index') }}">Flocker Integrations</a></li>
                 </ul>
-
+                {%- else %}
+                <h3><a href="{{ pathto('index') }}">Install &amp; Docs</a></h3>
+                <ul class="navbar-prelude">
+                    <li class="toctree-l1"><a class="reference internal" href="{{ pathto('index') }}">Flocker Integrations</a></li>
+                </ul>
+                {%- endif %}
                 {{ toctree(collapse=true, maxdepth=2) }}
                 <!-- Menu area end -->
             </div>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,13 +4,18 @@
         .toctree-wrapper { display:none; }
     </style>
 
-==================
-Installing Flocker
-==================
+====================
+Flocker Integrations
+====================
 
 .. _supported-orchestration-frameworks:
 
 Flocker allows you to launch and move stateful containers by integrating with a Cluster Manager of your choice.
+
+Flocker integrates with a range of Cluster Managers.
+
+Installing Flocker
+==================
 
 To install Flocker, first choose which Cluster Manager you are using, or intend to use:
 
@@ -20,19 +25,19 @@ To install Flocker, first choose which Cluster Manager you are using, or intend 
 	    <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
 			<img src="_static/images/docker2x.png" alt="Docker logo"/>
 			<span>Docker Swarm, with Docker Compose<em>Try it Now</em></span>
-	        <a href="docker-integration/" class="button button--fast">Install</a>
+	        <a href="docker-integration/" class="button button--fast">Install or Learn</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
 			<img src="_static/images/kubernetes2x.png" alt="Kubernetes logo"/>
 			<span>Kubernetes</span>
-	        <a href="kubernetes-integration/" class="button">Install</a>
+	        <a href="kubernetes-integration/" class="button">Install or Learn</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
 			<img src="_static/images/mesos2x.png" alt="mesos logo"/>
 			<span>Mesos</span>
-	        <a href="mesos-integration/" class="button">Install</a>
+	        <a href="mesos-integration/" class="button">Install or Learn</a>
 	    </div>
 	</div>
 
@@ -42,7 +47,7 @@ Alternatively, if you want to install Flocker without a specific Cluster Manager
 
 	 <div class="pod-boxout pod-boxout--minor pod-boxout--orchestration">
 		<span><img src="_static/images/icon-question2x.png" aria-hidden="true" alt=""/>&nbsp;Install Flocker without a Cluster Manager</span>
-        <a href="flocker-standalone/" class="button">Install</a>
+        <a href="flocker-standalone/" class="button">Install or Learn</a>
     </div>
 
 Is your chosen Cluster Manager missing?


### PR DESCRIPTION
Changes to navigation and Installing Flocker page to make docs homepage more findable and reduce confusion when navigating Flocker integrations (based on user testing).

**Before**
Navbar and docs homepage:
<img width="849" alt="screen shot 2016-01-28 at 10 31 13" src="https://cloud.githubusercontent.com/assets/264658/12641904/4d39fd24-c5aa-11e5-8c9c-175aa150c2bb.png">

Links on buttons:
<img width="917" alt="screen shot 2016-01-28 at 10 31 20" src="https://cloud.githubusercontent.com/assets/264658/12641912/5d62eea4-c5aa-11e5-88b5-c50747bfce9f.png">

**After**
Navbar and docs homepage:
<img width="884" alt="screen shot 2016-01-28 at 10 30 12" src="https://cloud.githubusercontent.com/assets/264658/12641894/3e44f878-c5aa-11e5-9a44-e2e8104545f7.png">

Links on buttons:
<img width="900" alt="screen shot 2016-01-28 at 10 30 23" src="https://cloud.githubusercontent.com/assets/264658/12641893/3e4306f8-c5aa-11e5-9bd3-f086addfa676.png">