### PR TITLE
[FLOC-4155] Cleanup leaked cloud instances from jenkins

### DIFF
--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -1,6 +1,13 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 """
 Utilities for cloud resource cleanup.
+
+XXX: This whole file needs refactoring to share helper functions from elsewhere
+in flocker.acceptance, flocker.provisioning and admin.acceptance.
+Additionally, there a bunch of free functions whose only purpose is to hide the
+differences between the libcloud EC2 and OpenStack drivers. It would be better
+to have an interface for the operations we need and cloud specific
+implementations of that interface.
 """
 from datetime import datetime, timedelta
 import json
@@ -62,6 +69,8 @@ def _get_node_creation_time(node):
     Get the creation time of a libcloud node.
 
     Rackspace and EC2 store the information in different metadeta.
+
+    EC2 nodes have a ``launch_time`` while Rackspace nodes have ``created``.
 
     :return: The creation time, if available.
     :rtype: datetime or None
@@ -256,7 +265,7 @@ class CleanVolumes(object):
 class CleanAcceptanceNodes(object):
     """
     :ivar timedelta lag: The age of nodes to destroy.
-    :param prefixes: List of prefixes of nodes to destroy.
+    :ivar list  prefixes: List of prefixes of nodes to destroy.
     """
     def start(self, config):
         # Get the libcloud drivers corresponding to the acceptance tests.
@@ -266,6 +275,8 @@ class CleanAcceptanceNodes(object):
 
         # Get the prefixes of the node names, appending the creator from
         # the config.
+        # XXX: Refactor this to share ``_make_node_name`` in:
+        # https://github.com/ClusterHQ/flocker/blob/43befe2d0d34ed62f6e96748a6416e646d38dcb4/admin/acceptance.py#L767
         creator = config['metadata']['creator']
         prefixes = tuple(map(lambda prefix: prefix + creator, self.prefixes))
 

--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -26,6 +26,12 @@ from twisted.python.usage import Options, UsageError
 from flocker.testtools.cluster_utils import MARKER
 
 
+DEFAULT_INSTANCE_NAME_PREFIXES = (
+    'acceptance-test-',
+    'client-test-'
+)
+
+
 def get_creation_time(node):
     """
     Get the creation time of a libcloud node.
@@ -325,16 +331,33 @@ class CleanupCloudResourcesOptions(Options):
          u"The oldest in minutes a volume may be "
          u"without being considered for deletion.\n",
          lambda option_value: timedelta(minutes=int(option_value))],
+        [u"instance-lag", None, timedelta(hours=2),
+         u"The oldest in minutes an instance may be "
+         u"without being considered for deletion.\n",
+         lambda option_value: timedelta(minutes=int(option_value))],
         [u"marker", None, MARKER,
          u"The marker which is used "
          u"as the ``node`` in the acceptance test cluster UUID.",
          lambda option_value: int(option_value, base=16)]
     ]
 
+    def opt_instance_name_prefix(self, instance_name_prefix):
+        """
+        Instances beginning with ``instance_name_prefix`` will be considered
+        for deletion. Defaults to: ``DEFAULT_INSTANCE_NAME_PREFIXES``.
+        """
+        self.setdefault('instance_name_prefixes', []).append(
+            instance_name_prefix
+        )
+
     def postOptions(self):
         self["dry-run"] = bool(self["dry-run"])
         if self["config-file"] is None:
             raise UsageError("Missing --config-file option.")
+        self.setdefault(
+            'instance_name_prefixes',
+            list(DEFAULT_INSTANCE_NAME_PREFIXES)
+        )
 
 
 def cleanup_cloud_resources_main(reactor, args, base_path, top_level):

--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -139,7 +139,7 @@ class CleanVolumes(object):
     Destroy volumes that leaked into the cloud from the acceptance and
     functional test suites.
     """
-    def start(self, config, dry_run=False):
+    def start(self, config):
         """
         Clean up old volumes belonging to test-created Flocker clusters.
         """
@@ -241,7 +241,7 @@ class CleanAcceptanceInstances(object):
     :ivar timedelta lag: The age of instances to destroy.
     :param prefixes: List of prefixes of instances to destroy.
     """
-    def start(self, config, dry_run=False):
+    def start(self, config):
         # Get the libcloud drivers corresponding to the acceptance tests.
         rackspace = get_rackspace_driver(config["rackspace"])
         ec2 = get_ec2_driver(config["aws"])

--- a/admin/cleanup_cloud_resources
+++ b/admin/cleanup_cloud_resources
@@ -9,6 +9,5 @@ from _preamble import TOPLEVEL, BASEPATH
 import sys
 
 if __name__ == '__main__':
-    from twisted.internet.task import react
     from admin.cleanup import cleanup_cloud_resources_main as main
-    react(main, (sys.argv[1:], BASEPATH, TOPLEVEL))
+    main(sys.argv[1:], BASEPATH, TOPLEVEL)

--- a/admin/publish-installer-images
+++ b/admin/publish-installer-images
@@ -9,6 +9,5 @@ from _preamble import TOPLEVEL, BASEPATH
 import sys
 
 if __name__ == '__main__':
-    from twisted.internet.task import react
     from admin.installer import publish_installer_images_main as main
-    react(main, (sys.argv[1:], BASEPATH, TOPLEVEL))
+    react(main(sys.argv[1:], BASEPATH, TOPLEVEL))

--- a/admin/publish-installer-images
+++ b/admin/publish-installer-images
@@ -9,5 +9,6 @@ from _preamble import TOPLEVEL, BASEPATH
 import sys
 
 if __name__ == '__main__':
+    from twisted.internet.task import react
     from admin.installer import publish_installer_images_main as main
-    react(main(sys.argv[1:], BASEPATH, TOPLEVEL))
+    react(main, (sys.argv[1:], BASEPATH, TOPLEVEL))

--- a/build.yaml
+++ b/build.yaml
@@ -468,10 +468,7 @@ common_cli:
     # We pass the URL of our Jenkins Slave to the acceptance test nodes
     # through the --build-server parameter below.
     #
-    # XXX Temporarily disable node cleanup so that there's something for the
-    # cleanup_cloud_resources script to do.
     ${venv}/bin/python admin/run-acceptance-tests \
-    --keep \
     --distribution ${DISTRIBUTION_NAME} \
     --provider ${ACCEPTANCE_TEST_PROVIDER} \
     --dataset-backend ${ACCEPTANCE_TEST_PROVIDER} \

--- a/build.yaml
+++ b/build.yaml
@@ -467,7 +467,11 @@ common_cli:
     # which are made available through a webserver running on port 80.
     # We pass the URL of our Jenkins Slave to the acceptance test nodes
     # through the --build-server parameter below.
+    #
+    # XXX Temporarily disable node cleanup so that there's something for the
+    # cleanup_cloud_resources script to do.
     ${venv}/bin/python admin/run-acceptance-tests \
+    --keep \
     --distribution ${DISTRIBUTION_NAME} \
     --provider ${ACCEPTANCE_TEST_PROVIDER} \
     --dataset-backend ${ACCEPTANCE_TEST_PROVIDER} \


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4155

I've ported the code from build.clusterhq.com with a few modifications:
 * I got rid of the ``deferToThread`` -- the operations are no longer asynchronous. @sarum90 and I discussed it and decided that it would be more straight forward and easier to maintain if the delete operations we're performed in sequence. In the future we could speed things up by running parallel cleanup operations for each cloud provider and each region. It's important that the nodes are destroyed before the volumes though.
 * I was tempted to rewrite it as Effects and performers but decided that that can be done in a followup issue.
 * I was also tempted to add Eliot logging to each of the actions, but  in the interests of keeping the branch small, I can do that in a follow up.
 * There are some Rackspace volumes which simply can't be deleted. I've reported those to Rackspace support and am waiting for them to fix their MySQL database for us (or whatever is involved).


I've temporarily configured Jenkins to use ``run-acceptance-tests --keep`` and manually forced a build on AWS and Rackspace.
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/cleanup_leaked_cloud_instances-FLOC-4155/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/1/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/cleanup_leaked_cloud_instances-FLOC-4155/job/_run_acceptance_on_Rackspace_Ubuntu_Trusty_with_Cinder/1/

The idea is that 2h later I can then force the cleanup_cloud_resources and see it clean up the nodes that were left behind...


...~2h later, I ran the script and it deleted the two left over AWS servers in the screenshot:
![screenshot from 2016-02-10 17-51-02](https://cloud.githubusercontent.com/assets/978965/12967913/e1f7cc28-d01f-11e5-987d-8ff93365da4d.png)

The log of the cleanup is here:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/cleanup_leaked_cloud_instances-FLOC-4155/job/_cleanup_cloud_resources/1/
