### PR TITLE
[FLOC-3810] Acceptance jobs junit

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -458,7 +458,7 @@ common_cli:
     eval `ssh-agent -s`
     ssh-add ${HOME}/.ssh/id_rsa
 
-  run_acceptance_aws_tests: &run_acceptance_aws_tests |
+  run_acceptance_tests: &run_acceptance_tests |
     # We gather the return code but make sure we come out of these tests with 0
     # we store that code and pass it to the end of the job execution,
     # as part of the JOB_EXIT_STATUS variable.
@@ -473,8 +473,9 @@ common_cli:
     # through the --build-server parameter below.
     ${venv}/bin/python admin/run-acceptance-tests \
     --distribution ${DISTRIBUTION_NAME} \
-    --provider aws --dataset-backend aws --branch ${TRIGGERED_BRANCH} \
-    --build-server  \
+    --provider ${ACCEPTANCE_TEST_PROVIDER} \
+    --dataset-backend ${ACCEPTANCE_TEST_PROVIDER} \
+    --branch ${TRIGGERED_BRANCH} --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
     --config-file /tmp/acceptance.yaml \
     -- --reporter=subunit ${ACCEPTANCE_TEST_MODULE} 2>&1 | tee trial.log
@@ -491,29 +492,6 @@ common_cli:
     ${venv}/bin/python admin/run-acceptance-tests \
     --distribution ${DISTRIBUTION_NAME} --number-of-nodes 1 \
     --provider ${ACCEPTANCE_TEST_PROVIDER} --dataset-backend loopback \
-    --branch ${TRIGGERED_BRANCH} \
-    --build-server  \
-    http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
-    --config-file /tmp/acceptance.yaml \
-    -- --reporter=subunit ${ACCEPTANCE_TEST_MODULE} 2>&1 | tee trial.log
-    JOB_EXIT_STATUS="$( updateExitStatus $? )"
-
-  run_acceptance_rackspace_tests: &run_acceptance_rackspace_tests |
-    # We gather the return code but make sure we come out of these tests with 0
-    # we store that code and pass it to the end of the job execution,
-    # as part of the JOB_EXIT_STATUS variable.
-    #
-    # The admin/run-acceptance-tests will provision a flocker cluster of
-    # several nodes. These nodes will install the flocker packages (RPM/DEB)
-    # during the provisioning process by that tool. These packages are fetched
-    # from a repository on the network through a common apt-get/yum install.
-    # The jenkins slave will be the repository host containing those packages
-    # which are made available through a webserver running on port 80.
-    # We pass the URL of our Jenkins Slave to the acceptance test nodes
-    # through the --build-server parameter below.
-    ${venv}/bin/python admin/run-acceptance-tests \
-    --distribution ${DISTRIBUTION_NAME} \
-    --provider rackspace --dataset-backend rackspace \
     --branch ${TRIGGERED_BRANCH} \
     --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
@@ -1431,7 +1409,8 @@ job_type:
                    *build_repo_metadata,
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
-                   *run_acceptance_aws_tests,
+                   'export ACCEPTANCE_TEST_PROVIDER=aws',
+                   *run_acceptance_tests,
                    *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
@@ -1460,7 +1439,8 @@ job_type:
                    *build_repo_metadata,
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
-                   *run_acceptance_aws_tests,
+                   'export ACCEPTANCE_TEST_PROVIDER=aws',
+                   *run_acceptance_tests,
                    *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
@@ -1540,7 +1520,8 @@ job_type:
                    *build_repo_metadata,
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
-                   *run_acceptance_rackspace_tests,
+                   'export ACCEPTANCE_TEST_PROVIDER=rackspace',
+                   *run_acceptance_tests,
                    *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
@@ -1567,7 +1548,8 @@ job_type:
                    *build_repo_metadata,
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
-                   *run_acceptance_rackspace_tests,
+                   'export ACCEPTANCE_TEST_PROVIDER=rackspace',
+                   *run_acceptance_tests,
                    *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]

--- a/build.yaml
+++ b/build.yaml
@@ -1419,6 +1419,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
+      publish_test_results: true
       # Give the acceptance test suite a nice long time to run.  Give it even
       # longer on CentOS than Ubuntu because Docker configuration on CentOS
       # causes some things to be particularly slow.  This value is just a guess
@@ -1449,6 +1450,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      publish_test_results: true
       # Similar to the reasoning for run_acceptance_on_AWS_CentOS_7_with_EBS
       # but slightly shorter since Ubuntu runs the tests faster.
       timeout: 90
@@ -1476,6 +1478,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
+      publish_test_results: true
       # Reasoning as for run_acceptance_on_AWS_CentOS_7_with_EBS
       timeout: 120
       directories_to_delete: []
@@ -1502,6 +1505,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      publish_test_results: true
       # Reasoning as for run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS
       timeout: 90
       directories_to_delete: []
@@ -1530,6 +1534,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
+      publish_test_results: true
       # Reasoning as for run_acceptance_on_AWS_CentOS_7_with_EBS
       timeout: 120
       directories_to_delete: []
@@ -1558,6 +1563,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      publish_test_results: true
       # Reasoning as for run_acceptance_on_AWS_Ubuntu_Trusty_with_EBS
       timeout: 90
       directories_to_delete: []

--- a/build.yaml
+++ b/build.yaml
@@ -477,7 +477,7 @@ common_cli:
     --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
     --config-file /tmp/acceptance.yaml \
-    ${ACCEPTANCE_TEST_MODULE} --reporter=subunit 2>&1 | tee trial.log
+    -- --reporter=subunit ${ACCEPTANCE_TEST_MODULE} 2>&1 | tee trial.log
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
   run_acceptance_loopback_tests: &run_acceptance_loopback_tests |
@@ -495,7 +495,7 @@ common_cli:
     --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
     --config-file /tmp/acceptance.yaml \
-    ${ACCEPTANCE_TEST_MODULE} --reporter=subunit 2>&1 | tee trial.log
+    -- --reporter=subunit ${ACCEPTANCE_TEST_MODULE} 2>&1 | tee trial.log
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
   run_acceptance_rackspace_tests: &run_acceptance_rackspace_tests |
@@ -518,7 +518,7 @@ common_cli:
     --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
     --config-file /tmp/acceptance.yaml \
-    ${ACCEPTANCE_TEST_MODULE}  --reporter=subunit 2>&1 | tee trial.log
+    -- --reporter=subunit ${ACCEPTANCE_TEST_MODULE} 2>&1 | tee trial.log
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
   run_client_tests: &run_client_tests |

--- a/build.yaml
+++ b/build.yaml
@@ -394,6 +394,7 @@ common_cli:
   # from our _main_multijob.
   # These are the remote logs from the acceptance tests.
   acceptance_tests_artifacts: &acceptance_tests_artifacts
+    - results.xml
     - run-acceptance-tests.log
     - _trial_temp/test.log
     - remote_logs.log
@@ -401,6 +402,7 @@ common_cli:
   # Ubuntu acceptance tests do not collect the logs from the remote nodes
   # https://clusterhq.atlassian.net/browse/FLOC-2560
   acceptance_tests_artifacts_ubuntu_special_case: &acceptance_tests_artifacts_ubuntu_special_case
+    - results.xml
     - run-acceptance-tests.log
     - remote_logs.log
     - _trial_temp/test.log

--- a/build.yaml
+++ b/build.yaml
@@ -1202,6 +1202,7 @@ job_type:
                    'export ACCEPTANCE_TEST_MODULE=${MODULE}',
                    'export ACCEPTANCE_TEST_PROVIDER=aws',
                    *run_acceptance_loopback_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }

--- a/build.yaml
+++ b/build.yaml
@@ -477,7 +477,7 @@ common_cli:
     --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
     --config-file /tmp/acceptance.yaml \
-    ${ACCEPTANCE_TEST_MODULE}
+    ${ACCEPTANCE_TEST_MODULE} --reporter=subunit 2>&1 | tee trial.log
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
   run_acceptance_loopback_tests: &run_acceptance_loopback_tests |
@@ -495,7 +495,7 @@ common_cli:
     --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
     --config-file /tmp/acceptance.yaml \
-    ${ACCEPTANCE_TEST_MODULE}
+    ${ACCEPTANCE_TEST_MODULE} --reporter=subunit 2>&1 | tee trial.log
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
   run_acceptance_rackspace_tests: &run_acceptance_rackspace_tests |
@@ -518,7 +518,7 @@ common_cli:
     --build-server  \
     http://$(wget -qO- http://instance-data/latest/meta-data/public-ipv4)  \
     --config-file /tmp/acceptance.yaml \
-    ${ACCEPTANCE_TEST_MODULE}
+    ${ACCEPTANCE_TEST_MODULE}  --reporter=subunit 2>&1 | tee trial.log
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
   run_client_tests: &run_client_tests |
@@ -1197,11 +1197,13 @@ job_type:
                    'export ACCEPTANCE_TEST_MODULE=${MODULE}',
                    'export ACCEPTANCE_TEST_PROVIDER=aws',
                    *run_acceptance_loopback_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts
+      publish_test_results: true
       timeout: 45
       directories_to_delete: *run_acceptance_directories_to_delete
 
@@ -1225,6 +1227,7 @@ job_type:
           }
       clean_repo: true
       archive_artifacts: *acceptance_tests_artifacts_ubuntu_special_case
+      publish_test_results: true
       timeout: 45
       directories_to_delete: *run_acceptance_directories_to_delete
 
@@ -1429,6 +1432,7 @@ job_type:
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_aws_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }
@@ -1457,6 +1461,7 @@ job_type:
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_aws_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }
@@ -1483,6 +1488,7 @@ job_type:
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    'export ACCEPTANCE_TEST_PROVIDER=gce',
                    *run_acceptance_loopback_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }
@@ -1508,6 +1514,7 @@ job_type:
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    'export ACCEPTANCE_TEST_PROVIDER=gce',
                    *run_acceptance_loopback_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }
@@ -1534,6 +1541,7 @@ job_type:
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_rackspace_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }
@@ -1560,6 +1568,7 @@ job_type:
                    *setup_authentication,
                    'export ACCEPTANCE_TEST_MODULE=flocker.acceptance',
                    *run_acceptance_rackspace_tests,
+                   *convert_results_to_junit,
                    *clean_packages,
                    *exit_with_return_code_from_test ]
           }


### PR DESCRIPTION
Updates Jenkins jobs to add test results for acceptance jobs. This will allow us to see which tests fail rather than being restricted to a binary output