### PR TITLE
[FLOC-4085] Tighten constraints on CloudFormation user Inputs

### DIFF
--- a/admin/installer/cloudformation.py
+++ b/admin/installer/cloudformation.py
@@ -70,22 +70,29 @@ template = Template()
 # Keys corresponding to CloudFormation user Inputs.
 access_key_id_param = template.add_parameter(Parameter(
     "AmazonAccessKeyID",
-    Description="Your Amazon AWS access key ID",
+    Description="Your Amazon AWS access key ID (mandatory)",
     Type="String",
     NoEcho=True,
     AllowedPattern="[\w]+",
+    MinLength="16",
+    MaxLength="32",
 ))
 secret_access_key_param = template.add_parameter(Parameter(
     "AmazonSecretAccessKey",
-    Description="Your Amazon AWS secret access key.",
+    Description="Your Amazon AWS secret access key (mandatory)",
     Type="String",
     NoEcho=True,
+    MinLength="1",
 ))
 keyname_param = template.add_parameter(Parameter(
     "EC2KeyPair",
     Description="Name of an existing EC2 KeyPair to enable SSH "
-                "access to the instance",
+                "access to the instance (mandatory)",
     Type="String",
+    MinLength="1",
+    AllowedPattern="[\x20-\x7E]*",
+    MaxLength="255",
+    ConstraintDescription="can contain only ASCII characters.",
 ))
 volumehub_token = template.add_parameter(Parameter(
     "VolumeHubToken",

--- a/admin/installer/cloudformation.py
+++ b/admin/installer/cloudformation.py
@@ -72,11 +72,14 @@ access_key_id_param = template.add_parameter(Parameter(
     "AmazonAccessKeyID",
     Description="Your Amazon AWS access key ID",
     Type="String",
+    NoEcho=True,
+    AllowedPattern="[\w]+",
 ))
 secret_access_key_param = template.add_parameter(Parameter(
     "AmazonSecretAccessKey",
     Description="Your Amazon AWS secret access key.",
     Type="String",
+    NoEcho=True,
 ))
 keyname_param = template.add_parameter(Parameter(
     "EC2KeyPair",


### PR DESCRIPTION
CloudFormation user can leave {AmazonAccessKeyID, AmazonSecretAccessKey, EC2KeyPair} Inputs empty, leading to failure in stack creation, and subsequent trouble in triaging cause of failure (due to stack rollback being default action).

This PR attempts to impose stricter constraints around user Inputs. The constraints are gathered from Amazon documentation.

Master copy of CloudFormation template has been updated with the changes in this PR in order to facilitate testing.

Testing:

* Manual tests passed

* Endtoend test passed:

```
ubuntu@ip-172-31-25-23:~/flocker/admin/installer$ KEEP_STACK=1 CLOUDFORMATION_TEMPLATE_URL=https://s3.amazonaws.com/installer.downloads.clusterhq.com/flocker-cluster.cloudformation.json KEY_PAIR=$KEY ACCESS_KEY_ID=$ACCESS_KEY_ID SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY VOLUMEHUB_TOKEN='' trial flocker.acceptance.endtoend.test_installer
flocker.acceptance.endtoend.test_installer
  DockerComposeTests
    test_docker_compose_up_postgres ... Warning: Permanently added '54.153.118.31' (ECDSA) to the list of known hosts.
                                   [OK]

-------------------------------------------------------------------------------
Ran 1 tests in 751.492s

PASSED (successes=1)
ubuntu@ip-172-31-25-23:~/flocker/admin/installer$ 
```
