### PR TITLE
[FLOC-4030] Ignore Jenkins links during linkcheck build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -324,6 +324,8 @@ linkcheck_ignore = [
     r'http://localhost/client/#/nodes/list',
     # UserVoice forbids (403) Buildbot, but works for browsers and local runs
     r'https://feedback.clusterhq.com/',
+    # Jenkins is not currently public and results in a 403
+    r'http://ci-live.clusterhq.com:8080/',
 
 
     # The following link checks fail because of a TLS handshake error.


### PR DESCRIPTION
Fixes [FLOC-4030](https://clusterhq.atlassian.net/browse/FLOC-4030).

Our Jenkins setup is not public and as a result the linkcheck build results in 403 for any links to Jenkins so add it to the list of ignored links.