### PR TITLE
[FLOC-3759] Version for benchmark JSON output

### DIFF
--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -28,6 +28,9 @@ from benchmark._driver import driver
 
 to_file(sys.stderr)
 
+# Change this number when changing the format of the output JSON
+OUTPUT_VERSION = 1
+
 # If modifying scenarios, operations, or metrics, please update
 # docs/gettinginvolved/benchmarking.rst
 
@@ -289,6 +292,7 @@ def main(argv, environ, react=react):
     timestamp = datetime.now().isoformat()
 
     result = dict(
+        version=OUTPUT_VERSION,
         timestamp=timestamp,
         client=dict(
             flocker_version=flocker_client_version,
@@ -303,6 +307,7 @@ def main(argv, environ, react=react):
     )
 
     userdata = parse_userdata(options)
+    print(userdata)
     if userdata:
         result['userdata'] = userdata
 

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -307,7 +307,6 @@ def main(argv, environ, react=react):
     )
 
     userdata = parse_userdata(options)
-    print(userdata)
     if userdata:
         result['userdata'] = userdata
 

--- a/benchmark/test/test_script.py
+++ b/benchmark/test/test_script.py
@@ -588,3 +588,28 @@ class MainTests(TestCase):
                 self.get_default_environ()
             )
         self.assertIn('Invalid sample count', exception.args[0])
+
+    def test_version(self):
+        """
+        Check that result contains the expected keys for the current version.
+
+        This only checks the keys generated in main, not the keys added by the
+        benchmarks.
+        """
+        result = self.call_main(
+            ['--userdata={"branch": "master"}'], self.get_default_environ()
+        )
+        self.assertEqual(
+            sorted(result['result'].keys()),
+            [
+                'client', 'metric', 'operation', 'scenario', 'timestamp',
+                'userdata', 'version',
+            ]
+        )
+        self.assertEqual(
+            sorted(result['result']['client'].keys()),
+            [
+                'flocker_version', 'nodename', 'platform', 'username',
+                'working_directory',
+            ]
+        )


### PR DESCRIPTION
Add a `version` to the benchmark JSON results, to help us deal with future changes to the schema.
