### PR TITLE
[FLOC-4177] Fix cputime error under load

### DIFF
--- a/benchmark/metrics/cputime.py
+++ b/benchmark/metrics/cputime.py
@@ -3,8 +3,6 @@
 CPU time metric for the control service benchmarks.
 """
 
-import subprocess
-
 from zope.interface import implementer
 
 from twisted.protocols.basic import LineOnlyReceiver
@@ -13,21 +11,6 @@ from flocker.common import gather_deferreds
 from flocker.common.runner import run_ssh
 
 from benchmark._interfaces import IMetric
-
-# Process 1 (usually `init`, `systemd`, or `launchd`) provides a process
-# name that is always present.
-_pid_1_name = subprocess.check_output(
-    ['ps', '-p', '1', '-o', 'comm=']
-).strip()
-
-
-_FLOCKER_PROCESSES = {
-    u'flocker-control',
-    u'flocker-dataset-agent',
-    u'flocker-container-agent',
-    u'flocker-docker-plugin',
-}
-
 
 _GET_CPUTIME_COMMAND = [
     # Use system ps to collect the information
@@ -42,9 +25,82 @@ _GET_CPUTIME_COMMAND = [
     b'-C',
 ]
 
+_GET_INIT_PROCESS_NAME_COMMAND = [
+    # Use system ps to collect the information
+    b'ps',
+    # Output the command name (truncated)
+    # `=` provides a header.  Making the header blank prevents the header
+    # line from being written.
+    b'-o', b'comm=',
+    # Output line for process 1
+    b'-p', b'1',
+]
+
+_FLOCKER_PROCESSES = {
+    u'flocker-control',
+    u'flocker-dataset-agent',
+    u'flocker-container-agent',
+    u'flocker-docker-plugin',
+}
+
 # A string that not a valid process name.  Any name with a space is good
 # because metric does not support process names containing spaces.
 WALLCLOCK_LABEL = '-- WALL --'
+
+
+class ProcessNameParser(LineOnlyReceiver):
+    """
+    Handler for the output lines returned from the cpu time command.
+
+    After parsing, the ``result`` attribute will contain a dictionary
+    mapping process names to elapsed CPU time.  Process names may be
+    truncated.  A special process will be added indicating the wallclock
+    time.
+    """
+
+    def __init__(self):
+        self.result = ''
+
+    def lineReceived(self, line):
+        """
+        Handle a single line output from the cpu time command.
+        """
+        if line:
+            self.result = line.strip()
+
+
+def get_node_init_process_name(runner, node):
+    """
+    Get the name of process 1 on a node.
+
+    :param runner: A method of running a command on a node.
+    :param node: A node to run the command on.
+    :return: Deferred firing with the name of process 1 on the node.
+    """
+    parser = ProcessNameParser()
+    d = runner.run(
+        node,
+        _GET_INIT_PROCESS_NAME_COMMAND,
+        handle_stdout=parser.lineReceived,
+    )
+
+    d.addCallback(lambda _ignored: parser.result)
+
+    return d
+
+
+def get_cluster_init_process_names(runner, nodes):
+    """
+    Get the names of process 1 running on each node.
+
+    :param runner: A method of running a command on a node.
+    :param nodes: A list of Node to run the command on.
+    :return: Deferred firing with a list of process names.
+    """
+    return gather_deferreds(list(
+        get_node_init_process_name(runner, node)
+        for node in nodes
+    ))
 
 
 class CPUParser(LineOnlyReceiver):
@@ -99,6 +155,87 @@ class CPUParser(LineOnlyReceiver):
         self.result[name] = self.result.get(name, 0) + cputime
 
 
+def get_node_cpu_times(reactor, runner, node, process_1_name, processes):
+    """
+    Get the CPU times for processes running on a node.
+
+    :param reactor: Twisted Reactor.
+    :param runner: A method of running a command on a node.
+    :param node: A node to run the command on.
+    :param process_1_name: The name of process 1 on each node.
+    :param processes: An iterator of process names to monitor. The process
+        names must not contain spaces.
+    :return: Deferred firing with a dictionary mapping process names to
+        elapsed cpu time.  Process names may be truncated in the dictionary.
+        If an error occurs, returns None (after logging error).
+    """
+    # If no named processes are running, `ps` will return an error.  To
+    # distinguish this case from real errors, ensure that at least one
+    # process is present by adding an always present process (pid 1) as
+    # a monitored process.  Remove it later.
+    process_list = list(processes)
+    if process_1_name in processes:
+        delete_process_1_name = False
+    else:
+        process_list.append(process_1_name)
+        delete_process_1_name = True
+
+    parser = CPUParser(reactor)
+    d = runner.run(
+        node,
+        _GET_CPUTIME_COMMAND + [b','.join(process_list)],
+        handle_stdout=parser.lineReceived,
+    )
+
+    def get_parser_result(ignored):
+        result = parser.result
+        # Remove unwanted value.
+        if delete_process_1_name and process_1_name in result:
+            del result[process_1_name]
+        return result
+    d.addCallback(get_parser_result)
+
+    return d
+
+
+def get_cluster_cpu_times(reactor, runner, nodes, inits, processes):
+    """
+    Get the CPU times for processes running on a cluster.
+
+    :param reactor: Twisted Reactor.
+    :param runner: A method of running a command on a node.
+    :param nodes: A list of nodes to run the command on.
+    :param inits: The names of the init process on each node.
+    :param processes: An iterator of process names to monitor. The process
+        names must not contain spaces.
+    :return: Deferred firing with a dictionary mapping process names to
+        elapsed cpu time.  Process names may be truncated in the dictionary.
+        If an error occurs, returns None (after logging error).
+    """
+    return gather_deferreds(list(
+        get_node_cpu_times(reactor, runner, node, init, processes)
+        for node, init in zip(nodes, inits)
+    ))
+
+
+def compute_change(labels, before, after):
+    """
+     Compute the difference between CPU times from consecutive measurements.
+
+    :param [str] labels: Label for each result.
+    :param before: Times collected per process name for time 0.
+    :param after: Times collected per process name for time 1.
+    :return: Dictionary mapping labels to dictionaries mapping process
+        names to elapsed CPU time between measurements.
+    """
+    result = {}
+    for (label, before, after) in zip(labels, before, after):
+        matched_keys = set(before) & set(after)
+        value = {key: after[key] - before[key] for key in matched_keys}
+        result[label] = value
+    return result
+
+
 class SSHRunner(object):
     """
     Run a command using ssh.
@@ -132,85 +269,6 @@ class SSHRunner(object):
         return d
 
 
-def get_node_cpu_times(reactor, runner, node, processes):
-    """
-    Get the CPU times for processes running on a node.
-
-    :param reactor: Twisted Reactor.
-    :param runner: A method of running a command on a node.
-    :param node: A node to run the command on.
-    :param processes: An iterator of process names to monitor. The process
-        names must not contain spaces.
-    :return: Deferred firing with a dictionary mapping process names to
-        elapsed cpu time.  Process names may be truncated in the dictionary.
-        If an error occurs, returns None (after logging error).
-    """
-    # If no named processes are running, `ps` will return an error.  To
-    # distinguish this case from real errors, ensure that at least one
-    # process is present by adding an always present process (pid 1) as
-    # a monitored process.  Remove it later.
-    process_list = list(processes)
-    if _pid_1_name in processes:
-        delete_pid_1_name = False
-    else:
-        process_list.append(_pid_1_name)
-        delete_pid_1_name = True
-
-    parser = CPUParser(reactor)
-    d = runner.run(
-        node,
-        _GET_CPUTIME_COMMAND + [b','.join(process_list)],
-        handle_stdout=parser.lineReceived,
-    )
-
-    def get_parser_result(ignored):
-        result = parser.result
-        # Remove unwanted value.
-        if delete_pid_1_name and _pid_1_name in result:
-            del result[_pid_1_name]
-        return result
-    d.addCallback(get_parser_result)
-
-    return d
-
-
-def get_cluster_cpu_times(reactor, runner, nodes, processes):
-    """
-    Get the CPU times for processes running on a cluster.
-
-    :param reactor: Twisted Reactor.
-    :param runner: A method of running a command on a node.
-    :param node: Node to run the command on.
-    :param processes: An iterator of process names to monitor. The process
-        names must not contain spaces.
-    :return: Deferred firing with a dictionary mapping process names to
-        elapsed cpu time.  Process names may be truncated in the dictionary.
-        If an error occurs, returns None (after logging error).
-    """
-    return gather_deferreds(list(
-        get_node_cpu_times(reactor, runner, node, processes)
-        for node in nodes
-    ))
-
-
-def compute_change(labels, before, after):
-    """
-     Compute the difference between CPU times from consecutive measurements.
-
-    :param [str] labels: Label for each result.
-    :param before: Times collected per process name for time 0.
-    :param after: Times collected per process name for time 1.
-    :return: Dictionary mapping labels to dictionaries mapping process
-        names to elapsed CPU time between measurements.
-    """
-    result = {}
-    for (label, before, after) in zip(labels, before, after):
-        matched_keys = set(before) & set(after)
-        value = {key: after[key] - before[key] for key in matched_keys}
-        result[label] = value
-    return result
-
-
 @implementer(IMetric)
 class CPUTime(object):
     """
@@ -230,6 +288,7 @@ class CPUTime(object):
 
     def measure(self, f, *a, **kw):
         nodes = []
+        inits = []
         before_cpu = []
         after_cpu = []
 
@@ -238,10 +297,15 @@ class CPUTime(object):
         # Retrieve the cluster nodes
         d = control_service.list_nodes().addCallback(nodes.extend)
 
+        # Obtain the init process on each node
+        d.addCallback(
+            lambda _ignored: get_cluster_init_process_names(self.runner, nodes)
+        ).addCallback(inits.extend)
+
         # Obtain elapsed CPU time before test
         d.addCallback(
             lambda _ignored: get_cluster_cpu_times(
-                self.reactor, self.runner, nodes, self.processes)
+                self.reactor, self.runner, nodes, inits, self.processes)
         ).addCallback(before_cpu.extend)
 
         # Perform the test function
@@ -250,7 +314,7 @@ class CPUTime(object):
         # Obtain elapsed CPU time after test
         d.addCallback(
             lambda _ignored: get_cluster_cpu_times(
-                self.reactor, self.runner, nodes, self.processes)
+                self.reactor, self.runner, nodes, inits, self.processes)
         ).addCallback(after_cpu.extend)
 
         # Create the result from before and after times

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -16,13 +16,8 @@ from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IMetric
 from benchmark.metrics.cputime import (
     WALLCLOCK_LABEL, CPUTime, CPUParser, get_node_cpu_times, compute_change,
+    _pid_1_name,
 )
-
-# Process 1 (usually `init`, `systemd`, or `launchd`) provides a process
-# name that is always present.
-_standard_process = subprocess.check_output(
-    ['ps', '-p', '1', '-o', 'comm=']
-).strip()
 
 # The command used to check cputimes only works on Linux
 on_linux = skipIf(platform.system() != 'Linux', 'Requires Linux')
@@ -117,12 +112,12 @@ class GetNodeCPUTimeTests(AsyncTestCase):
             Clock(),
             _LocalRunner(),
             Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1')),
-            [_standard_process],
+            [_pid_1_name],
         )
 
         def check(result):
             self.assertEqual(
-                result.keys(), [_standard_process, WALLCLOCK_LABEL]
+                result.keys(), [_pid_1_name, WALLCLOCK_LABEL]
             )
 
         d.addCallback(check)
@@ -213,7 +208,7 @@ class CPUTimeTests(AsyncTestCase):
                 None,
             ),
             _LocalRunner(),
-            processes=[_standard_process]
+            processes=[_pid_1_name]
         )
         d = metric.measure(lambda: clock.advance(5))
 
@@ -232,8 +227,8 @@ class CPUTimeTests(AsyncTestCase):
             self.assertEqual(
                 result,
                 {
-                    '10.0.0.1': {_standard_process: 0, WALLCLOCK_LABEL: 5},
-                    '10.0.0.2': {_standard_process: 0, WALLCLOCK_LABEL: 5}
+                    '10.0.0.1': {_pid_1_name: 0, WALLCLOCK_LABEL: 5},
+                    '10.0.0.2': {_pid_1_name: 0, WALLCLOCK_LABEL: 5}
                 }
             )
         d.addCallback(check)

--- a/benchmark/metrics/test/test_cputime.py
+++ b/benchmark/metrics/test/test_cputime.py
@@ -15,9 +15,14 @@ from flocker.testtools import TestCase, AsyncTestCase
 from benchmark.cluster import BenchmarkCluster
 from benchmark._interfaces import IMetric
 from benchmark.metrics.cputime import (
-    WALLCLOCK_LABEL, CPUTime, CPUParser, get_node_cpu_times, compute_change,
-    _pid_1_name,
+    WALLCLOCK_LABEL, CPUTime, CPUParser, get_node_init_process_name,
+    get_node_cpu_times, compute_change, _GET_INIT_PROCESS_NAME_COMMAND,
 )
+
+# Process 1 (usually `init`, `systemd`, or `launchd`) provides a process
+# name that is always present.
+_pid_1_name = subprocess.check_output(_GET_INIT_PROCESS_NAME_COMMAND).strip()
+
 
 # The command used to check cputimes only works on Linux
 on_linux = skipIf(platform.system() != 'Linux', 'Requires Linux')
@@ -98,6 +103,27 @@ class _LocalRunner(object):
         return deferToThread(self._run, command_args, handle_stdout)
 
 
+class GetNodeInitProcessNameTests(AsyncTestCase):
+    """
+    Test ``get_node_init_process_name`` command.
+    """
+
+    def test_get_node_init_process_name(self):
+        """
+        Success results in output of string containing name of process 1.
+        """
+        d = get_node_init_process_name(
+            _LocalRunner(),
+            Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1')),
+        )
+
+        def check(result):
+            self.assertEqual(result, _pid_1_name)
+        d.addCallback(check)
+
+        return d
+
+
 class GetNodeCPUTimeTests(AsyncTestCase):
     """
     Test ``get_node_cpu_times`` command.
@@ -112,6 +138,7 @@ class GetNodeCPUTimeTests(AsyncTestCase):
             Clock(),
             _LocalRunner(),
             Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1')),
+            _pid_1_name,
             [_pid_1_name],
         )
 
@@ -133,6 +160,7 @@ class GetNodeCPUTimeTests(AsyncTestCase):
             Clock(),
             _LocalRunner(),
             Node(uuid=uuid4(), public_address=IPAddress('10.0.0.1')),
+            _pid_1_name,
             ['n0n-exist'],
         )
 


### PR DESCRIPTION
The CPU time command used for benchmarking requires that at least one of the named processes exist, in order to distinguish an error result from an empty result.

The code uses `ps` for this extra process name, due to the command actually calling `ps`.  However, it has been observed that under heavy load (which is often seen in the benchmarks), the short-lived `ps` process doesn't see itself.  This causes a `KeyError` when we try to remove the unwanted `ps` data.

This PR uses the name of the init process (process 1) on each node instead, which should be more robust.