### PR TITLE
[FLOC-3758]  add --log-file option to the benchmark script

### DIFF
--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -26,8 +26,6 @@ from benchmark.cluster import BenchmarkCluster
 from benchmark._driver import driver
 
 
-to_file(sys.stderr)
-
 # Change this number when changing the format of the output JSON
 OUTPUT_VERSION = 1
 
@@ -86,7 +84,8 @@ class BenchmarkOptions(Options):
          'Environmental scenario under which to perform test.'],
         ['operation', None, 'default', 'Operation to measure.'],
         ['metric', None, 'default', 'Quantity to benchmark.'],
-        ['userdata', None, None, 'JSON data to add to output.']
+        ['userdata', None, None, 'JSON data to add to output.'],
+        ['log-file', None, None, 'File for writing log, stderr by default.'],
     ]
 
 
@@ -241,6 +240,22 @@ def main(argv, environ, react=react):
         options.parseOptions(argv[1:])
     except UsageError as e:
         usage(options, e.args[0])
+
+    if options['log-file'] is not None:
+        try:
+            log_file = open(options['log-file'], 'a')
+        except EnvironmentError as e:
+            usage(
+                options,
+                'Can not open the log file {}.\n{}: {}.'.format(
+                    options['log-file'],
+                    e.filename,
+                    e.strerror
+                )
+            )
+    else:
+        log_file = sys.stderr
+    to_file(log_file)
 
     cluster = get_cluster(options, environ)
 

--- a/benchmark/script.py
+++ b/benchmark/script.py
@@ -75,8 +75,6 @@ def create_factory_from_config(table, config):
 
 
 class BenchmarkOptions(Options):
-    description = "Run benchmark tests."
-
     optParameters = [
         ['cluster', None, None,
          'Directory containing cluster configuration files.  '


### PR DESCRIPTION
The option allows to specify a log file to use.
The log file is appended to.
By default the log messages still go to `stderr`.