### PR TITLE
[FLOC-4014] Fixing scenario cleanup so we don't lose the metrics output

### DIFF
--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -277,10 +277,6 @@ class RequestLoadScenario(object):
                 Message.log(key='force_stop_request', value=msg)
             scenario.addErrback(handle_timeout)
 
-            def return_metrics(_ignore):
-                return self.rate_measurer.get_metrics()
-            scenario.addCallback(return_metrics)
-
             def scenario_cleanup(ignored):
                 """
                 Calls the scenario cleanup, and wraps it inside an eliot
@@ -297,5 +293,9 @@ class RequestLoadScenario(object):
                     return self.scenario_setup.run_cleanup()
 
             scenario.addBoth(scenario_cleanup)
+
+            def return_metrics(_ignore):
+                return self.rate_measurer.get_metrics()
+            scenario.addCallback(return_metrics)
 
             return scenario.addActionFinish()

--- a/benchmark/scenarios/test/test_read_request_load.py
+++ b/benchmark/scenarios/test/test_read_request_load.py
@@ -123,6 +123,12 @@ class read_request_load_scenarioTest(TestCase):
         c.pump(repeat(1, sample_size))
         s.maintained().addBoth(lambda x: self.fail())
         d.addCallback(lambda ignored: s.stop())
+
+        def verify_scenario_returns_metrics(result):
+            self.assertIsInstance(result, dict)
+
+        d.addCallback(verify_scenario_returns_metrics)
+
         c.pump(repeat(1, sample_size))
         self.successResultOf(d)
 

--- a/benchmark/scenarios/test/test_write_request_load.py
+++ b/benchmark/scenarios/test/test_write_request_load.py
@@ -232,6 +232,12 @@ class write_request_load_scenarioTest(TestCase):
         c.pump(repeat(1, sample_size))
         s.maintained().addBoth(lambda x: self.fail())
         d.addCallback(lambda ignored: s.stop())
+
+        def verify_scenario_returns_metrics(result):
+            self.assertIsInstance(result, dict)
+
+        d.addCallback(verify_scenario_returns_metrics)
+
         self.successResultOf(d)
 
     @capture_logging(None)


### PR DESCRIPTION
Cleanup deferred that returned nothing, added after the metrics results, was causing the write load scenario not to generate any output. 
The only change needed was to add the metrics generation as the last step.