### PR TITLE
[FLOC-4012] Notify #engineering about GCE acceptance test failures.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1491,6 +1491,7 @@ job_type:
       # Reasoning as for run_acceptance_on_AWS_CentOS_7_with_EBS
       timeout: 120
       directories_to_delete: []
+      notify_slack: '#engineering'
 
     run_acceptance_on_GCE_Ubuntu_Trusty_with_LOOPBACK:
       at: '0 6 * * *'
@@ -1515,6 +1516,7 @@ job_type:
       # Reasoning as for run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS
       timeout: 90
       directories_to_delete: []
+      notify_slack: '#engineering'
 
     run_acceptance_on_Rackspace_CentOS_7_with_Cinder:
       at: '0 5 * * *'


### PR DESCRIPTION
These tests were merged to master after I branched, and I missed
them when I merged master.