### PR TITLE
[FLOC-2901] Increase maximum attached EBS volumes

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -16,6 +16,7 @@ Next Release
 * The new :ref:`CloudFormation installer <cloudformation>` has been made available, to provide a far simpler installation experience for users on AWS.
 * The :ref:`Flocker plugin for Docker <plugin>` should support the direct volume listing and inspection functionality added to Docker 1.10.
 * Fixed a regression that caused block device agents to poll backend APIs like EBS too frequently in some circumstances.
+* Increase limit on maximum Flocker volumes per AWS instance from 11 to 21.
 
 This Release
 ============

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -911,9 +911,7 @@ def _next_device():
     """
     Get the next available EBS device name for this EC2 instance.
 
-    :return Optional[unicode] file_name: available device name for
-        attaching EBS volume, or None if suitable EBS device names on this
-        EC2 instance are currently occupied
+    :return unicode file_name: available device name for attaching EBS volume.
     """
 
     return _select_free_device(_find_allocated_devices())
@@ -965,9 +963,7 @@ def _select_free_device(existing):
 
     :param Sequence[bytes]: List of allocated device basenames
         (e.g. ``[b'sda']``).
-    :return Optional[unicode] file_name: available device name for
-        attaching EBS volume, or None if suitable EBS device names on this
-        EC2 instance are currently occupied
+    :return unicode file_name: available device name for attaching EBS volume.
     """
 
     local_devices = frozenset(existing)
@@ -1266,6 +1262,7 @@ class EBSBlockDeviceAPI(object):
             associate the volume with the expected OS device file.  This
             indicates use on an unsupported OS, a misunderstanding of the EBS
             device assignment rules, or some other bug in this implementation.
+        :raises NoAvailableDevice: If there are no available device names.
         """
         ebs_volume = self._get_ebs_volume(blockdevice_id)
         volume = _blockdevicevolume_from_ebs_volume(ebs_volume)

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -894,6 +894,100 @@ def _get_blockdevices():
     return FilePath(b"/sys/block").children()
 
 
+def _next_device():
+    """
+    Get the next available EBS device name for this EC2 instance.
+
+    Devices available for EBS volume usage are ``/dev/sd[f-p]``.
+    Find the first device from this set that is currently not
+    in use.
+    XXX: Handle lack of free devices in ``/dev/sd[f-z]`` range
+    (see https://clusterhq.atlassian.net/browse/FLOC-1887).
+
+    :returns unicode file_name: available device name for attaching
+        EBS volume.
+    :returns ``None`` if suitable EBS device names on this EC2
+        instance are currently occupied.
+    """
+
+    return _select_next_device(_find_allocated_devices())
+
+
+def _find_allocated_devices():
+    """
+    Enumerate the allocated device names on this host.
+
+    :return Sequence[bytes]: List of allocated device basenames
+        (e.g. ``[b'sda']``).
+    """
+    command = [
+        b"/bin/lsblk",
+        b"--nodeps",           # Only print top-level devices
+        b"--noheadings",       # Do not display KNAME header
+        b"--output", b"KNAME"  # Only display kernel device name
+    ]
+    command_result = check_output(command)
+    existing = [
+        dev for dev in command_result.split("\n")
+        if dev.startswith(b"xvd") or dev.startswith(b'sd')
+    ]
+    return existing
+
+
+def _select_next_device(existing):
+    """
+    Given a list of allocated devices, return an available device name.
+
+    According to
+    http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+    all AWS Linux instances have ``/dev/sd[a-z]`` available.  However:
+    - ``sda`` is reserved for the root device;
+    - Amazon "strongly recommend that you don't" use names used for
+    instance store names (usually ``/dev/sd[b-e]``) "because the behavior
+    can be unpredictable";
+    - some "custom kernels might have restrictions that limit use to
+    ``/dev/sd[f-p]``".
+
+    ``sd[f-p]`` only allows 11 devices, so to increase this, ignore the
+    least stringent statement above, and allow ``sd[f-z]`` (21 devices).
+
+    To reduce the risk of failing on these "custom AMIs", select from
+    ``[f-p]`` first.
+
+    Any further increase will need to start mining the ``hd[a-z][1-15]``
+    and ``xvd[b-c][a-z]`` namespaces, but which to use depends on whether
+    the AMI uses paravirtualization or HVM.
+
+    :param Sequence[bytes]: List of allocated device basenames
+        (e.g. ``[b'sda']``).
+    :return:
+    :returns Optional[unicode] file_name: available device name for
+        attaching EBS volume, or None if suitable EBS device names on this
+        EC2 instance are currently occupied
+    """
+
+    local_devices = pset(existing)
+    sorted_devices = sorted(existing)
+    IN_USE_DEVICES(devices=sorted_devices).write()
+
+    for suffix in b"fghijklmonpqrstuvwxyz":
+        next_local_device = b'xvd' + suffix
+        next_local_sd_device = b'sd' + suffix
+        file_name = u'/dev/sd' + unicode(suffix)
+        possible_devices = [
+            next_local_device, next_local_sd_device
+        ]
+        if not any(
+            list(device in local_devices for device in possible_devices)
+        ):
+            return file_name
+
+    # Could not find any suitable device that is available
+    # for attachment. Log to Eliot before giving up.
+    NO_AVAILABLE_DEVICE(devices=sorted_devices).write()
+    return None
+
+
 @implementer(IBlockDeviceAPI)
 @implementer(IProfiledBlockDeviceAPI)
 @implementer(ICloudAPI)
@@ -1043,52 +1137,6 @@ class EBSBlockDeviceAPI(object):
         return volume.attach_to_instance(
             InstanceId=instance_id, Device=device)
 
-    def _next_device(self):
-        """
-        Get the next available EBS device name for this EC2 instance.
-
-        Devices available for EBS volume usage are ``/dev/sd[f-p]``.
-        Find the first device from this set that is currently not
-        in use.
-        XXX: Handle lack of free devices in ``/dev/sd[f-p]`` range
-        (see https://clusterhq.atlassian.net/browse/FLOC-1887).
-
-        :returns unicode file_name: available device name for attaching
-            EBS volume.
-        :returns ``None`` if suitable EBS device names on this EC2
-            instance are currently occupied.
-        """
-
-        command = [b"/bin/lsblk", b"--output", b"KNAME"]
-        # Command result returns a list of kernel device names
-        # separated by line breaks, with KNAME as the output of the
-        # header row. The top line is therefore ignored in the filter
-        # below.
-        command_result = check_output(command)
-        local_devices = pset(filter(
-            lambda d: d.startswith(b"xvd") or d.startswith('sd'),
-            command_result.split("\n")[1:]
-        ))
-        sorted_devices = sorted(list(thaw(local_devices)))
-        IN_USE_DEVICES(devices=sorted_devices).write()
-
-        for suffix in b"fghijklmonp":
-            next_local_device = b'xvd' + suffix
-            next_local_sd_device = b'sd' + suffix
-            file_name = u'/dev/sd' + unicode(suffix)
-            possible_devices = [
-                next_local_device, next_local_sd_device
-            ]
-            if not any(
-                list(device in local_devices for device in possible_devices)
-            ):
-                return file_name
-
-        # Could not find any suitable device that is available
-        # for attachment. Log to Eliot before giving up.
-        NO_AVAILABLE_DEVICE(devices=sorted_devices).write()
-        return None
-
     def create_volume(self, dataset_id, size):
         """
         Create a volume on EBS backend.
@@ -1231,7 +1279,7 @@ class EBSBlockDeviceAPI(object):
         attached = False
         for attach_attempt in range(3):
             with self.lock:
-                device = self._next_device()
+                device = _next_device()
                 if device is None:
                     # XXX: Handle lack of free devices in ``/dev/sd[f-p]``.
                     # (https://clusterhq.atlassian.net/browse/FLOC-1887).

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -28,7 +28,7 @@ from uuid import UUID
 from bitmath import Byte, GiB
 
 from characteristic import with_cmp
-from pyrsistent import PClass, field, pset, pmap
+from pyrsistent import PClass, field, pmap
 from zope.interface import implementer
 from twisted.python.constants import (
     Names, NamedConstant, Values, ValueConstant
@@ -963,7 +963,7 @@ def _select_free_device(existing):
         EC2 instance are currently occupied
     """
 
-    local_devices = pset(existing)
+    local_devices = frozenset(existing)
     sorted_devices = sorted(existing)
     IN_USE_DEVICES(devices=sorted_devices).write()
 
@@ -974,9 +974,7 @@ def _select_free_device(existing):
         possible_devices = [
             next_local_device, next_local_sd_device
         ]
-        if not any(
-            list(device in local_devices for device in possible_devices)
-        ):
+        if not local_devices.intersection(possible_devices):
             return file_name
 
     # Could not find any suitable device that is available

--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -28,7 +28,7 @@ from uuid import UUID
 from bitmath import Byte, GiB
 
 from characteristic import with_cmp
-from pyrsistent import PClass, field, pset, pmap, thaw
+from pyrsistent import PClass, field, pset, pmap
 from zope.interface import implementer
 from twisted.python.constants import (
     Names, NamedConstant, Values, ValueConstant
@@ -719,7 +719,7 @@ def _wait_for_volume_state_change(operation,
     start_time = time.time()
     poll_until(
         lambda: _reached_end_state(
-           operation, volume, update, time.time() - start_time, timeout
+            operation, volume, update, time.time() - start_time, timeout
         ),
         itertools.repeat(1)
     )

--- a/flocker/node/agents/functional/test_ebs.py
+++ b/flocker/node/agents/functional/test_ebs.py
@@ -26,7 +26,7 @@ from ..ebs import (
     VolumeOperations, VolumeStateTable, VolumeStates,
     TimeoutException, _reached_end_state, UnexpectedStateException,
     EBSMandatoryProfileAttributes, _get_volume_tag,
-    AttachUnexpectedInstance, VolumeBusy,
+    AttachUnexpectedInstance, VolumeBusy, _next_device,
 )
 from ....testtools import AsyncTestCase, async_runner
 
@@ -199,8 +199,7 @@ class EBSBlockDeviceAPIInterfaceTests(
         instance_id = self.api.compute_instance_id()
 
         # Attach manual volume using /xvd* device.
-        device_name = self.api._next_device()
-        device_name = device_name.replace('/sd', '/xvd')
+        device_name = _next_device().replace(u'/sd', u'/xvd')
         self.api._attach_ebs_volume(
             created_volume.id, instance_id, device_name)
         _wait_for_volume_state_change(VolumeOperations.ATTACH, created_volume)

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -258,9 +258,14 @@ class FindAllocatedDeviceTests(TestCase):
 
     def test_returns_device_name_list(self):
         """
-        Returns at least one device (the root device).
+        Returns at least one device (the root device).  All returned
+        values are existing devices.
         """
-        self.assertGreater(len(_find_allocated_devices()), 0)
+        devices = _find_allocated_devices()
+        self.assertGreater(len(devices), 0)
+        self.assertTrue(
+            all(FilePath('/dev/{}'.format(d)).exists() for d in devices)
+        )
 
 
 class SelectFreeDeviceTests(TestCase):

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -20,7 +20,7 @@ from ..ebs import (
     AttachedUnexpectedDevice, _expected_device,
     _attach_volume_and_wait_for_device, _get_blockdevices,
     _get_device_size, _wait_for_new_device, _find_allocated_devices,
-    _select_next_device,
+    _select_free_device,
 )
 from .._logging import NO_NEW_DEVICE_IN_OS
 from ..blockdevice import BlockDeviceVolume
@@ -259,7 +259,7 @@ class FindAllocatedDeviceTests(TestCase):
         self.assertGreater(len(_find_allocated_devices()), 0)
 
 
-class SelectNextDeviceTests(TestCase):
+class SelectFreeDeviceTests(TestCase):
     """
     Tests for selecting new device.
     """
@@ -268,11 +268,11 @@ class SelectNextDeviceTests(TestCase):
         """
         Return a device name.
         """
-        self.assertTrue(_select_next_device(['sda']).startswith(u'/dev/'))
+        self.assertTrue(_select_free_device(['sda']).startswith(u'/dev/'))
 
     def test_all_devices_used(self):
         """
         Return None if no available device names.
         """
         existing = ['sd' + ch for ch in ascii_lowercase]
-        self.assertIsNone(_select_next_device(existing))
+        self.assertIsNone(_select_free_device(existing))

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -20,7 +20,7 @@ from ..ebs import (
     AttachedUnexpectedDevice, _expected_device,
     _attach_volume_and_wait_for_device, _get_blockdevices,
     _get_device_size, _wait_for_new_device, _find_allocated_devices,
-    _select_free_device,
+    _select_free_device, NoAvailableDevice,
 )
 from .._logging import NO_NEW_DEVICE_IN_OS
 from ..blockdevice import BlockDeviceVolume
@@ -276,7 +276,7 @@ class SelectFreeDeviceTests(TestCase):
 
     def test_all_devices_used(self):
         """
-        Return None if no available device names.
+        Raises exception if no available device names.
         """
         existing = ['sd' + ch for ch in ascii_lowercase]
-        self.assertIsNone(_select_free_device(existing))
+        self.assertRaises(NoAvailableDevice, _select_free_device, existing)

--- a/flocker/node/agents/test/test_ebs.py
+++ b/flocker/node/agents/test/test_ebs.py
@@ -4,7 +4,7 @@
 Tests for ``flocker.node.agents.ebs``.
 """
 
-from string import lowercase
+from string import ascii_lowercase
 from uuid import uuid4
 
 from hypothesis import given
@@ -19,7 +19,8 @@ from eliot.testing import capture_logging, assertHasMessage
 from ..ebs import (
     AttachedUnexpectedDevice, _expected_device,
     _attach_volume_and_wait_for_device, _get_blockdevices,
-    _get_device_size, _wait_for_new_device,
+    _get_device_size, _wait_for_new_device, _find_allocated_devices,
+    _select_next_device,
 )
 from .._logging import NO_NEW_DEVICE_IN_OS
 from ..blockdevice import BlockDeviceVolume
@@ -30,7 +31,9 @@ from ....testtools import CustomException, TestCase
 # A Hypothesis strategy for generating /dev/sd?
 device_path = builds(
     lambda suffix: b"/dev/sd" + b"".join(suffix),
-    suffix=lists(elements=sampled_from(lowercase), min_size=1, max_size=2),
+    suffix=lists(
+        elements=sampled_from(ascii_lowercase), min_size=1, max_size=2
+    ),
 )
 
 
@@ -242,3 +245,34 @@ class WaitForNewDeviceTests(TestCase):
                 time_limit=0,
             )
         )
+
+
+class FindAllocatedDeviceTests(TestCase):
+    """
+    Tests for finding allocated devices.
+    """
+
+    def test_returns_device_name_list(self):
+        """
+        Returns at least one device (the root device).
+        """
+        self.assertGreater(len(_find_allocated_devices()), 0)
+
+
+class SelectNextDeviceTests(TestCase):
+    """
+    Tests for selecting new device.
+    """
+
+    def test_provides_device_name(self):
+        """
+        Return a device name.
+        """
+        self.assertTrue(_select_next_device(['sda']).startswith(u'/dev/'))
+
+    def test_all_devices_used(self):
+        """
+        Return None if no available device names.
+        """
+        existing = ['sd' + ch for ch in ascii_lowercase]
+        self.assertIsNone(_select_next_device(existing))


### PR DESCRIPTION
Flocker currently allows only 11 volumes to be attached on a single AWS node.  This is due to Flocker code only allowing the use of the 11 device names `/dev/sdf` to `/dev/sdp`.

AWS documentation indicates that this subset should always be available on every AMI.

However, we need to support more than 11 attached volumes.

This PR adds another 10 device names (`/dev/sdq` to `/dev/sdz`), which should be available on all but "some custom kernels".

The core change is the string that had the letters `f-p` now has `f-z`.  Everything else is refactoring, mostly to make the tests easier to create.