### PR TITLE
[FLOC-4010] Slower container creation

### DIFF
--- a/benchmark/_flocker.py
+++ b/benchmark/_flocker.py
@@ -1,0 +1,166 @@
+# Copyright 2016 ClusterHQ Inc.  See LICENSE file for details.
+"""
+Utilities to perform Flocker operations.
+"""
+
+from functools import partial
+from datetime import timedelta
+
+from flocker.common import loop_until, timeout as _timeout
+
+DEFAULT_TIMEOUT = timedelta(minutes=10)
+
+
+def loop_until_state_found(reactor, get_states, state_matches, timeout):
+    """
+    Loop until a state has been reached.
+
+    :param get_states: Callable returning a Deferred firing with a list
+        of states.
+    :param state_matches: Callable that accepts a state parameter, and
+        returns a boolean indicating whether the state matches.
+    :param timedelta timeout: Maximum time to wait for state to be found.
+    :return Deferred[Any]: The matching state.
+    """
+    def state_reached():
+        d = get_states()
+
+        def find_match(states):
+            for state in states:
+                if state_matches(state):
+                    return state
+            return None
+        d.addCallback(find_match)
+
+        return d
+
+    d = loop_until(reactor, state_reached)
+    _timeout(reactor, d, timeout.total_seconds())
+    return d
+
+
+def create_dataset(
+    reactor, control_service, node_uuid, dataset_id, volume_size,
+    timeout=DEFAULT_TIMEOUT
+):
+    """
+    Create a dataset, then wait for it to be mounted.
+
+    :param IReactorTime reactor: Twisted Reactor.
+    :param IFlockerAPIV1Client control_service: Benchmark control
+        service.
+    :param UUID node_uuid: Node on which to create dataset.
+    :param UUID dataset_id: ID for created dataset.
+    :param int volume_size: Size of volume in bytes.
+    :param timedelta timeout: Maximum time to wait for dataset to be
+        mounted.
+    :return Deferred[DatasetState]: The state of the created dataset.
+    """
+
+    d = control_service.create_dataset(
+        primary=node_uuid,
+        maximum_size=volume_size,
+        dataset_id=dataset_id,
+    )
+
+    def dataset_matches(dataset, state):
+        return (
+            state.dataset_id == dataset.dataset_id and
+            state.primary == dataset.primary and
+            state.path is not None
+        )
+
+    d.addCallback(
+        lambda dataset: loop_until_state_found(
+            reactor, control_service.list_datasets_state,
+            partial(dataset_matches, dataset), timeout
+        )
+    )
+
+    return d
+
+
+def create_container(
+    reactor, control_service, node_uuid, name, image, volumes=None,
+    timeout=DEFAULT_TIMEOUT
+):
+    """
+    Create a container, then wait for it to be running.
+
+    :param IReactorTime reactor: Twisted Reactor.
+    :param IFlockerAPIV1Client control_service: Benchmark control
+        service.
+    :param UUID node_uuid: Node on which to start the container.
+    :param unicode name: Name of the container.
+    :param DockerImage image: Docker image for the container.
+    :param Optional[Sequence[MountedDataset]] volumes: Volumes to attach
+        to the container.
+    :param timedelta timeout: Maximum time to wait for container to be
+        created.
+    :return Deferred[ContainerState]: The state of the created container.
+    """
+
+    d = control_service.create_container(node_uuid, name, image, volumes)
+
+    def container_matches(container, state):
+        return (
+            container.name == state.name and
+            container.node_uuid == state.node_uuid and
+            state.running
+        )
+
+    d.addCallback(
+        lambda container: loop_until_state_found(
+            reactor, control_service.list_containers_state,
+            partial(container_matches, container), timeout
+        )
+    )
+
+    return d
+
+
+def delete_container(reactor, control_service, container):
+    """
+    Delete a container, then wait for it to be removed.
+
+    :param IReactorTime reactor: Twisted Reactor.
+    :param IFlockerAPIV1Client control_service: Benchmark control
+        service.
+    :param ContainerState container: Container to be removed.
+    :return Deferred[ContainerState]: The state before removal.
+    """
+
+    def container_removed(expected):
+        """
+        Check whether a container has been removed (deleted and stopped).
+
+        :param ContainerState expected: A container state to match against the
+            results of ``list_containers_state``.
+        :return Deferred[Optional[ContainerState]]: ``None`` if the
+            ``expected`` container is found, or ``expected`` if it is not
+            found.
+        """
+        d = control_service.list_containers_state()
+
+        def container_matches(inspecting, expected):
+            return (
+                expected.name == inspecting.name and
+                expected.node_uuid == inspecting.node_uuid and
+                inspecting.running
+            )
+
+        def no_running_match(existing_state):
+            for state in existing_state:
+                if container_matches(state, expected):
+                    return None
+            return expected
+        d.addCallback(no_running_match)
+        return d
+
+    d = control_service.delete_container(container.name)
+
+    def loop_until_container_removed(_ignore):
+        return loop_until(reactor, partial(container_removed, container))
+    d.addCallback(loop_until_container_removed)
+
+    return d

--- a/benchmark/_flocker.py
+++ b/benchmark/_flocker.py
@@ -15,6 +15,7 @@ def loop_until_state_found(reactor, get_states, state_matches, timeout):
     """
     Loop until a state has been reached.
 
+    :param IReactorTime reactor: Twisted Reactor.
     :param get_states: Callable returning a Deferred firing with a list
         of states.
     :param state_matches: Callable that accepts a state parameter, and
@@ -115,7 +116,7 @@ def create_container(
             partial(container_matches, container), timeout
         )
 
-        # If an error occurs, delete container
+        # If an error occurs, delete container, but return original failure
         def delete_container(failure):
             d = control_service.delete_container(container.name)
             d.addCallback(lambda _ignore: failure)

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -21,6 +21,8 @@ from flocker.apiclient import FlockerClient, MountedDataset
 from benchmark._flocker import create_container
 
 
+DEFAULT_TIMEOUT = 3600
+
 MESSAGE_FORMATS = {
     'flocker.benchmark.container_setup:start':
         'Starting %(containers_per_node)s containers per node '
@@ -77,10 +79,10 @@ class ContainerOptions(usage.Options):
         ['cert-directory', None, None,
          'Location of the user and control certificates and user key'],
         ['max-size', None, 1,
-         'Size of the volume, in gigabytes. One GB by default'],
-        ['wait', None, 3600,
-         "The timeout in seconds for waiting until the operation is complete. "
-         "Defaults to 1 hour."],
+         'Size of the volume, in gigabytes.'],
+        ['wait', None, DEFAULT_TIMEOUT,
+         "The timeout in seconds for waiting until the operation is complete."
+         ],
     ]
 
     synopsis = ('Usage: setup-cluster-containers --app-per-node <containers '

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -273,7 +273,12 @@ class ClusterContainerDeployment(object):
                     image=self.image,
                     volumes=[volume])
             d.addCallback(start_container)
-            deferred_timeout(self.reactor, d, self.timeout.total_seconds())
+
+            # DeferredContext does not support ``cancel`` method.  Use the
+            # underlying Deferred for the timeout.
+            deferred_timeout(
+                self.reactor, d.result, self.timeout.total_seconds()
+            )
 
             def update_container_count(container):
                 self.container_count += 1

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -324,7 +324,8 @@ class ClusterContainerDeployment(object):
                 d = succeed(None)
                 for i in range(per_node):
                     d.addCallback(
-                        lambda _ignore: self.create_stateful_container(node, i)
+                        lambda _ignore, node=node, i=i:
+                            self.create_stateful_container(node, i)
                     )
                 deferred_list.append(d)
 

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -316,7 +316,7 @@ class ClusterContainerDeployment(object):
 
             def update_error_count(failure):
                 self.error_count += 1
-                failure.printTraceback()
+                failure.printTraceback(sys.stderr)
                 write_failure(failure)
 
             d.addCallbacks(update_container_count, update_error_count)

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -279,6 +279,7 @@ class ClusterContainerDeployment(object):
                     d = self.client.delete_dataset(dataset.dataset_id)
                     d.addErrback(write_failure)
                     d.addBoth(lambda _ignore: failure)
+                    return d
                 d.addErrback(delete_dataset)
 
                 return d
@@ -314,7 +315,9 @@ class ClusterContainerDeployment(object):
 
             def display_count():
                 print(
-                    '{} / {}'.format(self.container_count, total)
+                    '{} / {}'.format(
+                        self.container_count + self.error_count, total
+                    )
                 )
             loop = LoopingCall(display_count)
             loop.start(10, now=False)

--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -13,7 +13,7 @@ from twisted.python import usage
 from eliot import add_destination, start_action, write_failure
 from eliot.twisted import DeferredContext
 
-from flocker.common import gather_deferreds, timeout as deferred_timeout
+from flocker.common import gather_deferreds
 from flocker.control.httpapi import REST_API_PORT
 from flocker.control import DockerImage
 from flocker.apiclient import FlockerClient, MountedDataset

--- a/benchmark/operations/create_container.py
+++ b/benchmark/operations/create_container.py
@@ -4,176 +4,20 @@ Operation to create a container.
 """
 
 from functools import partial
-from datetime import timedelta
 from uuid import UUID, uuid4
 
 from pyrsistent import PClass, field
 from zope.interface import implementer
 
 from flocker.apiclient import MountedDataset
-from flocker.common import gather_deferreds, loop_until, timeout as _timeout
+from flocker.common import gather_deferreds
 from flocker.control import DockerImage
 
+from benchmark._flocker import (
+    create_dataset, create_container, delete_container
+)
 from benchmark._interfaces import IProbe, IOperation
 from benchmark.operations._common import select_node
-
-
-DEFAULT_TIMEOUT = timedelta(minutes=10)
-
-
-def loop_until_state_found(reactor, get_states, state_matches, timeout):
-    """
-    Loop until a state has been reached.
-
-    :param get_states: Callable returning a Deferred firing with a list
-        of states.
-    :param state_matches: Callable that accepts a state parameter, and
-        returns a boolean indicating whether the state matches.
-    :param timedelta timeout: Maximum time to wait for state to be found.
-    :return Deferred[Any]: The matching state.
-    """
-    def state_reached():
-        d = get_states()
-
-        def find_match(states):
-            for state in states:
-                if state_matches(state):
-                    return state
-            return None
-        d.addCallback(find_match)
-
-        return d
-
-    d = loop_until(reactor, state_reached)
-    _timeout(reactor, d, timeout.total_seconds())
-    return d
-
-
-def create_dataset(
-    reactor, control_service, node_uuid, dataset_id, volume_size,
-    timeout=DEFAULT_TIMEOUT
-):
-    """
-    Create a dataset, then wait for it to be mounted.
-
-    :param IReactorTime reactor: Twisted Reactor.
-    :param IFlockerAPIV1Client control_service: Benchmark control
-        service.
-    :param UUID node_uuid: Node on which to create dataset.
-    :param UUID dataset_id: ID for created dataset.
-    :param int volume_size: Size of volume in bytes.
-    :param timedelta timeout: Maximum time to wait for dataset to be
-        mounted.
-    :return Deferred[DatasetState]: The state of the created dataset.
-    """
-
-    d = control_service.create_dataset(
-        primary=node_uuid,
-        maximum_size=volume_size,
-        dataset_id=dataset_id,
-    )
-
-    def dataset_matches(dataset, state):
-        return (
-            state.dataset_id == dataset.dataset_id and
-            state.primary == dataset.primary and
-            state.path is not None
-        )
-
-    d.addCallback(
-        lambda dataset: loop_until_state_found(
-            reactor, control_service.list_datasets_state,
-            partial(dataset_matches, dataset), timeout
-        )
-    )
-
-    return d
-
-
-def create_container(
-    reactor, control_service, node_uuid, name, image, volumes=None,
-    timeout=DEFAULT_TIMEOUT
-):
-    """
-    Create a container, then wait for it to be running.
-
-    :param IReactorTime reactor: Twisted Reactor.
-    :param IFlockerAPIV1Client control_service: Benchmark control
-        service.
-    :param UUID node_uuid: Node on which to start the container.
-    :param unicode name: Name of the container.
-    :param DockerImage image: Docker image for the container.
-    :param Optional[Sequence[MountedDataset]] volumes: Volumes to attach
-        to the container.
-    :param timedelta timeout: Maximum time to wait for container to be
-        created.
-    :return Deferred[ContainerState]: The state of the created container.
-    """
-
-    d = control_service.create_container(node_uuid, name, image, volumes)
-
-    def container_matches(container, state):
-        return (
-            container.name == state.name and
-            container.node_uuid == state.node_uuid and
-            state.running
-        )
-
-    d.addCallback(
-        lambda container: loop_until_state_found(
-            reactor, control_service.list_containers_state,
-            partial(container_matches, container), timeout
-        )
-    )
-
-    return d
-
-
-def delete_container(reactor, control_service, container):
-    """
-    Delete a container, then wait for it to be removed.
-
-    :param IReactorTime reactor: Twisted Reactor.
-    :param IFlockerAPIV1Client control_service: Benchmark control
-        service.
-    :param ContainerState container: Container to be removed.
-    :return Deferred[ContainerState]: The state before removal.
-    """
-
-    def container_removed(expected):
-        """
-        Check whether a container has been removed (deleted and stopped).
-
-        :param ContainerState expected: A container state to match against the
-            results of ``list_containers_state``.
-        :return Deferred[Optional[ContainerState]]: ``None`` if the
-            ``expected`` container is found, or ``expected`` if it is not
-            found.
-        """
-        d = control_service.list_containers_state()
-
-        def container_matches(inspecting, expected):
-            return (
-                expected.name == inspecting.name and
-                expected.node_uuid == inspecting.node_uuid and
-                inspecting.running
-            )
-
-        def no_running_match(existing_state):
-            for state in existing_state:
-                if container_matches(state, expected):
-                    return None
-            return expected
-        d.addCallback(no_running_match)
-        return d
-
-    d = control_service.delete_container(container.name)
-
-    def loop_until_container_removed(_ignore):
-        return loop_until(reactor, partial(container_removed, container))
-    d.addCallback(loop_until_container_removed)
-
-    return d
 
 
 @implementer(IProbe)

--- a/benchmark/operations/test/test_create_container.py
+++ b/benchmark/operations/test/test_create_container.py
@@ -14,9 +14,10 @@ from flocker.apiclient import FakeFlockerClient, Node
 from flocker.testtools import TestCase
 
 from benchmark.cluster import BenchmarkCluster
+from benchmark._flocker import DEFAULT_TIMEOUT
 from benchmark._interfaces import IOperation, IProbe
 from benchmark.operations.create_container import (
-    CreateContainer, CreateContainerProbe, DEFAULT_TIMEOUT,
+    CreateContainer, CreateContainerProbe
 )
 from benchmark.operations._common import EmptyClusterError
 


### PR DESCRIPTION
For large clusters, creating and destroying large numbers of datasets causes problems, due to errors like AWS's RequestLimitExceeded.  This is a problem for benchmarking, where we need to quickly create and delete large numbers of datasets.

This PR changes the benchmarking script that creates stateful containers to slow it down.  Rather than sending up a massive cluster change, we start one stateful container per node in sequence, waiting for them to be running, until all are created.

I decided not to fix the cleanup-containers script because it does work - it just behaves badly while cleaning up - e.g. the AWS console will fail to report on status.  Slowing down cleanup means we must hang around staggering calls, when we may not want to.  Also, users are more likely to try this at home (cleaning up lots of datasets quickly) so it's not bad to remind ourselves about this problem.

This problem actually needs to be dealt with at a lower level. The cluster should accept any size of configuration changes, and throttle them as required.  Created FLOC-4059 for that.

The change is actually a fairly hefty rewrite of the `cluster-containers-setup.py` file, so it may be easier to review as a new file rather than as a diff to the existing file.  The other major cause of line changes was extracting some functions to start datasets and containers out of `benchmark/operations/create_container.py` and putting them into a separate file.

The code is also more careful to delete datasets and containers if an error occurs, as orphaned datasets can be a real problem when we're operating near the limits. (Benchmarking requires 20 datasets/node, our AWS code supports a maximum of 21 datasets/node).

An example run:
```
$ ./admin/setup-cluster --distribution ubuntu-14.04 --provider aws --dataset-backend aws --branch master --config-file benchmark.yml --purpose benchmark --number-of-nodes 5
(set environment variables)

$ ./benchmark/setup-cluster-containers --apps-per-node 20 --control-node ${FLOCKER_ACCEPTANCE_CONTROL_NODE} --cert-directory ${FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH} --wait 180 --image clusterhq/mongodb --mountpoint /data/db
Starting 20 containers per node on 5 nodes...
0 / 100
0 / 100
5 / 100
6 / 100
10 / 100
10 / 100
13 / 100
15 / 100
18 / 100
...
90 / 100
92 / 100
92 / 100
95 / 100
97 / 100
97 / 100
98 / 100
99 / 100
99 / 100
99 / 100
Started 100 containers with 0 failures.

$ ./benchmark/cleanup-cluster --control-node ${FLOCKER_ACCEPTANCE_CONTROL_NODE} --cert-directory ${FLOCKER_ACCEPTANCE_API_CERTIFICATES_PATH} 

```
