### PR TITLE
[FLOC-4019] Fix a regression in rackspace acceptance tests.

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -572,7 +572,7 @@ class LibcloudRunner(object):
         self.creator = creator
 
         self.metadata.update(self.identity.metadata)
-        self.metadata['distribution'] = self.distribution,
+        self.metadata['distribution'] = self.distribution
 
         # Try to make names unique even if the same creator is starting
         # multiple clusters at the same time.  This lets other code use the


### PR DESCRIPTION
The comma turns this value into a tuple, which makes rackspace fail to be able to set metadata.

We should probably not have such a fragile API with our provisioners.