### PR TITLE
[FLOC-4118] A command line tool to cleanup leaked acceptance test volumes

### DIFF
--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -69,9 +69,12 @@ def _get_volume_creation_time(volume):
     """
     Extract the creation time from an AWS or Rackspace volume.
 
-    libcloud doesn't represent volume creation time uniformly across
+    XXX: libcloud doesn't represent volume creation time uniformly across
     drivers.  Thus this method only works on drivers specifically accounted
-    for.
+    for. Should be extended or refactored for GCE support.
+
+    :param libcloud.compute.base.StorageVolume volume: The volume to query.
+    :returns: The datetime when the ``volume`` was created.
     """
     try:
         # AWS
@@ -87,7 +90,14 @@ def _get_volume_creation_time(volume):
 
 def _get_volume_region(volume):
     """
-    Get the name of the region the volume is in.
+    Extract the region name from an AWS or Rackspace volume.
+
+    XXX: libcloud doesn't represent volume creation time uniformly across
+    drivers.  Thus this method only works on drivers specifically accounted
+    for. Should be extended or refactored for GCE support.
+
+    :param libcloud.compute.base.StorageVolume volume: The volume to query.
+    :returns: The region of the ``volume``
     """
     return (
         # Rackspace
@@ -101,6 +111,9 @@ def _describe_volume(volume):
     """
     Create a dictionary giving lots of interesting details about a cloud
     volume.
+
+    :param libcloud.compute.base.StorageVolume volume: The volume to query.
+    :returns: A JSON serializable dict of ``volume`` information.
     """
     return {
         'id': volume.id,
@@ -162,6 +175,7 @@ class CleanVolumes(object):
         """
         Extract the Flocker-specific cluster identifier from the given volume.
 
+        :param libcloud.compute.base.StorageVolume volume: The volume to query.
         :raise: ``KeyError`` if the given volume is not tagged with a Flocker
             cluster id.
         """
@@ -294,6 +308,7 @@ def _yaml_configuration_path_option(option_name, option_value):
 
 class CleanupCloudResourcesOptions(Options):
     """
+    Command line options for ``cleanup_cloud_resources``.
     """
     optFlags = [
         ["dry-run", None,
@@ -302,7 +317,7 @@ class CleanupCloudResourcesOptions(Options):
 
     optParameters = [
         [u"config-file", None, None,
-         u"The config file containing cloud credentials.\n",
+         u"An acceptance.yml file containing cloud credentials.\n",
          lambda option_value: _yaml_configuration_path_option(
              u"config-file", option_value
          )],

--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -159,7 +159,7 @@ class CleanVolumes(object):
         for extra in config.get("extra-aws", []):
             extra_driver_config = base_ec2.copy()
             extra_driver_config.update(extra)
-            drivers.append(get_ec2_driver(config))
+            drivers.append(get_ec2_driver(extra_driver_config))
         return drivers
 
     def _get_cloud_volumes(self, drivers):

--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -1,0 +1,29 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Utilities for cloud resource cleanup.
+"""
+import sys
+
+from twisted.internet.defer import succeed
+from twisted.python.usage import Options, UsageError
+
+
+class CleanupCloudResourcesOptions(Options):
+    """
+
+    """
+
+
+def cleanup_cloud_resources_main(reactor, args, base_path, top_level):
+    options = CleanupCloudResourcesOptions()
+
+    try:
+        options.parseOptions(args)
+    except UsageError as e:
+        sys.stderr.write(
+            "Usage Error: %s: %s\n" % (
+                base_path.basename(), e
+            )
+        )
+        raise SystemExit(1)
+    return succeed(None)

--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -300,6 +300,10 @@ class CleanupCloudResourcesOptions(Options):
          lambda option_value: _yaml_configuration_path_option(
              u"config-file", option_value
          )],
+        [u"volume-lag", None, timedelta(minutes=30),
+         u"The oldest in minutes a volume may be "
+         u"without being considered for deletion.\n",
+         lambda option_value: timedelta(minutes=int(option_value))]
     ]
 
     def postOptions(self):
@@ -322,9 +326,8 @@ def cleanup_cloud_resources_main(reactor, args, base_path, top_level):
             ).encode('utf-8')
         )
         raise SystemExit(1)
-    cleaner = CleanVolumes(
-        lag=timedelta(minutes=30)
-    )
+
+    cleaner = CleanVolumes(lag=options["volume-lag"])
 
     actions = cleaner.start(config=options["config-file"])
     d = succeed(actions)

--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -2,15 +2,308 @@
 """
 Utilities for cloud resource cleanup.
 """
+from datetime import datetime, timedelta
+import json
 import sys
+from uuid import UUID
+import yaml
 
-from twisted.internet.defer import succeed
+from characteristic import attributes
+
+from dateutil.parser import parse as parse_date
+from dateutil.tz import tzutc
+
+from libcloud.compute.providers import get_driver, Provider
+
+from twisted.internet.threads import deferToThread
+from twisted.python.log import err
 from twisted.python.usage import Options, UsageError
+
+# Marker value defined by ``flocker.testtools.cluster_utils.MARKER``.  This
+# should never change and should always identify test-created clusters.
+MARKER = 0xAAAAAAAAAAAA
+
+
+def get_creation_time(node):
+    """
+    Get the creation time of a libcloud node.
+
+    Rackspace and EC2 store the information in different metadeta.
+
+    :return: The creation time, if available.
+    :rtype: datetime or None
+    """
+    date_string = node.extra.get("created", node.extra.get("launch_time"))
+    if date_string is None:
+        return None
+    else:
+        return parse_date(date_string)
+
+
+def get_rackspace_driver(rackspace):
+    """
+    Get a libcloud Rackspace driver given some credentials and other
+    configuration.
+    """
+    rackspace = get_driver(Provider.RACKSPACE)(
+        rackspace['username'], rackspace['key'],
+        region=rackspace['region'],
+    )
+    return rackspace
+
+
+def get_ec2_driver(aws):
+    """
+    Get a libcloud EC2 driver given some credentials and other configuration.
+    """
+    ec2 = get_driver(Provider.EC2)(
+        aws['access_key'], aws['secret_access_token'],
+        region=aws['region'],
+    )
+    return ec2
+
+
+@attributes(["lag"])
+class CleanVolumes(object):
+    """
+    Destroy volumes that leaked into the cloud from the acceptance and
+    functional test suites.
+    """
+    name = 'clean-volumes'
+    description = ['Cleaning', 'volumes']
+    descriptionDone = ['Clean', 'volumes']
+    haltOnFailure = False
+    flunkOnFailure = True
+
+    def start(self):
+        config = privateData['acceptance']['config']
+        d = deferToThread(self._blocking_clean_volumes, yaml.safe_load(config))
+        d.addCallback(self.log)
+        d.addErrback(self.failed)
+
+    def _get_cloud_drivers(self, config):
+        """
+        From the private buildbot configuration, construct a list of all of the
+        libcloud drivers where leaked volumes might be found.
+        """
+        base_ec2 = config["aws"]
+
+        drivers = [
+            get_rackspace_driver(config["rackspace"]),
+            get_ec2_driver(base_ec2),
+        ]
+
+        for extra in config["extra-aws"]:
+            extra_driver_config = base_ec2.copy()
+            extra_driver_config.update(extra)
+            drivers.append(get_ec2_driver(config))
+        return drivers
+
+    def _get_cloud_volumes(self, drivers):
+        """
+        From the given libcloud drivers, look up all existing volumes.
+        """
+        volumes = []
+        for driver in drivers:
+            volumes.extend(driver.list_volumes())
+        return volumes
+
+    def _get_cluster_id(self, volume):
+        """
+        Extract the Flocker-specific cluster identifier from the given volume.
+
+        :raise: ``KeyError`` if the given volume is not tagged with a Flocker
+            cluster id.
+        """
+        return _get_tag(volume, 'flocker-cluster-id')
+
+    def _is_test_cluster(self, cluster_id):
+        """
+        Determine whether or not the given Flocker cluster identifier belongs
+        to a cluster created by a test suite run.
+
+        :return: ``True`` if it does, ``False`` if it does not.
+        """
+        try:
+            return UUID(cluster_id).node == MARKER
+        except:
+            err(None, "Could not parse cluster_id {!r}".format(cluster_id))
+            return False
+
+    def _is_test_volume(self, volume):
+        """
+        Determine whether or not the given volume belongs to a test-created
+        Flocker cluster (and is therefore subject to automatic destruction).
+
+        :return: ``True`` if it does, ``False`` if it does not.
+        """
+        try:
+            cluster_id = self._get_cluster_id(volume)
+        except KeyError:
+            return False
+        return self._is_test_cluster(cluster_id)
+
+    def _get_volume_creation_time(self, volume):
+        """
+        Extract the creation time from an AWS or Rackspace volume.
+
+        libcloud doesn't represent volume creation time uniformly across
+        drivers.  Thus this method only works on drivers specifically accounted
+        for.
+        """
+        try:
+            # AWS
+            return volume.extra['create_time']
+        except KeyError:
+            # Rackspace.  Timestamps have no timezone indicated.  Manual
+            # experimentation indicates timestamps are in UTC (which of course
+            # is the only reasonable thing).
+            return parse_date(
+                volume.extra['created_at']
+            ).replace(tzinfo=tzutc())
+
+    def _filter_test_volumes(self, maximum_age, volumes):
+        """
+        From the given list of volumes, find volumes created by tests which are
+        older than the maximum age.
+
+        :param timedelta maximum_age: The oldest a volume may be without being
+            considered old enough to include in the result.
+        :param list all_volumes: The libcloud volumes representing all the
+            volumes we can see on a particular cloud service.
+
+        :rtype: ``VolumeActions``
+        """
+        now = datetime.now(tz=tzutc())
+        destroy = []
+        keep = []
+        for volume in volumes:
+            created = self._get_volume_creation_time(volume)
+            if self._is_test_volume(volume) and now - created > maximum_age:
+                destroy.append(volume)
+            else:
+                keep.append(volume)
+        return VolumeActions(destroy=destroy, keep=keep)
+
+    def _destroy_cloud_volumes(self, volumes):
+        """
+        Unconditionally and irrevocably destroy all of the given cloud volumes.
+        """
+        for volume in volumes:
+            try:
+                volume.destroy()
+            except:
+                err(None, "Destroying volume.")
+
+    def _blocking_clean_volumes(self, config):
+        """
+        Clean up old volumes belonging to test-created Flocker clusters.
+        """
+        drivers = self._get_cloud_drivers(config)
+        volumes = self._get_cloud_volumes(drivers)
+        actions = self._filter_test_volumes(self.lag, volumes)
+        self._destroy_cloud_volumes(actions.destroy)
+        return {
+            "destroyed": actions.destroy,
+            "kept": actions.keep,
+        }
+
+    def _get_volume_region(self, volume):
+        """
+        Get the name of the region the volume is in.
+        """
+        return (
+            # Rackspace
+            getattr(volume.driver, "region", None) or
+            # AWS
+            getattr(volume.driver, "region_name", None)
+        )
+
+    def _describe_volume(self, volume):
+        """
+        Create a dictionary giving lots of interesting details about a cloud
+        volume.
+        """
+        return {
+            'id': volume.id,
+            'creation_time': _format_time(
+                self._get_volume_creation_time(volume),
+            ),
+            'provider': volume.driver.name,
+            'region': self._get_volume_region(volume),
+            # *Stuffed* with non-JSON-encodable goodies.
+            'extra': repr(volume.extra),
+        }
+
+    def log(self, result):
+        """
+        Log the results of a cleanup run.
+
+        The log will include volumes that were destroyed and volumes that were
+        kept.  If volumes are destroyed, the step is considered to have failed.
+        The test suite should have cleaned those volumes up.  This is an
+        unfortunate time to be reporting the problem but it's better than never
+        reporting it.
+        """
+        for (kind, volumes) in result.items():
+            content = _dumps(
+                sorted(
+                    list(
+                        self._describe_volume(volume) for volume in volumes
+                    ), key=lambda description: description['creation_time'],
+                )
+            )
+            self.addCompleteLog(name=kind, text=content)
+
+        if len(result['destroyed']) > 0:
+            # We fail if we destroyed any volumes because that means that
+            # something is leaking volumes.
+            self.finished(FAILURE)
+        else:
+            self.finished(SUCCESS)
+
+
+def _dumps(obj):
+    """
+    JSON encode an object using some visually pleasing formatting.
+    """
+    return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
+
+
+def _format_time(when):
+    """
+    Format a time to ISO8601 format.  Or if there is no time, just return
+    ``None``.
+    """
+    if when is None:
+        return None
+    return datetime.isoformat(when)
+
+
+def _get_tag(volume, tag_name):
+    """
+    Get a "tag" from an EBS or Rackspace volume.
+
+    libcloud doesn't represent tags uniformly across drivers.  Thus this method
+    only works on drivers specifically account for.
+
+    :raise: ``KeyError`` if the tag is not present.
+    """
+    return volume.extra.get("tags", volume.extra.get("metadata"))[tag_name]
+
+
+@attributes(["destroy", "keep"])
+class VolumeActions(object):
+    """
+    Represent something to be done to some volumes.
+
+    :ivar destroy: Volumes to destroy.
+    :ivar keep: Volumes to keep.
+    """
 
 
 class CleanupCloudResourcesOptions(Options):
     """
-
     """
 
 
@@ -26,4 +319,4 @@ def cleanup_cloud_resources_main(reactor, args, base_path, top_level):
             )
         )
         raise SystemExit(1)
-    return succeed(None)
+    return CleanVolumes(lag=timedelta(minutes=30)).start()

--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -23,7 +23,7 @@ from twisted.python.usage import Options, UsageError
 
 # Marker value defined by ``flocker.testtools.cluster_utils.MARKER``.  This
 # should never change and should always identify test-created clusters.
-MARKER = 0xAAAAAAAAAAAA
+from flocker.testtools.cluster_utils import MARKER
 
 
 def get_creation_time(node):
@@ -120,12 +120,6 @@ class CleanVolumes(object):
     Destroy volumes that leaked into the cloud from the acceptance and
     functional test suites.
     """
-    name = 'clean-volumes'
-    description = ['Cleaning', 'volumes']
-    descriptionDone = ['Clean', 'volumes']
-    haltOnFailure = False
-    flunkOnFailure = True
-
     def start(self, config):
         """
         Clean up old volumes belonging to test-created Flocker clusters.

--- a/admin/cleanup_cloud_resources
+++ b/admin/cleanup_cloud_resources
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Cleanup unused cloud resources
+"""
+
+from _preamble import TOPLEVEL, BASEPATH
+
+import sys
+
+if __name__ == '__main__':
+    from twisted.internet.task import react
+    from admin.cleanup import cleanup_cloud_resources_main as main
+    react(main, (sys.argv[1:], BASEPATH, TOPLEVEL))

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -325,7 +325,7 @@ And then run the acceptance tests on those nodes using the following command:
 Test Cleanup
 ============
 
-``admin/cleanup_cloud_resources`` creates a number of test datasets.
+``admin/run-acceptance-tests`` creates a number of test datasets.
 It will normally cleanup the test datasets and any cloud block devices that have been created.
 However, if there are bugs in the tests or if the process is killed it may leak volumes.
 
@@ -333,7 +333,7 @@ These volumes can be cleaned up using ``admin/cleanup_cloud_resources``.
 The tool uses the credentials in an ``acceptance.yml`` file to destroy cloud block devices that are older than 30 minutes,
 and which belong to an acceptance testing cluster with a special the acceptance test cluster UUID containing a marker.
 The tool will destroy all matching cloud block devices on AWS and Rackspace.
-It will print a JSON encoded report of the block devices that have been destroyed and those that have been kept, to stdout.
+It will print a JSON encoded report of the block devices that have been destroyed and those that have been kept, to ``stdout``.
 
 Run the command as follows:
 

--- a/docs/gettinginvolved/acceptance-testing.rst
+++ b/docs/gettinginvolved/acceptance-testing.rst
@@ -106,7 +106,7 @@ Configuration is loaded from the item in the top-level mapping with a key matchi
 The top-level mapping may contain a ``logging`` stanza, which must match the format described in `PEP 0391 <https://www.python.org/dev/peps/pep-0391/>`_.
 
 An example stanza:
- 
+
 .. code-block:: yaml
 
    logging:
@@ -320,6 +320,27 @@ And then run the acceptance tests on those nodes using the following command:
      --branch=master \
      --flocker-version='' \
      flocker.acceptance.obsolete.test_containers.ContainerAPITests.test_create_container_with_ports
+
+
+Test Cleanup
+============
+
+``admin/cleanup_cloud_resources`` creates a number of test datasets.
+It will normally cleanup the test datasets and any cloud block devices that have been created.
+However, if there are bugs in the tests or if the process is killed it may leak volumes.
+
+These volumes can be cleaned up using ``admin/cleanup_cloud_resources``.
+The tool uses the credentials in an ``acceptance.yml`` file to destroy cloud block devices that are older than 30 minutes,
+and which belong to an acceptance testing cluster with a special the acceptance test cluster UUID containing a marker.
+The tool will destroy all matching cloud block devices on AWS and Rackspace.
+It will print a JSON encoded report of the block devices that have been destroyed and those that have been kept, to stdout.
+
+Run the command as follows:
+
+.. code-block:: console
+
+    ./admin/cleanup_cloud_resources --config-file=$PWD/acceptance.yml
+
 
 CloudFormation Installer Tests
 ==============================


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4118

This is a port of the code from https://github.com/ClusterHQ/build.clusterhq.com/pull/109.

It's blocking at the moment, but in a follow up I can also port the Instance cleanup code and run instance and volume cleanup in parallel threads.

Next I'll add this to a jenkins cron job.
 * https://clusterhq.atlassian.net/browse/FLOC-4119