### PR TITLE
[FLOC-4099] Disable API response validation

### DIFF
--- a/benchmark/benchmark.yml
+++ b/benchmark/benchmark.yml
@@ -6,14 +6,41 @@ scenarios:
     type: read-request-load
     request_rate: 5
 
+  - name: list-container-state-1
+    type: read-request-load
+    method: list_containers_state
+    request_rate: 1
+
+  - name: list-container-state-2
+    type: read-request-load
+    method: list_containers_state
+    request_rate: 2
+
+  - name: list-container-state-3
+    type: read-request-load
+    method: list_containers_state
+    request_rate: 3
+
   - name: list-container-state-4
     type: read-request-load
     method: list_containers_state
     request_rate: 4
 
-  - name: write-request-5
+  - name: write-request-1
     type: write-request-load
-    request_rate: 5
+    request_rate: 1
+
+  - name: write-request-2
+    type: write-request-load
+    request_rate: 2
+
+  - name: write-request-3
+    type: write-request-load
+    request_rate: 3
+
+  - name: write-request-4
+    type: write-request-load
+    request_rate: 4
 
 operations:
   - name: default

--- a/docs/administering/debugging.rst
+++ b/docs/administering/debugging.rst
@@ -227,6 +227,13 @@ For example:
    profile.sort_stats('cumulative').print_stats(10)
 
 
+Validation
+==========
+
+Additional validation of HTTP API responses is performed when running unit tests.
+This validation can be disabled for unit tests by setting the environment variable ``FLOCKER_VALIDATE_API_RESPONSES=no``.
+It can enabled for contexts other than unit tests by setting the environment variable ``FLOCKER_VALIDATE_API_RESPONSES=yes``.
+
 .. _`systemd's journal`: http://www.freedesktop.org/software/systemd/man/journalctl.html
 .. _`Eliot`: https://eliot.readthedocs.org
 .. _`eliot-tree`: https://github.com/jonathanj/eliottree

--- a/flocker/restapi/_infrastructure.py
+++ b/flocker/restapi/_infrastructure.py
@@ -146,13 +146,22 @@ def _remote_logging(original):
 
 # Set _validate_responses to True to perform jsonschema validation of
 # API responses from the control service.  Schema validation
-# demonstrates that outputs are valid, but is computationally expensive
-# for large responses.  Currently, validation is only enabled when
-# running using trial or the Python unittest module.
-if os.path.basename(sys.argv[0]) in ('trial', 'python -m unittest'):
-    _validate_responses = True
-else:
-    _validate_responses = Flse
+# confirms that outputs are valid, but is computationally expensive for
+# large responses.  Validation can be explicitly controlled by setting
+# the environment variable FLOCKER_VALIDATE_API_RESPONSES to "no" to
+# disable validation or any other value to enable.  If the environment
+# variable is not set, validation is only enabled when running using
+# trial or the Python unittest module.
+try:
+    if os.environ['FLOCKER_VALIDATE_API_RESPONSES'] == 'no':
+        _validate_responses = False
+    else:
+        _validate_responses = True
+except KeyError:
+    if os.path.basename(sys.argv[0]) in ('trial', 'python -m unittest'):
+        _validate_responses = True
+    else:
+        _validate_responses = False
 
 
 def _serialize(outputValidator):

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -567,6 +567,9 @@ class StructuredJSONTests(TestCase):
         """
         If the response body doesn't match the provided schema, then the
         request automatically receives a I{INTERNAL SERVER ERROR} response.
+
+        This test fails if we are not running under trial.  Hence it also
+        confirms that validation is enabled under trial.
         """
         request = dummyRequest(
             b"GET", b"/foo/badresponse",

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -586,11 +586,7 @@ class StructuredJSONTests(TestCase):
         """
         If _validate_responses is False, then JSON is not validated.
         """
-        def cleanup(saved=_infrastructure._validate_responses):
-            _infrastructure._validate_responses = saved
-        self.addCleanup(cleanup)
-
-        _infrastructure._validate_responses = False
+        self.patch(_infrastructure, '_validate_responses', False)
 
         request = dummyRequest(
             b"GET", b"/foo/badresponse",

--- a/flocker/restapi/test/test_infrastructure.py
+++ b/flocker/restapi/test/test_infrastructure.py
@@ -568,8 +568,8 @@ class StructuredJSONTests(TestCase):
         If the response body doesn't match the provided schema, then the
         request automatically receives a I{INTERNAL SERVER ERROR} response.
 
-        This test fails if we are not running under trial.  Hence it also
-        confirms that validation is enabled under trial.
+        This test fails if ``_validate_responses == False``.  Hence it also
+        confirms that validation is enabled for other tests.
         """
         request = dummyRequest(
             b"GET", b"/foo/badresponse",


### PR DESCRIPTION
Profiling shows that the JSON schema validation of control service API responses causes a large proportion of CPU load on the control service for clusters containing a large number of containers. See the comments for issue FLOC-4099 for some numbers.

This PR disables validation of the responses for contexts other than unit testing.

The principle being moved towards is to validate data when it arrives at the service and then to assume it is valid from there on, including on the way out.  This should be true if 1. all input data is validated, and 2. there are no bugs.

FLOC-4121 will review and, if required, update the situation for validating all input data, and validation for unit tests is kept to detect bugs.

In addition, I updated the `benchmark.yml` file defining the benchmark scenarios to reflect the actual tests we've been running.