### PR TITLE
[FLOC-4145] Test type of JSON schema validation errors

### DIFF
--- a/flocker/control/schema/types.yml
+++ b/flocker/control/schema/types.yml
@@ -150,6 +150,7 @@ definitions:
     patternProperties:
       "^.+$":
         type: string
+    additionalProperties: false
 
   volume:
     title: "A volume attached to a container"

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -333,7 +333,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'node_uuid': a_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
-                'volumes': [{'dataset_id': "x" * 36}],
+                'volumes': [{'dataset_id': a_uuid}],
             },
         ],
         INVALID_WRONG_TYPE: [
@@ -463,7 +463,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'node_uuid': a_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
-                'volumes': [{'dataset_id': "x" * 36,
+                'volumes': [{'dataset_id': a_uuid,
                              'mountpoint': 123}],
             },
             # Command line must be array
@@ -591,7 +591,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             'node_uuid': a_uuid,
             'image': 'postgres',
             'name': 'postgres',
-            'volumes': [{'dataset_id': unicode(uuid4()),
+            'volumes': [{'dataset_id': a_uuid,
                          'mountpoint': '/var/db'}],
         },
         {
@@ -703,7 +703,7 @@ CONFIGURATION_DATASETS_PASSING_INSTANCES = [
          dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256)},
 
     # dataset_id is a string of 36 characters
-    {u"primary": a_uuid, u"dataset_id": unicode(uuid4())},
+    {u"primary": a_uuid, u"dataset_id": a_uuid},
 
     # deleted is a boolean
     {u"primary": a_uuid, u"deleted": False},
@@ -718,7 +718,7 @@ CONFIGURATION_DATASETS_PASSING_INSTANCES = [
      u"metadata":
          dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256),
      u"maximum_size": 1024 * 1024 * 64,
-     u"dataset_id": unicode(uuid4()),
+     u"dataset_id": a_uuid,
      u"deleted": True},
 ]
 
@@ -745,14 +745,16 @@ CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES = (
     CONFIGURATION_DATASETS_FAILING_INSTANCES.copy()
 )
 
-CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES[INVALID_OBJECT_PROPERTY_MISSING] = (
-    CONFIGURATION_DATASETS_FAILING_INSTANCES.get(INVALID_OBJECT_PROPERTY_MISSING, []) + [
-        # primary is required for create
-        {u"metadata": {},
-         u"maximum_size": 1024 * 1024 * 1024,
-         u"dataset_id": a_uuid}
-    ]
-)
+CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES[
+    INVALID_OBJECT_PROPERTY_MISSING
+] = CONFIGURATION_DATASETS_FAILING_INSTANCES.get(
+    INVALID_OBJECT_PROPERTY_MISSING, []
+) + [
+    # primary is required for create
+    {u"metadata": {},
+     u"maximum_size": 1024 * 1024 * 1024,
+     u"dataset_id": a_uuid}
+]
 
 ConfigurationDatasetsCreateSchemaTests = build_schema_test(
     name="ConfigurationDatasetsCreateSchemaTests",
@@ -768,12 +770,6 @@ StateDatasetsArraySchemaTests = build_schema_test(
     schema={'$ref': '/v1/endpoints.json#/definitions/state_datasets_array'},
     schema_store=SCHEMAS,
     failing_instances={
-        INVALID_STRING_PATTERN: [
-            # null primary
-            [{u"primary": None,
-              u"maximum_size": 1024 * 1024 * 1024,
-              u"dataset_id": u"x" * 36}],
-        ],
         INVALID_OBJECT_PROPERTY_MISSING: [
             # missing dataset_id
             [{u"primary": a_uuid,
@@ -783,10 +779,15 @@ StateDatasetsArraySchemaTests = build_schema_test(
             # not an array
             {}, u"lalala", 123,
 
+            # null primary
+            [{u"primary": None,
+              u"maximum_size": 1024 * 1024 * 1024,
+              u"dataset_id": a_uuid}],
+
             # null path
             [{u"path": None,
               u"maximum_size": 1024 * 1024 * 1024,
-              u"dataset_id": u"x" * 36}],
+              u"dataset_id": a_uuid}],
 
             # XXX Ideally there'd be a couple more tests here:
             # * primary without path
@@ -795,27 +796,27 @@ StateDatasetsArraySchemaTests = build_schema_test(
 
             # wrong type for path
             [{u"primary": a_uuid,
-              u"dataset_id": u"x" * 36,
+              u"dataset_id": a_uuid,
               u"path": 123}],
         ],
     },
     passing_instances=[
         # missing primary and path
         [{u"maximum_size": 1024 * 1024 * 1024,
-          u"dataset_id": unicode(uuid4())}],
+          u"dataset_id": a_uuid}],
 
         # maximum_size is integer
         [{u"primary": a_uuid,
-          u"dataset_id": unicode(uuid4()),
+          u"dataset_id": a_uuid,
           u"path": u"/123",
           u"maximum_size": 1024 * 1024 * 64}],
 
         # multiple entries:
         [{u"primary": a_uuid,
-          u"dataset_id": unicode(uuid4()),
+          u"dataset_id": a_uuid,
           u"path": u"/123"},
          {u"primary": a_uuid,
-          u"dataset_id": unicode(uuid4()),
+          u"dataset_id": a_uuid,
           u"path": u"/123",
           u"maximum_size": 1024 * 1024 * 64}],
     ]
@@ -940,8 +941,8 @@ NodeTests = build_schema_test(
 )
 
 
-LEASE_WITH_EXPIRATION = {'dataset_id': unicode(uuid4()),
-                         'node_uuid': unicode(uuid4()),
+LEASE_WITH_EXPIRATION = {'dataset_id': a_uuid,
+                         'node_uuid': a_uuid,
                          'expires': 15}
 # Can happen sometimes, means time went backwards or a bug but at least we
 # should report things accurately.

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -24,7 +24,7 @@ INVALID_OBJECT_PROPERTIES_MAXIMUM = 'maxProperties'
 INVALID_OBJECT_NO_MATCH = 'oneOf'
 INVALID_WRONG_TYPE = 'type'
 
-a_uuid = unicode(uuid4())
+valid_uuid = unicode(uuid4())
 
 # The following two UUIDs are invalid, but are of the correct
 # length and loose format for a UUID. They will be caught out
@@ -73,7 +73,7 @@ ConfigurationContainersUpdateSchemaTests = build_schema_test(
     failing_instances={
         INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Extra properties
-            {u'node_uuid': a_uuid, u'image': u'nginx:latest'},
+            {u'node_uuid': valid_uuid, u'image': u'nginx:latest'},
         ],
         INVALID_STRING_PATTERN: [
             # Node UUID not a uuid
@@ -89,7 +89,7 @@ ConfigurationContainersUpdateSchemaTests = build_schema_test(
         ],
     },
     passing_instances=[
-        {u'node_uuid': a_uuid},
+        {u'node_uuid': valid_uuid},
     ],
 )
 
@@ -102,7 +102,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
         INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Volume with extra field
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'volumes': [{'dataset_id': "x" * 36,
@@ -111,14 +111,14 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Ports given but invalid key present
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'ports': [{'container': 80, 'external': '1'}]
             },
             # Environment given with empty name
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'environment': {
@@ -130,7 +130,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
         INVALID_NUMERIC_TOO_HIGH: [
             # Links given but local port is greater than max (65535)
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -141,7 +141,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Links given but remote port is greater than max (65535)
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -152,7 +152,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # CPU shares given but greater than max
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'cpu_shares': 1025
@@ -161,7 +161,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
         INVALID_ARRAY_ITEMS_MAXIMUM: [
             # More than one volume (this will eventually work - see FLOC-49)
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'volumes': [{'dataset_id': "x" * 36,
@@ -173,14 +173,14 @@ ConfigurationContainersSchemaTests = build_schema_test(
         INVALID_NUMERIC_TOO_LOW: [
             # CPU shares given but negative
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'cpu_shares': -512
             },
             # Memory limit given but negative
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'memory_limit': -1024
@@ -190,21 +190,21 @@ ConfigurationContainersSchemaTests = build_schema_test(
             # None of the schemas under oneOf match, so all errors are oneOf
             # Restart policy given but not a string
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'restart_policy': 1
             },
             # Restart policy string given but not an allowed value
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'restart_policy': {"name": "no restart"}
             },
             # Restart policy is on-failure but max retry count is negative
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'restart_policy': {
@@ -213,7 +213,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Restart policy is on-failure but max retry count is NaN
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'restart_policy': 'on-failure',
@@ -223,7 +223,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Restart policy has max retry count but no name
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'restart_policy': 'on-failure',
@@ -252,10 +252,14 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'name': 'my_container'
             },
             # Name not valid
-            {'node_uuid': a_uuid, 'image': 'clusterhq/redis', 'name': '@*!'},
+            {
+                'node_uuid': valid_uuid,
+                'image': 'clusterhq/redis',
+                'name': '@*!'
+            },
             # Links given but alias has hyphen
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -266,7 +270,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Links given but alias has underscore
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -277,23 +281,23 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Path doesn't start with /
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
-                'volumes': [{'dataset_id': a_uuid,
+                'volumes': [{'dataset_id': valid_uuid,
                              'mountpoint': 'var/db2'}],
             },
         ],
         INVALID_OBJECT_PROPERTY_MISSING: [
             # Name missing
-            {'node_uuid': a_uuid, 'image': 'clusterhq/redis'},
+            {'node_uuid': valid_uuid, 'image': 'clusterhq/redis'},
             # node_uuid missing
             {'image': 'clusterhq/redis', 'name': 'my_container'},
             # Image missing
-            {'node_uuid': a_uuid, 'name': 'my_container'},
+            {'node_uuid': valid_uuid, 'name': 'my_container'},
             # Links given but alias missing
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -303,7 +307,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Links given but local port missing
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -313,7 +317,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Links given but remote port missing
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -323,17 +327,17 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Volume missing dataset_id
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'volumes': [{'mountpoint': '/var/db'}],
             },
             # Volume missing mountpoint
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
-                'volumes': [{'dataset_id': a_uuid}],
+                'volumes': [{'dataset_id': valid_uuid}],
             },
         ],
         INVALID_WRONG_TYPE: [
@@ -344,47 +348,47 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'name': 'my_container'
             },
             # Name wrong type
-            {'node_uuid': a_uuid, 'image': 'clusterhq/redis', 'name': 1},
+            {'node_uuid': valid_uuid, 'image': 'clusterhq/redis', 'name': 1},
             # Image wrong type
-            {'node_uuid': a_uuid, 'image': 1, 'name': 'my_container'},
+            {'node_uuid': valid_uuid, 'image': 1, 'name': 'my_container'},
             # Ports given but not a list of mappings
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'ports': 'I am not a list of port maps'
             },
             # Ports given but internal is not valid
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'ports': [{'internal': 'xxx', 'external': 8080}]
             },
             # Ports given but external is not valid
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'ports': [{'internal': 80, 'external': '1'}]
             },
             # Ports given but external is not valid integer
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'ports': [{'internal': 80, 'external': 22.5}]
             },
             # Environment given but not a dict
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'environment': 'x=y'
             },
             # Environment given but at least one entry is not a string
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'environment': {
@@ -394,21 +398,21 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # CPU shares given but not an integer
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'cpu_shares': '512'
             },
             # Memory limit given but not an integer
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'memory_limit': '250MB'
             },
             # Links given but not a list
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': {
@@ -419,7 +423,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Links given but alias is not a string
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -430,7 +434,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Links given but local port is not an integer
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -441,7 +445,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Links given but remote port is not an integer
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'nginx:latest',
                 'name': 'webserver',
                 'links': [{
@@ -452,7 +456,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Volume with dataset_id of wrong type
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'volumes': [{'dataset_id': 123,
@@ -460,22 +464,22 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
             # Volume with mountpoint of wrong type
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
-                'volumes': [{'dataset_id': a_uuid,
+                'volumes': [{'dataset_id': valid_uuid,
                              'mountpoint': 123}],
             },
             # Command line must be array
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'command_line': 'xx'
             },
             # Command line must be array of strings
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'command_line': ['xx', 123]
@@ -484,7 +488,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
         INVALID_ARRAY_ITEMS_NOT_UNIQUE: [
             # Ports given but not unique
             {
-                'node_uuid': a_uuid,
+                'node_uuid': valid_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
                 'ports': [
@@ -496,33 +500,33 @@ ConfigurationContainersSchemaTests = build_schema_test(
     },
     passing_instances=[
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': 'postgres'
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': '/postgres-8.1_server'
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres',
             'name': 'postgres'
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres:latest',
             'name': 'postgres'
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': 'postgres',
             'ports': [{'internal': 80, 'external': 8080}]
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': 'postgres',
             'ports': [
@@ -531,7 +535,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             ]
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': 'postgres',
             'environment': {
@@ -540,25 +544,25 @@ ConfigurationContainersSchemaTests = build_schema_test(
             }
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres:latest',
             'name': 'postgres',
             'restart_policy': {'name': 'never'}
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres:latest',
             'name': 'postgres',
             'restart_policy': {'name': 'always'}
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres:latest',
             'name': 'postgres',
             'restart_policy': {'name': 'on-failure'}
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres:latest',
             'name': 'postgres',
             'restart_policy': {
@@ -566,19 +570,19 @@ ConfigurationContainersSchemaTests = build_schema_test(
             }
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres:latest',
             'name': 'postgres',
             'cpu_shares': 512
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'docker/postgres:latest',
             'name': 'postgres',
             'memory_limit': 262144000
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'nginx:latest',
             'name': 'webserver',
             'links': [{
@@ -588,20 +592,20 @@ ConfigurationContainersSchemaTests = build_schema_test(
             }]
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': 'postgres',
-            'volumes': [{'dataset_id': a_uuid,
+            'volumes': [{'dataset_id': valid_uuid,
                          'mountpoint': '/var/db'}],
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': 'postgres',
             'volumes': [],
         },
         {
-            'node_uuid': a_uuid,
+            'node_uuid': valid_uuid,
             'image': 'postgres',
             'name': 'postgres',
             'command_line': ['ls', '/data'],
@@ -612,113 +616,113 @@ ConfigurationContainersSchemaTests = build_schema_test(
 CONFIGURATION_DATASETS_FAILING_INSTANCES = {
     INVALID_OBJECT_PROPERTY_UNDEFINED: [
         # too-long string property name in metadata
-        {u"primary": a_uuid, u"metadata": {u"x" * 257: u"10"}},
+        {u"primary": valid_uuid, u"metadata": {u"x" * 257: u"10"}},
     ],
     INVALID_OBJECT_PROPERTIES_MAXIMUM: [
         # too many metadata properties
-        {u"primary": a_uuid,
+        {u"primary": valid_uuid,
          u"metadata":
              dict.fromkeys((unicode(i) for i in range(257)), u"value")},
     ],
     INVALID_STRING_TOO_LONG: [
         # too-long string property value in metadata
-        {u"primary": a_uuid, u"metadata": {u"foo": u"x" * 257}},
+        {u"primary": valid_uuid, u"metadata": {u"foo": u"x" * 257}},
     ],
     INVALID_NUMERIC_TOO_LOW: [
         # too-small (but multiple of 1024) value for maximum size
-        {u"primary": a_uuid, u"maximum_size": 1024},
+        {u"primary": valid_uuid, u"maximum_size": 1024},
     ],
     INVALID_NUMERIC_NOT_MULTIPLE_OF: [
         # Value for maximum_size that is not a multiple of 1024 (but is larger
         # than the minimum allowed)
-        {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64 + 1023},
+        {u"primary": valid_uuid, u"maximum_size": 1024 * 1024 * 64 + 1023},
     ],
     INVALID_STRING_PATTERN: [
         # too short string for dataset_id
-        {u"primary": a_uuid, u"dataset_id": a_uuid[:35]},
+        {u"primary": valid_uuid, u"dataset_id": valid_uuid[:35]},
 
         # too long string for dataset_id
-        {u"primary": a_uuid, u"dataset_id": a_uuid + 'a'},
+        {u"primary": valid_uuid, u"dataset_id": valid_uuid + 'a'},
 
         # dataset_id not a valid UUID
-        {u"primary": a_uuid, u"dataset_id": bad_uuid_1},
+        {u"primary": valid_uuid, u"dataset_id": bad_uuid_1},
 
         # non-IPv4-address for primary
         {u"primary": u"10.0.0.257",
          u"metadata": {},
          u"maximum_size": 1024 * 1024 * 1024,
-         u"dataset_id": a_uuid},
+         u"dataset_id": valid_uuid},
 
         {u"primary": u"example.com",
          u"metadata": {},
          u"maximum_size": 1024 * 1024 * 1024,
-         u"dataset_id": a_uuid},
+         u"dataset_id": valid_uuid},
 
     ],
     INVALID_WRONG_TYPE: [
         # wrong type for dataset_id
-        {u"primary": a_uuid, u"dataset_id": 10},
+        {u"primary": valid_uuid, u"dataset_id": 10},
 
         # wrong type for metadata
-        {u"primary": a_uuid, u"metadata": 10},
+        {u"primary": valid_uuid, u"metadata": 10},
 
         # wrong type for value in metadata
-        {u"primary": a_uuid, u"metadata": {u"foo": 10}},
+        {u"primary": valid_uuid, u"metadata": {u"foo": 10}},
 
         # wrong type for maximum size
-        {u"primary": a_uuid, u"maximum_size": u"123"},
+        {u"primary": valid_uuid, u"maximum_size": u"123"},
 
         # wrong numeric type for maximum size
-        {u"primary": a_uuid, u"maximum_size": float(1024 * 1024 * 64)},
+        {u"primary": valid_uuid, u"maximum_size": float(1024 * 1024 * 64)},
 
         # wrong type for primary
         {u"primary": 10,
          u"metadata": {},
          u"maximum_size": 1024 * 1024 * 1024,
-         u"dataset_id": a_uuid},
+         u"dataset_id": valid_uuid},
 
         # wrong type for deleted
-        {u"primary": a_uuid,
+        {u"primary": valid_uuid,
          u"deleted": u"hello"},
     ],
 }
 
 CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES = [
     {},
-    {u"primary": a_uuid},
+    {u"primary": valid_uuid},
 ]
 
 CONFIGURATION_DATASETS_UPDATE_FAILING_INSTANCES = {
     INVALID_OBJECT_PROPERTY_UNDEFINED: [
-        {u"primary": a_uuid, u'x': 1},
+        {u"primary": valid_uuid, u'x': 1},
     ],
 }
 
 CONFIGURATION_DATASETS_PASSING_INSTANCES = [
-    {u"primary": a_uuid},
+    {u"primary": valid_uuid},
 
     # metadata is an object with a handful of short string key/values
-    {u"primary": a_uuid,
+    {u"primary": valid_uuid,
      u"metadata":
          dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256)},
 
     # dataset_id is a string of 36 characters
-    {u"primary": a_uuid, u"dataset_id": a_uuid},
+    {u"primary": valid_uuid, u"dataset_id": valid_uuid},
 
     # deleted is a boolean
-    {u"primary": a_uuid, u"deleted": False},
+    {u"primary": valid_uuid, u"deleted": False},
     # maximum_size is an integer of at least 64MiB
-    {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64},
+    {u"primary": valid_uuid, u"maximum_size": 1024 * 1024 * 64},
 
     # maximum_size may be null, which means no size limit
-    {u"primary": a_uuid, u"maximum_size": None},
+    {u"primary": valid_uuid, u"maximum_size": None},
 
     # All of them can be combined.
-    {u"primary": a_uuid,
+    {u"primary": valid_uuid,
      u"metadata":
          dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256),
      u"maximum_size": 1024 * 1024 * 64,
-     u"dataset_id": a_uuid,
+     u"dataset_id": valid_uuid,
      u"deleted": True},
 ]
 
@@ -753,7 +757,7 @@ CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES[
     # primary is required for create
     {u"metadata": {},
      u"maximum_size": 1024 * 1024 * 1024,
-     u"dataset_id": a_uuid}
+     u"dataset_id": valid_uuid}
 ]
 
 ConfigurationDatasetsCreateSchemaTests = build_schema_test(
@@ -772,7 +776,7 @@ StateDatasetsArraySchemaTests = build_schema_test(
     failing_instances={
         INVALID_OBJECT_PROPERTY_MISSING: [
             # missing dataset_id
-            [{u"primary": a_uuid,
+            [{u"primary": valid_uuid,
               u"path": u"/123"}],
         ],
         INVALID_WRONG_TYPE: [
@@ -782,12 +786,12 @@ StateDatasetsArraySchemaTests = build_schema_test(
             # null primary
             [{u"primary": None,
               u"maximum_size": 1024 * 1024 * 1024,
-              u"dataset_id": a_uuid}],
+              u"dataset_id": valid_uuid}],
 
             # null path
             [{u"path": None,
               u"maximum_size": 1024 * 1024 * 1024,
-              u"dataset_id": a_uuid}],
+              u"dataset_id": valid_uuid}],
 
             # XXX Ideally there'd be a couple more tests here:
             # * primary without path
@@ -795,28 +799,28 @@ StateDatasetsArraySchemaTests = build_schema_test(
             # See FLOC-2170
 
             # wrong type for path
-            [{u"primary": a_uuid,
-              u"dataset_id": a_uuid,
+            [{u"primary": valid_uuid,
+              u"dataset_id": valid_uuid,
               u"path": 123}],
         ],
     },
     passing_instances=[
         # missing primary and path
         [{u"maximum_size": 1024 * 1024 * 1024,
-          u"dataset_id": a_uuid}],
+          u"dataset_id": valid_uuid}],
 
         # maximum_size is integer
-        [{u"primary": a_uuid,
-          u"dataset_id": a_uuid,
+        [{u"primary": valid_uuid,
+          u"dataset_id": valid_uuid,
           u"path": u"/123",
           u"maximum_size": 1024 * 1024 * 64}],
 
         # multiple entries:
-        [{u"primary": a_uuid,
-          u"dataset_id": a_uuid,
+        [{u"primary": valid_uuid,
+          u"dataset_id": valid_uuid,
           u"path": u"/123"},
-         {u"primary": a_uuid,
-          u"dataset_id": a_uuid,
+         {u"primary": valid_uuid,
+          u"dataset_id": valid_uuid,
           u"path": u"/123",
           u"maximum_size": 1024 * 1024 * 64}],
     ]
@@ -830,7 +834,7 @@ ConfigurationDatasetsListTests = build_schema_test(
     failing_instances={
         INVALID_NUMERIC_TOO_LOW: [
             # Failing dataset type (maximum_size less than minimum allowed)
-            [{u"primary": a_uuid, u"maximum_size": 123}],
+            [{u"primary": valid_uuid, u"maximum_size": 123}],
         ],
         INVALID_WRONG_TYPE: [
             # Incorrect type
@@ -841,8 +845,8 @@ ConfigurationDatasetsListTests = build_schema_test(
     },
     passing_instances=[
         [],
-        [{u"primary": a_uuid}],
-        [{u"primary": a_uuid}, {u"primary": unicode(uuid4())}]
+        [{u"primary": valid_uuid}],
+        [{u"primary": valid_uuid}, {u"primary": valid_uuid}]
     ],
 )
 
@@ -854,7 +858,7 @@ StateContainersArrayTests = build_schema_test(
     failing_instances={
         INVALID_OBJECT_PROPERTY_MISSING: [
             # Failing dataset type (missing running)
-            [{u"node_uuid": a_uuid, u"name": u"lalala",
+            [{u"node_uuid": valid_uuid, u"name": u"lalala",
               u"image": u"busybox:latest"}]
         ],
         INVALID_WRONG_TYPE: [
@@ -867,15 +871,15 @@ StateContainersArrayTests = build_schema_test(
     passing_instances=[
         [],
         [{u"name": u"lalala",
-          u"node_uuid": a_uuid,
+          u"node_uuid": valid_uuid,
           u"image": u"busybox:latest", u'running': True}],
         [{
-            u"node_uuid": a_uuid,
+            u"node_uuid": valid_uuid,
             u'image': u'nginx:latest',
             u'name': u'webserver2',
             u'running': True},
          {
-             u"node_uuid": unicode(uuid4()),
+             u"node_uuid": valid_uuid,
              u'image': u'nginx:latest',
              u'name': u'webserver',
              u'running': False}],
@@ -890,28 +894,28 @@ NodesTests = build_schema_test(
     failing_instances={
         INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Extra key
-            [{'host': '192.168.1.10', 'uuid': unicode(uuid4()), 'x': 'y'}],
+            [{'host': '192.168.1.10', 'uuid': valid_uuid, 'x': 'y'}],
         ],
         INVALID_OBJECT_PROPERTY_MISSING: [
             # Missing host
-            [{"uuid": unicode(uuid4())}],
+            [{"uuid": valid_uuid}],
             # Missing uuid
             [{'host': '192.168.1.10'}],
         ],
         INVALID_WRONG_TYPE: [
             # Wrong type
-            {'host': '192.168.1.10', 'uuid': unicode(uuid4())},
+            {'host': '192.168.1.10', 'uuid': valid_uuid},
             # Wrong uuid type
             [{'host': '192.168.1.10', 'uuid': 123}],
             # Wrong host type
-            [{'host': 192, 'uuid': unicode(uuid4())}],
+            [{'host': 192, 'uuid': valid_uuid}],
         ],
     },
     passing_instances=[
         [],
-        [{'host': '192.168.1.10', 'uuid': unicode(uuid4())}],
-        [{'host': '192.168.1.10', 'uuid': unicode(uuid4())},
-         {'host': '192.168.1.11', 'uuid': unicode(uuid4())}],
+        [{'host': '192.168.1.10', 'uuid': valid_uuid}],
+        [{'host': '192.168.1.10', 'uuid': valid_uuid},
+         {'host': '192.168.1.11', 'uuid': valid_uuid}],
     ],
 )
 
@@ -922,7 +926,7 @@ NodeTests = build_schema_test(
     failing_instances={
         INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Extra key
-            {'uuid': unicode(uuid4()), 'x': 'y'},
+            {'uuid': valid_uuid, 'x': 'y'},
         ],
         INVALID_OBJECT_PROPERTY_MISSING: [
             # Missing uuid
@@ -936,47 +940,47 @@ NodeTests = build_schema_test(
         ],
     },
     passing_instances=[
-        {'uuid': unicode(uuid4())},
+        {'uuid': valid_uuid},
     ],
 )
 
 
-LEASE_WITH_EXPIRATION = {'dataset_id': a_uuid,
-                         'node_uuid': a_uuid,
+LEASE_WITH_EXPIRATION = {'dataset_id': valid_uuid,
+                         'node_uuid': valid_uuid,
                          'expires': 15}
 # Can happen sometimes, means time went backwards or a bug but at least we
 # should report things accurately.
-LEASE_WITH_NEGATIVE_EXPIRATION = {'dataset_id': unicode(uuid4()),
-                                  'node_uuid': unicode(uuid4()),
+LEASE_WITH_NEGATIVE_EXPIRATION = {'dataset_id': valid_uuid,
+                                  'node_uuid': valid_uuid,
                                   'expires': -0.1}
-LEASE_NO_EXPIRES = {'dataset_id': unicode(uuid4()),
-                    'node_uuid': unicode(uuid4()),
+LEASE_NO_EXPIRES = {'dataset_id': valid_uuid,
+                    'node_uuid': valid_uuid,
                     'expires': None}
 BAD_LEASES = {
     INVALID_OBJECT_PROPERTY_UNDEFINED: [
         # Extra key:
-        {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
+        {'dataset_id': valid_uuid, 'node_uuid': valid_uuid,
          'expires': None, 'extra': 'key'},
     ],
     INVALID_OBJECT_PROPERTY_MISSING: [
         # Missing dataset_id:
-        {'node_uuid': unicode(uuid4()), 'expires': None},
+        {'node_uuid': valid_uuid, 'expires': None},
         # Missing node_uuid:
-        {'dataset_id': unicode(uuid4()), 'expires': None},
+        {'dataset_id': valid_uuid, 'expires': None},
         # Missing expires:
-        {'node_uuid': unicode(uuid4()), 'dataset_id': unicode(uuid4())},
+        {'node_uuid': valid_uuid, 'dataset_id': valid_uuid},
     ],
     INVALID_WRONG_TYPE: [
         # Wrong types:
         None, [], 1,
         # Wrong type for dataset_id:
-        {'node_uuid': unicode(uuid4()), 'dataset_id': 123,
+        {'node_uuid': valid_uuid, 'dataset_id': 123,
          'expires': None},
         # Wrong type for node_uuid:
-        {'dataset_id': unicode(uuid4()), 'node_uuid': 123,
+        {'dataset_id': valid_uuid, 'node_uuid': 123,
          'expires': None},
         # Wrong type for expires:
-        {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
+        {'dataset_id': valid_uuid, 'node_uuid': valid_uuid,
          'expires': []},
     ],
 }

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -26,40 +26,54 @@ VersionsTests = build_schema_test(
     name="VersionsTests",
     schema={'$ref': '/v1/endpoints.json#/definitions/versions'},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Missing version information
-        {},
-        # Wrong type for Flocker version
-        {'flocker': []},
-        # Unexpected version.
-        {
-            'flocker': '0.3.0-10-dirty',
-            'OtherService': '0.3.0-10-dirty',
-        },
-    ],
+    failing_instances={
+        'additionalProperties': [
+            # Unexpected version.
+            {
+                'flocker': '0.3.0-10-dirty',
+                'OtherService': '0.3.0-10-dirty',
+            },
+        ],
+        'required': [
+            # Missing version information
+            {},
+        ],
+        'type': [
+            # Wrong type for Flocker version
+            {'flocker': []},
+        ],
+    },
     passing_instances=[
         {'flocker': '0.3.0-10-dirty'},
     ],
 )
 
 
-ConfigurationContainersSchemaTests = build_schema_test(
+ConfigurationContainersUpdateSchemaTests = build_schema_test(
     name="ConfigurationContainersUpdateSchemaTests",
     schema={
         '$ref':
             '/v1/endpoints.json#/definitions/configuration_container_update'
     },
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Host missing
-        {},
-        # node_uuid wrong type
-        {u'node_uuid': 1},
-        # Node UUID not a uuid
-        {u'node_uuid': u'idonotexist'},
-        # Extra properties
-        {u'node_uuid': a_uuid, u'image': u'nginx:latest'},
-    ],
+    failing_instances={
+        'additionalProperties': [
+            # Extra properties
+            {u'node_uuid': a_uuid, u'image': u'nginx:latest'},
+        ],
+        'pattern': [
+            # Node UUID not a uuid
+            {u'node_uuid': u'idonotexist'},
+        ],
+        'required': [
+            # Host missing
+            {},
+        ],
+        'type': [
+            # node_uuid wrong type
+            {u'node_uuid': 1},
+        ],
+    },
     passing_instances=[
         {u'node_uuid': a_uuid},
     ],
@@ -70,369 +84,392 @@ ConfigurationContainersSchemaTests = build_schema_test(
     name="ConfigurationContainersSchemaTests",
     schema={'$ref': '/v1/endpoints.json#/definitions/configuration_container'},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # node_uuid wrong type
-        {'node_uuid': 1, 'image': 'clusterhq/redis', 'name': 'my_container'},
-        # node_uuid not UUID format
-        {
-            'node_uuid': 'idonotexist',
-            'image': 'clusterhq/redis',
-            'name': 'my_container'
-        },
-        # node_uuid not a valid v4 UUID
-        {
-            'node_uuid': bad_uuid_1,
-            'image': 'clusterhq/redis',
-            'name': 'my_container'
-        },
-        # node_uuid not a valid hex UUID
-        {
-            'node_uuid': bad_uuid_2,
-            'image': 'clusterhq/redis',
-            'name': 'my_container'
-        },
-        # Name wrong type
-        {'node_uuid': a_uuid, 'image': 'clusterhq/redis', 'name': 1},
-        # Image wrong type
-        {'node_uuid': a_uuid, 'image': 1, 'name': 'my_container'},
-        # Name missing
-        {'node_uuid': a_uuid, 'image': 'clusterhq/redis'},
-        # node_uuid missing
-        {'image': 'clusterhq/redis', 'name': 'my_container'},
-        # Image missing
-        {'node_uuid': a_uuid, 'name': 'my_container'},
-        # Name not valid
-        {'node_uuid': a_uuid, 'image': 'clusterhq/redis', 'name': '@*!'},
-        # Ports given but not a list of mappings
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'ports': 'I am not a list of port maps'
-        },
-        # Ports given but internal is not valid
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'ports': [{'internal': 'xxx', 'external': 8080}]
-        },
-        # Ports given but external is not valid
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'ports': [{'internal': 80, 'external': '1'}]
-        },
-        # Ports given but invalid key present
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'ports': [{'container': 80, 'external': '1'}]
-        },
-        # Ports given but external is not valid integer
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'ports': [{'internal': 80, 'external': 22.5}]
-        },
-        # Ports given but not unique
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'ports': [
-                {'internal': 80, 'external': 8080},
-                {'internal': 80, 'external': 8080},
-            ]
-        },
-        # Environment given but not a dict
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'environment': 'x=y'
-        },
-        # Environment given but at least one entry is not a string
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'environment': {
-                'POSTGRES_USER': 'admin',
-                'POSTGRES_VERSION': 9.4
+    failing_instances={
+        'additionalProperties': [
+            # Volume with extra field
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'volumes': [{'dataset_id': "x" * 36,
+                             'mountpoint': '/var/db',
+                             'extra': 'value'}],
+            },
+            # Ports given but invalid key present
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'ports': [{'container': 80, 'external': '1'}]
+            },
+        ],
+        'maximum': [
+            # Links given but local port is greater than max (65535)
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'postgres',
+                    'local_port': 65536,
+                    'remote_port': 54320
+                }]
+            },
+            # Links given but remote port is greater than max (65535)
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'postgres',
+                    'local_port': 5432,
+                    'remote_port': 65536
+                }]
+            },
+            # CPU shares given but greater than max
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'cpu_shares': 1025
+            },
+        ],
+        'maxItems': [
+            # More than one volume (this will eventually work - see FLOC-49)
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'volumes': [{'dataset_id': "x" * 36,
+                             'mountpoint': '/var/db'},
+                            {'dataset_id': "y" * 36,
+                             'mountpoint': '/var/db2'}],
+            },
+        ],
+        'minimum': [
+            # CPU shares given but negative
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'cpu_shares': -512
+            },
+            # Memory limit given but negative
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'memory_limit': -1024
+            },
+        ],
+        'oneOf': [
+            # XXX strange that all these end up here?
+            # Restart policy given but not a string
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'restart_policy': 1
+            },
+            # Restart policy string given but not an allowed value
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'restart_policy': {"name": "no restart"}
+            },
+            # Restart policy is on-failure but max retry count is negative
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'restart_policy': {
+                    "name": "on-failure", "maximum_retry_count": -1
+                }
+            },
+            # Restart policy is on-failure but max retry count is NaN
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'restart_policy': 'on-failure',
+                'restart_policy': {
+                    "name": "on-failure", "maximum_retry_count": "15"
+                }
+            },
+            # Restart policy has max retry count but no name
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'restart_policy': 'on-failure',
+                'restart_policy': {
+                    "maximum_retry_count": 15
+                }
+            },
+        ],
+        'pattern': [
+            # node_uuid not UUID format
+            {
+                'node_uuid': 'idonotexist',
+                'image': 'clusterhq/redis',
+                'name': 'my_container'
+            },
+            # node_uuid not a valid v4 UUID
+            {
+                'node_uuid': bad_uuid_1,
+                'image': 'clusterhq/redis',
+                'name': 'my_container'
+            },
+            # node_uuid not a valid hex UUID
+            {
+                'node_uuid': bad_uuid_2,
+                'image': 'clusterhq/redis',
+                'name': 'my_container'
+            },
+            # Name not valid
+            {'node_uuid': a_uuid, 'image': 'clusterhq/redis', 'name': '@*!'},
+            # Links given but alias has hyphen
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'xxx-yyy',
+                    'local_port': 5432,
+                    'remote_port': 54320
+                }]
+            },
+            # Links given but alias has underscore
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'xxx_yyy',
+                    'local_port': 5432,
+                    'remote_port': 54320
+                }]
+            },
+            # Path doesn't start with /
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'volumes': [{'dataset_id': "y" * 36,
+                             'mountpoint': 'var/db2'}],
+            },
+        ],
+        'required': [
+            # Name missing
+            {'node_uuid': a_uuid, 'image': 'clusterhq/redis'},
+            # node_uuid missing
+            {'image': 'clusterhq/redis', 'name': 'my_container'},
+            # Image missing
+            {'node_uuid': a_uuid, 'name': 'my_container'},
+            # Links given but alias missing
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'local_port': 5432,
+                    'remote_port': 54320
+                }]
+            },
+            # Links given but local port missing
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'postgres',
+                    'remote_port': 54320
+                }]
+            },
+            # Links given but remote port missing
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'postgres',
+                    'local_port': 5432,
+                }]
+            },
+            # Volume missing dataset_id
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'volumes': [{'mountpoint': '/var/db'}],
+            },
+            # Volume missing mountpoint
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'volumes': [{'dataset_id': "x" * 36}],
+            },
+        ],
+        'type': [
+            # node_uuid wrong type
+            {
+                'node_uuid': 1,
+                'image': 'clusterhq/redis',
+                'name': 'my_container'
+            },
+            # Name wrong type
+            {'node_uuid': a_uuid, 'image': 'clusterhq/redis', 'name': 1},
+            # Image wrong type
+            {'node_uuid': a_uuid, 'image': 1, 'name': 'my_container'},
+            # Ports given but not a list of mappings
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'ports': 'I am not a list of port maps'
+            },
+            # Ports given but internal is not valid
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'ports': [{'internal': 'xxx', 'external': 8080}]
+            },
+            # Ports given but external is not valid
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'ports': [{'internal': 80, 'external': '1'}]
+            },
+            # Ports given but external is not valid integer
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'ports': [{'internal': 80, 'external': 22.5}]
+            },
+            # Environment given but not a dict
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'environment': 'x=y'
+            },
+            # Environment given but at least one entry is not a string
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'environment': {
+                    'POSTGRES_USER': 'admin',
+                    'POSTGRES_VERSION': 9.4
+                }
+            },
+            # CPU shares given but not an integer
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'cpu_shares': '512'
+            },
+            # Memory limit given but not an integer
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'memory_limit': '250MB'
+            },
+            # Links given but not a list
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': {
+                    'alias': 'postgres',
+                    'local_port': 5432,
+                    'remote_port': 54320
+                }
+            },
+            # Links given but alias is not a string
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': {"name": "postgres"},
+                    'local_port': 5432,
+                    'remote_port': 54320
+                }]
+            },
+            # Links given but local port is not an integer
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'postgres',
+                    'local_port': '5432',
+                    'remote_port': 54320
+                }]
+            },
+            # Links given but remote port is not an integer
+            {
+                'node_uuid': a_uuid,
+                'image': 'nginx:latest',
+                'name': 'webserver',
+                'links': [{
+                    'alias': 'postgres',
+                    'local_port': 5432,
+                    'remote_port': '54320'
+                }]
+            },
+            # Volume with dataset_id of wrong type
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'volumes': [{'dataset_id': 123,
+                             'mountpoint': '/var/db'}],
+            },
+            # Volume with mountpoint of wrong type
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'volumes': [{'dataset_id': "x" * 36,
+                             'mountpoint': 123}],
+            },
+            # Command line must be array
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'command_line': 'xx'
+            },
+            # Command line must be array of strings
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'command_line': ['xx', 123]
             }
-        },
-        # Restart policy given but not a string
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'restart_policy': 1
-        },
-        # Restart policy string given but not an allowed value
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'restart_policy': {"name": "no restart"}
-        },
-        # Restart policy is on-failure but max retry count is negative
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'restart_policy': {
-                "name": "on-failure", "maximum_retry_count": -1
-            }
-        },
-        # Restart policy is on-failure but max retry count is NaN
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'restart_policy': 'on-failure',
-            'restart_policy': {
-                "name": "on-failure", "maximum_retry_count": "15"
-            }
-        },
-        # Restart policy has max retry count but no name
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'restart_policy': 'on-failure',
-            'restart_policy': {
-                "maximum_retry_count": 15
-            }
-        },
-        # CPU shares given but not an integer
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'cpu_shares': '512'
-        },
-        # CPU shares given but negative
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'cpu_shares': -512
-        },
-        # CPU shares given but greater than max
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'cpu_shares': 1025
-        },
-        # Memory limit given but not an integer
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'memory_limit': '250MB'
-        },
-        # Memory limit given but negative
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'memory_limit': -1024
-        },
-        # Links given but not a list
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': {
-                'alias': 'postgres',
-                'local_port': 5432,
-                'remote_port': 54320
-            }
-        },
-        # Links given but alias missing
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'local_port': 5432,
-                'remote_port': 54320
-            }]
-        },
-        # Links given but alias has hyphen
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'xxx-yyy',
-                'local_port': 5432,
-                'remote_port': 54320
-            }]
-        },
-        # Links given but alias has underscore
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'xxx_yyy',
-                'local_port': 5432,
-                'remote_port': 54320
-            }]
-        },
-        # Links given but local port missing
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'postgres',
-                'remote_port': 54320
-            }]
-        },
-        # Links given but remote port missing
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'postgres',
-                'local_port': 5432,
-            }]
-        },
-        # Links given but alias is not a string
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': {"name": "postgres"},
-                'local_port': 5432,
-                'remote_port': 54320
-            }]
-        },
-        # Links given but local port is not an integer
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'postgres',
-                'local_port': '5432',
-                'remote_port': 54320
-            }]
-        },
-        # Links given but remote port is not an integer
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'postgres',
-                'local_port': 5432,
-                'remote_port': '54320'
-            }]
-        },
-        # Links given but local port is greater than max (65535)
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'postgres',
-                'local_port': 65536,
-                'remote_port': 54320
-            }]
-        },
-        # Links given but remote port is greater than max (65535)
-        {
-            'node_uuid': a_uuid,
-            'image': 'nginx:latest',
-            'name': 'webserver',
-            'links': [{
-                'alias': 'postgres',
-                'local_port': 5432,
-                'remote_port': 65536
-            }]
-        },
-        # Volume with dataset_id of wrong type
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'volumes': [{'dataset_id': 123,
-                         'mountpoint': '/var/db'}],
-        },
-        # Volume with mountpoint of wrong type
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'volumes': [{'dataset_id': "x" * 36,
-                         'mountpoint': 123}],
-        },
-        # Volume missing dataset_id
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'volumes': [{'mountpoint': '/var/db'}],
-        },
-        # Volume missing mountpoint
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'volumes': [{'dataset_id': "x" * 36}],
-        },
-        # Volume with extra field
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'volumes': [{'dataset_id': "x" * 36,
-                         'mountpoint': '/var/db',
-                         'extra': 'value'}],
-        },
-        # More than one volume (this will eventually work - see FLOC-49)
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'volumes': [{'dataset_id': "x" * 36,
-                         'mountpoint': '/var/db'},
-                        {'dataset_id': "y" * 36,
-                         'mountpoint': '/var/db2'}],
-        },
-        # Path doesn't start with /
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'volumes': [{'dataset_id': "y" * 36,
-                         'mountpoint': 'var/db2'}],
-        },
-        # Command line must be array
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'command_line': 'xx'
-        },
-        # Command line must be array of strings
-        {
-            'node_uuid': a_uuid,
-            'image': 'postgres',
-            'name': 'postgres',
-            'command_line': ['xx', 123]
-        }
-    ],
+        ],
+        'uniqueItems': [
+            # Ports given but not unique
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'ports': [
+                    {'internal': 80, 'external': 8080},
+                    {'internal': 80, 'external': 8080},
+                ]
+            },
+        ],
+    },
     passing_instances=[
         {
             'node_uuid': a_uuid,
@@ -548,74 +585,94 @@ ConfigurationContainersSchemaTests = build_schema_test(
     ],
 )
 
-CONFIGURATION_DATASETS_FAILING_INSTANCES = [
-    # wrong type for dataset_id
-    {u"primary": a_uuid, u"dataset_id": 10},
+CONFIGURATION_DATASETS_FAILING_INSTANCES = {
+    'additionalProperties': [
+        # too-long string property name in metadata
+        {u"primary": a_uuid, u"metadata": {u"x" * 257: u"10"}},
+    ],
+    'maxProperties': [
+        # too many metadata properties
+        {u"primary": a_uuid,
+         u"metadata":
+             dict.fromkeys((unicode(i) for i in range(257)), u"value")},
+    ],
+    'maxLength': [
+        # too-long string property value in metadata
+        {u"primary": a_uuid, u"metadata": {u"foo": u"x" * 257}},
+    ],
+    'minimum': [
+        # too-small (but multiple of 1024) value for maximum size
+        {u"primary": a_uuid, u"maximum_size": 1024},
+    ],
+    'multipleOf': [
+        # Value for maximum_size that is not a multiple of 1024 (but is larger
+        # than the minimum allowed)
+        {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64 + 1023},
+    ],
+    'pattern': [
+        # too short string for dataset_id
+        {u"primary": a_uuid, u"dataset_id": u"x" * 35},
 
-    # too short string for dataset_id
-    {u"primary": a_uuid, u"dataset_id": u"x" * 35},
+        # too long string for dataset_id
+        {u"primary": a_uuid, u"dataset_id": u"x" * 37},
 
-    # too long string for dataset_id
-    {u"primary": a_uuid, u"dataset_id": u"x" * 37},
+        # dataset_id not a valid UUID
+        {u"primary": a_uuid, u"dataset_id": bad_uuid_1},
 
-    # dataset_id not a valid UUID
-    {u"primary": a_uuid, u"dataset_id": bad_uuid_1},
+        # non-IPv4-address for primary - XXX invalid dataset_id
+        {u"primary": u"10.0.0.257",
+         u"metadata": {},
+         u"maximum_size": 1024 * 1024 * 1024,
+         u"dataset_id": u"x" * 36},
 
-    # wrong type for metadata
-    {u"primary": a_uuid, u"metadata": 10},
+        {u"primary": u"example.com",
+         u"metadata": {},
+         u"maximum_size": 1024 * 1024 * 1024,
+         u"dataset_id": a_uuid},
 
-    # wrong type for value in metadata
-    {u"primary": a_uuid, u"metadata": {u"foo": 10}},
+    ],
+    'type': [
+        # wrong type for dataset_id
+        {u"primary": a_uuid, u"dataset_id": 10},
 
-    # too-long string property name in metadata
-    {u"primary": a_uuid, u"metadata": {u"x" * 257: u"10"}},
+        # wrong type for metadata
+        {u"primary": a_uuid, u"metadata": 10},
 
-    # too-long string property value in metadata
-    {u"primary": a_uuid, u"metadata": {u"foo": u"x" * 257}},
+        # wrong type for value in metadata
+        {u"primary": a_uuid, u"metadata": {u"foo": 10}},
 
-    # too many metadata properties
-    {u"primary": a_uuid,
-     u"metadata":
-         dict.fromkeys((unicode(i) for i in range(257)), u"value")},
+        # wrong type for maximum size
+        {u"primary": a_uuid, u"maximum_size": u"123"},
 
-    # wrong type for maximum size
-    {u"primary": a_uuid, u"maximum_size": u"123"},
+        # wrong numeric type for maximum size
+        {u"primary": a_uuid, u"maximum_size": float(1024 * 1024 * 64)},
 
-    # wrong numeric type for maximum size
-    {u"primary": a_uuid, u"maximum_size": float(1024 * 1024 * 64)},
+        # wrong type for primary
+        {u"primary": 10,
+         u"metadata": {},
+         u"maximum_size": 1024 * 1024 * 1024,
+         u"dataset_id": a_uuid},
 
-    # too-small (but multiple of 1024) value for maximum size
-    {u"primary": a_uuid, u"maximum_size": 1024},
-
-    # Value for maximum_size that is not a multiple of 1024 (but is larger than
-    # the minimum allowed)
-    {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64 + 1023},
-
-    # wrong type for primary
-    {u"primary": 10,
-     u"metadata": {},
-     u"maximum_size": 1024 * 1024 * 1024,
-     u"dataset_id": a_uuid},
-
-    # non-IPv4-address for primary
-    {u"primary": u"10.0.0.257",
-     u"metadata": {},
-     u"maximum_size": 1024 * 1024 * 1024,
-     u"dataset_id": u"x" * 36},
-    {u"primary": u"example.com",
-     u"metadata": {},
-     u"maximum_size": 1024 * 1024 * 1024,
-     u"dataset_id": a_uuid},
-
-    # wrong type for deleted
-    {u"primary": a_uuid,
-     u"deleted": u"hello"},
-]
+        # wrong type for deleted
+        {u"primary": a_uuid,
+         u"deleted": u"hello"},
+    ],
+}
 
 CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES = [
-    # everything optional except primary
+    # requires primary
     {u"primary": a_uuid},
 ]
+
+CONFIGURATION_DATASETS_UPDATE_FAILING_INSTANCES = {
+    'additionalProperties': [
+        {u"primary": a_uuid, u'x': 1},
+    ],
+    # 'required': [
+    #     # XXX - this passes, seems it should be required
+    #     {}
+    # ],
+}
 
 CONFIGURATION_DATASETS_PASSING_INSTANCES = (
     CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES + [
@@ -660,24 +717,30 @@ ConfigurationDatasetsUpdateSchemaTests = build_schema_test(
     schema={'$ref':
             '/v1/endpoints.json#/definitions/configuration_datasets_update'},
     schema_store=SCHEMAS,
-    failing_instances=CONFIGURATION_DATASETS_FAILING_INSTANCES,
+    failing_instances=CONFIGURATION_DATASETS_UPDATE_FAILING_INSTANCES,
     passing_instances=CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES,
 )
 
+CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES = (
+    CONFIGURATION_DATASETS_FAILING_INSTANCES.copy()
+)
+
+CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES['pattern'] = (
+    CONFIGURATION_DATASETS_FAILING_INSTANCES.get('pattern', []) + [
+        # primary is required for create
+        # XXX actually fails for invalid UUID format for dataset_id
+        {u"metadata": {},
+         u"maximum_size": 1024 * 1024 * 1024,
+         u"dataset_id": u"x" * 36}
+    ]
+)
 
 ConfigurationDatasetsCreateSchemaTests = build_schema_test(
     name="ConfigurationDatasetsCreateSchemaTests",
     schema={'$ref':
             '/v1/endpoints.json#/definitions/configuration_datasets_create'},
     schema_store=SCHEMAS,
-    failing_instances=(
-        CONFIGURATION_DATASETS_FAILING_INSTANCES + [
-            # missing primary
-            {u"metadata": {},
-             u"maximum_size": 1024 * 1024 * 1024,
-             u"dataset_id": u"x" * 36},
-        ]
-    ),
+    failing_instances=CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES,
     passing_instances=CONFIGURATION_DATASETS_PASSING_INSTANCES,
 )
 
@@ -685,35 +748,38 @@ StateDatasetsArraySchemaTests = build_schema_test(
     name="StateDatasetsArraySchemaTests",
     schema={'$ref': '/v1/endpoints.json#/definitions/state_datasets_array'},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # not an array
-        {}, u"lalala", 123,
+    failing_instances={
+        'pattern': [
+            # null primary
+            [{u"primary": None,
+              u"maximum_size": 1024 * 1024 * 1024,
+              u"dataset_id": u"x" * 36}],
+        ],
+        'required': [
+            # missing dataset_id
+            [{u"primary": a_uuid,
+              u"path": u"/123"}],
+        ],
+        'type': [
+            # not an array
+            {}, u"lalala", 123,
 
-        # null primary
-        [{u"primary": None,
-          u"maximum_size": 1024 * 1024 * 1024,
-          u"dataset_id": u"x" * 36}],
+            # null path
+            [{u"path": None,
+              u"maximum_size": 1024 * 1024 * 1024,
+              u"dataset_id": u"x" * 36}],
 
-        # null path
-        [{u"path": None,
-          u"maximum_size": 1024 * 1024 * 1024,
-          u"dataset_id": u"x" * 36}],
+            # XXX Ideally there'd be a couple more tests here:
+            # * primary without path
+            # * path without primary
+            # See FLOC-2170
 
-        # XXX Ideally there'd be a couple more tests here:
-        # * primary without path
-        # * path without primary
-        # See FLOC-2170
-
-        # missing dataset_id
-        [{u"primary": a_uuid,
-          u"path": u"/123"}],
-
-        # wrong type for path
-        [{u"primary": a_uuid,
-          u"dataset_id": u"x" * 36,
-          u"path": 123}],
-    ],
-
+            # wrong type for path
+            [{u"primary": a_uuid,
+              u"dataset_id": u"x" * 36,
+              u"path": 123}],
+        ],
+    },
     passing_instances=[
         # missing primary and path
         [{u"maximum_size": 1024 * 1024 * 1024,
@@ -741,14 +807,18 @@ ConfigurationDatasetsListTests = build_schema_test(
     schema={'$ref':
             '/v1/endpoints.json#/definitions/configuration_datasets_list'},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Incorrect type
-        {},
-        # Wrong item type
-        ["string"],
-        # Failing dataset type (maximum_size less than minimum allowed)
-        [{u"primary": a_uuid, u"maximum_size": 123}]
-    ],
+    failing_instances={
+        'minimum': [
+            # Failing dataset type (maximum_size less than minimum allowed)
+            [{u"primary": a_uuid, u"maximum_size": 123}],
+        ],
+        'type': [
+            # Incorrect type
+            {},
+            # Wrong item type
+            ["string"],
+        ],
+    },
     passing_instances=[
         [],
         [{u"primary": a_uuid}],
@@ -761,15 +831,19 @@ StateContainersArrayTests = build_schema_test(
     schema={'$ref':
             '/v1/endpoints.json#/definitions/state_containers_array'},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Incorrect type
-        {},
-        # Wrong item type
-        ["string"],
-        # Failing dataset type (missing running)
-        [{u"node_uuid": a_uuid, u"name": u"lalala",
-          u"image": u"busybox:latest"}]
-    ],
+    failing_instances={
+        'required': [
+            # Failing dataset type (missing running)
+            [{u"node_uuid": a_uuid, u"name": u"lalala",
+              u"image": u"busybox:latest"}]
+        ],
+        'type': [
+            # Incorrect type
+            {},
+            # Wrong item type
+            ["string"],
+        ],
+    },
     passing_instances=[
         [],
         [{u"name": u"lalala",
@@ -793,20 +867,26 @@ NodesTests = build_schema_test(
     name="NodesTests",
     schema={'$ref': '/v1/endpoints.json#/definitions/nodes_array'},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Wrong type
-        {'host': '192.168.1.10', 'uuid': unicode(uuid4())},
-        # Missing host
-        [{"uuid": unicode(uuid4())}],
-        # Missing uuid
-        [{'host': '192.168.1.10'}],
-        # Wrong uuid type
-        [{'host': '192.168.1.10', 'uuid': 123}],
-        # Wrong host type
-        [{'host': 192, 'uuid': unicode(uuid4())}],
-        # Extra key
-        [{'host': '192.168.1.10', 'uuid': unicode(uuid4()), 'x': 'y'}],
-    ],
+    failing_instances={
+        'additionalProperties': [
+            # Extra key
+            [{'host': '192.168.1.10', 'uuid': unicode(uuid4()), 'x': 'y'}],
+        ],
+        'required': [
+            # Missing host
+            [{"uuid": unicode(uuid4())}],
+            # Missing uuid
+            [{'host': '192.168.1.10'}],
+        ],
+        'type': [
+            # Wrong type
+            {'host': '192.168.1.10', 'uuid': unicode(uuid4())},
+            # Wrong uuid type
+            [{'host': '192.168.1.10', 'uuid': 123}],
+            # Wrong host type
+            [{'host': 192, 'uuid': unicode(uuid4())}],
+        ],
+    },
     passing_instances=[
         [],
         [{'host': '192.168.1.10', 'uuid': unicode(uuid4())}],
@@ -819,16 +899,22 @@ NodeTests = build_schema_test(
     name="NodeTests",
     schema={'$ref': '/v1/endpoints.json#/definitions/node'},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Wrong type
-        [], 1, None,
-        # Missing uuid
-        {},
-        # Wrong uuid type
-        {'uuid': 123},
-        # Extra key
-        {'uuid': unicode(uuid4()), 'x': 'y'},
-    ],
+    failing_instances={
+        'additionalProperties': [
+            # Extra key
+            {'uuid': unicode(uuid4()), 'x': 'y'},
+        ],
+        'required': [
+            # Missing uuid
+            {},
+        ],
+        'type': [
+            # Wrong type
+            [], 1, None,
+            # Wrong uuid type
+            {'uuid': 123},
+        ],
+    },
     passing_instances=[
         {'uuid': unicode(uuid4())},
     ],
@@ -846,35 +932,46 @@ LEASE_WITH_NEGATIVE_EXPIRATION = {'dataset_id': unicode(uuid4()),
 LEASE_NO_EXPIRES = {'dataset_id': unicode(uuid4()),
                     'node_uuid': unicode(uuid4()),
                     'expires': None}
-BAD_LEASES = [
-    # Wrong types:
-    None, [], 1,
-    # Missing dataset_id:
-    {'node_uuid': unicode(uuid4()), 'expires': None},
-    # Missing node_uuid:
-    {'dataset_id': unicode(uuid4()), 'expires': None},
-    # Missing expires:
-    {'node_uuid': unicode(uuid4()), 'dataset_id': unicode(uuid4())},
-    # Wrong type for dataset_id:
-    {'node_uuid': unicode(uuid4()), 'dataset_id': 123,
-     'expires': None},
-    # Wrong type for node_uuid:
-    {'dataset_id': unicode(uuid4()), 'node_uuid': 123,
-     'expires': None},
-    # Wrong type for expires:
-    {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
-     'expires': []},
-    # Extra key:
-    {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
-     'expires': None, 'extra': 'key'},
-]
+BAD_LEASES = {
+    'additionalProperties': [
+        # Extra key:
+        {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
+         'expires': None, 'extra': 'key'},
+    ],
+    'required': [
+        # Missing dataset_id:
+        {'node_uuid': unicode(uuid4()), 'expires': None},
+        # Missing node_uuid:
+        {'dataset_id': unicode(uuid4()), 'expires': None},
+        # Missing expires:
+        {'node_uuid': unicode(uuid4()), 'dataset_id': unicode(uuid4())},
+    ],
+    'type': [
+        # Wrong types:
+        None, [], 1,
+        # Wrong type for dataset_id:
+        {'node_uuid': unicode(uuid4()), 'dataset_id': 123,
+         'expires': None},
+        # Wrong type for node_uuid:
+        {'dataset_id': unicode(uuid4()), 'node_uuid': 123,
+         'expires': None},
+        # Wrong type for expires:
+        {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
+         'expires': []},
+    ],
+}
+
+BAD_LEASE_LISTS = {
+    'type': [
+        None, {}, 1
+    ] + list([bad] for bad in BAD_LEASES)
+}
 
 ListLeasesTests = build_schema_test(
     name="ListLeasesTests",
     schema={'$ref': '/v1/endpoints.json#/definitions/list_leases'},
     schema_store=SCHEMAS,
-    failing_instances=[None, {}, 1] + list(
-        [bad] for bad in BAD_LEASES),
+    failing_instances=BAD_LEASE_LISTS,
     passing_instances=[
         [],
         [LEASE_NO_EXPIRES],

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -102,6 +102,16 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'name': 'postgres',
                 'ports': [{'container': 80, 'external': '1'}]
             },
+            # Environment given with empty name
+            {
+                'node_uuid': a_uuid,
+                'image': 'postgres',
+                'name': 'postgres',
+                'environment': {
+                    'POSTGRES_USER': 'admin',
+                    '': 9.4
+                }
+            },
         ],
         'maximum': [
             # Links given but local port is greater than max (65535)

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -10,6 +10,20 @@ from ...restapi.testtools import build_schema_test
 from ..httpapi import SCHEMAS
 
 
+# The validator that detects a validity problem
+INVALID_NUMERIC_NOT_MULTIPLE_OF = 'multipleOf'
+INVALID_NUMERIC_TOO_HIGH = 'maximum'
+INVALID_NUMERIC_TOO_LOW = 'minimum'
+INVALID_STRING_TOO_LONG = 'maxLength'
+INVALID_STRING_PATTERN = 'pattern'
+INVALID_ARRAY_ITEMS_MAXIMUM = 'maxItems'
+INVALID_ARRAY_ITEMS_NOT_UNIQUE = 'uniqueItems'
+INVALID_OBJECT_PROPERTY_MISSING = 'required'
+INVALID_OBJECT_PROPERTY_UNDEFINED = 'additionalProperties'
+INVALID_OBJECT_PROPERTIES_MAXIMUM = 'maxProperties'
+INVALID_OBJECT_NO_MATCH = 'oneOf'
+INVALID_WRONG_TYPE = 'type'
+
 a_uuid = unicode(uuid4())
 
 # The following two UUIDs are invalid, but are of the correct
@@ -27,18 +41,18 @@ VersionsTests = build_schema_test(
     schema={'$ref': '/v1/endpoints.json#/definitions/versions'},
     schema_store=SCHEMAS,
     failing_instances={
-        'additionalProperties': [
+        INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Unexpected version.
             {
                 'flocker': '0.3.0-10-dirty',
                 'OtherService': '0.3.0-10-dirty',
             },
         ],
-        'required': [
+        INVALID_OBJECT_PROPERTY_MISSING: [
             # Missing version information
             {},
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # Wrong type for Flocker version
             {'flocker': []},
         ],
@@ -57,19 +71,19 @@ ConfigurationContainersUpdateSchemaTests = build_schema_test(
     },
     schema_store=SCHEMAS,
     failing_instances={
-        'additionalProperties': [
+        INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Extra properties
             {u'node_uuid': a_uuid, u'image': u'nginx:latest'},
         ],
-        'pattern': [
+        INVALID_STRING_PATTERN: [
             # Node UUID not a uuid
             {u'node_uuid': u'idonotexist'},
         ],
-        'required': [
+        INVALID_OBJECT_PROPERTY_MISSING: [
             # Host missing
             {},
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # node_uuid wrong type
             {u'node_uuid': 1},
         ],
@@ -85,7 +99,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
     schema={'$ref': '/v1/endpoints.json#/definitions/configuration_container'},
     schema_store=SCHEMAS,
     failing_instances={
-        'additionalProperties': [
+        INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Volume with extra field
             {
                 'node_uuid': a_uuid,
@@ -113,7 +127,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 }
             },
         ],
-        'maximum': [
+        INVALID_NUMERIC_TOO_HIGH: [
             # Links given but local port is greater than max (65535)
             {
                 'node_uuid': a_uuid,
@@ -144,7 +158,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'cpu_shares': 1025
             },
         ],
-        'maxItems': [
+        INVALID_ARRAY_ITEMS_MAXIMUM: [
             # More than one volume (this will eventually work - see FLOC-49)
             {
                 'node_uuid': a_uuid,
@@ -156,7 +170,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                              'mountpoint': '/var/db2'}],
             },
         ],
-        'minimum': [
+        INVALID_NUMERIC_TOO_LOW: [
             # CPU shares given but negative
             {
                 'node_uuid': a_uuid,
@@ -172,7 +186,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'memory_limit': -1024
             },
         ],
-        'oneOf': [
+        INVALID_OBJECT_NO_MATCH: [
             # None of the schemas under oneOf match, so all errors are oneOf
             # Restart policy given but not a string
             {
@@ -218,7 +232,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 }
             },
         ],
-        'pattern': [
+        INVALID_STRING_PATTERN: [
             # node_uuid not UUID format
             {
                 'node_uuid': 'idonotexist',
@@ -270,7 +284,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                              'mountpoint': 'var/db2'}],
             },
         ],
-        'required': [
+        INVALID_OBJECT_PROPERTY_MISSING: [
             # Name missing
             {'node_uuid': a_uuid, 'image': 'clusterhq/redis'},
             # node_uuid missing
@@ -322,7 +336,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'volumes': [{'dataset_id': "x" * 36}],
             },
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # node_uuid wrong type
             {
                 'node_uuid': 1,
@@ -467,7 +481,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'command_line': ['xx', 123]
             }
         ],
-        'uniqueItems': [
+        INVALID_ARRAY_ITEMS_NOT_UNIQUE: [
             # Ports given but not unique
             {
                 'node_uuid': a_uuid,
@@ -596,35 +610,35 @@ ConfigurationContainersSchemaTests = build_schema_test(
 )
 
 CONFIGURATION_DATASETS_FAILING_INSTANCES = {
-    'additionalProperties': [
+    INVALID_OBJECT_PROPERTY_UNDEFINED: [
         # too-long string property name in metadata
         {u"primary": a_uuid, u"metadata": {u"x" * 257: u"10"}},
     ],
-    'maxProperties': [
+    INVALID_OBJECT_PROPERTIES_MAXIMUM: [
         # too many metadata properties
         {u"primary": a_uuid,
          u"metadata":
              dict.fromkeys((unicode(i) for i in range(257)), u"value")},
     ],
-    'maxLength': [
+    INVALID_STRING_TOO_LONG: [
         # too-long string property value in metadata
         {u"primary": a_uuid, u"metadata": {u"foo": u"x" * 257}},
     ],
-    'minimum': [
+    INVALID_NUMERIC_TOO_LOW: [
         # too-small (but multiple of 1024) value for maximum size
         {u"primary": a_uuid, u"maximum_size": 1024},
     ],
-    'multipleOf': [
+    INVALID_NUMERIC_NOT_MULTIPLE_OF: [
         # Value for maximum_size that is not a multiple of 1024 (but is larger
         # than the minimum allowed)
         {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64 + 1023},
     ],
-    'pattern': [
+    INVALID_STRING_PATTERN: [
         # too short string for dataset_id
-        {u"primary": a_uuid, u"dataset_id": u"x" * 35},
+        {u"primary": a_uuid, u"dataset_id": a_uuid[:35]},
 
         # too long string for dataset_id
-        {u"primary": a_uuid, u"dataset_id": u"x" * 37},
+        {u"primary": a_uuid, u"dataset_id": a_uuid + 'a'},
 
         # dataset_id not a valid UUID
         {u"primary": a_uuid, u"dataset_id": bad_uuid_1},
@@ -641,7 +655,7 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = {
          u"dataset_id": a_uuid},
 
     ],
-    'type': [
+    INVALID_WRONG_TYPE: [
         # wrong type for dataset_id
         {u"primary": a_uuid, u"dataset_id": 10},
 
@@ -675,7 +689,7 @@ CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES = [
 ]
 
 CONFIGURATION_DATASETS_UPDATE_FAILING_INSTANCES = {
-    'additionalProperties': [
+    INVALID_OBJECT_PROPERTY_UNDEFINED: [
         {u"primary": a_uuid, u'x': 1},
     ],
 }
@@ -731,8 +745,8 @@ CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES = (
     CONFIGURATION_DATASETS_FAILING_INSTANCES.copy()
 )
 
-CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES['required'] = (
-    CONFIGURATION_DATASETS_FAILING_INSTANCES.get('required', []) + [
+CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES[INVALID_OBJECT_PROPERTY_MISSING] = (
+    CONFIGURATION_DATASETS_FAILING_INSTANCES.get(INVALID_OBJECT_PROPERTY_MISSING, []) + [
         # primary is required for create
         {u"metadata": {},
          u"maximum_size": 1024 * 1024 * 1024,
@@ -754,18 +768,18 @@ StateDatasetsArraySchemaTests = build_schema_test(
     schema={'$ref': '/v1/endpoints.json#/definitions/state_datasets_array'},
     schema_store=SCHEMAS,
     failing_instances={
-        'pattern': [
+        INVALID_STRING_PATTERN: [
             # null primary
             [{u"primary": None,
               u"maximum_size": 1024 * 1024 * 1024,
               u"dataset_id": u"x" * 36}],
         ],
-        'required': [
+        INVALID_OBJECT_PROPERTY_MISSING: [
             # missing dataset_id
             [{u"primary": a_uuid,
               u"path": u"/123"}],
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # not an array
             {}, u"lalala", 123,
 
@@ -813,11 +827,11 @@ ConfigurationDatasetsListTests = build_schema_test(
             '/v1/endpoints.json#/definitions/configuration_datasets_list'},
     schema_store=SCHEMAS,
     failing_instances={
-        'minimum': [
+        INVALID_NUMERIC_TOO_LOW: [
             # Failing dataset type (maximum_size less than minimum allowed)
             [{u"primary": a_uuid, u"maximum_size": 123}],
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # Incorrect type
             {},
             # Wrong item type
@@ -837,12 +851,12 @@ StateContainersArrayTests = build_schema_test(
             '/v1/endpoints.json#/definitions/state_containers_array'},
     schema_store=SCHEMAS,
     failing_instances={
-        'required': [
+        INVALID_OBJECT_PROPERTY_MISSING: [
             # Failing dataset type (missing running)
             [{u"node_uuid": a_uuid, u"name": u"lalala",
               u"image": u"busybox:latest"}]
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # Incorrect type
             {},
             # Wrong item type
@@ -873,17 +887,17 @@ NodesTests = build_schema_test(
     schema={'$ref': '/v1/endpoints.json#/definitions/nodes_array'},
     schema_store=SCHEMAS,
     failing_instances={
-        'additionalProperties': [
+        INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Extra key
             [{'host': '192.168.1.10', 'uuid': unicode(uuid4()), 'x': 'y'}],
         ],
-        'required': [
+        INVALID_OBJECT_PROPERTY_MISSING: [
             # Missing host
             [{"uuid": unicode(uuid4())}],
             # Missing uuid
             [{'host': '192.168.1.10'}],
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # Wrong type
             {'host': '192.168.1.10', 'uuid': unicode(uuid4())},
             # Wrong uuid type
@@ -905,15 +919,15 @@ NodeTests = build_schema_test(
     schema={'$ref': '/v1/endpoints.json#/definitions/node'},
     schema_store=SCHEMAS,
     failing_instances={
-        'additionalProperties': [
+        INVALID_OBJECT_PROPERTY_UNDEFINED: [
             # Extra key
             {'uuid': unicode(uuid4()), 'x': 'y'},
         ],
-        'required': [
+        INVALID_OBJECT_PROPERTY_MISSING: [
             # Missing uuid
             {},
         ],
-        'type': [
+        INVALID_WRONG_TYPE: [
             # Wrong type
             [], 1, None,
             # Wrong uuid type
@@ -938,12 +952,12 @@ LEASE_NO_EXPIRES = {'dataset_id': unicode(uuid4()),
                     'node_uuid': unicode(uuid4()),
                     'expires': None}
 BAD_LEASES = {
-    'additionalProperties': [
+    INVALID_OBJECT_PROPERTY_UNDEFINED: [
         # Extra key:
         {'dataset_id': unicode(uuid4()), 'node_uuid': unicode(uuid4()),
          'expires': None, 'extra': 'key'},
     ],
-    'required': [
+    INVALID_OBJECT_PROPERTY_MISSING: [
         # Missing dataset_id:
         {'node_uuid': unicode(uuid4()), 'expires': None},
         # Missing node_uuid:
@@ -951,7 +965,7 @@ BAD_LEASES = {
         # Missing expires:
         {'node_uuid': unicode(uuid4()), 'dataset_id': unicode(uuid4())},
     ],
-    'type': [
+    INVALID_WRONG_TYPE: [
         # Wrong types:
         None, [], 1,
         # Wrong type for dataset_id:
@@ -967,7 +981,7 @@ BAD_LEASES = {
 }
 
 BAD_LEASE_LISTS = {
-    'type': [
+    INVALID_WRONG_TYPE: [
         None, {}, 1
     ] + list([bad] for bad in BAD_LEASES)
 }

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -280,7 +280,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
                 'node_uuid': a_uuid,
                 'image': 'postgres',
                 'name': 'postgres',
-                'volumes': [{'dataset_id': "y" * 36,
+                'volumes': [{'dataset_id': a_uuid,
                              'mountpoint': 'var/db2'}],
             },
         ],

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -749,16 +749,14 @@ CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES = (
     CONFIGURATION_DATASETS_FAILING_INSTANCES.copy()
 )
 
-CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES[
-    INVALID_OBJECT_PROPERTY_MISSING
-] = CONFIGURATION_DATASETS_FAILING_INSTANCES.get(
+CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES.setdefault(
     INVALID_OBJECT_PROPERTY_MISSING, []
-) + [
+).append(
     # primary is required for create
     {u"metadata": {},
      u"maximum_size": 1024 * 1024 * 1024,
      u"dataset_id": valid_uuid}
-]
+)
 
 ConfigurationDatasetsCreateSchemaTests = build_schema_test(
     name="ConfigurationDatasetsCreateSchemaTests",

--- a/flocker/control/test/test_schemas.py
+++ b/flocker/control/test/test_schemas.py
@@ -163,7 +163,7 @@ ConfigurationContainersSchemaTests = build_schema_test(
             },
         ],
         'oneOf': [
-            # XXX strange that all these end up here?
+            # None of the schemas under oneOf match, so all errors are oneOf
             # Restart policy given but not a string
             {
                 'node_uuid': a_uuid,
@@ -619,11 +619,11 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = {
         # dataset_id not a valid UUID
         {u"primary": a_uuid, u"dataset_id": bad_uuid_1},
 
-        # non-IPv4-address for primary - XXX invalid dataset_id
+        # non-IPv4-address for primary
         {u"primary": u"10.0.0.257",
          u"metadata": {},
          u"maximum_size": 1024 * 1024 * 1024,
-         u"dataset_id": u"x" * 36},
+         u"dataset_id": a_uuid},
 
         {u"primary": u"example.com",
          u"metadata": {},
@@ -660,7 +660,7 @@ CONFIGURATION_DATASETS_FAILING_INSTANCES = {
 }
 
 CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES = [
-    # requires primary
+    {},
     {u"primary": a_uuid},
 ]
 
@@ -668,39 +668,35 @@ CONFIGURATION_DATASETS_UPDATE_FAILING_INSTANCES = {
     'additionalProperties': [
         {u"primary": a_uuid, u'x': 1},
     ],
-    # 'required': [
-    #     # XXX - this passes, seems it should be required
-    #     {}
-    # ],
 }
 
-CONFIGURATION_DATASETS_PASSING_INSTANCES = (
-    CONFIGURATION_DATASETS_UPDATE_PASSING_INSTANCES + [
-        # metadata is an object with a handful of short string key/values
-        {u"primary": a_uuid,
-         u"metadata":
-             dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256)},
+CONFIGURATION_DATASETS_PASSING_INSTANCES = [
+    {u"primary": a_uuid},
 
-        # dataset_id is a string of 36 characters
-        {u"primary": a_uuid, u"dataset_id": unicode(uuid4())},
+    # metadata is an object with a handful of short string key/values
+    {u"primary": a_uuid,
+     u"metadata":
+         dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256)},
 
-        # deleted is a boolean
-        {u"primary": a_uuid, u"deleted": False},
-        # maximum_size is an integer of at least 64MiB
-        {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64},
+    # dataset_id is a string of 36 characters
+    {u"primary": a_uuid, u"dataset_id": unicode(uuid4())},
 
-        # maximum_size may be null, which means no size limit
-        {u"primary": a_uuid, u"maximum_size": None},
+    # deleted is a boolean
+    {u"primary": a_uuid, u"deleted": False},
+    # maximum_size is an integer of at least 64MiB
+    {u"primary": a_uuid, u"maximum_size": 1024 * 1024 * 64},
 
-        # All of them can be combined.
-        {u"primary": a_uuid,
-         u"metadata":
-             dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256),
-         u"maximum_size": 1024 * 1024 * 64,
-         u"dataset_id": unicode(uuid4()),
-         u"deleted": True},
-    ]
-)
+    # maximum_size may be null, which means no size limit
+    {u"primary": a_uuid, u"maximum_size": None},
+
+    # All of them can be combined.
+    {u"primary": a_uuid,
+     u"metadata":
+         dict.fromkeys((unicode(i) for i in range(16)), u"x" * 256),
+     u"maximum_size": 1024 * 1024 * 64,
+     u"dataset_id": unicode(uuid4()),
+     u"deleted": True},
+]
 
 ConfigurationDatasetsSchemaTests = build_schema_test(
     name="ConfigurationDatasetsSchemaTests",
@@ -725,13 +721,12 @@ CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES = (
     CONFIGURATION_DATASETS_FAILING_INSTANCES.copy()
 )
 
-CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES['pattern'] = (
-    CONFIGURATION_DATASETS_FAILING_INSTANCES.get('pattern', []) + [
+CONFIGURATION_DATASETS_CREATE_FAILING_INSTANCES['required'] = (
+    CONFIGURATION_DATASETS_FAILING_INSTANCES.get('required', []) + [
         # primary is required for create
-        # XXX actually fails for invalid UUID format for dataset_id
         {u"metadata": {},
          u"maximum_size": 1024 * 1024 * 1024,
-         u"dataset_id": u"x" * 36}
+         u"dataset_id": a_uuid}
     ]
 )
 

--- a/flocker/dockerplugin/test/test_schemas.py
+++ b/flocker/dockerplugin/test/test_schemas.py
@@ -22,18 +22,24 @@ def build_simple_test(command_name):
         name=str(command_name + "Tests"),
         schema={"$ref": "/endpoints.json#/definitions/" + command_name},
         schema_store=SCHEMAS,
-        failing_instances=[
-            # Wrong types:
-            [], "", None,
-            # Missing field:
-            {},
-            # Wrong fields:
-            {"Result": "hello"},
-            # Wrong Err types:
-            {"Err": 1}, {"Err": {}}, {"Err": None},
-            # Extra field:
-            {"Err": "", "Extra": ""},
-        ],
+        failing_instances={
+            b'additionalProperties': [
+                # Extra field:
+                {"Err": "", "Extra": ""},
+                # Wrong fields:
+                {"Result": "hello"},
+            ],
+            b'required': [
+                # Missing field:
+                {},
+            ],
+            b'type': [
+                # Wrong types:
+                [], "", None,
+                # Wrong Err types:
+                {"Err": 1}, {"Err": {}}, {"Err": None},
+            ],
+        },
         passing_instances=[
             {"Err": ""},
             {"Err": "Something went wrong!"},
@@ -48,16 +54,22 @@ PluginActivateTests = build_schema_test(
     name=str("PluginActivateTests"),
     schema={"$ref": "/endpoints.json#/definitions/PluginActivate"},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Wrong types:
-        [], "", None,
-        # Missing field:
-        {},
-        # Wrong fields:
-        {"Result": "hello"},
-        # Extra field:
-        {"Implements": ["VolumeDriver"], "X": "Y"},
-    ],
+    failing_instances={
+        b'additionalProperties': [
+            # Extra field:
+            {"Implements": ["VolumeDriver"], "X": "Y"},
+            # Wrong fields:
+            {"Result": "hello"},
+        ],
+        b'required': [
+            # Missing field:
+            {},
+        ],
+        b'type': [
+            # Wrong types:
+            [], "", None,
+        ],
+    },
     passing_instances=[
         {"Implements": ["VolumeDriver"]},
     ])
@@ -76,16 +88,22 @@ def build_path_result_tests(name):
         name=str(name + "Tests"),
         schema={"$ref": "/endpoints.json#/definitions/" + name},
         schema_store=SCHEMAS,
-        failing_instances=[
-            # Wrong types:
-            [], "", None,
-            # Missing field:
-            {}, {"Mountpoint": "/x"},
-            # Wrong fields:
-            {"Result": "hello"},
-            # Extra field:
-            {"Err": "", "Mountpoint": "/x", "extra": "y"},
-        ],
+        failing_instances={
+            b'additionalProperties': [
+                # Extra field:
+                {"Err": "", "Mountpoint": "/x", "extra": "y"},
+                # Wrong fields:
+                {"Result": "hello"},
+            ],
+            b'required': [
+                # Missing field:
+                {}, {"Mountpoint": "/x"},
+            ],
+            b'type': [
+                # Wrong types:
+                [], "", None,
+            ],
+        },
         passing_instances=[
             {"Err": "Something went wrong."},
             {"Err": "", "Mountpoint": "/x/"},
@@ -99,24 +117,30 @@ GetTests = build_schema_test(
     name=str("GetTests"),
     schema={"$ref": "/endpoints.json#/definitions/Get"},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Wrong types:
-        [], "", None,
-        # Missing field:
-        {}, {"Volume": "/x"},
-        # Wrong fields:
-        {"Result": "hello"},
-        # Extra field:
-        {"Err": "", "Volume": {"Name": "x",
-                               "Mountpoint": "/y"}, "extra": "y"},
-        # Missing field:
-        {"Err": "", "Volume": {"Mountpoint": "/y"}},
-        {"Err": "", "Volume": {"Name": "/x"}},
-        # Extra field:
-        {"Err": "", "Volume": {"Name": "/x",
-                               "Mountpoint": "y",
-                               "extra": "r"}},
-    ],
+    failing_instances={
+        b'additionalProperties': [
+            # Extra field:
+            {"Err": "", "Volume": {"Name": "x",
+                                   "Mountpoint": "/y"}, "extra": "y"},
+            # Extra field:
+            {"Err": "", "Volume": {"Name": "/x",
+                                   "Mountpoint": "y",
+                                   "extra": "r"}},
+            # Wrong fields:
+            {"Result": "hello"},
+        ],
+        b'required': [
+            # Missing field:
+            {}, {"Volume": "/x"},
+            # Missing field:
+            {"Err": "", "Volume": {"Mountpoint": "/y"}},
+            {"Err": "", "Volume": {"Name": "/x"}},
+        ],
+        b'type': [
+            # Wrong types:
+            [], "", None,
+        ],
+    },
     passing_instances=[
         {"Err": "Something went wrong."},
         {"Err": "", "Volume": {
@@ -129,23 +153,29 @@ ListTests = build_schema_test(
     name=str("GetTests"),
     schema={"$ref": "/endpoints.json#/definitions/List"},
     schema_store=SCHEMAS,
-    failing_instances=[
-        # Wrong types:
-        [], "", None,
-        # Missing field:
-        {}, {"Volumes": []},
-        # Wrong fields:
-        {"Result": "hello"},
-        # Extra field:
-        {"Err": "", "Volumes": [], "extra": "y"},
-        # Missing field:
-        {"Err": "", "Volumes": [{"Mountpoint": "/y"}]},
-        {"Err": "", "Volumes": [{"Name": "/x"}]},
-        # Extra field:
-        {"Err": "", "Volumes": [{"Name": "/x",
-                                 "Mountpoint": "y",
-                                 "extra": "r"}]},
-    ],
+    failing_instances={
+        b'additionalProperties': [
+            # Extra field:
+            {"Err": "", "Volumes": [], "extra": "y"},
+            # Extra field:
+            {"Err": "", "Volumes": [{"Name": "/x",
+                                     "Mountpoint": "y",
+                                     "extra": "r"}]},
+            # Wrong fields:
+            {"Result": "hello"},
+        ],
+        b'required': [
+            # Missing field:
+            {}, {"Volumes": []},
+            # Missing field:
+            {"Err": "", "Volumes": [{"Mountpoint": "/y"}]},
+            {"Err": "", "Volumes": [{"Name": "/x"}]},
+        ],
+        b'type': [
+            # Wrong types:
+            [], "", None,
+        ],
+    },
     passing_instances=[
         {"Err": "Something went wrong."},
         {"Err": "", "Volumes": [

--- a/flocker/restapi/testtools.py
+++ b/flocker/restapi/testtools.py
@@ -594,12 +594,15 @@ def build_schema_test(name, schema, schema_store,
         'passing_instances': passing_instances,
         'failing_instances': failing_instances,
         }
-    for i, inst in enumerate(failing_instances):
-        def test(self, inst=inst):
-            self.assertRaises(ValidationError,
-                              self.validator.validate, inst)
-        test.__name__ = 'test_fails_validation_%d' % (i,)
-        body[test.__name__] = test
+    for error_type in failing_instances:
+        for i, inst in enumerate(failing_instances[error_type]):
+            def test(self, inst=inst, error_type=error_type):
+                e = self.assertRaises(
+                    ValidationError, self.validator.validate, inst
+                )
+                self.assertEqual(e.validator, error_type)
+            test.__name__ = 'test_fails_validation_%s_%d' % (error_type, i)
+            body[test.__name__] = test
 
     for i, inst in enumerate(passing_instances):
         def test(self, inst=inst):


### PR DESCRIPTION
FLOC-3862 PR #2621 was an error in validation that occurred partly because the test that was supposed to fail due to the value being the wrong type actually failed due to the value not being a multiple of 1024.  Since the failures were not distinguished, the bug slipped through testing.

This PR separates the tests by expected validation error. This ensures that we are testing the correct failure reason. Using this new code, the FLOC-3862 test was evidently in the wrong section.

In addition, we now have some tests which actually have multiple validation errors, but with the new structure, we can see that they are failing for the desired reason. https://github.com/ClusterHQ/flocker/blob/81dfb8d68964608e11f188e5d45812ae29c18a30/flocker/control/test/test_schemas.py#L90-L97 is an example. The dataset_id UUID is invalid, which would give a `pattern` error, but it is clear we are failing for the desired reason: an additional `extra` property.

During the cleanup, a few other problems were fixed:
- An environment stanza could contain an empty variable name with any type.
- The `ConfigurationContainersSchemaTests` was redefined, meaning some tests were not being run.
- The `ConfigurationDatasetsUpdateSchemaTests` used a common stanza with other dataset commands, but for update they were all testing the same error (`additionalProperties`). This PR separates the update failures into a simpler set.
- The test that `ConfigurationDatasetsCreateSchemaTests` fails if `primary` is not present, was actually failing because the `dataset_id` UUID format was invalid.

Note, this PR broadly keeps the same tests, but in a different order (to group failures by validation error), and with some fixes. It does not add or modify any tests to improve completeness of the validation.  

There was only one change to the schema (to make "" an invalid environment variable name).