### PR TITLE
[FLOC-4124] Patch cluster management scripts to use eliot_to_stdout

### DIFF
--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -1432,7 +1432,7 @@ def main(reactor, args, base_path, top_level):
     """
     options = RunOptions(top_level=top_level)
 
-    eliot_logging_acceptance()
+    configure_eliot_logging_for_acceptance()
     try:
         options.parseOptions(args)
     except UsageError as e:

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -1254,7 +1254,11 @@ ACTION_START_FORMATS = {
 }
 
 
-def eliot_logging_acceptance():
+def configure_eliot_logging_for_acceptance():
+    """
+    Set up eliot logging for use in scripts which are used in
+    acceptance tests
+    """
     eliot_to_stdout(MESSAGE_FORMATS, ACTION_START_FORMATS)
 
 

--- a/admin/acceptance.py
+++ b/admin/acceptance.py
@@ -1254,6 +1254,10 @@ ACTION_START_FORMATS = {
 }
 
 
+def eliot_logging_acceptance():
+    eliot_to_stdout(MESSAGE_FORMATS, ACTION_START_FORMATS)
+
+
 def capture_upstart(reactor, host, output_file):
     """
     SSH into given machine and capture relevant logs, writing them to
@@ -1424,7 +1428,7 @@ def main(reactor, args, base_path, top_level):
     """
     options = RunOptions(top_level=top_level)
 
-    eliot_to_stdout(MESSAGE_FORMATS, ACTION_START_FORMATS)
+    eliot_logging_acceptance()
     try:
         options.parseOptions(args)
     except UsageError as e:

--- a/admin/cluster_add_nodes.py
+++ b/admin/cluster_add_nodes.py
@@ -17,7 +17,7 @@ from flocker.provision._common import Cluster
 from .acceptance import (
     capture_journal,
     capture_upstart,
-    eliot_logging_acceptance,
+    configure_eliot_logging_for_acceptance,
     get_default_volume_size,
     make_managed_nodes,
     save_backend_configuration,
@@ -100,7 +100,7 @@ def main(reactor, args, base_path, top_level):
     :param FilePath base_path: The executable being run.
     :param FilePath top_level: The top-level of the Flocker repository.
     """
-    eliot_logging_acceptance()
+    configure_eliot_logging_for_acceptance()
     options = RunOptions(top_level=top_level)
     try:
         options.parseOptions(args)

--- a/admin/cluster_add_nodes.py
+++ b/admin/cluster_add_nodes.py
@@ -17,7 +17,7 @@ from flocker.provision._common import Cluster
 from .acceptance import (
     capture_journal,
     capture_upstart,
-    eliot_output,
+    eliot_logging_acceptance,
     get_default_volume_size,
     make_managed_nodes,
     save_backend_configuration,
@@ -100,7 +100,7 @@ def main(reactor, args, base_path, top_level):
     :param FilePath base_path: The executable being run.
     :param FilePath top_level: The top-level of the Flocker repository.
     """
-    add_destination(eliot_output)
+    eliot_logging_acceptance()
     options = RunOptions(top_level=top_level)
     try:
         options.parseOptions(args)

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -25,7 +25,7 @@ from .acceptance import (
     LibcloudRunner as OldLibcloudRunner,
     capture_journal,
     capture_upstart,
-    eliot_logging_acceptance,
+    configure_eliot_logging_for_acceptance,
     get_default_volume_size,
     get_trial_environment,
     save_backend_configuration,
@@ -347,7 +347,7 @@ def main(reactor, args, base_path, top_level):
     """
     options = RunOptions(top_level=top_level)
 
-    eliot_logging_acceptance()
+    configure_eliot_logging_for_acceptance()
     try:
         options.parseOptions(args)
     except UsageError as e:

--- a/admin/cluster_setup.py
+++ b/admin/cluster_setup.py
@@ -25,7 +25,7 @@ from .acceptance import (
     LibcloudRunner as OldLibcloudRunner,
     capture_journal,
     capture_upstart,
-    eliot_output,
+    eliot_logging_acceptance,
     get_default_volume_size,
     get_trial_environment,
     save_backend_configuration,
@@ -347,7 +347,7 @@ def main(reactor, args, base_path, top_level):
     """
     options = RunOptions(top_level=top_level)
 
-    add_destination(eliot_output)
+    eliot_logging_acceptance()
     try:
         options.parseOptions(args)
     except UsageError as e:

--- a/admin/test/test_cluster_setup.py
+++ b/admin/test/test_cluster_setup.py
@@ -1,5 +1,3 @@
-import mock
-
 from twisted.python.usage import UsageError
 
 from flocker.testtools import TestCase
@@ -8,10 +6,14 @@ from ..acceptance import CommonOptions
 from ..cluster_setup import RunOptions
 
 
+class RunOptionsForTest(RunOptions):
+
+    def postOptions(self):
+        pass
+
 class RunOptionsTest(TestCase):
 
-    @mock.patch.object(CommonOptions, 'postOptions')
-    def test_purpose(self, mock_postOpts):
+    def test_purpose(self):
         """
         RunOptions are parsed correctly when a purpose is provided
         """
@@ -20,6 +22,6 @@ class RunOptionsTest(TestCase):
             "--provider", "aws",
             "--purpose", "test"
         )
-        run_options = RunOptions(self.mktemp())
+        run_options = RunOptionsForTest(self.mktemp())
         run_options.parseOptions(arg_options)
         self.assertEquals(run_options['purpose'], 'test')

--- a/admin/test/test_cluster_setup.py
+++ b/admin/test/test_cluster_setup.py
@@ -1,0 +1,25 @@
+import mock
+
+from twisted.python.usage import UsageError
+
+from flocker.testtools import TestCase
+
+from ..acceptance import CommonOptions
+from ..cluster_setup import RunOptions
+
+
+class RunOptionsTest(TestCase):
+
+    @mock.patch.object(CommonOptions, 'postOptions')
+    def test_purpose(self, mock_postOpts):
+        """
+        RunOptions are parsed correctly when a purpose is provided
+        """
+        arg_options = (
+            "--distribution", "ubuntu-14.04",
+            "--provider", "aws",
+            "--purpose", "test"
+        )
+        run_options = RunOptions(self.mktemp())
+        run_options.parseOptions(arg_options)
+        self.assertEquals(run_options['purpose'], 'test')

--- a/admin/test/test_cluster_setup.py
+++ b/admin/test/test_cluster_setup.py
@@ -8,6 +8,11 @@ from ..cluster_setup import RunOptions
 
 class RunOptionsForTest(RunOptions):
 
+    """
+    Patch this so it's not run during the test, which
+    would result in quite a lot of logic related to 
+    connecting to a cloud provider being run.
+    """
     def postOptions(self):
         pass
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,7 @@ jmespath==0.9.0
 lazy-object-proxy==1.2.1
 MarkupSafe==0.23
 mccabe==0.3.1
+mock==1.3.0
 ndg-httpsclient==0.4.0
 packaging==15.2
 paramiko==1.15.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,7 +22,6 @@ jmespath==0.9.0
 lazy-object-proxy==1.2.1
 MarkupSafe==0.23
 mccabe==0.3.1
-mock==1.3.0
 ndg-httpsclient==0.4.0
 packaging==15.2
 paramiko==1.15.2

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -164,15 +164,15 @@ def eliot_to_stdout(message_formats, action_formats, stdout=sys.stdout):
         action_type = message.get('action_type')
         action_status = message.get('action_status')
 
-        message_format = '%s'
+        message_format = ''
         if message_type is not None:
             if message_type == 'twisted:log' and message.get('error'):
                 message_format = '%(message)s'
             else:
-                message_format = message_formats.get(message_type, '%s')
+                message_format = message_formats.get(message_type, '')
         elif action_type is not None:
             if action_status == 'started':
-                message_format = action_formats.get('action_type', '%s')
+                message_format = action_formats.get('action_type', '')
             # We don't consider other status, since we
             # have no meaningful messages to write.
         stdout.write(message_format % message)


### PR DESCRIPTION
eliot_to_stdout moved and it's usage in e.g. cluster_setup.py wasn't caught as there were no tests of any kind for that. This PR:

- Updates cluster_setup.py and cluster_add_nodes.py to use eliot_to_stdout (via a convenience function)
- Patches eliot_to_stdout to be less verbose when used in the cluster scripts (this was done on the advice of dwgebler)
- Added a basic test for the options parsing. Note that I chose to introduce use of mock in order to get around the fact that the option parser was embedding quite a lot of logic to connect to the cloud provider.