### PR TITLE
[FLOC-4061] Rename titles on Integration homepage

### DIFF
--- a/docs/docker-integration/index.rst
+++ b/docs/docker-integration/index.rst
@@ -39,8 +39,10 @@ Flocker Installation Options
 
 .. _docker-tutorials:
 
-Next Step: Follow a Tutorial
-============================
+Tutorial
+========
+
+.. XXX this title should be renamed to "Tutorials" when there are more than one tutorial
 
 .. raw:: html
 
@@ -51,8 +53,8 @@ Next Step: Follow a Tutorial
 	    </div>
     </div>
 
-Next Step: Related Blog Articles
-================================
+Related Blog Articles
+=====================
 
 * `Tutorial: PostgreSQL on Docker with Flocker <https://clusterhq.com/2016/01/08/tutorial-flocker-volume-driver-postgres/>`_
 * `Walkthrough: Docker Volumes vs Docker Volumes with Flocker <https://clusterhq.com/2015/12/09/difference-docker-volumes-flocker-volumes/>`_

--- a/docs/kubernetes-integration/index.rst
+++ b/docs/kubernetes-integration/index.rst
@@ -35,8 +35,10 @@ Flocker Installation Options
 
 .. _kubernetes-tutorials:
 
-Follow a Tutorial
-=================
+Tutorial
+========
+
+.. XXX this title should be renamed to "Tutorials" when there are more than one tutorial
 
 .. raw:: html
 

--- a/docs/mesos-integration/index.rst
+++ b/docs/mesos-integration/index.rst
@@ -19,8 +19,10 @@ Flocker works with Mesos via two different integration paths.
 
 .. _mesos-tutorials:
 
-Follow a Tutorial
-=================
+Tutorial
+========
+
+.. XXX this title should be renamed to "Tutorials" when there are more than one tutorial
 
 .. raw:: html
 


### PR DESCRIPTION
Fixes 4061

The current titles for Tutorials and Blog Articles did not test well in User Testing - this issue reverts the titles to something simple, adding an internal note that they will need to be changed when further tutorials are added.