### PR TITLE
[FLOC-4092] Use testtools 2.0.0, rather than our fork

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,7 +45,7 @@ sphinx-prompt==1.0.0
 sphinx-rtd-theme==0.1.8
 sphinxcontrib-httpdomain==1.3.0
 sphinxcontrib-spelling==2.1.2
-testtools==1.9.0chq5
+testtools==2.0.0
 tox==2.1.1
 troposphere==1.3.0
 six==1.10.0

--- a/flocker/testtools/_base.py
+++ b/flocker/testtools/_base.py
@@ -17,19 +17,8 @@ from testtools.content import Content, text_content
 from testtools.content_type import UTF8_TEXT
 from testtools.twistedsupport import (
     AsynchronousDeferredRunTestForBrokenTwisted, assert_fails_with,
+    CaptureTwistedLogs,
 )
-
-try:
-    from testtools.deferredruntest import CaptureTwistedLogs
-except ImportError:
-    # We are using a fork of testtools, which unfortunately means that we need
-    # to do special things to make sure we're using the latest version. Raise
-    # an error message that will help people figure out what they need to do.
-    raise Exception(
-        'Cannot import CaptureTwistedLogs. Maybe upgrade your version of '
-        'testtools: pip install --upgrade --process-dependency-links .[dev]'
-    )
-
 
 from twisted.python import log
 from twisted.python.filepath import FilePath
@@ -128,8 +117,7 @@ class _AsyncRunner(AsynchronousDeferredRunTestForBrokenTwisted):
     def _get_log_fixture(self):
         """Return a fixture used to capture logs."""
         # XXX: This is a hack, relying on the internal implementation details
-        # of AsynchronousDeferredRunTest as implemented in
-        # https://github.com/testing-cabal/testtools/pull/172.
+        # of AsynchronousDeferredRunTest.
         #
         # We want to use the _SplitEliotLogs fixture, but we want to make sure
         # that it's set up & torn down *outside* the test itself.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 Generate a Flocker package that can be deployed onto cluster nodes.
 """
 
-import os
 import platform
 from setuptools import setup, find_packages
 import versioneer
@@ -99,13 +98,6 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
 
     dependency_links = [
-        # Use our fork of testtools until #165, #171, and #172 are merged and
-        # released. See FLOC-3498.
-        #
-        # "git+https" weirdness is due to setuptools expecting:
-        #     vcs+proto://host/path@revision#egg=project-version
-        # See https://setuptools.readthedocs.org/en/latest/setuptools.html
-        "git+https://github.com/ClusterHQ/testtools@clusterhq-fork#egg=testtools-1.9.0chq5",  # noqa
     ],
 
     # Some "trove classifiers" which are relevant.


### PR DESCRIPTION
testing-cabal/testtools#172 has landed & been released, so we can control our logging destiny.