### PR TITLE
[FLOC-3941] Pre-pull Docker Swarm when building the Docker image

### DIFF
--- a/admin/installer/_images.py
+++ b/admin/installer/_images.py
@@ -300,6 +300,7 @@ class RealPerformers(object):
             base_dispatcher
         ])
 
+
 def _validate_constant(constants, option_value, option_name):
     try:
         constant_value = constants.lookupByValue(option_value)

--- a/admin/installer/packer/provision_ubuntu-14.04_docker.sh
+++ b/admin/installer/packer/provision_ubuntu-14.04_docker.sh
@@ -7,3 +7,6 @@ apt-get update -qq -y
 apt-get install -qq -y --force-yes curl
 apt-get purge -qq -y lxc-docker* || true
 curl -sSL https://get.docker.com/ | sh
+
+# Prepull swarm
+docker pull "swarm:${SWARM_VERSION:-latest}"

--- a/admin/installer/packer/template_ubuntu-14.04_docker.json
+++ b/admin/installer/packer/template_ubuntu-14.04_docker.json
@@ -1,4 +1,7 @@
 {
+    "variables": {
+        "SWARM_VERSION": "{{env `SWARM_VERSION`}}"
+    },
     "builders": [{
         "type": "amazon-ebs",
         "region": "",
@@ -7,12 +10,18 @@
         "ssh_username": "ubuntu",
         "ami_name": "clusterhq_ubuntu-14.04_docker_{{timestamp}}",
         "ami_groups": ["all"],
-        "ami_regions": []
+        "ami_regions": [],
+        "tags": {
+            "SWARM_VERSION": "{{user `SWARM_VERSION`}}"
+        }
     }],
     "provisioners": [
         {
             "type": "shell",
             "script": "{{template_dir}}/provision_ubuntu-14.04_docker.sh",
+            "environment_vars": [
+                "SWARM_VERSION={{user `SWARM_VERSION`}}"
+            ],
             "execute_command": "{{ .Vars }} sudo -E -S sh '{{ .Path }}'"
         }
     ]

--- a/admin/test/test_images.py
+++ b/admin/test/test_images.py
@@ -21,7 +21,7 @@ from pyrsistent import PClass, field, pmap_field, thaw
 
 from testtools.matchers import StartsWith
 from testtools.content import text_content, content_from_file, ContentType
-from testtols.matchers import Contains
+from testtools.matchers import Contains
 
 from fixtures import Fixture
 

--- a/admin/test/test_images.py
+++ b/admin/test/test_images.py
@@ -11,6 +11,14 @@ import boto3
 from botocore.exceptions import (
     ClientError, NoCredentialsError, EndpointConnectionError
 )
+from botocore.vendored.requests.packages.urllib3.contrib.pyopenssl import (
+    extract_from_urllib3,
+)
+
+# Don't use pyOpenSSL in urllib3 - it causes an ``OpenSSL.SSL.Error``
+# exception when we try an API call on an idled persistent connection.
+# See https://github.com/boto/boto3/issues/220
+extract_from_urllib3()
 
 from effect import Effect, sync_perform
 from effect.testing import perform_sequence


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-3941

I also introduced some changes to allow the version to be supplied as an environment variable when calling the script.
And modified the integration test to check the tags when the images have built.

I'll follow up with a way to specify and tag the Docker package version in 
 * https://clusterhq.atlassian.net/browse/FLOC-4102
 * https://github.com/ClusterHQ/flocker/compare/choose-docker-version-FLOC-4102