### PR TITLE
[FLOC 4065] Reword the CTA on the Kubernetes tutorial

### DIFF
--- a/docs/kubernetes-integration/index.rst
+++ b/docs/kubernetes-integration/index.rst
@@ -44,8 +44,8 @@ Tutorial
 
     <div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--2up pod-boxout--tutorial">
-		   <span>Tutorial: using Flocker with Kubernetes</span>
-		     <a href="http://kubernetes.io/v1.1/examples/flocker/" target="_blank" class="button">Kubernetes Flocker Docs</a>
+		   <span>Tutorial: Using Flocker volumes, provided by Kubernetes</span>
+		     <a href="http://kubernetes.io/v1.1/examples/flocker/" target="_blank" class="button">Open the Kubernetes Tutorial</a>
 	    </div>
 	</div>
 


### PR DESCRIPTION
Fixes 4065

The CTA on the Kubernetes tutorial button wasn't clear that the tutorial was provided by Kubernetes. The wording on the button, and the intro have been amended to be clearer.