### PR TITLE
[FLOC-4167] build all AWS flocker jobs on medium instances 

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -978,7 +978,7 @@ job_type:
   run_trial:
     # http://build.clusterhq.com/builders/flocker-centos-7
     run_trial_on_AWS_CentOS_7:
-      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Small'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_modules: *run_trial_modules
       with_steps:
         - { type: 'shell', cli: *run_trial_cli }
@@ -990,7 +990,7 @@ job_type:
       directories_to_delete: *run_trial_directories_to_delete
 
     run_trial_on_AWS_CentOS_7_as_root:
-      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Small'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_modules: *run_trial_as_root_modules
       with_steps:
         - { type: 'shell', cli: *run_trial_cli_as_root }
@@ -1004,7 +1004,7 @@ job_type:
     # http://build.clusterhq.com/builders/flocker-admin
     # http://build.clusterhq.com/builders/flocker-ubuntu-14.04
     run_trial_on_AWS_Ubuntu_Trusty:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_modules: *run_trial_modules
       with_steps:
         - { type: 'shell', cli: *run_trial_cli }
@@ -1016,7 +1016,7 @@ job_type:
       directories_to_delete: *run_trial_directories_to_delete
 
     run_trial_on_AWS_Ubuntu_Trusty_as_root:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_modules: *run_trial_as_root_modules
       with_steps:
         - { type: 'shell', cli: *run_trial_cli_as_root }
@@ -1047,7 +1047,7 @@ job_type:
     # Split out just to do the CentOS version above,
     # for the reasons outlined in that section
     run_trial_on_AWS_Ubuntu_Trusty_flocker.node.functional.test_docker:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       module: flocker.node.functional.test_docker
       with_steps:
         - { type: 'shell', cli: *run_trial_cli }
@@ -1060,7 +1060,7 @@ job_type:
 
   run_trial_for_storage_driver:
     run_trial_for_ebs_storage_driver_on_CentOS_7:
-      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Small'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
       with_modules: *run_trial_functional_agent_modules
       with_steps:
         - { type: 'shell',
@@ -1079,7 +1079,7 @@ job_type:
       directories_to_delete: *run_trial_directories_to_delete
 
     run_trial_for_ebs_storage_driver_on_Ubuntu_trusty:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_modules: *run_trial_functional_agent_modules
       with_steps:
         - { type: 'shell',
@@ -1145,7 +1145,7 @@ job_type:
   # http://build.clusterhq.com/builders/flocker-docs
   run_sphinx:
     run_sphinx:
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1253,7 +1253,7 @@ job_type:
 
   run_lint:
     run_lint:
-      on_nodes_with_labels: 'aws-centos-7-T2Small'
+      on_nodes_with_labels: 'aws-centos-7-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1574,7 +1574,7 @@ job_type:
 
     run_sphinx_link_check:
       at: '0 8 * * *'
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,
@@ -1587,7 +1587,7 @@ job_type:
 
     cleanup_cloud_resources:
       at: '0 8 * * *'
-      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Small'
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
       with_steps:
         - { type: 'shell',
             cli: [ *hashbang, *add_shell_functions,  *setup_pip_cache,


### PR DESCRIPTION
Change all builds to use the same sized instance (medium) on AWS.

The belief is a homogeneous environment should give us
- greater reuse of provisioned slaves
- faster builds 

https://clusterhq.atlassian.net/browse/FLOC-4167
