### PR TITLE
[FLOC-3998] Flocker dataset config

### DIFF
--- a/docs/gettinginvolved/plugins/building-driver.rst
+++ b/docs/gettinginvolved/plugins/building-driver.rst
@@ -125,7 +125,12 @@ Here's what the module could look like:
     FLOCKER_BACKEND = BackendDescription(
         name=u"mystorage_flocker_plugin",
         needs_reactor=False, needs_cluster_id=True,
-        api_factory=api_factory, deployer_type=DeployerType.block)
+        api_factory=api_factory,
+        required_config=set("username", "password",),
+        deployer_type=DeployerType.block)
+
+The ``required_config`` set in a ``BackendDescription`` is an optional set of configuration keys that must be present in your backend's ``agent.yml`` for your driver to successfully initialize.
+If you specify ``required_config``, the dataset agent will validate that all of these keys are present in the user's ``dataset`` configuration when starting.
 
 The ``cluster_id`` parameter is a Python :py:obj:`uuid.UUID` instance uniquely identifying the cluster.
 This is useful if you want to build a system that supports multiple Flocker clusters talking to a shared storage backend.

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -23,7 +23,7 @@ from zope.interface import implementer
 from twisted.python.filepath import FilePath
 from twisted.python.usage import Options, UsageError
 from twisted.internet.ssl import Certificate
-from twisted.internet import reactor  # pylint: disable=unused-import
+from twisted.internet import reactor
 from twisted.internet.defer import succeed
 from twisted.python.constants import Names, NamedConstant
 from twisted.python.reflect import namedAny
@@ -438,7 +438,7 @@ class BackendDescription(PClass):
     # out.
     needs_cluster_id = field(type=bool, mandatory=True)
     # Config "dataset" keys required to initialize this backend.
-    required_config = field(type=set, mandatory=True)
+    required_config = field(type=set, mandatory=True, initial=set())
     api_factory = field(mandatory=True)
     deployer_type = field(
         mandatory=True,

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -23,7 +23,7 @@ from zope.interface import implementer
 from twisted.python.filepath import FilePath
 from twisted.python.usage import Options, UsageError
 from twisted.internet.ssl import Certificate
-from twisted.internet import reactor
+from twisted.internet import reactor  # pylint: disable=unused-import
 from twisted.internet.defer import succeed
 from twisted.python.constants import Names, NamedConstant
 from twisted.python.reflect import namedAny

--- a/flocker/node/test/dummybackend.py
+++ b/flocker/node/test/dummybackend.py
@@ -29,5 +29,4 @@ def api_factory(cluster_id, **kwargs):
 FLOCKER_BACKEND = BackendDescription(
     name=u"dummybackend",  # Not actually used for 3rd party plugins
     needs_reactor=False, needs_cluster_id=True,
-    api_factory=api_factory, deployer_type=DeployerType.block,
-    required_config=set(),)
+    api_factory=api_factory, deployer_type=DeployerType.block,)


### PR DESCRIPTION
Fixes FLOC-3998, including a default value for `required_config` to prevent existing plugins breaking.