### PR TITLE
[FLOC-3862] Do not accept floats for maximum size of a dataset

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,6 +9,11 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
+Next Release
+============
+
+* The Control Service API enforces that the type of a dataset ``maximum_size`` is an integer, rather then any number.
+
 This Release
 ============
 

--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -245,7 +245,7 @@ definitions:
       The upper limit on how much data the dataset will be allowed to
       store, as an integer number of bytes.
     type:
-      - "number"
+      - integer
       - "null"
     # 64 MiB.  Sort of an arbitrary limit but inspired by the lower bound
     # on what this can be set to for the ZFS backend.  Could probably be

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -582,7 +582,7 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = [
     {u"primary": a_uuid, u"maximum_size": u"123"},
 
     # wrong numeric type for maximum size
-    {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64 + 0.5},
+    {u"primary": a_uuid, u"maximum_size": float(1024 * 1024 * 64)},
 
     # too-small (but multiple of 1024) value for maximum size
     {u"primary": a_uuid, u"maximum_size": 1024},


### PR DESCRIPTION
The `maximum_size` property of datasets is an integer:
- The API docs text for `maximum_size` state it is an (optional) integer.
- The Dataset PClass in `flocker.apiclient` constrins it to an integer.
- No fractional value of bytes is valid (in fact only multiples of 1024 are valid).

However, the server-side JSON schema allows the type of `maximum_size` to be `number` which permits floats. The Dataset PClass on the server side does not constrain the type.  So, a float type is not detected as an error until it is passed back to the client, after the control service data is made invalid.

The test that should have detected this fails since the value tested did not meet a different constraint (multiple of 1024).

This PR fixes the test and the constraint to only allow integers.