### PR TITLE
[FLOC 4146] Clean up references on flockerctl documentation

### DIFF
--- a/docs/flocker-features/flockerctl.rst
+++ b/docs/flocker-features/flockerctl.rst
@@ -12,11 +12,8 @@ The ``flockerctl`` Command
         <p>This page describes one of our experimental projects, developed to less rigorous quality and testing standards than the mainline Flocker distribution. It is not built with production-readiness in mind.</p>
 	</div>
 
-``flockerctl`` is a CLI for controlling the Flocker Control Service.
-It is specific to datasets, and should not be confused with ``flocker-deploy`` (which is deprecated) or ``flocker-ca`` (which can be used as part of the manual initial configuration of a cluster's certificates).
-
-``flockerctl`` has commands for listing nodes, creating volumes, and moving them around.
-It supports supplying metadata such as size, name and :ref:`storage-profiles`.
+``flockerctl`` is a CLI for controlling the Flocker Control Service, with commands for listing nodes, creating volumes, and moving them around.
+``flockerctl`` supports supplying metadata such as size, name and :ref:`storage-profiles`.
 
 Install & Configure
 ===================

--- a/docs/flocker-features/flockerctl.rst
+++ b/docs/flocker-features/flockerctl.rst
@@ -18,15 +18,13 @@ The ``flockerctl`` Command
 Install & Configure
 ===================
 
-You can use ``flockerctl`` with Flocker installed via :ref:`any installation method <supported-orchestration-frameworks>`.
-
-Install it with:
+Run the following command to install ``flockerctl``:
 
 .. prompt:: bash $
 
    curl -sSL https://get.flocker.io |sh
 
-If you used our :ref:`CloudFormation installer <cloudformation>` to create your cluster, or an alternative method such as a manual installation, you will need to set some environment variables for ``flockerctl`` to pick up:
+You will need to set some environment variables which define the address and credentials that ``flockerctl`` will use to connect to the Flocker control service:
 
 * ``FLOCKER_CERTS_PATH`` - typically ``/etc/flocker`` if you're running ``flockerctl`` from a node in the cluster, otherwise, where your certificates are stored.
 * ``FLOCKER_USER`` - the name of a flocker user which has ``.key`` and ``.crt`` file in the certs path. See :ref:`generate-api-standalone-flocker`.

--- a/docs/flocker-features/flockerctl.rst
+++ b/docs/flocker-features/flockerctl.rst
@@ -18,9 +18,7 @@ The ``flockerctl`` Command
 Install & Configure
 ===================
 
-``flockerctl`` is packaged along with the :ref:`labs-installer`.
-You don't have to use the labs installer in order to use ``flockerctl``, though.
-You can use ``flockerctl`` with Flocker installed via :ref:`any installation mechanism <supported-orchestration-frameworks>`.
+You can use ``flockerctl`` with Flocker installed via :ref:`any installation method <supported-orchestration-frameworks>`.
 
 Install it with:
 
@@ -28,13 +26,15 @@ Install it with:
 
    curl -sSL https://get.flocker.io |sh
 
-If you use the :ref:`labs-installer` to install your cluster ``flockerctl`` will work with the ``cluster.yml`` file that it generates and figure out how to connect to your cluster based on that.
-
-If you have used an alternative method to create your cluster, such as a manual installation or our :ref:`CloudFormation installer <cloudformation>`, you will need to set some environment variables for ``flockerctl`` to pick up:
+If you used our :ref:`CloudFormation installer <cloudformation>` to create your cluster, or an alternative method such as a manual installation, you will need to set some environment variables for ``flockerctl`` to pick up:
 
 * ``FLOCKER_CERTS_PATH`` - typically ``/etc/flocker`` if you're running ``flockerctl`` from a node in the cluster, otherwise, where your certificates are stored.
 * ``FLOCKER_USER`` - the name of a flocker user which has ``.key`` and ``.crt`` file in the certs path. See :ref:`generate-api-standalone-flocker`.
 * ``FLOCKER_CONTROL_SERVICE`` - the address (DNS name or IP address) of the control service. The name you use should match up with the name you specified when creating the cluster certificates.
+
+.. note::
+
+   If you used the :ref:`labs-installer` to install your cluster, ``flockerctl`` will work with the generated ``cluster.yml`` file and can  figure out how to connect to your cluster based on that.
 
 Running the CLI
 ===============


### PR DESCRIPTION
Fixes 4146

The flockerctl document had several references to the Labs installer, and some confusing text about other Flocker tools. This issue cleans that up.