### PR TITLE
[FLOC-3976 ] support for batch cloud provisioning

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -674,6 +674,22 @@ class LibcloudRunner(object):
         return d
 
     def _provision_with_retry(self, reactor, name, result):
+        """
+        Wait for a node to get created and the provision it.
+        Re-create the node and retry the provisioning if either the node
+        creation or provisioning fails.
+
+        This method is used in conjuction with bulk creation of new nodes,
+        so that a failure for any single node can be retried individually
+        (rather than failing all the nodes and starting from scratch).
+
+        :param reactor: The reactor.
+        :param str name: The name of the node.
+        :param Deferred result: Deferred that fires with the node when it's
+            created.
+        :return: Deferred that fires with the node when it's created and
+            provisioned.
+        """
         def provision(node):
             print "created node", name
             print "provisioning..."

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -638,7 +638,8 @@ class LibcloudRunner(object):
         print "re-creating and re-trying node", name
 
         def create_attempt():
-            # A list with a single Deferred must be returned.
+            # A list with a single Deferred must be returned as we are
+            # requesting a single node.
             [d] = self.provisioner.create_nodes(
                 reactor=reactor,
                 names=[name],

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -377,6 +377,20 @@ class AWSProvisioner(PClass):
         return False
 
     def create_nodes(self, reactor, names, distribution, metadata={}):
+        """
+        Create nodes with the given names.
+
+        :param reactor: The reactor.
+        :param name: The names of the nodes.
+        :type name: list of str
+        :param str distribution: The name of the distribution to
+            install on the nodes.
+        :param dict metadata: Metadata to associate with the nodes.
+
+        :return: A list of ``Deferred``s each firing with an INode
+            when the corresponding node is created.   The list has
+            the same order as :param:`names`.
+        """
         size = self._default_size
         disk_size = 8
 

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -4,11 +4,12 @@
 AWS provisioner.
 """
 
-from itertools import repeat
+from itertools import izip_longest, repeat
 from textwrap import dedent
 
 from pyrsistent import PClass, field
 
+from twisted.internet.defer import DeferredList, fail, maybeDeferred
 from zope.interface import implementer
 
 
@@ -18,13 +19,14 @@ from boto.ec2.blockdevicemapping import (
 )
 from boto.exception import EC2ResponseError
 
-from ..common import poll_until
+from ..common import loop_until, poll_until
 
 from ._common import INode, IProvisioner
 
 from ._install import provision_for_any_user
 
-from eliot import start_action, Message
+from eliot import Message, start_action, write_failure
+from eliot.twisted import DeferredContext
 
 from ._ssh import run_remotely, run_from_args
 
@@ -128,6 +130,51 @@ def _wait_until_running(instance):
         context.add_success_fields(instance_state_reason=instance.state_reason)
     if instance.state != u'running':
         raise FailedToRun(instance.state_reason)
+
+
+def _async_wait_until_running(reactor, instance):
+    """
+    Wait until a instance is running.
+
+    :param reactor: The reactor.
+    :param boto.ec2.instance.Instance instance: The instance to wait for.
+    :return: Deferred that fires when the instance has become running
+        or failed to run (within a predefined period of time).
+    """
+
+    action = start_action(
+        action_type=u"flocker:provision:aws:wait_until_running",
+        instance_id=instance.id,
+    )
+
+    def check_final_state(ignored):
+        if instance.state != u'running':
+            raise FailedToRun(instance.state_reason)
+        action.add_success_fields(
+            instance_state=instance.state,
+            instance_state_reason=instance.state_reason,
+        )
+        return instance
+
+    def finished_booting():
+        d = maybeDeferred(_node_is_booting, instance)
+        d.addCallback(lambda x: not x)
+        return d
+
+    with action.context():
+        # Since we are refreshing the instance's state once in a while
+        # we may miss some transitions.  So, here we are waiting until
+        # the node has transitioned out of the original state and then
+        # check if the new state is the one that we expect.
+        d = loop_until(
+            reactor,
+            finished_booting,
+            repeat(5, INSTANCE_TIMEOUT)
+        )
+        d = DeferredContext(d)
+        d.addCallback(check_final_state)
+        d.addActionFinish()
+        return d.result
 
 
 @implementer(INode)
@@ -266,11 +313,37 @@ class AWSProvisioner(PClass):
         Return either boto.ec2.instance object or None if the instance
         could not be created.
         """
+
         with start_action(
-            action_type=u"flocker:provision:aws:create_node:run_instances",
+            action_type=u"flocker:provision:aws:get_node",
         ) as context:
+            [instance] = self._run_nodes(1, image_id, size, diskmap)
+            context.add_success_fields(instance_id=instance.id)
+
+            poll_until(lambda: self._set_metadata(instance, metadata),
+                       repeat(1, INSTANCE_TIMEOUT))
+            try:
+                _wait_until_running(instance)
+                return instance
+            except FailedToRun:
+                instance.terminate()
+                return None     # the instance is in the wrong state
+
+    def _run_nodes(self, count, image_id, size, diskmap):
+        """
+        Create an AWS instance with the given parameters.
+
+        Return either boto.ec2.instance object or None if the instance
+        could not be created.
+        """
+        with start_action(
+            action_type=u"flocker:provision:aws:create_node:run_nodes",
+            instance_count=count,
+        ):
             reservation = self._connection.run_instances(
                 image_id,
+                min_count=1,
+                max_count=count,
                 key_name=self._keyname,
                 instance_type=size,
                 security_groups=self._security_groups,
@@ -284,18 +357,7 @@ class AWSProvisioner(PClass):
                     sed -i '/Defaults *requiretty/d' /etc/sudoers
                     """),
             )
-
-            instance = reservation.instances[0]
-            context.add_success_fields(instance_id=instance.id)
-
-        poll_until(lambda: self._set_metadata(instance, metadata),
-                   repeat(1, INSTANCE_TIMEOUT))
-        try:
-            _wait_until_running(instance)
-            return instance
-        except FailedToRun:
-            instance.terminate()
-            return None     # the instance is in the wrong state
+            return reservation.instances
 
     def _set_metadata(self, instance, metadata):
         """
@@ -313,6 +375,98 @@ class AWSProvisioner(PClass):
                 u"flocker:provision:aws:set_metadata:retry"
             )
         return False
+
+    def create_nodes(self, reactor, names, distribution, metadata={}):
+        size = self._default_size
+        disk_size = 8
+
+        action = start_action(
+            action_type=u"flocker:provision:aws:create_nodes",
+            instance_count=len(names),
+            distribution=distribution,
+            image_size=size,
+            disk_size=disk_size,
+            metadata=metadata,
+        )
+        with action.context():
+            disk1 = EBSBlockDeviceType()
+            disk1.size = disk_size
+            disk1.delete_on_termination = True
+            diskmap = BlockDeviceMapping()
+            diskmap['/dev/sda1'] = disk1
+
+            images = self._connection.get_all_images(
+                filters={'name': IMAGE_NAMES[distribution]},
+            )
+
+            instances = self._run_nodes(
+                count=len(names),
+                image_id=images[0].id,
+                size=size,
+                diskmap=diskmap
+            )
+
+            def make_node(ignored, name, instance):
+                return AWSNode(
+                    name=name,
+                    _provisioner=self,
+                    _instance=instance,
+                    distribution=distribution,
+                )
+
+            results = []
+            for name, instance in izip_longest(names, instances):
+                if instance is None:
+                    results.append(fail(Exception("Could not run instance")))
+                else:
+                    node_metadata = metadata.copy()
+                    node_metadata['Name'] = name
+                    d = self._async_get_node(reactor, instance, node_metadata)
+                    d = DeferredContext(d)
+                    d.addCallback(make_node, name, instance)
+                    results.append(d.result)
+            action_completion = DeferredContext(DeferredList(results))
+            action_completion.addActionFinish()
+            # Individual results and errors should be consumed by the caller,
+            # so we can leave action_completion alone now.
+            return results
+
+    def _async_get_node(self, reactor, instance, metadata):
+        """
+        Configure the given AWS instance, wait until it's running
+        and create an ``AWSNode`` object for it.
+
+        :param reactor: The reactor.
+        :param boto.ec2.instance.Instance instance: The instance to set up.
+        :param dict metadata: The metadata to set for the instance.
+        :return: Deferred that fires when the instance is ready.
+        """
+        def instance_error(failure):
+            Message.log(
+                message_type="flocker:provision:aws:async_get_node:failed"
+            )
+            instance.terminate()
+            write_failure(failure)
+            return failure
+
+        action = start_action(
+            action_type=u"flocker:provision:aws:async_get_node",
+            name=metadata['Name'],
+            instance_id=instance.id,
+        )
+        with action.context():
+            d = loop_until(
+                reactor,
+                lambda: maybeDeferred(self._set_metadata, instance, metadata),
+                repeat(5, INSTANCE_TIMEOUT),
+            )
+            d = DeferredContext(d)
+            d.addCallback(
+                lambda _: _async_wait_until_running(reactor, instance)
+            )
+            d.addErrback(instance_error)
+            d.addActionFinish()
+            return d.result
 
 
 def aws_provisioner(

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -153,3 +153,19 @@ class IProvisioner(Interface):
 
         :return INode: The created node.
         """
+
+    def create_nodes(reactor, names, distribution, metadata={}):
+        """
+        Create nodes with the given names.
+
+        :param reactor: The reactor.
+        :param name: The names of the nodes.
+        :type name: list of str
+        :param str distribution: The name of the distribution to
+            install on the nodes.
+        :param dict metadata: Metadata to associate with the nodes.
+
+        :return: A list of ``Deferred``s each firing with an INode
+            when the corresponding node is created.   The list has
+            the same order as :param:`names`.
+        """

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -461,6 +461,20 @@ class GCEProvisioner(PClass):
             compute=self.compute
         )
 
+    def create_nodes(reactor, names, distribution, metadata={}):
+        """
+        Create nodes with the given names.
+
+        This method is not implemented as it is not used yet.
+        As of this time create_nodes is only used by setup-cluster
+        which does not support GCE.
+        One way to implement this method would be to use a variant of
+        wait_for_operation that uses loop_until instead of poll_until
+        to perform the waiting.
+        """
+        raise NotImplementedError(
+            "GCE does not have create_nodes implemented yet.")
+
 
 def gce_provisioner(
     zone, project, ssh_public_key, gce_credentials=None

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -461,7 +461,7 @@ class GCEProvisioner(PClass):
             compute=self.compute
         )
 
-    def create_nodes(reactor, names, distribution, metadata={}):
+    def create_nodes(self, reactor, names, distribution, metadata={}):
         """
         Create nodes with the given names.
 

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -506,8 +506,8 @@ class LibcloudProvisioner(object):
         :param set target_states: The states to compare the compute instance's
             actual state against.
 
-        :return: ``True`` if the compute instance is currently in one of
-            ``target_states``, ``False`` otherwise.
+        :return: Deferred that fires with ``True`` if the compute instance is
+            currently in one of ``target_states``, ``False`` otherwise.
         """
         d = self._async_refresh_node(reactor, target_node)
 

--- a/flocker/provision/_libcloud.py
+++ b/flocker/provision/_libcloud.py
@@ -3,24 +3,29 @@
 """
 Helpers for using libcloud.
 """
+import socket
 
 from time import sleep
 from zope.interface import implementer
 
 from characteristic import attributes, Attribute
 
+from twisted.internet.defer import DeferredList, maybeDeferred
 from twisted.python.reflect import fullyQualifiedName
 from twisted.conch.ssh.keys import Key
 
-from eliot import Message, write_traceback
+from eliot import Message, start_action, write_failure, write_traceback
+from eliot.twisted import DeferredContext
 
 from flocker.provision._ssh import run_remotely, run_from_args
 
 from ._common import INode, IProvisioner
 
-from ..common import poll_until
+from ..common import loop_until, poll_until
+from ..common._retry import function_serializer
 
 from libcloud.compute.types import NodeState
+from libcloud.utils.networking import is_valid_ip_address
 
 
 def get_size(driver, size_id):
@@ -156,6 +161,18 @@ class LibcloudProvisioner(object):
         should be populated. This should be specified if the cluster nodes
         use the private address for inter-node communication.
     """
+    # Here are the states that indicate we've either succeeded or failed.
+    # Only RUNNING indicates success.  The rest are failure states.  Once
+    # the node is in one of those states, it makes no sense to keep
+    # waiting.
+    TERMINAL_STATES = {
+        NodeState.RUNNING,
+        NodeState.ERROR,
+        NodeState.TERMINATED,
+        NodeState.STOPPED,
+        NodeState.SUSPENDED,
+        NodeState.PAUSED,
+    }
 
     def get_ssh_key(self):
         """
@@ -255,23 +272,9 @@ class LibcloudProvisioner(object):
         # waiting for much longer than necessary.
         #
         # So do a loop ourselves.
-
-        # Here are the states that indicate we've either succeeded or failed.
-        # Only RUNNING indicates success.  The rest are failure states.  Once
-        # the node is in one of those states, it makes no sense to keep
-        # waiting.
-        terminal_states = {
-            NodeState.RUNNING,
-            NodeState.ERROR,
-            NodeState.TERMINATED,
-            NodeState.STOPPED,
-            NodeState.SUSPENDED,
-            NodeState.PAUSED,
-        }
-
         try:
             poll_until(
-                predicate=lambda: self._node_in_state(node, terminal_states),
+                lambda: self._node_in_state(node, self.TERMINAL_STATES),
                 # Overall retry sleep time (not quite the same as timeout since
                 # it doesn't count time spent in the predicate) is just copied
                 # from the default libcloud timeout for wait_until_running.
@@ -341,6 +344,270 @@ class LibcloudProvisioner(object):
                 _retry_exception(node.destroy)
                 return
 
+    def create_nodes(self, reactor, names, distribution, metadata={}):
+        """
+        Create nodes with the given names.
+
+        :param reactor: The reactor.
+        :param name: The names of the nodes.
+        :type name: list of str
+        :param str distribution: The name of the distribution to
+            install on the nodes.
+        :param dict metadata: Metadata to associate with the nodes.
+
+        :return: A list of ``Deferred``s each firing with an INode
+            when the corresponding node is created.   The list has
+            the same order as :param:`names`.
+
+        """
+        size = self._default_size
+        image_name = self._image_names[distribution]
+        create_node_arguments = self._create_node_arguments()
+
+        def handle_create_error(failure, name):
+            # XXX This could be dangerous... What about a pre-existing
+            # node with the same name (or even multiple nodes if the name
+            # does not have to be unique)?
+            Message.log(
+                message_type="flocker:provision:libcloud:create_node:failed",
+                node_name=name,
+            )
+            write_failure(failure)
+            d = self._async_cleanup_node_named(reactor, name)
+            d.addCallback(lambda _: failure)
+            return d
+
+        def make_node(node):
+            public_address = _filter_ipv4(node.public_ips)[0]
+            if isinstance(public_address, unicode):
+                public_address = public_address.encode("ascii")
+
+            if self._use_private_addresses:
+                private_address = _filter_ipv4(node.private_ips)[0]
+            else:
+                private_address = None
+
+            if isinstance(private_address, unicode):
+                private_address = private_address.encode("ascii")
+
+            Message.log(
+                message_type="flocker:provision:libcloud:node_created",
+                name=node.name,
+                id=node.id,
+                public_address=public_address,
+                private_address=private_address,
+            )
+            return LibcloudNode(
+                provisioner=self,
+                node=node, address=public_address,
+                private_address=private_address,
+                distribution=distribution)
+
+        action = start_action(
+            action_type=u"flocker:provision:libcloud:create_nodes",
+            instance_count=len(names),
+            distribution=distribution,
+            size=size,
+            metadata=metadata,
+        )
+        with action.context():
+            results = []
+            for name in names:
+                Message.log(
+                    message_type=u"flocker:provision:libcloud:creating_node",
+                    node_name=name,
+                )
+                d = maybeDeferred(
+                    self._driver.create_node,
+                    name=name,
+                    image=get_image(self._driver, image_name),
+                    size=get_size(self._driver, size),
+                    ex_keyname=self._keyname,
+                    ex_metadata=metadata,
+                    **create_node_arguments
+                )
+                d = DeferredContext(d)
+                d.addCallbacks(
+                    lambda node: self._wait_until_running(reactor, node),
+                    errback=handle_create_error,
+                    errbackArgs=(name,),
+                )
+                d.addCallback(make_node)
+                results.append(d.result)
+
+            action_completion = DeferredContext(DeferredList(results))
+            action_completion.addActionFinish()
+            # Individual results and errors should be consumed by the caller,
+            # so we can leave action_completion alone now.
+            return results
+
+    def _async_cleanup_node_named(self, reactor, name):
+        """
+        Destroy a node with the given name, if there is one.  Otherwise, do
+        nothing.
+        """
+        d = _retry_exception_async(reactor, self._driver.list_nodes)
+        d = DeferredContext(d)
+
+        def destroy_if_found(nodes):
+            for node in nodes:
+                if node.name == name:
+                    Message.new(
+                        message_type=(
+                            u"flocker:provision:libcloud:cleanup_node_named"
+                        ),
+                        name=name,
+                        id=node.id,
+                        state=node.state,
+                    ).write()
+                    return _retry_exception_async(reactor, node.destroy)
+
+        d.addCallback(destroy_if_found)
+        return d.result
+
+    def _async_refresh_node(self, reactor, target_node):
+        """
+        Determine the latest state of the node.
+
+        :param target_node: A libcloud node object representing the compute
+            instance to examine.
+
+        :return: Deferred that fires with a libcloud node object that
+            has the updated information about the node if the node is found,
+            ``None`` otherwise (e.g. if the node has been destroyed).
+        """
+        d = _retry_exception_async(reactor, self._driver.list_nodes)
+
+        def got_nodes(nodes):
+            for node in nodes:
+                if node.uuid == target_node.uuid:
+                    Message.log(
+                        message_type=(
+                            u"flocker:provision:libcloud:refresh_node"
+                        ),
+                        name=node.name,
+                        id=node.id,
+                        state=node.state,
+                        public_ips=node.public_ips,
+                        private_ips=node.private_ips,
+                    )
+                    return node
+            return None
+
+        d.addCallback(got_nodes)
+        return d
+
+    def _async_node_in_state(self, reactor, target_node, target_states):
+        """
+        Determine whether a compute instance is in one of the given states.
+
+        :param target_node: A libcloud node object representing the compute
+            instance to examine.
+        :param set target_states: The states to compare the compute instance's
+            actual state against.
+
+        :return: ``True`` if the compute instance is currently in one of
+            ``target_states``, ``False`` otherwise.
+        """
+        d = self._async_refresh_node(reactor, target_node)
+
+        def check_state(node):
+            if node is not None:
+                if node.state in target_states:
+                    Message.log(
+                        message_type=(
+                            u"flocker:provision:libcloud:node_in_state"
+                        ),
+                        name=node.name,
+                        id=node.id,
+                        state=node.state,
+                    )
+                    return True
+            return False
+
+        d.addCallback(check_state)
+        return d
+
+    def _wait_until_running(self, reactor, node):
+        """
+        Wait until the node is running and its network interface is configured.
+
+        This method fails if the node does not reach the expected state until
+        the predefined timeout expires or if the node goes into an error state
+        or an unexpected state.
+
+        :param node: A libcloud node object representing the compute instance
+            of interest.
+        :return: Deferred that fires with a libcloud node object representing
+            the latest state of the instance in the case of success.
+        """
+        # Overall retry sleep time (not quite the same as timeout since
+        # it doesn't count time spent in the predicate) is just copied
+        # from the default libcloud timeout for wait_until_running.
+        # Maybe some other value would be better.
+        action = start_action(
+            action_type=u"flocker:provision:libcloud:wait_until_running",
+            name=node.name,
+            id=node.id,
+        )
+        with action.context():
+            steps = iter([15] * (600 / 15))
+            d = loop_until(
+                reactor,
+                lambda: self._async_node_in_state(
+                    reactor,
+                    node,
+                    self.TERMINAL_STATES
+                ),
+                steps=steps,
+            )
+            d = DeferredContext(d)
+
+            def got_ip_addresses():
+                d = self._async_refresh_node(reactor, node)
+                d = DeferredContext(d)
+
+                def is_running(updated_node):
+                    if updated_node.state is not NodeState.RUNNING:
+                        raise Exception("Node failed to run")
+                    return updated_node
+
+                def check_addresses(updated_node):
+                    """
+                    Check if the node has got at least one IPv4 public address
+                    and, if requested, an IPv4 private address.  If yes, then
+                    return the node object with the addresses, None otherwise.
+                    """
+                    public_ips = _filter_ipv4(updated_node.public_ips)
+                    if len(public_ips) > 0:
+                        if self._use_private_addresses:
+                            private_ips = _filter_ipv4(
+                                updated_node.private_ips
+                            )
+                            if len(private_ips) == 0:
+                                return None
+                        return updated_node
+                    else:
+                        return None
+
+                d.addCallback(is_running)
+                d.addCallback(check_addresses)
+                return d.result
+
+            # Once node is in a stable state ensure that it is running
+            # and it has necessary IP addresses assigned.
+            d.addCallback(
+                lambda _: loop_until(reactor, got_ip_addresses, steps=steps)
+            )
+
+            def failed_to_run(failure):
+                d = _retry_exception_async(reactor, node.destroy)
+                d.addCallback(lambda _: failure)
+                return d
+
+            d.addErrback(failed_to_run)
+            return d.addActionFinish()
+
 
 def _retry_exception(f, steps=(0.1,) * 10, sleep=sleep):
     """
@@ -371,3 +638,66 @@ def _retry_exception(f, steps=(0.1,) * 10, sleep=sleep):
                 # Didn't hit the break, so didn't iterate at all, so we're out
                 # of retry steps.  Fail now.
                 raise
+
+
+def _retry_exception_async(reactor, f, steps=(0.1,) * 10):
+    """
+    Retry a function if it raises an exception.
+
+    :return: Deferred that fires with whatever the function returns or the
+        last raised exception if the function never succeeds.
+    """
+    # Any failure is recorded and converted to False so that loop_until keeps
+    # trying.  Any success is recorded and converted to True so that
+    # loop_until completes even if the result evaluates to False.
+    # If loop_until() succeeds then the recorded result is returned, otherwise
+    # the last recorded failure is returned.
+    saved_failure = [None]
+    saved_result = [None]
+
+    def handle_success(result):
+        saved_result[0] = result
+        return True
+
+    def handle_failure(failure):
+        Message.log(
+            message_type=(
+                u"flocker:provision:libcloud:retry_exception:got_exception"
+            ),
+        )
+        write_failure(failure)
+        saved_failure[0] = failure
+        return False
+
+    def make_call():
+        d = maybeDeferred(f)
+        d = DeferredContext(d)
+        d.addCallbacks(handle_success, errback=handle_failure)
+        return d.result
+
+    action = start_action(
+        action_type=u"flocker:provision:libcloud:retry_exception",
+        function=function_serializer(f),
+    )
+    with action.context():
+        d = loop_until(reactor, make_call, steps)
+        d = DeferredContext(d)
+        d.addCallbacks(
+            lambda _: saved_result[0],
+            errback=lambda _: saved_failure[0],
+        )
+        return d.addActionFinish()
+
+
+def _filter_ipv4(addresses):
+    """
+    Select IPv4 addresses from the list of IP addresses.
+
+    :param list addresses: The list of the addresses to filter.
+    :return: The list of addresses that are IPv4 addresses.
+    :rtype: list
+    """
+    return [
+        address for address in addresses
+        if is_valid_ip_address(address=address, family=socket.AF_INET)
+    ]


### PR DESCRIPTION
`IProvisioner.create_nodes()` is a new interface that allows to request multiple nodes at once.
The method returns a list of Deferreds with one Deferred for each requested node.
The implementations request multiple nodes from a platform at once if the platform permits (AWS)
or one by one if not (Rackspace). But in either case the waiting for nodes to become running and accessible is done in parallel and asynchronously.