### PR TITLE
[FLOC-3974] Convert JSON benchmarking files to CSV

### DIFF
--- a/benchmark/metrics-parser
+++ b/benchmark/metrics-parser
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Read JSON metrics files from the benchmarking tool and produce a CSV report.
+"""
+import sys
+
+from benchmark.metrics_parser import main
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -1,5 +1,6 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
+import argparse
 import json
 from collections import defaultdict
 
@@ -8,7 +9,6 @@ example = {"flocker_control":6,
 
 def apply_cpu_metric(result_blob):
     wall_time = float(result_blob.get(u'-- WALL --'))
-    #result_blob.remove(u'--WALL--')
     for k, v in result_blob.iteritems():
         if not k == u'-- WALL --':
             result_blob[k] = v/wall_time
@@ -27,16 +27,27 @@ def print_averages(results):
         )
         print s
 
-def main(args):
-    for json_file in args:
-        with open(json_file) as f:
-            results = json.load(f)
-            # XXX adding schema json validation
-            result_table = defaultdict(list)
-            for sample in results[u'samples']:
-                for result in sample[u'value'].itervalues():
-                    apply_cpu_metric(result)
-                    add_results_to_table(result, result_table)
 
-            print result_table
-            print_averages(result_table)
+def parse_args(args):
+    parser = argparse.ArgumentParser(
+        description="Produce CSV from benchmarking results"
+    )
+    parser.add_argument("files", nargs="*", type=argparse.FileType(),
+                        help="Input JSON files to be processed")
+
+    return parser.parse_args(args).files
+
+def main(args):
+    files = parse_args(args)
+
+    for f in files:
+        results = json.load(f)
+        # XXX adding schema json validation
+        result_table = defaultdict(list)
+        for sample in results[u'samples']:
+            for result in sample[u'value'].itervalues():
+                apply_cpu_metric(result)
+                add_results_to_table(result, result_table)
+
+        print result_table
+        print_averages(result_table)

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -123,19 +123,23 @@ def handle_cputime_metric(common_props, sample):
 
     :param common_props: Common properties shared with all other samples.
     :param sample: Original sample to extract values from.
+
+    :return list: The created samples.
     """
-    cputime_sample = dict(common_props)
+    cputime_samples = []
 
     wallclock_key = u'-- WALL --'
     for data in sample['value'].itervalues():
         wall_time = data[wallclock_key]
         for process, value in data.iteritems():
             if process != wallclock_key:
+                cputime_sample = dict(common_props)
                 cputime_sample['process'] = process
                 cputime_sample['value'] = value
                 cputime_sample['wallclock'] = wall_time
+                cputime_samples.append(cputime_sample)
 
-    return cputime_sample
+    return cputime_samples
 
 
 def handle_wallclock_metric(common_props, sample):
@@ -144,10 +148,14 @@ def handle_wallclock_metric(common_props, sample):
 
     :param common_props: Common properties shared with all other samples.
     :param sample: Original sample to extract values from.
+
+    :return list: The created samples.
     """
+    wallclock_samples = []
     wallclock_sample = dict(common_props)
     wallclock_sample['value'] = sample['value']
-    return wallclock_sample
+    wallclock_samples.append(wallclock_sample)
+    return wallclock_samples
 
 
 METRIC_HANDLER = {
@@ -299,7 +307,7 @@ class BenchmarkingResults(object):
 
         for sample in results['samples']:
             if sample['success']:
-                flattened.append(
+                flattened.extend(
                     METRIC_HANDLER[metric_type](common_props, sample)
                 )
         return flattened

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -21,7 +21,7 @@ def add_results_to_table(ip, result, result_table):
             result_table[ip][k] = []
             result_table[ip][k].append(v)
     else:
-        for k, v in result_table[ip].iteritems():
+        for k, v in result.iteritems():
             print "V is (2) ", v, "\n"
             result_table[ip][k].append(v)
 
@@ -32,8 +32,8 @@ def main(args):
             results = json.load(f)
             # XXX adding schema json validation
             result_table  = {}
-            for v in results[u'samples']:
-                for ip, result in v[u'value'].iteritems():
+            for sample in results[u'samples']:
+                for ip, result in sample[u'value'].iteritems():
                     apply_cpu_metric(result)
                     add_results_to_table(ip, result, result_table)
 

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -129,7 +129,10 @@ class BenchmarkingResults(object):
         """
         summary = self._create_summary()
         for scenario, result in summary.iteritems():
-            write_csv(result, '{0}-{1}.csv'.format(prefix, scenario))
+            filename = '{prefix}-{scenario}.csv'.format(
+                prefix=prefix, scenario=scenario
+            )
+            write_csv(result, filename)
 
     def _versions(self):
         """

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -1,0 +1,44 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+import json
+from collections import defaultdict
+
+example_resultxs = {
+    "master": [
+        {
+            "num_nodes": 10,
+            "num_containers": 10,
+            "metrics": [
+                {
+                    "cpu_no_load": 0.145
+                }
+            ]
+        },
+    ]
+}
+
+
+def combine_metrics(metrics):
+    combined_metrics = defaultdict(list)
+    for metric in metrics:
+        for k, v in metric[u'value'].iteritems():
+            combined_metrics[k].append(v)
+    print combined_metrics
+
+
+def get_branch_results(results):
+    parsed_results = {}
+    for result in results:
+        version = result[u'control_service'][u'flocker_version']
+        # num_nodes = result[u'control_service'][u'num_nodes']
+        # num_containers = result[u'control_service'][u'num_containers']
+        combine_metrics(result[u'samples'])
+    return parsed_results
+
+
+def main(args):
+    results = []
+    for arg in args:
+        with open(arg) as f:
+            results.append(json.load(f))
+    get_branch_results(results)

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -72,6 +72,21 @@ def wallclock_for_operation(results, operation, fn=mean):
     return fn(values)
 
 
+def container_convergence(results, seconds):
+    convergence_results = [
+        r for r in results if r['metric']['type'] == 'wallclock'
+        and r['operation']['type'] == 'create-container'
+    ]
+    num_convergences = len(convergence_results)
+    if num_convergences > 0:
+        convergences_within_limit = [
+            r for r in convergence_results if r['value'] < seconds
+        ]
+        return len(convergences_within_limit) / num_convergences
+
+    return None
+
+
 def flatten(results):
     flattened = []
     common = dict(
@@ -135,7 +150,7 @@ def extract_results(all_results):
                 u'ContainerAgentCPUWriteLoad':
                     cputime_for_process(results, 'flocker-contain', 'write-request-load'),
                 u'ContainerAdditionConvergence':
-                    wallclock_for_operation(results, 'create-container'),
+                    container_convergence(results, 60),
             }
             summary.append(result)
     return summary

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -99,22 +99,7 @@ def flatten(results):
     return flattened
 
 
-def parse_args(args):
-    parser = argparse.ArgumentParser(
-        description="Produce CSV from benchmarking results"
-    )
-    parser.add_argument("files", nargs="*", type=argparse.FileType(),
-                        help="Input JSON files to be processed")
-
-    return parser.parse_args(args).files
-
-
-def main(args):
-    files = parse_args(args)
-    all_results = []
-    for f in files:
-        all_results.extend(flatten(json.load(f)))
-
+def extract_results(all_results):
     summary = []
     node_counts = control_service_attribute(all_results, 'node_count')
     container_counts = control_service_attribute(all_results, 'container_count')
@@ -152,4 +137,22 @@ def main(args):
                     wallclock_for_operation(results, 'create-container'),
             }
             summary.append(result)
-    write_csv(summary, 'results.csv')
+    return summary
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(
+        description="Produce CSV from benchmarking results"
+    )
+    parser.add_argument("files", nargs="*", type=argparse.FileType(),
+                        help="Input JSON files to be processed")
+
+    return parser.parse_args(args).files
+
+
+def main(args):
+    files = parse_args(args)
+    results = []
+    for f in files:
+        results.extend(flatten(json.load(f)))
+    write_csv(extract_results(results), 'results.csv')

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -5,6 +5,7 @@ from collections import defaultdict, OrderedDict
 import csv
 import itertools
 import json
+import sys
 
 
 def write_csv(results, headers, filename):
@@ -336,6 +337,11 @@ def parse_args(args):
                         dest='latency_limit', default=30,
                         help="Request latency limit in seconds")
     parsed_args = parser.parse_args(args)
+
+    if not parsed_args.files:
+        parser.print_help()
+        sys.exit(1)
+
     return parsed_args
 
 

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -13,11 +13,9 @@ def apply_cpu_metric(result_blob):
         if not k == u'-- WALL --':
             result_blob[k] = v/wall_time
 
-def add_results_to_table(ip, result, result_table):
-    if result_table.get(ip) is None:
-        result_table[ip] = defaultdict(list)
+def add_results_to_table(result, result_table):
     for k, v in result.iteritems():
-        result_table[ip][k].append(v)
+        result_table[k].append(v)
 
 
 def main(args):
@@ -25,10 +23,10 @@ def main(args):
         with open(json_file) as f:
             results = json.load(f)
             # XXX adding schema json validation
-            result_table = {}
+            result_table = defaultdict(list)
             for sample in results[u'samples']:
-                for ip, result in sample[u'value'].iteritems():
+                for result in sample[u'value'].itervalues():
                     apply_cpu_metric(result)
-                    add_results_to_table(ip, result, result_table)
+                    add_results_to_table(result, result_table)
 
             print result_table

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -1,22 +1,32 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 import argparse
+import csv
 import json
 
 
 WALL_CLOCK_KEY = u'-- WALL --'
 
 
-def apply_cpu_metric(result_blob):
-    wall_time = float(result_blob.get(WALL_CLOCK_KEY))
-    for k, v in result_blob.iteritems():
-        if not k == WALL_CLOCK_KEY:
-            result_blob[k] = v/wall_time
+HEADERS = [
+    u'FlockerVersion',
+    u'Nodes',
+    u'Containers',
+    u'ControlServiceCPUSteady',
+    u'CombinedAgentCPUSteady',
+    u'ControlServiceCPUReadLoad',
+    u'CombinedAgentCPUReadLoad',
+    u'ControlServiceCPUWriteLoad',
+    u'CombinedAgentCPUWriteLoad',
+    u'ContainerAdditionConvergence',
+]
 
 
-def add_results_to_table(result, result_table):
-    for k, v in result.iteritems():
-        result_table[k].append(v)
+def write_csv(results, filename):
+    with open(filename, 'w') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=HEADERS, restval='N/A')
+        writer.writeheader()
+        writer.writerows(results)
 
 
 def print_averages(results):

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -18,6 +18,15 @@ def add_results_to_table(result, result_table):
         result_table[k].append(v)
 
 
+def print_averages(results):
+    print "Results for benchmarking:"
+    for process, result in results.iteritems():
+        s = "{process}: {result}".format(
+            process=process,
+            result=sum(result) / len(result)
+        )
+        print s
+
 def main(args):
     for json_file in args:
         with open(json_file) as f:
@@ -30,3 +39,4 @@ def main(args):
                     add_results_to_table(result, result_table)
 
             print result_table
+            print_averages(result_table)

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -35,19 +35,24 @@ def flatten(results):
         [(k, results.get(k)) for k in results.iterkeys() if k != 'samples']
     )
 
-    # This function assumes the format is for the cputime metric.
-    # Change it so that it can handle the wallclock metrics.
+    metric_type = results['metric']['type']
+
     for sample in results['samples']:
-        for ip, data in sample['value'].iteritems():
-            wall_time = data[WALL_CLOCK_KEY]
-            for process, value in data.iteritems():
-                if process != WALL_CLOCK_KEY:
-                    doc = dict(common)
-                    doc['node_ip'] = ip
-                    doc['process'] = process
-                    doc['value'] = value
-                    doc['wallclock'] = wall_time
-                    flattened.append(doc)
+        if metric_type  == 'cputime':
+            for ip, data in sample['value'].iteritems():
+                wall_time = data[WALL_CLOCK_KEY]
+                for process, value in data.iteritems():
+                    if process != WALL_CLOCK_KEY:
+                        doc = dict(common)
+                        doc['node_ip'] = ip
+                        doc['process'] = process
+                        doc['value'] = value
+                        doc['wallclock'] = wall_time
+                        flattened.append(doc)
+        elif metric_type == 'wallclock':
+            doc = dict(common)
+            doc['value'] = sample['value']
+            flattened.append(doc)
     return flattened
 
 

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -30,7 +30,7 @@ def write_csv(results, filename):
 
 def mean(values):
     if len(values) > 0:
-        return sum(values) / len(values)
+        return float(sum(values)) / len(values)
     return None
 
 
@@ -78,7 +78,7 @@ def container_convergence(results, seconds):
         convergences_within_limit = [
             r for r in convergence_results if r['value'] < seconds
         ]
-        return len(convergences_within_limit) / num_convergences
+        return float(len(convergences_within_limit)) / num_convergences
 
     return None
 

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -33,17 +33,20 @@ def cpu_usage_for_process(results, process):
     Calculate the CPU percentage for a process running in a particular
     scenario.
 
-    By default this will return the `mean` result.
-
     :param results: Results to extract values from.
     :param process: Process name to calculate CPU usage for.
     """
-    process_results = itertools.ifilter(
-        lambda r: r['metric']['type'] == 'cputime' and r['process'] == process,
-        results
-    )
-    values = [float(r['value']) / r['wallclock'] for r in process_results]
-    return mean(values)
+    process_results = [
+        r for r in results if r['metric']['type'] == 'cputime' and
+        r['process'] == process
+    ]
+
+    cpu_values = sum(r['value'] for r in process_results)
+    wallclock_values = sum(r['wallclock'] for r in process_results)
+
+    if wallclock_values > 0:
+        return float(cpu_values) / wallclock_values
+    return None
 
 
 def wallclock_for_operation(results, operation):
@@ -51,10 +54,10 @@ def wallclock_for_operation(results, operation):
     Calculate the wallclock time for a process running in a particular
     scenario.
 
-    By default this will return the `mean` result.
-
     :param results: Results to extract values from.
     :param operation: Operation name to calculate wallclock results for.
+
+    :return: The mean wallclock time observed.
     """
     operation_results = itertools.ifilter(
         lambda r: r['metric']['type'] == 'wallclock' and

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -6,7 +6,6 @@ import csv
 import itertools
 import json
 
-itertools.groupby
 
 WALL_CLOCK_KEY = u'-- WALL --'
 

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -141,14 +141,14 @@ class BenchmarkingResults(object):
         versions = [
             r['control_service']['flocker_version'] for r in self.results
         ]
-        return list(set(versions))
+        return set(versions)
 
     def _node_counts(self):
         """
         Return all unique node counts present in the results.
         """
         nodes = [r['control_service']['node_count'] for r in self.results]
-        return list(set(nodes))
+        return set(nodes)
 
     def _container_counts(self):
         """
@@ -157,14 +157,14 @@ class BenchmarkingResults(object):
         containers = [
             r['control_service']['container_count'] for r in self.results
         ]
-        return list(set(containers))
+        return set(containers)
 
     def _scenarios(self):
         """
         Return all unique scenarios present in the results.
         """
         scenarios = [r['scenario']['name'] for r in self.results]
-        return list(set(scenarios))
+        return set(scenarios)
 
     def _filter_results(self, node_count, container_count, version, scenario):
         """

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -1,4 +1,4 @@
-# Copyright ClusterHQ Inc.  See LICENSE file for details.
+# Copyright 2016 ClusterHQ Inc.  See LICENSE file for details.
 
 import argparse
 from collections import defaultdict

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -34,9 +34,10 @@ def mean(values):
     return None
 
 
-def cputime_for_process(results, process):
+def cpu_usage_for_process(results, process):
     """
-    Calculate the CPU time for a process running in a particular scenario.
+    Calculate the CPU percentage for a process running in a particular
+    scenario.
 
     By default this will return the `mean` result.
     """
@@ -44,7 +45,7 @@ def cputime_for_process(results, process):
         lambda r: r['metric']['type'] == 'cputime' and r['process'] == process,
         results
     )
-    values = [r['value'] / r['wallclock'] for r in process_results]
+    values = [float(r['value']) / r['wallclock'] for r in process_results]
     return mean(values)
 
 
@@ -76,7 +77,7 @@ def container_convergence(results, seconds):
     num_convergences = len(convergence_results)
     if num_convergences > 0:
         convergences_within_limit = [
-            r for r in convergence_results if r['value'] < seconds
+            r for r in convergence_results if r['value'] <= seconds
         ]
         return float(len(convergences_within_limit)) / num_convergences
 
@@ -103,10 +104,10 @@ def request_latency(results, seconds):
         requests_under_limit = 0
         for metric in unique_metrics:
             for k, v in metric['call_durations'].iteritems():
-                if float(k) < seconds:
+                if float(k) <= seconds:
                     requests_under_limit += v
             total_requests += metric['ok_count'] + metric['err_count']
-        return requests_under_limit / total_requests
+        return float(requests_under_limit) / total_requests
     return None
 
 
@@ -204,11 +205,11 @@ class BenchmarkingResults(object):
                     u'Containers': container,
                     u'Scenario': scenario,
                     u'Control Service CPU':
-                        cputime_for_process(results, 'flocker-control'),
+                        cpu_usage_for_process(results, 'flocker-control'),
                     u'Dataset Agent CPU':
-                        cputime_for_process(results, 'flocker-dataset'),
+                        cpu_usage_for_process(results, 'flocker-dataset'),
                     u'Container Agent CPU':
-                        cputime_for_process(results, 'flocker-contain'),
+                        cpu_usage_for_process(results, 'flocker-contain'),
                     u'Containers Converged Within Limit':
                         container_convergence(results, 60),
                     u'Scenario Requests Within Limit':

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -8,8 +8,6 @@ import json
 
 
 WALL_CLOCK_KEY = u'-- WALL --'
-
-
 HEADERS = [
     u'Flocker Version',
     u'Nodes',
@@ -58,8 +56,8 @@ def wallclock_for_operation(results, operation):
     By default this will return the `mean` result.
     """
     operation_results = itertools.ifilter(
-        lambda r: r['metric']['type'] == 'wallclock'
-        and r['operation']['type'] == operation,
+        lambda r: r['metric']['type'] == 'wallclock' and
+        r['operation']['type'] == operation,
         results
     )
     values = [r['value'] for r in operation_results]
@@ -72,8 +70,8 @@ def container_convergence(results, seconds):
     time period.
     """
     convergence_results = [
-        r for r in results if r['metric']['type'] == 'wallclock'
-        and r['operation']['type'] == 'create-container'
+        r for r in results if r['metric']['type'] == 'wallclock' and
+        r['operation']['type'] == 'create-container'
     ]
     num_convergences = len(convergence_results)
     if num_convergences > 0:
@@ -91,9 +89,8 @@ def request_latency(results, seconds):
     specified time limit.
     """
     scenario_results = [
-        r['scenario'] for r in results
-        if r['scenario'].get('metrics')
-        and r['scenario']['metrics'].get('call_durations')
+        r['scenario'] for r in results if r['scenario'].get('metrics') and
+        r['scenario']['metrics'].get('call_durations')
     ]
 
     if len(scenario_results) > 0:
@@ -172,10 +169,10 @@ class BenchmarkingResults(object):
         number of containers, Flocker version and benchmarking scenario.
         """
         return [r for r in self.results
-                if r['control_service']['node_count'] == node_count
-                and r['control_service']['container_count'] == container_count
-                and r['control_service']['flocker_version'] == version
-                and r['scenario']['name'] == scenario]
+                if r['control_service']['node_count'] == node_count and
+                r['control_service']['container_count'] == container_count and
+                r['control_service']['flocker_version'] == version and
+                r['scenario']['name'] == scenario]
 
     def _create_summary(self):
         """
@@ -243,9 +240,9 @@ class BenchmarkingResults(object):
                                 doc['wallclock'] = wall_time
                                 flattened.append(doc)
                 elif metric_type == 'wallclock':
-                        doc = dict(common)
-                        doc['value'] = sample['value']
-                        flattened.append(doc)
+                    doc = dict(common)
+                    doc['value'] = sample['value']
+                    flattened.append(doc)
         return flattened
 
 

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -81,21 +81,22 @@ def flatten(results):
     metric_type = results['metric']['type']
 
     for sample in results['samples']:
-        if metric_type == 'cputime':
-            for ip, data in sample['value'].iteritems():
-                wall_time = data[WALL_CLOCK_KEY]
-                for process, value in data.iteritems():
-                    if process != WALL_CLOCK_KEY:
-                        doc = dict(common)
-                        doc['node_ip'] = ip
-                        doc['process'] = process
-                        doc['value'] = value
-                        doc['wallclock'] = wall_time
-                        flattened.append(doc)
-        elif metric_type == 'wallclock':
-            doc = dict(common)
-            doc['value'] = sample['value']
-            flattened.append(doc)
+        if sample['success']:
+            if metric_type == 'cputime':
+                for ip, data in sample['value'].iteritems():
+                    wall_time = data[WALL_CLOCK_KEY]
+                    for process, value in data.iteritems():
+                        if process != WALL_CLOCK_KEY:
+                            doc = dict(common)
+                            doc['node_ip'] = ip
+                            doc['process'] = process
+                            doc['value'] = value
+                            doc['wallclock'] = wall_time
+                            flattened.append(doc)
+            elif metric_type == 'wallclock':
+                    doc = dict(common)
+                    doc['value'] = sample['value']
+                    flattened.append(doc)
     return flattened
 
 

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -52,7 +52,7 @@ def mean(values):
 
 
 def cputime_for_process(results, process, scenario, fn=mean):
-    process_results= itertools.ifilter(
+    process_results = itertools.ifilter(
         lambda r: r['metric']['type'] == 'cputime'
         and r['process'] == process
         and r['scenario']['type'] == scenario,

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -15,15 +15,9 @@ def apply_cpu_metric(result_blob):
 
 def add_results_to_table(ip, result, result_table):
     if result_table.get(ip) is None:
-        result_table[ip] = {}
-        for k, v in result.iteritems():
-            print "V is (1) ", v, "\n"
-            result_table[ip][k] = []
-            result_table[ip][k].append(v)
-    else:
-        for k, v in result.iteritems():
-            print "V is (2) ", v, "\n"
-            result_table[ip][k].append(v)
+        result_table[ip] = defaultdict(list)
+    for k, v in result.iteritems():
+        result_table[ip][k].append(v)
 
 
 def main(args):
@@ -31,7 +25,7 @@ def main(args):
         with open(json_file) as f:
             results = json.load(f)
             # XXX adding schema json validation
-            result_table  = {}
+            result_table = {}
             for sample in results[u'samples']:
                 for ip, result in sample[u'value'].iteritems():
                     apply_cpu_metric(result)

--- a/benchmark/metrics_parser.py
+++ b/benchmark/metrics_parser.py
@@ -7,9 +7,6 @@ import itertools
 import json
 
 
-WALL_CLOCK_KEY = u'-- WALL --'
-
-
 def write_csv(results, headers, filename):
     """
     Write a set of results to a CSV file.
@@ -129,10 +126,11 @@ def handle_cputime_metric(common_props, sample):
     """
     cputime_sample = dict(common_props)
 
+    wallclock_key = u'-- WALL --'
     for data in sample['value'].itervalues():
-        wall_time = data[WALL_CLOCK_KEY]
+        wall_time = data[wallclock_key]
         for process, value in data.iteritems():
-            if process != WALL_CLOCK_KEY:
+            if process != wallclock_key:
                 cputime_sample['process'] = process
                 cputime_sample['value'] = value
                 cputime_sample['wallclock'] = wall_time

--- a/benchmark/test/test_metrics_parser.py
+++ b/benchmark/test/test_metrics_parser.py
@@ -52,9 +52,9 @@ class MetricsParserTests(TestCase):
 
     def test_cpu_usage_for_process_calculates_result(self):
         """
-        cputime_for_process correctly calculates the mean CPU percentage
-        for a process by dividing the cputime by the wallclock time for
-        each sample
+        cputime_for_process correctly calculates the CPU percentage for
+        a process by dividing the total cputime by the total wallclock
+        time across all the samples.
         """
         process_name = 'test-process'
         results = [
@@ -64,7 +64,7 @@ class MetricsParserTests(TestCase):
                 },
                 'process': process_name,
                 'value': 10,
-                'wallclock': 50
+                'wallclock': 60
             },
             {
                 'metric': {
@@ -76,6 +76,8 @@ class MetricsParserTests(TestCase):
             },
         ]
         cputime_result = cpu_usage_for_process(results, process_name)
+        # Total CPU time: 40
+        # Total wallclock time: 160
         self.assertEqual(cputime_result, 0.25)
 
     def test_wallclock_for_operation_no_matching_results(self):

--- a/benchmark/test/test_metrics_parser.py
+++ b/benchmark/test/test_metrics_parser.py
@@ -1,0 +1,72 @@
+# Copyright 2016 ClusterHQ Inc.  See LICENSE file for details.
+
+from benchmark.metrics_parser import mean, container_convergence
+from flocker.testtools import TestCase
+
+
+class MetricsParserTests(TestCase):
+    """
+    Tests for the metrics parsing script.
+    """
+
+    def test_mean_returns_floating_point_number(self):
+        values = [1, 2, 3, 4]
+        mean_result = mean(values)
+        self.assertIsInstance(mean_result, float)
+
+    def test_mean_returns_none_for_no_values(self):
+        values = []
+        self.assertEqual(mean(values), None)
+
+    def test_mean_correctly_calculates_mean(self):
+        values = [1, 2, 3, 4, 5, 6]
+        self.assertEqual(mean(values), 3.5)
+
+    def test_container_convergence_returns_none_when_no_relevant_results(self):
+        results = [
+            {
+                'metric': {
+                    'type': 'cputime'
+                },
+                'operation': {
+                    'type': 'create-container'
+                },
+                'value': 4
+            },
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': 'read-request'
+                },
+                'value': 10,
+            },
+        ]
+
+        convergence_results = container_convergence(results, 10)
+        self.assertEqual(convergence_results, None)
+
+    def test_container_convergence_calculates_result(self):
+        results = [
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': 'create-container'
+                },
+                'value': 4
+            },
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': 'create-container'
+                },
+                'value': 9,
+            },
+        ]
+        convergence_results = container_convergence(results, 5)
+        self.assertEqual(convergence_results, 0.5)

--- a/benchmark/test/test_metrics_parser.py
+++ b/benchmark/test/test_metrics_parser.py
@@ -1,6 +1,9 @@
 # Copyright 2016 ClusterHQ Inc.  See LICENSE file for details.
 
-from benchmark.metrics_parser import mean, container_convergence
+from benchmark.metrics_parser import (
+    mean, container_convergence, cpu_usage_for_process,
+    wallclock_for_operation, request_latency
+)
 from flocker.testtools import TestCase
 
 
@@ -22,7 +25,122 @@ class MetricsParserTests(TestCase):
         values = [1, 2, 3, 4, 5, 6]
         self.assertEqual(mean(values), 3.5)
 
-    def test_container_convergence_returns_none_when_no_relevant_results(self):
+    def test_cpu_usage_for_process_no_matching_results(self):
+        """
+        cputime_for_process only considers results which have the
+        'cputime' metric type and match the specified process name.
+        None is returned if no results match.
+        """
+        process_name = 'test-process'
+        results = [
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'process': process_name
+            },
+            {
+                'metric': {
+                    'type': 'cputime'
+                },
+                'process': 'another-process'
+            },
+        ]
+        cputime_result = cpu_usage_for_process(results, process_name)
+        self.assertEqual(cputime_result, None)
+
+    def test_cpu_usage_for_process_calculates_result(self):
+        """
+        cputime_for_process correctly calculates the mean CPU percentage
+        for a process by dividing the cputime by the wallclock time for
+        each sample
+        """
+        process_name = 'test-process'
+        results = [
+            {
+                'metric': {
+                    'type': 'cputime'
+                },
+                'process': process_name,
+                'value': 10,
+                'wallclock': 50
+            },
+            {
+                'metric': {
+                    'type': 'cputime'
+                },
+                'process': process_name,
+                'value': 30,
+                'wallclock': 100
+            },
+        ]
+        cputime_result = cpu_usage_for_process(results, process_name)
+        self.assertEqual(cputime_result, 0.25)
+
+    def test_wallclock_for_operation_no_matching_results(self):
+        """
+        wallclock_for_operation only considers results which have the
+        'wallclock' metrics and match the specified operation name.
+        None is returned if no results match.
+        """
+        operation_name = 'test-operation'
+        results = [
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': 'another-operation'
+                }
+            },
+            {
+                'metric': {
+                    'type': 'cputime'
+                },
+                'operation': {
+                    'type': operation_name
+                }
+            },
+        ]
+        wallclock_result = wallclock_for_operation(results, operation_name)
+        self.assertEqual(wallclock_result, None)
+
+    def test_wallclock_for_operation_calculates_result(self):
+        """
+        wallclock_for_process returns the mean of the values from
+        samples which have the 'wallclock' metric type and match the
+        specified operation.
+        """
+        operation = 'test-operation'
+        results = [
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': operation
+                },
+                'value': 11
+            },
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': operation
+                },
+                'value': 14
+            },
+        ]
+        wallclock_result = wallclock_for_operation(results, operation)
+        self.assertEqual(wallclock_result, 12.5)
+
+    def test_container_convergence_no_matching_results(self):
+        """
+        container_convergence only considers results which have the
+        'wallclock' metric and are for the 'create-container' operation.
+        None is returned if no results match.
+        """
         results = [
             {
                 'metric': {
@@ -48,6 +166,11 @@ class MetricsParserTests(TestCase):
         self.assertEqual(convergence_results, None)
 
     def test_container_convergence_calculates_result(self):
+        """
+        container_convergence returns the percentage of
+        'create-container' operations that completed within the
+        specified time limit.
+        """
         results = [
             {
                 'metric': {
@@ -65,8 +188,95 @@ class MetricsParserTests(TestCase):
                 'operation': {
                     'type': 'create-container'
                 },
+                'value': 2
+            },
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': 'create-container'
+                },
+                'value': 5
+            },
+            {
+                'metric': {
+                    'type': 'wallclock'
+                },
+                'operation': {
+                    'type': 'create-container'
+                },
                 'value': 9,
             },
         ]
         convergence_results = container_convergence(results, 5)
-        self.assertEqual(convergence_results, 0.5)
+        self.assertEqual(convergence_results, 0.75)
+
+    def test_request_latency_no_matching_results(self):
+        """
+        request_latency only considers results which have the
+        'scenario.metrics.call_durations' property.
+        None is returned if no results match.
+        """
+        results = [
+            {
+                'scenario': {
+                    'name': 'test-scenario',
+                    'type': 'test-scenario-type'
+                },
+            },
+            {
+                'scenario': {
+                    'name': 'test-scenario',
+                    'type': 'test-scenario-type',
+                    'metrics': {}
+                },
+            }
+        ]
+        latency_result = request_latency(results, 10)
+        self.assertEqual(latency_result, None)
+
+    def test_request_latency_calculates_result(self):
+        """
+        request_latency correctly calculates the percentage of scenario
+        requests that complete within the specified time limit.
+        """
+        results = [
+            {
+                'scenario': {
+                    'name': 'test-scenario',
+                    'type': 'test-scenario-type',
+                    'metrics': {
+                        'call_durations': {
+                            '1.0': 10,
+                            '0.8': 10,
+                            '0.9': 10,
+                            '1.1': 10,
+                            '0.7': 10
+                        },
+                        'ok_count': 50,
+                        'err_count': 0,
+                    }
+                },
+            },
+            {
+                'scenario': {
+                    'name': 'test-scenario',
+                    'type': 'test-scenario-type',
+                    'metrics': {
+                        'call_durations': {
+                            '1.0': 10,
+                            '0.8': 10,
+                            '0.9': 10,
+                            '1.1': 10,
+                            '0.7': 10
+                        },
+                        'ok_count': 40,
+                        'err_count': 10,
+                    }
+                },
+            }
+        ]
+        latency_result = request_latency(results, 1)
+        # 20/100 requests took more that 1 second.
+        self.assertEqual(latency_result, 0.8)


### PR DESCRIPTION
This changes adds a script which can be used to convert JSON results from the benchmarking tool to a set of CSV files which summarise the results. This script outputs a CSV file for each different scenario and each file contains all the results that were obtained for that scenario. The results in the file are divided by number of nodes that were used in the cluster and the number of containers started in that cluster.

This script is unfortunately not very neat or clear to read so I expect that a number of changes will need to be made :smile: The approach I took was to flatten each set of results to separate each sample that was collected. The results are then filtered and combined again before being written CSV.