### PR TITLE
[FLOC-3980] Release Flocker 1.10

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,8 +9,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
-Next Release
+This Release
 ============
+
+v1.10.0
+-------
 
 * The :ref:`Flocker documentation <supported-orchestration-frameworks>` has been re-designed to better reflect that Flocker now integrates with Cluster Managers, rather than providing its own container management features.
 * The new :ref:`CloudFormation installer <cloudformation>` has been made available, to provide a far simpler installation experience for users on AWS.
@@ -18,8 +21,13 @@ Next Release
 * Fixed a regression that caused block device agents to poll backend APIs like EBS too frequently in some circumstances.
 * Increase limit on maximum Flocker volumes per AWS instance from 11 to 21.
 
-This Release
-============
+Previous Releases
+=================
+
+.. contents::
+   :local:
+   :backlinks: none
+   :depth: 2
 
 v1.9.0
 ------
@@ -39,13 +47,6 @@ v1.9.0
 * The :ref:`Flocker plugin for Docker<plugin>` now supports specifying the size during volume creation.
 * Fixed a bug where Flocker would fail to service requests that had an unexpected format.
 
-Previous Releases
-=================
-
-.. contents::
-   :local:
-   :backlinks: none
-   :depth: 2
 
 v1.8.0
 ------

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -12,7 +12,7 @@ You can learn more about where we might be going with future releases by:
 This Release
 ============
 
-v1.10.0
+v1.10.1
 -------
 
 * The :ref:`Flocker documentation <supported-orchestration-frameworks>` has been re-designed to better reflect that Flocker now integrates with Cluster Managers, rather than providing its own container management features.
@@ -28,6 +28,11 @@ Previous Releases
    :local:
    :backlinks: none
    :depth: 2
+
+v1.10.0
+-------
+
+Unreleased.
 
 v1.9.0
 ------


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-3980

(This is just #2587 with the branch renamed)