### PR TITLE
[FLOC-4189] Release Flocker-1.10.3.dev1

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,8 +9,18 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
-This Release
+Next Release
 ============
+
+No significant changes since last release.
+
+Previous Releases
+=================
+
+.. contents::
+   :local:
+   :backlinks: none
+   :depth: 2
 
 v1.10.2
 -------
@@ -21,14 +31,6 @@ v1.10.2
 * Block device plugins can now specify the configuration keys they require.
   This allows better error messages to be generated.
 * Several outdated references in the documentation have been removed.
-
-Previous Releases
-=================
-
-.. contents::
-   :local:
-   :backlinks: none
-   :depth: 2
 
 v1.10.1
 -------


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4189

I couldn't find any note worthy changes so I just updated the heading and moved the last release down.

The process states that I should wait for green builds, but it's taking ages so I may as well get approval of the release notes changes.

I'm still waiting for test results:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/view/releases/job/release-release-flocker-1.10.3.dev1/

Meanwhile I've fixed a bug in the ``initialize-release`` tool:
 * https://clusterhq.atlassian.net/browse/FLOC-4190