### PR TITLE
Revert "[FLOC-4086] Warn users about needing access to S3 buckets during CloudFormation"

### DIFF
--- a/admin/installer/cloudformation.py
+++ b/admin/installer/cloudformation.py
@@ -141,7 +141,7 @@ template = Template()
 # Keys corresponding to CloudFormation user Inputs.
 access_key_id_param = template.add_parameter(Parameter(
     "AmazonAccessKeyID",
-    Description="Required: Your Amazon AWS access key ID",
+    Description="Your Amazon AWS access key ID (mandatory)",
     Type="String",
     NoEcho=True,
     AllowedPattern="[\w]+",
@@ -150,32 +150,25 @@ access_key_id_param = template.add_parameter(Parameter(
 ))
 secret_access_key_param = template.add_parameter(Parameter(
     "AmazonSecretAccessKey",
-    Description="Required: Your Amazon AWS secret access key",
+    Description="Your Amazon AWS secret access key (mandatory)",
     Type="String",
     NoEcho=True,
     MinLength="1",
 ))
 keyname_param = template.add_parameter(Parameter(
     "EC2KeyPair",
-    Description="Required: Name of an existing EC2 KeyPair to enable SSH "
-                "access to the instance",
-    Type="AWS::EC2::KeyPair::KeyName",
-))
-secret_access_key_param = template.add_parameter(Parameter(
-    "S3AccessPolicy",
-    Description="Required: Is current IAM user allowed to access S3? "
-                "S3 access is required to distribute Flocker and Docker "
-                "configuration amongst stack nodes. Reference: "
-                "http://docs.aws.amazon.com/IAM/latest/UserGuide/"
-                "access_permissions.html Stack creation will fail if user "
-                "cannot access S3",
+    Description="Name of an existing EC2 KeyPair to enable SSH "
+                "access to the instance (mandatory)",
     Type="String",
-    AllowedValues=["Yes"],
+    MinLength="1",
+    AllowedPattern="[\x20-\x7E]*",
+    MaxLength="255",
+    ConstraintDescription="can contain only ASCII characters.",
 ))
 volumehub_token = template.add_parameter(Parameter(
     "VolumeHubToken",
     Description=(
-        "Optional: Your Volume Hub token. "
+        "Your Volume Hub token (optional). "
         "You'll find the token at https://volumehub.clusterhq.com/v1/token."
     ),
     Type="String",

--- a/flocker/acceptance/endtoend/test_installer.py
+++ b/flocker/acceptance/endtoend/test_installer.py
@@ -268,10 +268,6 @@ class DockerComposeTests(AsyncTestCase):
             {
                 'ParameterKey': 'VolumeHubToken',
                 'ParameterValue': os.environ['VOLUMEHUB_TOKEN']
-            },
-            {
-                'ParameterKey': 'S3AccessPolicy',
-                'ParameterValue': 'Yes'
             }
         ]
 


### PR DESCRIPTION
Reverts ClusterHQ/flocker#2638

There's a bug in the new template which means that the S3 policy value is used for the AWS secret access key.