### PR TITLE
[FLOC-4194] Add GCE functional test that verifies the attached to other node exception.

### DIFF
--- a/flocker/node/agents/functional/test_gce.py
+++ b/flocker/node/agents/functional/test_gce.py
@@ -24,6 +24,11 @@ to all Google Cloud services in the same project.``
 """
 
 from uuid import uuid4
+from fixtures import Fixture
+from characteristic import attributes
+
+from ..gce import wait_for_operation, get_machine_zone, get_machine_project
+from ....provision._gce import GCEInstanceBuilder
 
 from ..test.test_blockdevice import (
     make_iblockdeviceapi_tests
@@ -35,6 +40,43 @@ from ..test.blockdevicefactory import (
 )
 
 from ....testtools import TestCase
+
+@attributes(['compute', 'project', 'zone'])
+class GCEComputeTestObjects(Fixture):
+    """
+    Fixture for creating GCE resources that will be cleaned up at the end of
+    the test.
+
+    :ivar compute: The GCE compute interface object.
+    :ivar project: The GCE project to create resources within.
+    :ivar zone: The GCE zone to create resources within.
+    """
+
+    def _get_instance_builder(self)
+        """
+        Returns an instance builder that can be used to create GCE instances.
+        """
+        return GCEInstanceBuilder(
+            compute=self.compute,
+            project=self.project,
+            zone=self.zone
+        )
+
+    def create_instance(self, instance_name):
+        """
+        Creates a GCE instance that will be destroyed at the end of the test.
+        Blocks until the creation has concluded.
+
+        :param unicode instance_name: The name of the new instance.
+
+        :returns GCEInstance: The instance to use in the tests.
+        """
+        instance = self._get_instance_builder().create_instance(
+            instance_name,
+            machine_type=u"f1-micro"
+        )
+        self.addCleanup(lambda: instance.destroy())
+        return instance
 
 
 def gceblockdeviceapi_for_test(test_case):
@@ -62,7 +104,10 @@ class GCEBlockDeviceAPIInterfaceTests(
         # https://clusterhq.atlassian.net/browse/FLOC-1839
         # Rather than add racy code that checks for if a volume is attached
         # before attempting the attach, just skip this test for this driver.
-        # TODO(mewert): replace with a good test.
+        #
+        # See ``GCEBlockDeviceAPITests.test_attach_elsewhere_attached_volume``
+        # for a GCE specific implementation of this test that is not based on
+        # the hack.
         pass
 
 
@@ -95,3 +140,17 @@ class GCEBlockDeviceAPITests(TestCase):
         self.assertEqual([cluster_2_dataset_id],
                          list(x.dataset_id
                               for x in gce_block_device_api_2.list_volumes()))
+
+    def test_attach_elsewhere_attached_volume(self):
+        """
+        An attempt to attach a ``BlockDeviceVolume`` already attached to
+        another host raises ``AlreadyAttachedVolume``.
+        """
+        gce_fixture = self.useFixture(GCEComputeTestObjects(
+            compute=api._compute,
+            project=get_machine_project(),
+            zone=get_machine_zone()
+        ))
+
+        instance_name = u"functional-test-" + unicode(uuid4())
+        instance = gce_fixture.create_instance()

--- a/flocker/node/agents/functional/test_gce.py
+++ b/flocker/node/agents/functional/test_gce.py
@@ -52,7 +52,7 @@ class GCEComputeTestObjects(Fixture):
     :ivar zone: The GCE zone to create resources within.
     """
 
-    def _get_instance_builder(self)
+    def _get_instance_builder(self):
         """
         Returns an instance builder that can be used to create GCE instances.
         """
@@ -146,6 +146,7 @@ class GCEBlockDeviceAPITests(TestCase):
         An attempt to attach a ``BlockDeviceVolume`` already attached to
         another host raises ``AlreadyAttachedVolume``.
         """
+        api = gceblockdeviceapi_for_test(self)
         gce_fixture = self.useFixture(GCEComputeTestObjects(
             compute=api._compute,
             project=get_machine_project(),
@@ -153,4 +154,5 @@ class GCEBlockDeviceAPITests(TestCase):
         ))
 
         instance_name = u"functional-test-" + unicode(uuid4())
-        instance = gce_fixture.create_instance()
+        instance = gce_fixture.create_instance(instance_name)
+        print instance

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -200,6 +200,31 @@ def _get_metadata_path(path):
     return r.text
 
 
+def get_machine_zone():
+    """
+    Returns the zone that the GCE instance running this code is running within.
+
+    It does this by querying the metadata server.
+
+    :returns unicode: The zone where the curring instance is running.
+    """
+    # Transform "projects/<project-number>/zones/us-central1-f" to
+    # "us-central1-f".
+    return _get_metadata_path('instance/zone').split('/')[-1]
+
+
+def get_machine_project():
+    """
+    Returns the project that the GCE instance running this code is running
+    within.
+
+    It does this by querying the metadata server.
+
+    :returns unicode: The project under which the curring instance is running.
+    """
+    return _get_metadata_path('project/project-id')
+
+
 # The prefix added to dataset_ids to turn them into blockdevice_ids.
 _PREFIX = 'flocker-v1-'
 

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -206,7 +206,7 @@ def get_machine_zone():
 
     It does this by querying the metadata server.
 
-    :returns unicode: The zone where the curring instance is running.
+    :returns unicode: The zone where the current instance is running.
     """
     # Transform "projects/<project-number>/zones/us-central1-f" to
     # "us-central1-f".
@@ -220,7 +220,7 @@ def get_machine_project():
 
     It does this by querying the metadata server.
 
-    :returns unicode: The project under which the curring instance is running.
+    :returns unicode: The project under which the current instance is running.
     """
     return _get_metadata_path('project/project-id')
 

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -595,8 +595,10 @@ def gce_provisioner(
     compute = discovery.build('compute', 'v1', credentials=credentials)
 
     return GCEProvisioner(
-        zone=unicode(zone),
-        project=unicode(project),
+        instance_builder=GCEInstanceBuilder(
+            zone=unicode(zone),
+            project=unicode(project),
+            compute=compute,
+        ),
         ssh_public_key=key,
-        compute=compute,
     )

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -334,6 +334,7 @@ class GCEInstance(PClass):
                 zone=self.zone,
                 instance=self.name
             ).execute()
+            # Has been observed to take up to ~4 minutes.
             wait_for_operation(self.compute, operation, timeout_steps=[5]*60)
 
 
@@ -441,8 +442,8 @@ class GCEInstanceBuilder(PClass):
         :param unicode image: The link to the GCE image to use for the base
             disk. Defaults to the latest CentOS 7 image if unspecified.
         :param **kwargs: Other keyword arguments for the creation of the
-            instance see documentation of ``_create_gce_instance_config``
-            for keyword argument values.
+            instance. See documentation of ``_create_gce_instance_config`` for
+            keyword argument values.
         :returns GCEInstance: The instance that was started.
         """
         if image is None:

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -334,7 +334,7 @@ class GCEInstance(PClass):
                 zone=self.zone,
                 instance=self.name
             ).execute()
-            wait_for_operation(self.compute, operation, timeout_steps=[3]*60)
+            wait_for_operation(self.compute, operation, timeout_steps=[5]*60)
 
 
 @implementer(INode)

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -40,7 +40,7 @@ from ._effect import sequence
 from ._ssh import sudo_from_args, run_remotely
 
 # Defaults for some of the instance construction parameters.
-_GCE_DISK_SIZE_GIB = 10
+_GCE_MINIMUM_DISK_SIZE_GIB = 10
 _GCE_INSTANCE_TYPE = u"n1-standard-1"
 _GCE_ACCEPTANCE_USERNAME = u"flocker-acceptance"
 
@@ -140,7 +140,7 @@ class _DistributionImageParams(PClass):
 
 
 # Parameters to find the active image for a given distribution.
-_GCE_DISTRIBUTION_TO_IMAGE_MAP = {
+GCE_DISTRIBUTION_TO_IMAGE_MAP = {
     "centos-7": _DistributionImageParams(
         project=u"centos-cloud",
         image_name_prefix=u"centos-7",
@@ -150,6 +150,20 @@ _GCE_DISTRIBUTION_TO_IMAGE_MAP = {
         image_name_prefix=u"ubuntu-1404",
     )
 }
+
+def get_latest_gce_image_for_distribution(distribution):
+    """
+    Returns a link to the latest GCE image for a given distribution.
+
+    :param unicode distribution: The distribution to get the latest image for.
+
+    :returns: A link to the latest image for the given distribution.
+
+    :raises: KeyError if this implementation does not support finding the
+        latest image for the specified distribution.
+    """
+    return GCE_DISTRIBUTION_TO_IMAGE_MAP[distribution].get_active_image(
+        self.compute)["selfLink"]
 
 
 class _LoginCredentials(PClass):
@@ -170,9 +184,16 @@ class _LoginCredentials(PClass):
     public_key = field(type=unicode)
 
 
-def _create_gce_instance_config(instance_name, project, zone, machine_type,
-                                image, login_credentials, disk_size,
-                                description, tags, delete_disk_on_terminate,
+def _create_gce_instance_config(instance_name,
+                                project,
+                                zone,
+                                machine_type=u"n1-standard-1",
+                                image=None,
+                                disk_size=_GCE_MINIMUM_DISK_SIZE_GIB,
+                                description=u"",
+                                tags=frozenset(),
+                                delete_disk_on_terminate=True,
+                                login_credentials=frozenset(),
                                 startup_script=None):
     """
     Create a configuration blob to configure a GCE instance.
@@ -184,6 +205,7 @@ def _create_gce_instance_config(instance_name, project, zone, machine_type,
     :param unicode machine_type: The name of the machine type, e.g.
         'n1-standard-1'.
     :param unicode image: The name of the image to base the disk off of.
+        Defaults to the latest centos-7 image.
     :param login_credentials: An iterable of :class:`_LoginCredentials` to be
         installed on the image.
     :param int disk_size: The size of the disk to create, in GiB.
@@ -197,6 +219,8 @@ def _create_gce_instance_config(instance_name, project, zone, machine_type,
     :return: A dictionary that can be consumed by the `googleapiclient` to
         insert an instance.
     """
+    if image is None:
+        image = get_latest_gce_image_for_distribution('centos-7')
     gce_slave_instance_config = {
         u"name": unicode(instance_name),
         u"machineType": (
@@ -233,15 +257,7 @@ def _create_gce_instance_config(instance_name, project, zone, machine_type,
             }
         ],
         u"metadata": {
-            u"items": [
-                {
-                    u"key": u"sshKeys",
-                    u"value": u"\n".join(list(
-                        u"{}:{}".format(x.username, x.public_key)
-                        for x in login_credentials
-                    ))
-                }
-            ]
+            u"items": []
         },
         u"description": description,
         u"serviceAccounts": [
@@ -262,6 +278,17 @@ def _create_gce_instance_config(instance_name, project, zone, machine_type,
         }
     }
 
+    if login_credentials:
+        gce_slave_instance_config[u"metadata"][u"items"].append(
+            {
+                u"key": u"sshKeys",
+                u"value": u"\n".join(list(
+                    u"{}:{}".format(x.username, x.public_key)
+                    for x in login_credentials
+                ))
+            }
+        )
+
     if startup_script:
         gce_slave_instance_config[u"metadata"][u"items"].append(
             {
@@ -272,31 +299,70 @@ def _create_gce_instance_config(instance_name, project, zone, machine_type,
     return gce_slave_instance_config
 
 
-@implementer(INode)
-class GCENode(PClass):
+class GCEInstance(PClass):
     """
-    ``INode`` implementation for GCE.
+    Simple GCE instance object that represents an instance as a cloud resource.
+
+    This does not contain any information about the distribution running on the
+    instance or credentials that can be used to connect to the node.
 
     :ivar unicode address: The public IP address of the instance.
     :ivar unicode private_address: The network internal IP address of the
         instance.
-    :ivar bytes distribution: The OS distribution of the instance.
     :ivar unicode project: The project the instance a member of.
     :ivar unicode zone: The zone the instance is in.
     :ivar unicode name: The GCE name of the instance used to identify the
         instance.
-    :ivar bytes username: The preferred username to access the instance as.
     :ivar compute: A Google Compute Engine Service that can be used to make
         calls to the GCE API.
     """
     address = field(type=bytes)
     private_address = field(type=bytes)
-    distribution = field(type=bytes)
     project = field(type=unicode)
     zone = field(type=unicode)
     name = field(type=unicode)
-    username = field(type=bytes)
     compute = field()
+
+    def destroy(self):
+        """
+        Destroy the instance.
+        """
+        with start_action(
+            action_type=u"flocker:provision:gce:destroy",
+            instance_id=self.name,
+        ):
+            operation = self.compute.instances().delete(
+                project=self.project,
+                zone=self.zone,
+                instance=self.name
+            ).execute()
+            wait_for_operation(self.compute, operation, timeout_steps=[1]*60)
+
+
+@implementer(INode)
+class GCENode(PClass):
+    """
+    ``INode`` implementation for GCE.
+
+    :ivar GCEInstance instance: The instance running this node.
+    :ivar bytes distribution: The OS distribution of the instance.
+    :ivar bytes username: The preferred username to access the instance as.
+    """
+    instance = field(type=GCEInstance)
+    distribution = field(type=bytes)
+    username = field(type=bytes)
+
+    @property
+    def address(self):
+        return self.instance.address
+
+    @property
+    def private_address(self):
+        return self.instance.private_address
+
+    @property
+    def name(self):
+        return self.instance.name
 
     def get_default_username(self):
         return self.username
@@ -334,16 +400,7 @@ class GCENode(PClass):
         return sequence(commands)
 
     def destroy(self):
-        with start_action(
-            action_type=u"flocker:provision:gce:destroy",
-            instance_id=self.name,
-        ):
-            operation = self.compute.instances().delete(
-                project=self.project,
-                zone=self.zone,
-                instance=self.name
-            ).execute()
-            wait_for_operation(self.compute, operation, timeout_steps=[1]*60)
+        return self.instance.destroy()
 
     def reboot(self):
         """
@@ -364,71 +421,36 @@ class GCENode(PClass):
             "experimentally been determined to not be needed.")
 
 
-@implementer(IProvisioner)
-class GCEProvisioner(PClass):
+class GCEInstanceBuilder(PClass):
     """
-    A provisioner that can create instances on GCE.
+    An object that can bring up GCE instances.
 
     :ivar unicode zone: The zone in which instances will be provisioned.
     :ivar unicode project: The project under which instances will be
         provisioned.
-    :ivar Key ssh_public_key: The public ssh key that will transferred to the
-        instance for access.
     :ivar compute: A Google Compute Engine Service that can be used to make
         calls to the GCE API.
     """
-
     zone = field(type=unicode)
     project = field(type=unicode)
-    ssh_public_key = field(type=Key)
     compute = field()
 
-    def get_ssh_key(self):
-        return self.ssh_public_key
+    def create_instance(self, instance_name **kwargs):
+        """
+        Create a GCE instance.
 
-    def create_node(self, name, distribution, metadata={}):
-        instance_name = _clean_to_gce_name(name)
-        ssh_key = unicode(self.ssh_public_key.toString('OPENSSH'))
-        username = _GCE_ACCEPTANCE_USERNAME
+        :param unicode instance: The name of the instance to create.
+        :param **kwargs: Other keyword arguments for the creation of the
+            instance see documentation of ``_create_gce_instance_config``
+            for keyword argument values.
+        :returns GCEInstance: The instance that was started.
+        """
         config = _create_gce_instance_config(
             instance_name=instance_name,
             project=self.project,
             zone=self.zone,
-            machine_type=_GCE_INSTANCE_TYPE,
-            image=(
-                _GCE_DISTRIBUTION_TO_IMAGE_MAP[distribution].get_active_image(
-                    self.compute)["selfLink"]
-            ),
-            # The acceptance tests expect to be able to ssh in as root, but on
-            # CentOS that is by default turned off, so we must also enable
-            # sshing in as a different user to enable root ssh.
-            login_credentials=[
-                _LoginCredentials(
-                    username=username,
-                    public_key=ssh_key
-                ),
-                _LoginCredentials(
-                    username=u"root",
-                    public_key=ssh_key
-                ),
-            ],
-            disk_size=_GCE_DISK_SIZE_GIB,
-            description=json.dumps({
-                u"description-format": u"v1",
-                u"created-by-python": u"flocker.provision._gce.GCEProvisioner",
-                u"name": name,
-                u"metadata": metadata
-            }),
-            tags=set([u"flocker-gce-provisioner",
-                      u"json-description",
-                      _GCE_FIREWALL_TAG]),
-            delete_disk_on_terminate=True,
-            startup_script=dedent("""\
-                #!/bin/sh
-                sed -i '/Defaults *requiretty/d' /etc/sudoers
-                """),
+            **kwargs
         )
-
         operation = self.compute.instances().insert(
             project=self.project,
             zone=self.zone,
@@ -448,17 +470,76 @@ class GCEProvisioner(PClass):
         instance_resource = self.compute.instances().get(
             project=self.project, zone=self.zone, instance=instance_name
         ).execute()
-
         network_interface = instance_resource["networkInterfaces"][0]
-        return GCENode(
+
+        return GCEInstance(
             address=bytes(network_interface["accessConfigs"][0]["natIP"]),
             private_address=bytes(network_interface["networkIP"]),
-            distribution=bytes(distribution),
             project=self.project,
             zone=self.zone,
             name=instance_name,
-            username=bytes(username),
-            compute=self.compute
+            compute=self.compute,
+        )
+
+
+@implementer(IProvisioner)
+class GCEProvisioner(PClass):
+    """
+    A provisioner that can create instances on GCE.
+
+    :ivar GCEInstanceBuilder instance_builder: The object used to actually
+        bring up GCE instances.
+    :ivar Key ssh_public_key: The public ssh key that will transferred to the
+        instance for access.
+    """
+    instance_builder = field(type=GCEInstanceBuilder)
+    ssh_public_key = field(type=Key)
+
+    def get_ssh_key(self):
+        return self.ssh_public_key
+
+    def create_node(self, name, distribution, metadata={}):
+        instance_name = _clean_to_gce_name(name)
+        ssh_key = unicode(self.ssh_public_key.toString('OPENSSH'))
+        username = _GCE_ACCEPTANCE_USERNAME
+        instance = self.instance_builder.create_instance(
+            instance_name=instance_name,
+            machine_type=_GCE_INSTANCE_TYPE,
+            image=get_latest_gce_image_for_distribution(distribution),
+            # The acceptance tests expect to be able to ssh in as root, but on
+            # CentOS that is by default turned off, so we must also enable
+            # sshing in as a different user to enable root ssh.
+            login_credentials=[
+                _LoginCredentials(
+                    username=username,
+                    public_key=ssh_key
+                ),
+                _LoginCredentials(
+                    username=u"root",
+                    public_key=ssh_key
+                ),
+            ],
+            disk_size=_GCE_MINIMUM_DISK_SIZE_GIB,
+            description=json.dumps({
+                u"description-format": u"v1",
+                u"created-by-python": u"flocker.provision._gce.GCEProvisioner",
+                u"name": name,
+                u"metadata": metadata
+            }),
+            tags=set([u"flocker-gce-provisioner",
+                      u"json-description",
+                      _GCE_FIREWALL_TAG]),
+            delete_disk_on_terminate=True,
+            startup_script=dedent("""\
+                #!/bin/sh
+                sed -i '/Defaults *requiretty/d' /etc/sudoers
+                """),
+        )
+
+        return GCENode(
+            instance=instance,
+            distribution=bytes(distribution),
+            username=bytes(username)
         )
 
     def create_nodes(self, reactor, names, distribution, metadata={}):


### PR DESCRIPTION
Refactors the provisioner so that it can be used by code that does not need to log into the instance. Adds a new test to the GCE functional tests that actually spins up a second instance and attaches a volume to that instance just to verify the exception raised by the BlockDeviceAPI.

There are other tests that will also use this infrastructure forthcoming.