### PR TITLE
[FLOC-4086] Warn users about needing access to S3 buckets during CloudFormation

### DIFF
--- a/admin/installer/cloudformation.py
+++ b/admin/installer/cloudformation.py
@@ -141,7 +141,7 @@ template = Template()
 # Keys corresponding to CloudFormation user Inputs.
 access_key_id_param = template.add_parameter(Parameter(
     "AmazonAccessKeyID",
-    Description="Your Amazon AWS access key ID (mandatory)",
+    Description="Required: Your Amazon AWS access key ID",
     Type="String",
     NoEcho=True,
     AllowedPattern="[\w]+",
@@ -150,25 +150,32 @@ access_key_id_param = template.add_parameter(Parameter(
 ))
 secret_access_key_param = template.add_parameter(Parameter(
     "AmazonSecretAccessKey",
-    Description="Your Amazon AWS secret access key (mandatory)",
+    Description="Required: Your Amazon AWS secret access key",
     Type="String",
     NoEcho=True,
     MinLength="1",
 ))
 keyname_param = template.add_parameter(Parameter(
     "EC2KeyPair",
-    Description="Name of an existing EC2 KeyPair to enable SSH "
-                "access to the instance (mandatory)",
+    Description="Required: Name of an existing EC2 KeyPair to enable SSH "
+                "access to the instance",
+    Type="AWS::EC2::KeyPair::KeyName",
+))
+template.add_parameter(Parameter(
+    "S3AccessPolicy",
+    Description="Required: Is current IAM user allowed to access S3? "
+                "S3 access is required to distribute Flocker and Docker "
+                "configuration amongst stack nodes. Reference: "
+                "http://docs.aws.amazon.com/IAM/latest/UserGuide/"
+                "access_permissions.html Stack creation will fail if user "
+                "cannot access S3",
     Type="String",
-    MinLength="1",
-    AllowedPattern="[\x20-\x7E]*",
-    MaxLength="255",
-    ConstraintDescription="can contain only ASCII characters.",
+    AllowedValues=["Yes"],
 ))
 volumehub_token = template.add_parameter(Parameter(
     "VolumeHubToken",
     Description=(
-        "Your Volume Hub token (optional). "
+        "Optional: Your Volume Hub token. "
         "You'll find the token at https://volumehub.clusterhq.com/v1/token."
     ),
     Type="String",

--- a/flocker/acceptance/endtoend/test_installer.py
+++ b/flocker/acceptance/endtoend/test_installer.py
@@ -268,6 +268,10 @@ class DockerComposeTests(AsyncTestCase):
             {
                 'ParameterKey': 'VolumeHubToken',
                 'ParameterValue': os.environ['VOLUMEHUB_TOKEN']
+            },
+            {
+                'ParameterKey': 'S3AccessPolicy',
+                'ParameterValue': 'Yes'
             }
         ]
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4086
Based on #2638 with a bug fix.

If user's AWS account does not have a Policy that allows him/her to access S3 buckets, CloudFormation stack creation fails. Instead of wasting user's time and EC2 resources, it would be better to have user check a box during CloudFormation workflow confirming S3 access.

This PR also includes an unrelated change where user is allowed to choose from existing KeyPairs instead of typing in the name of the KeyPair.
