### PR TITLE
[FLOC-4110] Fix log message attribute so it gets displayed correctly.

### DIFF
--- a/benchmark/cluster_containers_setup.py
+++ b/benchmark/cluster_containers_setup.py
@@ -377,7 +377,7 @@ class ClusterContainerDeployment(object):
 
         def log_totals(result):
             Message.log(
-                action_type='flocker.benchmark.container_setup:finish',
+                message_type='flocker.benchmark.container_setup:finish',
                 container_count=self.container_count,
                 error_count=self.error_count
             )


### PR DESCRIPTION
The `setup-cluster-containers` script should print a final status message before exiting. To do this it uses the `eliot_output` function which maps Eliot messages to display strings.

The final log message used `action_type` instead of `message_type`, so does not get mapped correctly.

Simple change to use correct attribute.
