### PR TITLE
[FLOC-4113] Expand functional test set up docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -62,9 +62,7 @@ Install Flocker's development dependencies in a ``virtualenv`` by running the fo
 .. prompt:: bash $
 
    mkvirtualenv flocker
-   pip install --process-dependency-links --editable .[dev]
-
-.. Need --process-dependency-links while are using a fork of testtools.
+   pip install --editable .[dev]
 
 .. _Docker: https://www.docker.com/
 

--- a/admin/release.py
+++ b/admin/release.py
@@ -879,7 +879,7 @@ def initialize_release(version, path, top_level):
         os.environ["LDFLAGS"] = '-L{}/lib" CFLAGS="-I{}/include'.format(
             brew_openssl, brew_openssl)
     check_call(
-        ["pip install --process-dependency-links -e .[dev]"], shell=True,
+        ["pip install -e .[dev]"], shell=True,
         stdout=open(os.devnull, 'w'))
 
     sys.stdout.write("Updating LICENSE file...\n")

--- a/build.yaml
+++ b/build.yaml
@@ -319,9 +319,7 @@ common_cli:
     # using the caching-layer, install all the dependencies
     pip install --upgrade pip
     pip install . ${PIP_ADDITIONAL_OPTIONS}
-    # Install Flocker. Use --process-dependency-links so we can temporarily use
-    # testtools fork. See FLOC-3498.
-    pip install --process-dependency-links  ".[dev]" ${PIP_ADDITIONAL_OPTIONS}
+    pip install ".[dev]" ${PIP_ADDITIONAL_OPTIONS}
     # install junix for our coverage report
     pip install python-subunit junitxml ${PIP_ADDITIONAL_OPTIONS}
 

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -4,6 +4,9 @@ Functional Testing
 
 The tests for the various cloud block device backends depend on access to credentials supplied from the environment.
 
+These tests must be run from an instance of the cloud provider.
+For example, to run the EBS functional tests, you will need to run the tests from an EC2 instance.
+
 The tests look for the following environment variables:
 
 .. XXX
@@ -30,6 +33,36 @@ or the name of the stanza, if the ``provider`` key is missing.
 If the environment variables are not present, the tests will be skipped.
 The tests that do not correspond to the configured provider will also be skipped.
 
+Setting up the Flocker environment
+==================================
+
+To run the functional tests, you will need to set up a Flocker development environment on your cloud instance.
+
+To install this environment on CentOS, run the following commands:
+
+.. prompt:: bash
+
+   yum install python-devel openssl-devel git libffi-devel python-pip
+   yum groupinstall "Development tools"
+   pip install virtualenvwrapper
+   source /usr/bin/virtualenvwrapper.sh
+   mkvirtualenv flocker
+   git clone https://github.com/ClusterHQ/flocker
+   cd flocker/
+   pip install -e .[dev]
+
+Or for Ubuntu:
+
+.. prompt:: bash
+
+   apt-get install python-dev libssl-dev git libffi-dev python-pip
+   pip install virtualenvwrapper
+   source /usr/local/bin/virtualenvwrapper.sh
+   mkvirtualenv flocker
+   git clone https://github.com/ClusterHQ/flocker
+   cd flocker/
+   pip install -e .[dev]
+
 AWS
 ===
 
@@ -41,7 +74,7 @@ The configuration stanza for the EBS backend looks as follows:
      access_key: <aws access key>
      secret_access_token: <aws secret access token>
 
-To run the functional tests, run the following command:
+Now run the following command to set up the environment and run the tests:
 
 .. prompt:: bash #
 

--- a/docs/gettinginvolved/infrastructure/packaging.rst
+++ b/docs/gettinginvolved/infrastructure/packaging.rst
@@ -13,9 +13,7 @@ To build omnibus packages, create a VirtualEnv and install Flocker then its rele
    cd /path/to/flocker
    mkvirtualenv flocker-packaging
    pip install .
-   pip install --process-dependency-links .[dev]
-
-.. Need --process-dependency-links while we're using a fork of testtools.
+   pip install .[dev]
 
 Then run the following command from a clean checkout of the Flocker repository:
 

--- a/flocker/testtools/_flaky.py
+++ b/flocker/testtools/_flaky.py
@@ -250,8 +250,7 @@ class _RetryFlaky(testtools.RunTest):
             # what they need to do.
             raise Exception(
                 "Could not reset TestCase. Maybe upgrade your version of "
-                "testtools: pip install --upgrade --process-dependency-links "
-                ".[dev]")
+                "testtools: pip install --upgrade .[dev]")
         self._run_test(case, tmp_result)
         result_type = _get_result_type(tmp_result)
         details = pmap(case.getDetails())

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ minversion = 1.6
 [testenv]
 commands =
     pip install -r requirements.txt
-    pip install --process-dependency-links .[dev]
+    pip install .[dev]
     trial --rterrors {posargs:flocker}
 setenv =
     PYTHONHASHSEED=random
@@ -18,7 +18,7 @@ basepython = python2.7
 changedir = {toxinidir}
 commands =
     pip install -r requirements.txt
-    pip install --process-dependency-links .[dev]
+    pip install .[dev]
     flake8 flocker
     pylint flocker
 
@@ -27,7 +27,7 @@ basepython = python2.7
 changedir = {toxinidir}
 commands =
     pip install -r requirements.txt
-    pip install --process-dependency-links .[dev]
+    pip install .[dev]
     rm -rf docs/_build/html
     sphinx-build -a -b spelling docs/ docs/_build/spelling
     sphinx-build -a -b html docs/ docs/_build/html
@@ -38,5 +38,5 @@ usedevelop = True
 changedir = {toxinidir}
 commands =
     pip install -r requirements.txt
-    pip install --process-dependency-links .[dev]
+    pip install .[dev]
     trial --rterrors admin


### PR DESCRIPTION
Fixes FLOC-4113. Explains that cloud backend tests must be run from an instance of the cloud provider and how to set up an instance to run the functional tests.