### PR TITLE
[FLOC-4111] Add package source to get_trial_environment parameters

### DIFF
--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -401,11 +401,13 @@ def main(reactor, args, base_path, top_level):
     if options['no-keep']:
         print("not keeping cluster")
     else:
-        save_environment(options['cert-directory'], cluster)
+        save_environment(
+            options['cert-directory'], cluster, options.package_source()
+        )
         reactor.removeSystemEventTrigger(cleanup_trigger_id)
 
 
-def save_environment(directory, cluster):
+def save_environment(directory, cluster, package_source):
     """
     Report environment variables describing the cluster.
     The variables are printed on standard output and also
@@ -413,8 +415,9 @@ def save_environment(directory, cluster):
 
     :param FilePath directory: The variables are saved in this directory.
     :param Cluster cluster: The cluster.
+    :param PackageSource package_source: The source of Flocker omnibus package.
     """
-    environment_variables = get_trial_environment(cluster)
+    environment_variables = get_trial_environment(cluster, package_source)
     environment_strings = list()
     for environment_variable in environment_variables:
         environment_strings.append(


### PR DESCRIPTION
Commit https://github.com/ClusterHQ/flocker/commit/f72dd544395a4b9317f010962f369f01ac8d3c8b added an extra parameter to the function `get_trial_environment` to pass the package versions info to subsequent stages.  The  change is very useful for the benchmarking workflow, as we are currently passing the branch name manually.

However, for benchmarking, we call the `get_trial_environment` function from `cluster_setup.py`, but it has not been changed there.

This PR fixes that omission.


