### PR TITLE
[FLOC-3998] Flocker dataset config

### DIFF
--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -426,6 +426,8 @@ class BackendDescription(PClass):
     :ivar api_factory: An object which can be called with some simple
         configuration data and which returns the API object implementing this
         storage backend.
+    :ivar required_config: A ``set`` of the dataset configuration keys
+        required to initialize this backend.
     :ivar deployer_type: A constant from ``DeployerType`` indicating which kind
         of ``IDeployer`` the API object returned by ``api_factory`` is usable
         with.
@@ -435,6 +437,8 @@ class BackendDescription(PClass):
     # XXX Eventually everyone will take cluster_id so we will throw this flag
     # out.
     needs_cluster_id = field(type=bool, mandatory=True)
+    # Config "dataset" keys required to initialize this backend.
+    required_config = field(type=set, mandatory=True)
     api_factory = field(mandatory=True)
     deployer_type = field(
         mandatory=True,
@@ -454,22 +458,28 @@ _DEFAULT_BACKENDS = [
     BackendDescription(
         name=u"zfs", needs_reactor=True, needs_cluster_id=False,
         api_factory=_zfs_storagepool, deployer_type=DeployerType.p2p,
+        required_config=set(),
     ),
     BackendDescription(
         name=u"loopback", needs_reactor=False, needs_cluster_id=False,
         # XXX compute_instance_id is the wrong type
         api_factory=LoopbackBlockDeviceAPI.from_path,
         deployer_type=DeployerType.block,
+        required_config=set(),
     ),
     BackendDescription(
         name=u"openstack", needs_reactor=False, needs_cluster_id=True,
         api_factory=cinder_from_configuration,
         deployer_type=DeployerType.block,
+        required_config=set(["region", ]),
     ),
     BackendDescription(
         name=u"aws", needs_reactor=False, needs_cluster_id=True,
         api_factory=aws_from_configuration,
         deployer_type=DeployerType.block,
+        required_config=set(
+            ["region", "zone", "access_key_id", "secret_access_key", ]
+        ),
     ),
 ]
 
@@ -524,6 +534,13 @@ def get_api(backend, api_args, reactor, cluster_id):
         api_args = api_args.set("cluster_id", cluster_id)
     if backend.needs_reactor:
         api_args = api_args.set("reactor", reactor)
+
+    for config_key in backend.required_config:
+        if config_key not in api_args:
+            raise UsageError(
+                u"Configuration error: Required key {} is missing.".format(
+                    config_key.decode("utf-8"))
+            )
 
     try:
         return backend.api_factory(**api_args)

--- a/flocker/node/test/dummybackend.py
+++ b/flocker/node/test/dummybackend.py
@@ -29,4 +29,5 @@ def api_factory(cluster_id, **kwargs):
 FLOCKER_BACKEND = BackendDescription(
     name=u"dummybackend",  # Not actually used for 3rd party plugins
     needs_reactor=False, needs_cluster_id=True,
-    api_factory=api_factory, deployer_type=DeployerType.block)
+    api_factory=api_factory, deployer_type=DeployerType.block,
+    required_config=set(),)

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -326,10 +326,12 @@ class AgentServiceGetAPITests(TestCase):
                 BackendDescription(
                     name=u"foo", needs_reactor=False, needs_cluster_id=False,
                     api_factory=API, deployer_type=DeployerType.p2p,
+                    required_config=set(),
                 ),
                 BackendDescription(
                     name=u"bar", needs_reactor=False, needs_cluster_id=False,
                     api_factory=WrongAPI, deployer_type=DeployerType.block,
+                    required_config=set(),
                 ),
             ],
         ).set(
@@ -361,6 +363,7 @@ class AgentServiceGetAPITests(TestCase):
                     name=self.agent_service.backend_name,
                     needs_reactor=True, needs_cluster_id=False,
                     api_factory=API, deployer_type=DeployerType.p2p,
+                    required_config=set(),
                 ),
             ],
         ).set(
@@ -388,6 +391,7 @@ class AgentServiceGetAPITests(TestCase):
                     name=self.agent_service.backend_name,
                     needs_reactor=False, needs_cluster_id=True,
                     api_factory=API, deployer_type=DeployerType.p2p,
+                    required_config=set(),
                 ),
             ],
         )
@@ -518,6 +522,7 @@ class AgentServiceDeployerTests(TestCase):
                     name=self.agent_service.backend_name,
                     needs_reactor=False, needs_cluster_id=False,
                     api_factory=None, deployer_type=DeployerType.p2p,
+                    required_config=set(),
                 ),
             ],
         ).set(

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -24,6 +24,7 @@ from twisted.internet.defer import Deferred
 from twisted.python.filepath import FilePath
 from twisted.application.service import Service
 from twisted.python.runtime import platform
+from twisted.python.usage import UsageError
 
 from ...common.script import ICommandLineScript
 from ...common import get_all_ips
@@ -399,6 +400,35 @@ class AgentServiceGetAPITests(TestCase):
         self.assertEqual(
             API(cluster_id=self.ca_set.node.cluster_uuid),
             api,
+        )
+
+    def test_required_config(self):
+        """
+        A ``UsageError`` is raised if the loaded configuration for the API
+        factory does not contain a key in the corresponding backend's required
+        configuration keys.
+        """
+        class API(PClass):
+            region = field()
+            api_key = field()
+
+        agent_service = self.agent_service.set(
+            "backends", [
+                BackendDescription(
+                    name=self.agent_service.backend_name,
+                    needs_reactor=False, needs_cluster_id=False,
+                    api_factory=API, deployer_type=DeployerType.p2p,
+                    required_config=set(["region", "api_key", ]),
+                ),
+            ],
+        )
+        agent_service = agent_service.set("api_args", {
+            "region": "abc",
+        })
+        error = self.assertRaises(UsageError, agent_service.get_api)
+        self.assertEqual(
+            error.message,
+            u'Configuration error: Required key api_key is missing.'
         )
 
     def test_default_openstack(self):


### PR DESCRIPTION
Fixes https://clusterhq.atlassian.net/browse/FLOC-3998

Ensures that the loaded config contains at a minimum the parameters required by the chosen backend's API factory, preventing failure with an ugly `TypeError` missing parameters traceback when the config is missing data.