### PR TITLE
[FLOC-3922] Lint benchmark directory

### DIFF
--- a/benchmark/metrics/__init__.py
+++ b/benchmark/metrics/__init__.py
@@ -1,2 +1,7 @@
 from .cputime import CPUTime
 from .wallclock import WallClock
+
+__all__ = [
+    'CPUTime',
+    'WallClock',
+]

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -219,14 +219,14 @@ class CPUTimeTests(AsyncTestCase):
 
         # Although it is unlikely, it's possible that we could get a CPU
         # time != 0, so filter values out.
-        def filter(node_cpu_times):
+        def remove_process_times(node_cpu_times):
             for process_times in node_cpu_times.values():
                 if process_times:
                     for process in process_times:
                         if process != WALLCLOCK_LABEL:
                             process_times[process] = 0
             return node_cpu_times
-        d.addCallback(filter)
+        d.addCallback(remove_process_times)
 
         def check(result):
             self.assertEqual(

--- a/benchmark/operations/__init__.py
+++ b/benchmark/operations/__init__.py
@@ -3,3 +3,11 @@ from .create_dataset import CreateDataset
 from .no_op import NoOperation
 from .read_request import ReadRequest
 from .wait import Wait
+
+__all__ = [
+    'CreateContainer',
+    'CreateDataset',
+    'NoOperation',
+    'ReadRequest',
+    'Wait',
+]

--- a/benchmark/operations/test/test_read_request.py
+++ b/benchmark/operations/test/test_read_request.py
@@ -96,8 +96,8 @@ class ReadRequestTests(TestCase):
         d.addCallback(run_probe)
 
         # Only want to check the primaries of the cluster state
-        def filter(states):
+        def state_to_primary(states):
             return [state.primary for state in states]
-        d.addCallback(filter)
+        d.addCallback(state_to_primary)
 
         self.assertEqual(self.successResultOf(d), [primary])

--- a/benchmark/scenarios/__init__.py
+++ b/benchmark/scenarios/__init__.py
@@ -7,24 +7,24 @@ Shared benchmarking scenarios components.
     sample size.
 """
 
-__all__ = [
-    'read_request_load_scenario', 'write_request_load_scenario',
-    'DatasetCreationTimeout', 'RateMeasurer',
-    'RequestRateTooLow', 'RequestRateNotReached',
-    'RequestOverload', 'NoNodesFound', 'RequestLoadScenario',
-
-    'DEFAULT_SAMPLE_SIZE',
-]
-
 from .no_load import NoLoadScenario
 from .read_request_load import read_request_load_scenario
-
 from .write_request_load import (
-    write_request_load_scenario, DatasetCreationTimeout
+    write_request_load_scenario, DatasetCreationTimeout,
 )
-from ._rate_measurer import RateMeasurer, DEFAULT_SAMPLE_SIZE
 from ._request_load import (
-    RequestRateTooLow, RequestRateNotReached,
-    RequestOverload, NoNodesFound, RequestLoadScenario,
-    RequestScenarioAlreadyStarted
+    RequestRateTooLow, RequestRateNotReached, RequestOverload, NoNodesFound,
+    RequestScenarioAlreadyStarted,
 )
+
+__all__ = [
+    'NoLoadScenario',
+    'read_request_load_scenario',
+    'write_request_load_scenario',
+    'DatasetCreationTimeout',
+    'RequestRateTooLow',
+    'RequestRateNotReached',
+    'RequestOverload',
+    'NoNodesFound',
+    'RequestScenarioAlreadyStarted',
+]

--- a/benchmark/scenarios/_request_load.py
+++ b/benchmark/scenarios/_request_load.py
@@ -141,8 +141,8 @@ class RequestLoadScenario(object):
 
                 d = self.request.make_request()
 
-                def get_time(_ignore):
-                    return self.reactor.seconds() - t0
+                def get_time(_ignore, reactor=self.reactor, t0=t0):
+                    return reactor.seconds() - t0
                 d.addCallback(get_time)
 
                 self.rate_measurer.request_sent()

--- a/benchmark/scenarios/test/test_read_request_load.py
+++ b/benchmark/scenarios/test/test_read_request_load.py
@@ -14,8 +14,8 @@ from flocker.testtools import TestCase
 
 from benchmark.cluster import BenchmarkCluster
 from benchmark.scenarios import (
-    RequestRateTooLow, RequestRateNotReached,
-    RequestOverload, read_request_load_scenario, RequestScenarioAlreadyStarted,
+    read_request_load_scenario, RequestRateTooLow, RequestOverload,
+    RequestScenarioAlreadyStarted,
 )
 
 DEFAULT_VOLUME_SIZE = 1073741824

--- a/benchmark/scenarios/test/test_write_request_load.py
+++ b/benchmark/scenarios/test/test_write_request_load.py
@@ -17,8 +17,8 @@ from flocker.testtools import TestCase
 
 from benchmark.cluster import BenchmarkCluster
 from benchmark.scenarios import (
-    write_request_load_scenario, RequestRateTooLow, RequestRateNotReached,
-    RequestOverload, DatasetCreationTimeout, RequestScenarioAlreadyStarted,
+    write_request_load_scenario, RequestRateTooLow, RequestOverload,
+    DatasetCreationTimeout, RequestScenarioAlreadyStarted,
 )
 
 DEFAULT_VOLUME_SIZE = 1073741824

--- a/benchmark/submit.py
+++ b/benchmark/submit.py
@@ -102,8 +102,8 @@ def main(reactor, args):
 
     d = submit(server_url, result)
 
-    def succeeded(id):
-        print("Assigned result ID: {}".format(id))
+    def succeeded(result_id):
+        print("Assigned result ID: {}".format(result_id))
 
     def failed(failure):
         failure.trap(SubmitFailure)

--- a/benchmark/test/test_driver.py
+++ b/benchmark/test/test_driver.py
@@ -114,11 +114,11 @@ class SampleTest(TestCase):
         sampled = sample(
             FakeOperation(repeat(False)), FakeMetric(repeat(5)), 1)
 
-        def filter(sample):
+        def replace_reason_with_type(sample):
             if 'reason' in sample:
                 sample['reason'] = type(sample['reason'])
             return sample
-        sampled.addCallback(filter)
+        sampled.addCallback(replace_reason_with_type)
 
         self.assertEqual(
             self.successResultOf(sampled), {'success': False, 'reason': str}

--- a/build.yaml
+++ b/build.yaml
@@ -882,7 +882,7 @@ common_cli:
     # run flake8 lint tests on Flocker source code
     flake8 --format=pylint --output flake8.lint.txt flocker
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
-    pylint flocker > pylint.lint.txt
+    pylint benchmark flocker > pylint.lint.txt
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
     set -e
 

--- a/build.yaml
+++ b/build.yaml
@@ -880,7 +880,7 @@ common_cli:
     # Disable exiting on error, so we can run multiple lints
     set +e
     # run flake8 lint tests on Flocker source code
-    flake8 --format=pylint --output flake8.lint.txt flocker
+    flake8 --format=pylint --output flake8.lint.txt benchmark flocker
     JOB_EXIT_STATUS="$( updateExitStatus $? )"
     pylint benchmark flocker > pylint.lint.txt
     JOB_EXIT_STATUS="$( updateExitStatus $? )"

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ changedir = {toxinidir}
 commands =
     pip install -r requirements.txt
     pip install .[dev]
-    flake8 flocker
-    pylint flocker
+    flake8 benchmark flocker
+    pylint benchmark flocker
 
 [testenv:sphinx]
 basepython = python2.7


### PR DESCRIPTION
This PR adds the `benchmark` directory to the lint tests.

Code in the directory was changed to pass the lint tests.  Most were stylistic issues, but there was one bug where the variable `t0` was used in a closure within a loop, meaning that some elapsed time measurements may have been shorter than the actual time taken, probably by a fraction of a second.
