### PR TITLE
[FLOC-4105] Extract the lint output in a useful way.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1260,6 +1260,7 @@ job_type:
                    *run_lint, *exit_with_return_code_from_test ]
           }
       timeout: 10
+      publish_lint: true
       directories_to_delete: []
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -878,7 +878,9 @@ common_cli:
   run_lint: &run_lint |
     # run flake8 lint tests on Flocker source code
     flake8 --format=pylint --output flake8.lint flocker
+    JOB_EXIT_STATUS="$( updateExitStatus $? )"
     pylint flocker > pylint.lint
+    JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
   lint_artifacts: &lint_artifacts
     - flake8.lint
@@ -1255,7 +1257,7 @@ job_type:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
-                   *run_lint ]
+                   *run_lint, *exit_with_return_code_from_test ]
           }
       timeout: 10
       directories_to_delete: []

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-# vim: ai ts=4 sts=4 et sw=4 ft=yaml fdm=indent et foldlevel=0
+# vim: ai ts=4 sts=4 et sw=4 ft=yaml et
 #
 # build.yaml
 #

--- a/build.yaml
+++ b/build.yaml
@@ -1260,6 +1260,7 @@ job_type:
           }
       timeout: 10
       publish_lint: true
+      archive_artifacts: ["*.lint"]
       directories_to_delete: []
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -882,10 +882,6 @@ common_cli:
     pylint flocker > pylint.lint
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
 
-  lint_artifacts: &lint_artifacts
-    - flake8.lint
-    - pylint.lint
-
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point
 #-----------------------------------------------------------------------------#

--- a/build.yaml
+++ b/build.yaml
@@ -879,9 +879,9 @@ common_cli:
     # Disable exiting on error, so we can run multiple lints
     set +e
     # run flake8 lint tests on Flocker source code
-    flake8 --format=pylint --output flake8.lint flocker
+    flake8 --format=pylint --output flake8.lint.txt flocker
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
-    pylint flocker > pylint.lint
+    pylint flocker > pylint.lint.txt
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
     set -e
 
@@ -1260,7 +1260,7 @@ job_type:
           }
       timeout: 10
       publish_lint: true
-      archive_artifacts: ["*.lint"]
+      archive_artifacts: ["*.lint.txt"]
       directories_to_delete: []
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -876,16 +876,13 @@ common_cli:
     tar --verbose --list --file "${BOX_NAME}" || abort_build
 
   run_lint: &run_lint |
-    # we need to unset PIP_INDEX_URL since it causes tox to fail.
-    # in order to use our pip caching we need to append --trusted-hosts
-    # which we currently can't do through tox.
-    unset PIP_INDEX_URL
     # run flake8 lint tests on Flocker source code
-    tox -e lint
+    flake8 --format=pylint --output flake8.lint flocker
+    pylint flocker > pylint.lint
 
-  install_flake8: &install_flake8 |
-    # flake8 is used by lint tests on Flocker source code
-    pip install flake8 ${PIP_ADDITIONAL_OPTIONS}
+  lint_artifacts: &lint_artifacts
+    - flake8.lint
+    - pylint.lint
 
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point
@@ -1258,7 +1255,7 @@ job_type:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
                    *cleanup, *setup_venv, *setup_flocker_modules,
-                   *install_flake8, *run_lint ]
+                   *run_lint ]
           }
       timeout: 10
       directories_to_delete: []

--- a/build.yaml
+++ b/build.yaml
@@ -876,11 +876,14 @@ common_cli:
     tar --verbose --list --file "${BOX_NAME}" || abort_build
 
   run_lint: &run_lint |
+    # Disable exiting on error, so we can run multiple lints
+    set +e
     # run flake8 lint tests on Flocker source code
     flake8 --format=pylint --output flake8.lint flocker
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
     pylint flocker > pylint.lint
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
+    set -e
 
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -1,4 +1,4 @@
-// vim: ai ts=2 sts=2 et sw=2 ft=groovy fdm=indent et foldlevel=0
+// vim: ai ts=2 sts=2 et sw=2 ft=groovy et
 /* jobs.groovy
 
   This Groovy file contains the jenkins job DSL plugin code to build all the

--- a/jobs.groovy
+++ b/jobs.groovy
@@ -389,6 +389,12 @@ def build_publishers(v, branchName, dashProject, dashBranchName, job_name) {
                 failNoReports(true)
             }
         }
+        if (v.publish_lint) {
+          violations {
+            sourcePathPattern('**/*.py')
+            pylint(1, null, null, '*.lint')
+          }
+        }
         if (job_name) {
             /* Update the commit status on GitHub with the build result We use the
                flexible-publish plugin combined with the the any-buildstep plugin to

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ versionfile_source = flocker/_version.py
 versionfile_build = flocker/_version.py
 tag_prefix =
 parentdir_prefix = Flocker-
+
+[flake8]
+exclude=flocker/_version.py,flocker/restapi/docs/hidden_code_block.py

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ changedir = {toxinidir}
 commands =
     pip install -r requirements.txt
     pip install --process-dependency-links .[dev]
-    flake8 --exclude=_version.py,flocker/restapi/docs/hidden_code_block.py flocker
+    flake8 flocker
     pylint flocker
 
 [testenv:sphinx]


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-4105

See http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/extract-lint-output-broken/job/run_lint/1/violations/ for a demonstration ([diff](https://github.com/ClusterHQ/flocker/compare/extract-lint-output-FLOC-4105...extract-lint-output-broken))