### PR TITLE
[FLOC-3846] Benchmark scenario catch up

### DIFF
--- a/benchmark/_interfaces.py
+++ b/benchmark/_interfaces.py
@@ -89,32 +89,24 @@ class IMetric(Interface):
         """
 
 
-class IRequestScenarioSetup(Interface):
+class IRequest(Interface):
     """
-    Setup for a load scenario.
-    It will provide a setup function and a make request function to
-    make requests of a certain type
+    A request that may require setup and cleanup.
     """
 
     def run_setup():
         """
-        Interface for the scenario load setup. It should do all the actions
-        needed to configure the environment to make the requests defined in
-        the ``make_request`` function, like creating dataset or configuring
-        all we need in the cluster.
+        Perform any steps that need to be done before a request.
 
         :return Deferred: firing once the setup has been completed and the
-            requests defined in ``make_request`` can be safely done. It should
-            have a timeout set so the Deferred fails if something went wrong
-            and the setup got stuck.
+            requests defined in ``make_request`` can be safely done.
         """
 
     def make_request():
         """
-        Interface for request generator
-        This function will make a single REST request. It can use everything
+        This function will make a single request. It can use everything
         that has been setup and/or created in ``run_setup``, and has the
-        pre-requesite that ``run_setup`` has successfully finished.
+        pre-requisite that ``run_setup`` has successfully finished.
 
         :return Deferred: that fires when the REST request has been
             completed, and returns the results of the request.
@@ -122,8 +114,8 @@ class IRequestScenarioSetup(Interface):
 
     def run_cleanup():
         """
-        Interface function for the scenario cleanup, to delete anything that
-        might have been created or modified in the setup
+        Interface function for the request cleanup, to delete anything that
+        might have been created or modified.
 
         :return Deferred: that will fire once the cleanup is completed.
         """

--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -55,7 +55,7 @@ class RequestLoadScenario(object):
 
     :ivar reactor: Reactor to use.
     :ivar scenario_setup: provider of the interface
-        ``IRequestScenarioSetup``.
+        ``IRequest``.
     :ivar request_rate: The target number of requests per second.
     :ivar sample_size: The number of samples to collect when measuring
         the rate.
@@ -85,7 +85,7 @@ class RequestLoadScenario(object):
 
         :param reactor: Reactor to use.
         :param scenario_setup_instance: provider of the
-            ``IRequestScenarioSetup`` interface.
+            ``IRequest`` interface.
         :param request_rate: target number of request per second.
         :param sample_size: number of samples to collect when measuring
             the rate.

--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -54,8 +54,7 @@ class RequestLoadScenario(object):
     requests at a specified rate.
 
     :ivar reactor: Reactor to use.
-    :ivar scenario_setup: provider of the interface
-        ``IRequest``.
+    :ivar scenario_setup: provider of the interface ``IRequest``.
     :ivar request_rate: The target number of requests per second.
     :ivar sample_size: The number of samples to collect when measuring
         the rate.
@@ -84,8 +83,7 @@ class RequestLoadScenario(object):
         ``RequestLoadScenario`` constructor.
 
         :param reactor: Reactor to use.
-        :param scenario_setup_instance: provider of the
-            ``IRequest`` interface.
+        :param scenario_setup_instance: provider of the ``IRequest`` interface.
         :param request_rate: target number of request per second.
         :param sample_size: number of samples to collect when measuring
             the rate.

--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -136,6 +136,9 @@ class RequestLoadScenario(object):
             self.rate_measurer.request_failed(result)
             write_failure(result)
 
+        if count != 1:
+            Message.log(function='_request_and_measure', count=count)
+
         for i in range(count):
             self.rate_measurer.update_rate()
 

--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -54,7 +54,7 @@ class RequestLoadScenario(object):
     requests at a specified rate.
 
     :ivar reactor: Reactor to use.
-    :ivar scenario_setup: provider of the interface ``IRequest``.
+    :ivar request: provider of the interface ``IRequest``.
     :ivar request_rate: The target number of requests per second.
     :ivar sample_size: The number of samples to collect when measuring
         the rate.
@@ -75,25 +75,20 @@ class RequestLoadScenario(object):
     """
 
     def __init__(
-        self, reactor, scenario_setup_instance, request_rate=10,
+        self, reactor, request, request_rate=10,
         sample_size=DEFAULT_SAMPLE_SIZE, timeout=45,
         tolerance_percentage=0.2
     ):
         """
         ``RequestLoadScenario`` constructor.
 
-        :param reactor: Reactor to use.
-        :param scenario_setup_instance: provider of the ``IRequest`` interface.
-        :param request_rate: target number of request per second.
-        :param sample_size: number of samples to collect when measuring
-            the rate.
         :param tolerance_percentage: error percentage in the rate that is
             considered valid. For example, if we request a ``request_rate``
             of 20, and we give a tolerance_percentage of 0.2 (20%), anything
             in [16,20] will be a valid rate.
         """
         self.reactor = reactor
-        self.scenario_setup = scenario_setup_instance
+        self.request = request
         self.request_rate = request_rate
         self.timeout = timeout
         self._maintained = Deferred()
@@ -143,7 +138,7 @@ class RequestLoadScenario(object):
             for i in range(self.request_rate):
                 t0 = self.reactor.seconds()
 
-                d = self.scenario_setup.make_request()
+                d = self.request.make_request()
 
                 def get_time(_ignore):
                     return self.reactor.seconds() - t0
@@ -199,7 +194,7 @@ class RequestLoadScenario(object):
         else:
             self.is_started = True
 
-        d = self.scenario_setup.run_setup()
+        d = self.request.run_setup()
         d.addCallback(self.run_scenario)
         return d
 
@@ -309,7 +304,7 @@ class RequestLoadScenario(object):
                     action_type=u'flocker:benchmark:scenario:cleanup',
                     scenario='request_load'
                 ):
-                    return self.scenario_setup.run_cleanup()
+                    return self.request.run_cleanup()
 
             scenario.addBoth(scenario_cleanup)
 

--- a/benchmark/scenarios/read_request_load.py
+++ b/benchmark/scenarios/read_request_load.py
@@ -9,12 +9,12 @@ from twisted.internet.defer import succeed
 
 from flocker.apiclient import IFlockerAPIV1Client
 
-from .._interfaces import IRequestScenarioSetup
+from .._interfaces import IRequest
 from .._method import validate_no_arg_method
 from ._request_load import RequestLoadScenario, DEFAULT_SAMPLE_SIZE
 
 
-@implementer(IRequestScenarioSetup)
+@implementer(IRequest)
 class ReadRequest(object):
     """
     Implementation of the setup and request maker for the read load

--- a/benchmark/scenarios/test/test_request_load.py
+++ b/benchmark/scenarios/test/test_request_load.py
@@ -1,0 +1,65 @@
+# Copyright 2016 ClusterHQ Inc.  See LICENSE file for details.
+
+from zope.interface import implementer
+
+from twisted.internet.defer import succeed
+from twisted.internet.task import Clock
+
+from flocker.testtools import TestCase
+
+from benchmark._interfaces import IRequest
+from benchmark.scenarios._request_load import RequestLoadScenario
+
+
+@implementer(IRequest)
+class TestRequest:
+    """
+    A very simple request that does nothing but always succeeds.
+    """
+
+    def run_setup(self):
+        return succeed(None)
+
+    def make_request(self):
+        return succeed(None)
+
+    def run_cleanup(self):
+        return succeed(None)
+
+
+class RequestMeasureTests(TestCase):
+    """
+    Tests for ``_request_and_measure``.
+    """
+
+    def test_single_count(self):
+        """
+        Adds ``request_rate`` samples per call.
+        """
+        calls_per_second = 10
+        clock = Clock()
+        request = TestRequest()
+        scenario = RequestLoadScenario(
+            clock, request, request_rate=calls_per_second
+        )
+        scenario._request_and_measure(1)
+        self.assertEqual(
+            scenario.rate_measurer.get_metrics()['ok_count'], calls_per_second
+        )
+
+    def test_multiple_count(self):
+        """
+        The count controls how many requests are made.
+        """
+        calls_per_second = 10
+        seconds = 2
+        clock = Clock()
+        request = TestRequest()
+        scenario = RequestLoadScenario(
+            clock, request, request_rate=calls_per_second
+        )
+        scenario._request_and_measure(seconds)
+        self.assertEqual(
+            scenario.rate_measurer.get_metrics()['ok_count'],
+            calls_per_second * seconds
+        )

--- a/benchmark/scenarios/test/test_write_request_load.py
+++ b/benchmark/scenarios/test/test_write_request_load.py
@@ -159,12 +159,12 @@ class write_request_load_scenarioTest(TestCase):
             self.assertNotEqual(returned_datasets, [])
 
         # Create a datasest and verify we get a success
-        d = s.scenario_setup._create_dataset(self.node1)
-        d.addCallback(s.scenario_setup._set_dataset_id)
+        d = s.request._create_dataset(self.node1)
+        d.addCallback(s.request._set_dataset_id)
         self.successResultOf(d)
 
         # Verify that a dataset is actually being created
-        d2 = s.scenario_setup.control_service.list_datasets_configuration()
+        d2 = s.request.control_service.list_datasets_configuration()
         d2.addCallback(assert_created)
         s.stop()
 
@@ -176,14 +176,16 @@ class write_request_load_scenarioTest(TestCase):
         """
         reactor = Clock()
         cluster = self.make_cluster(self.get_fake_flocker_client_instance())
-        write_scenario = write_request_load_scenario(reactor, cluster, 5, sample_size=3)
+        write_scenario = write_request_load_scenario(
+            reactor, cluster, 5, sample_size=3
+        )
 
         d = write_scenario.start()
 
         d.addCallback(write_scenario.stop)
 
         def list_datasets(ignored):
-            return write_scenario.scenario_setup.control_service.list_datasets_state()
+            return write_scenario.request.control_service.list_datasets_state()
 
         d.addCallback(list_datasets)
 
@@ -208,7 +210,7 @@ class write_request_load_scenarioTest(TestCase):
         s = write_request_load_scenario(c, cluster, 5, sample_size=3)
 
         d = s.start()
-        c.pump(repeat(1, s.scenario_setup.timeout+1))
+        c.pump(repeat(1, s.request.timeout+1))
 
         failure = self.failureResultOf(d)
         self.assertIsInstance(failure.value, DatasetCreationTimeout)

--- a/benchmark/scenarios/write_request_load.py
+++ b/benchmark/scenarios/write_request_load.py
@@ -10,7 +10,7 @@ from twisted.internet.defer import CancelledError
 
 from flocker.common import timeout
 
-from .._interfaces import IRequestScenarioSetup
+from .._interfaces import IRequest
 from ._request_load import (
     RequestLoadScenario, NoNodesFound
 )
@@ -23,7 +23,7 @@ class DatasetCreationTimeout(Exception):
     """
 
 
-@implementer(IRequestScenarioSetup)
+@implementer(IRequest)
 class WriteRequest(object):
     """
     Implementation of the write setup.


### PR DESCRIPTION
The benchmarking load scenarios work by generating `n` requests per second in a LoopingCall.  LoopingCall can skip iterations, if a single iteration takes longer than the interval between calls.  If that happens, a `count` > 1 is passed to the next iteration.

Current code uses this count to increase the number of seconds passed in the rate measurer, but failed to increase the number of new requests generated - it should be the rate (per second) times the number of seconds passed.

This PR fixes that problem so that the number of requests generated catches up all missed intervals.

Also rename `IRequestScenarioSetup` to the simpler name `IRequest`, since it is mainly encapsulating an arbitrary request.