### PR TITLE
[FLOC 4103] Remove all references to uft

### DIFF
--- a/docs/installation/cluster-cleanup.rst
+++ b/docs/installation/cluster-cleanup.rst
@@ -12,13 +12,13 @@ If you have completed the steps in our :ref:`short tutorial <short-tutorial>`, y
 
     ssh -i $KEY root@$NODE2 docker rm -f app
     ssh -i $KEY root@$NODE2 docker rm -f redis
-    uft-flocker-volumes list
+    flocker-volumes list
     # Note the dataset id of the volume, then destroy it
-    uft-flocker-volumes destroy --dataset=$DATASET_ID
+    flocker-volumes destroy --dataset=$DATASET_ID
     # Wait for the dataset to disappear from the list
-    uft-flocker-volumes list
+    flocker-volumes list
     # Once it's gone, go ahead and delete the nodes
-    uft-flocker-destroy-nodes
+    flocker-destroy-nodes
     cd ~/clusters
     rm -rf test
 

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -29,7 +29,7 @@ The following diagram illustrates the architecture for the Installer:
 * The Installer provisions servers for you, and it writes a ``cluster.yml`` in your cluster directory containing the addresses of the servers.
 * You run the Installer on the ``cluster.yml``.
 * The Installer creates certificates for you, saves them in your cluster directory, installs Flocker and the certificates on servers, and starts Flocker.
-* You can now interact with your Flocker cluster using the ``docker`` CLI on the nodes, or locally by using the ``uft-flocker-deploy`` tool or the ``uft-flocker-volumes`` tool.
+* You can now interact with your Flocker cluster using the ``docker`` CLI on the nodes, or locally by using the ``flocker-volumes`` tool.
 
 The following instructions will take you through installing Flocker with the Installer, and running a tutorial to check everything is working:
 

--- a/docs/installation/installer-getstarted.rst
+++ b/docs/installation/installer-getstarted.rst
@@ -35,7 +35,7 @@ This guide will show you how to use the Labs Installer to deploy a Flocker clust
 
      .. prompt:: bash $
 
-        uft-flocker-ca --version
+        flocker-ca --version
 
      This should return something like ``1.9.0``, showing you which version of the Flocker Client is installed.
 
@@ -94,8 +94,8 @@ This guide will show you how to use the Labs Installer to deploy a Flocker clust
 
      .. prompt:: bash $
 
-        uft-flocker-sample-files
-        uft-flocker-get-nodes --ubuntu-aws
+        flocker-sample-files
+        flocker-get-nodes --ubuntu-aws
 
      This step should take 30-40 seconds, and then you should see output like this::
 
@@ -111,7 +111,7 @@ This guide will show you how to use the Labs Installer to deploy a Flocker clust
 
    .. prompt:: bash $
 
-      uft-flocker-install cluster.yml && uft-flocker-config cluster.yml && uft-flocker-plugin-install cluster.yml
+      flocker-install cluster.yml && flocker-config cluster.yml && flocker-plugin-install cluster.yml
 
    This step should take about 5 minutes, and will:
 
@@ -126,8 +126,8 @@ This guide will show you how to use the Labs Installer to deploy a Flocker clust
 
    .. prompt:: bash $
 
-      uft-flocker-volumes list-nodes
-      uft-flocker-volumes list
+      flocker-volumes list-nodes
+      flocker-volumes list
 
    You can see that there are no volumes yet.
 

--- a/docs/installation/installer-tutorial.rst
+++ b/docs/installation/installer-tutorial.rst
@@ -27,7 +27,7 @@ When you have completed the steps in :ref:`labs-installing-unofficial-flocker-to
       chmod 0600 $KEY
       ssh -i $KEY root@$NODE1 docker run -d -v demo:/data --volume-driver=flocker --name=redis redis:latest
       ssh -i $KEY root@$NODE1 docker run -d -e USE_REDIS_HOST=redis --link redis:redis -p 80:80 --name=app binocarlos/moby-counter:latest
-      uft-flocker-volumes list
+      flocker-volumes list
 
    This may take up to a minute since Flocker is provisioning and attaching an volume from the storage backend for the Flocker ``demo`` volume.
    At the end you should see the volume created and attached to the first node.
@@ -41,7 +41,7 @@ When you have completed the steps in :ref:`labs-installing-unofficial-flocker-to
       ssh -i $KEY root@$NODE1 docker rm -f redis
       ssh -i $KEY root@$NODE2 docker run -d -v demo:/data --volume-driver=flocker --name=redis redis:latest
       ssh -i $KEY root@$NODE2 docker run -d -e USE_REDIS_HOST=redis --link redis:redis -p 80:80 --name=app binocarlos/moby-counter:latest
-      uft-flocker-volumes list
+      flocker-volumes list
 
    At the end you should see the volume has moved to the second node.
 

--- a/docs/installation/installer.rst
+++ b/docs/installation/installer.rst
@@ -36,7 +36,7 @@ This diagram shows you what you are about to set up.
 * Installer provisions servers for you, and it writes a ``cluster.yml`` in your cluster directory containing the addresses of the servers.
 * You run the installer on the ``cluster.yml``.
 * Installer creates certificates for you, saves them in your cluster directory, installs Flocker and certificates on servers, and starts Flocker.
-* You can now interact with your Flocker cluster using the ``docker`` CLI on the nodes, or locally by using the ``uft-flocker-deploy`` tool or the :ref:`flockerctl` tool.
+* You can now interact with your Flocker cluster using the ``docker`` CLI on the nodes, or locally by using the :ref:`flockerctl` tool.
 
 Supported Configurations
 ========================


### PR DESCRIPTION
Fixes 4103

Several commands were pre-fixed ``uft-``. This PR removes that. Additionally, there were 2 instances of recommending use of ``flocker-deploy``, which were removed.