### PR TITLE
[FLOC-4090] Refactor eliot_output

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -15,7 +15,7 @@ from tempfile import mkdtemp
 from zope.interface import Interface, implementer
 from characteristic import attributes
 from eliot import (
-    add_destination, write_failure, FileDestination
+    write_failure, FileDestination
 )
 from pyrsistent import PClass, field, pvector
 from bitmath import GiB
@@ -39,6 +39,8 @@ from flocker.common import (
     loop_until,
     validate_signature_against_kwargs,
 )
+from flocker.common.script import eliot_to_stdout
+
 from flocker.provision import PackageSource, Variants, CLOUD_PROVIDERS
 from flocker.provision._ssh import (
     run_remotely,
@@ -1236,29 +1238,6 @@ ACTION_START_FORMATS = {
 }
 
 
-def eliot_output(message):
-    """
-    Write pretty versions of eliot log messages to stdout.
-    """
-    message_type = message.get('message_type')
-    action_type = message.get('action_type')
-    action_status = message.get('action_status')
-
-    format = ''
-    if message_type is not None:
-        if message_type == 'twisted:log' and message.get('error'):
-            format = '%(message)s'
-        else:
-            format = MESSAGE_FORMATS.get(message_type, '')
-    elif action_type is not None:
-        if action_status == 'started':
-            format = ACTION_START_FORMATS.get('action_type', '')
-        # We don't consider other status, since we
-        # have no meaningful messages to write.
-    sys.stdout.write(format % message)
-    sys.stdout.flush()
-
-
 def capture_upstart(reactor, host, output_file):
     """
     SSH into given machine and capture relevant logs, writing them to
@@ -1429,7 +1408,7 @@ def main(reactor, args, base_path, top_level):
     """
     options = RunOptions(top_level=top_level)
 
-    add_destination(eliot_output)
+    eliot_to_stdout(MESSAGE_FORMATS, ACTION_START_FORMATS)
     try:
         options.parseOptions(args)
     except UsageError as e:

--- a/admin/testbrew.py
+++ b/admin/testbrew.py
@@ -18,8 +18,6 @@ import os
 import sys
 import urllib2
 
-from eliot import add_destination
-
 from twisted.internet.defer import inlineCallbacks
 from twisted.internet.error import ProcessTerminated
 from twisted.python.filepath import FilePath
@@ -35,6 +33,7 @@ from flocker.provision._effect import sequence
 from txeffect import perform
 from flocker import __version__
 
+from flocker.common.script import eliot_to_stdout
 from flocker.common.runner import run
 
 YOSEMITE_VMX_PATH = os.path.expanduser((
@@ -93,15 +92,6 @@ MESSAGE_FORMATS = {
 }
 
 
-def eliot_output(message):
-    """
-    Write pretty versions of eliot log messages to stdout.
-    """
-    message_type = message.get('message_type', message.get('action_type'))
-    sys.stdout.write(MESSAGE_FORMATS.get(message_type, '') % message)
-    sys.stdout.flush()
-
-
 @inlineCallbacks
 def main(reactor, args, base_path, top_level):
     try:
@@ -112,7 +102,7 @@ def main(reactor, args, base_path, top_level):
             sys.stderr.write("Error: {error}.\n".format(error=str(e)))
             sys.exit(1)
 
-        add_destination(eliot_output)
+        eliot_to_stdout(MESSAGE_FORMATS, {})
 
         recipe_url = options['recipe_url']
         options['vmpath'] = FilePath(options['vmpath'])

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -164,18 +164,18 @@ def eliot_to_stdout(message_formats, action_formats, stdout=sys.stdout):
         action_type = message.get('action_type')
         action_status = message.get('action_status')
 
-        format = ''
+        message_format = '%s'
         if message_type is not None:
             if message_type == 'twisted:log' and message.get('error'):
-                format = '%(message)s'
+                message_format = '%(message)s'
             else:
-                format = message_formats.get(message_type, '')
+                message_format = message_formats.get(message_type, '%s')
         elif action_type is not None:
             if action_status == 'started':
-                format = action_formats.get('action_type', '')
+                message_format = action_formats.get('action_type', '%s')
             # We don't consider other status, since we
             # have no meaningful messages to write.
-        stdout.write(format % message)
+        stdout.write(message_format % message)
         stdout.flush()
 
     add_destination(eliot_output)

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -6,7 +6,9 @@ import sys
 
 from bitmath import MiB
 
-from eliot import MessageType, fields, Logger, FileDestination
+from eliot import (
+    MessageType, fields, Logger, FileDestination, add_destination,
+)
 from eliot.logwriter import ThreadedWriter
 
 from twisted.application.service import MultiService, Service
@@ -151,6 +153,32 @@ def eliot_logging_service(destination, reactor, capture_stdout):
 TWISTED_LOG_MESSAGE = MessageType("twisted:log",
                                   fields(error=bool, message=unicode),
                                   u"A log message from Twisted.")
+
+
+def eliot_to_stdout(message_formats, action_formats, stdout=sys.stdout):
+    """
+    Write pretty versions of eliot log messages to stdout.
+    """
+    def eliot_output(message):
+        message_type = message.get('message_type')
+        action_type = message.get('action_type')
+        action_status = message.get('action_status')
+
+        format = ''
+        if message_type is not None:
+            if message_type == 'twisted:log' and message.get('error'):
+                format = '%(message)s'
+            else:
+                format = message_formats.get(message_type, '')
+        elif action_type is not None:
+            if action_status == 'started':
+                format = action_formats.get('action_type', '')
+            # We don't consider other status, since we
+            # have no meaningful messages to write.
+        stdout.write(format % message)
+        stdout.flush()
+
+    add_destination(eliot_output)
 
 
 class EliotObserver(Service):


### PR DESCRIPTION
Fixes FLOC-4090. Removes the three separate definitions of `eliot_output` and refactors it in to one function inside `flocker.common.script`.