### PR TITLE
[FLOC-4200] Retry scp operations in test_installer

### DIFF
--- a/admin/test/test_installer.py
+++ b/admin/test/test_installer.py
@@ -320,15 +320,15 @@ class DockerComposeTests(AsyncTestCase):
 
         def set_stack_variables(stack_report):
             outputs = stack_report['Outputs']
-            stack_id = stack_report['StackId']
+            # stack_id = stack_report['StackId']
             for variable_name, stack_output_name in STACK_VARIABLES.items():
                 setattr(
                     self, variable_name, get_output(outputs, stack_output_name)
                 )
-            if 'KEEP_STACK' not in os.environ:
-                self.addCleanup(
-                    delete_cloudformation_stack, stack_id, aws_config
-                )
+            # if 'KEEP_STACK' not in os.environ:
+            #     self.addCleanup(
+            #         delete_cloudformation_stack, stack_id, aws_config
+            #     )
         d.addCallback(set_stack_variables)
         return d
 
@@ -346,8 +346,8 @@ class DockerComposeTests(AsyncTestCase):
 
         def stack_ready(ignored):
             self.docker_host = 'tcp://' + self.control_node_ip + ':2376'
-            self.addCleanup(self._cleanup_flocker)
-            self.addCleanup(self._cleanup_compose)
+            # self.addCleanup(self._cleanup_flocker)
+            # self.addCleanup(self._cleanup_compose)
         d.addCallback(stack_ready)
 
         return d

--- a/admin/test/test_installer.py
+++ b/admin/test/test_installer.py
@@ -365,7 +365,7 @@ class DockerComposeTests(AsyncTestCase):
         d = download(
             reactor=reactor,
             username=b'ubuntu',
-            host=self.client_node_ip,
+            host=self.client_node_ip.encode('ascii'),
             remote_path=FilePath('/etc/flocker'),
             local_path=local_certs_path
         )
@@ -376,7 +376,7 @@ class DockerComposeTests(AsyncTestCase):
                 certificates_path=local_certs_path,
                 num_agent_nodes=2,
                 hostname_to_public_address={},
-                username='user1',
+                username=b'user1',
             )
         )
         d.addCallback(
@@ -472,7 +472,7 @@ class DockerComposeTests(AsyncTestCase):
         template creates a PostgreSQL server on one node. The second template
         moves the PostgreSQL server to the second node.
         """
-        client_username = u"ubuntu"
+        client_username = b"ubuntu"
         client_home = FilePath('/home').child(client_username)
         remote_compose_directory = client_home.child(random_name(self))
         self.compose_node1 = (
@@ -487,7 +487,7 @@ class DockerComposeTests(AsyncTestCase):
             return upload(
                 reactor=reactor,
                 username=client_username,
-                host=self.client_node_ip,
+                host=self.client_node_ip.encode('ascii'),
                 local_path=FilePath(__file__).parent().descendant(
                     ['installer', 'postgres']
                 ),

--- a/admin/test/test_installer.py
+++ b/admin/test/test_installer.py
@@ -18,7 +18,7 @@ from twisted.python.filepath import FilePath
 
 from eliot import Message
 
-from flocker.common.runner import run_ssh
+from flocker.common.runner import run_ssh, upload
 from flocker.common import gather_deferreds, loop_until, retry_failure
 from flocker.testtools import AsyncTestCase, async_runner, random_name
 from flocker.acceptance.testtools import (
@@ -488,7 +488,14 @@ class DockerComposeTests(AsyncTestCase):
         self.compose_node2 = (
             remote_compose_directory + "/docker-compose-node2.yml"
         )
-
+        d = upload(
+            reactor=reactor,
+            username=u"ubuntu",
+            host=self.client_node_ip,
+            local_path=FilePath(__file__).parent().descendant(
+                ['installer', 'postgres']),
+            remote_path=remote_compose_directory,
+        )
         # This isn't in the tutorial, but docker-compose doesn't retry failed
         # pulls and pulls fail all the time.
         def pull_postgres():

--- a/admin/test/test_installer.py
+++ b/admin/test/test_installer.py
@@ -320,15 +320,15 @@ class DockerComposeTests(AsyncTestCase):
 
         def set_stack_variables(stack_report):
             outputs = stack_report['Outputs']
-            # stack_id = stack_report['StackId']
+            stack_id = stack_report['StackId']
             for variable_name, stack_output_name in STACK_VARIABLES.items():
                 setattr(
                     self, variable_name, get_output(outputs, stack_output_name)
                 )
-            # if 'KEEP_STACK' not in os.environ:
-            #     self.addCleanup(
-            #         delete_cloudformation_stack, stack_id, aws_config
-            #     )
+            if 'KEEP_STACK' not in os.environ:
+                self.addCleanup(
+                    delete_cloudformation_stack, stack_id, aws_config
+                )
         d.addCallback(set_stack_variables)
         return d
 
@@ -346,8 +346,8 @@ class DockerComposeTests(AsyncTestCase):
 
         def stack_ready(ignored):
             self.docker_host = 'tcp://' + self.control_node_ip + ':2376'
-            # self.addCleanup(self._cleanup_flocker)
-            # self.addCleanup(self._cleanup_compose)
+            self.addCleanup(self._cleanup_flocker)
+            self.addCleanup(self._cleanup_compose)
         d.addCallback(stack_ready)
 
         return d

--- a/admin/test/test_installer.py
+++ b/admin/test/test_installer.py
@@ -497,7 +497,8 @@ class DockerComposeTests(AsyncTestCase):
             reactor=reactor,
             function=upload_docker_compose_files,
             expected=(SCPConnectionError,),
-            steps=repeat(1, 5)
+            # Wait 60s for the client SSH server to accept connections.
+            steps=repeat(1, 60)
         )
 
         # This isn't in the tutorial, but docker-compose doesn't retry failed

--- a/build.yaml
+++ b/build.yaml
@@ -1615,6 +1615,8 @@ job_type:
                    *setup_flocker_modules,
                    *setup_coverage,
                    *setup_aws_env_vars,
+                   *check_version,
+                   *setup_authentication,
                    'export ACCEPTANCE_YAML=/tmp/acceptance.yaml',
                    *run_trial_with_coverage,
                    *run_coverage,

--- a/flocker/acceptance/endtoend/test_diagnostics.py
+++ b/flocker/acceptance/endtoend/test_diagnostics.py
@@ -49,8 +49,8 @@ class DiagnosticsTests(AsyncTestCase):
             local_archive_path = FilePath(self.mktemp())
             return download(
                 reactor=reactor,
-                username=u'root',
-                host=node_address,
+                username=b'root',
+                host=node_address.encode('ascii'),
                 remote_path=remote_archive_path,
                 local_path=local_archive_path,
             ).addCallback(lambda ignored: local_archive_path)

--- a/flocker/acceptance/endtoend/test_diagnostics.py
+++ b/flocker/acceptance/endtoend/test_diagnostics.py
@@ -10,7 +10,7 @@ import tarfile
 from twisted.internet import reactor
 from twisted.python.filepath import FilePath
 
-from ...common.runner import run_ssh, download_file
+from ...common.runner import run_ssh, download
 from ...testtools import AsyncTestCase
 from ..testtools import require_cluster
 
@@ -47,12 +47,12 @@ class DiagnosticsTests(AsyncTestCase):
 
         def download_archive(remote_archive_path):
             local_archive_path = FilePath(self.mktemp())
-            return download_file(
-                reactor,
-                'root',
-                node_address,
-                remote_archive_path,
-                local_archive_path,
+            return download(
+                reactor=reactor,
+                username=u'root',
+                host=node_address,
+                remote_path=remote_archive_path,
+                local_path=local_archive_path,
             ).addCallback(lambda ignored: local_archive_path)
         downloading = creating.addCallback(download_archive)
 

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -922,7 +922,7 @@ class Cluster(PClass):
         d = download(
             reactor=reactor,
             username=b"root",
-            host=node.public_address,
+            host=node.public_address.encode('ascii'),
             remote_path=path,
             local_path=destination,
         )

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -42,7 +42,7 @@ from ..common import gather_deferreds, loop_until, timeout, retry_failure
 from ..common.configuration import (
     extract_substructure, MissingConfigError, Optional
 )
-from ..common.runner import download_file, run_ssh
+from ..common.runner import download, run_ssh
 
 from ..control.httpapi import REST_API_PORT
 from ..ca import treq_with_authentication, UserCredential
@@ -919,8 +919,12 @@ class Cluster(PClass):
         fd, name = mkstemp()
         close(fd)
         destination = FilePath(name)
-        d = download_file(
-            reactor, b"root", node.public_address, path, destination
+        d = download(
+            reactor=reactor,
+            username=b"root",
+            host=node.public_address,
+            remote_path=path,
+            local_path=destination,
         )
         d.addCallback(lambda ignored: destination)
         return d

--- a/flocker/common/functional/test_runner.py
+++ b/flocker/common/functional/test_runner.py
@@ -15,7 +15,13 @@ from flocker.testtools import AsyncTestCase, random_name
 
 
 class UploadTests(AsyncTestCase):
+    """
+    Tests for ``flocker.common.runner.upload``.
+    """
     def test_upload_file(self):
+        """
+        A single file can be uploaded.
+        """
         expected_content = random_name(self)
         local_path = self.make_temporary_file()
         local_path.setContent(expected_content)
@@ -25,6 +31,9 @@ class UploadTests(AsyncTestCase):
         )
 
     def test_upload_directory(self):
+        """
+        A directory can be uploaded recursively.
+        """
         local_path = self.make_temporary_directory()
         local_path.child('child1').open('w')
         return self.assert_upload(
@@ -33,6 +42,15 @@ class UploadTests(AsyncTestCase):
         )
 
     def assert_upload(self, local_path, matcher):
+        """
+        Assert that the ``local_path`` can be uploaded to and then downloaded
+        from a remote SSH server and that the contents are preserved.
+
+        :param FilePath local_path: The local file or directory to upload.
+        :param matcher: A ``testtools`` matcher which will be compared to the
+            downloaded ``FilePath.path``.
+        :returns: A ``Deferred`` that fires when the assertion is complete.
+        """
         self.ssh_server = create_ssh_server(
             base_path=self.make_temporary_directory()
         )

--- a/flocker/common/functional/test_runner.py
+++ b/flocker/common/functional/test_runner.py
@@ -65,12 +65,11 @@ class UploadTests(AsyncTestCase):
                 local_path=download_path,
                 port=self.ssh_server.port,
                 identity_file=self.ssh_server.key_path,
-                recursive=True,
             )
         d.addCallback(download)
 
         def check(ignored):
             self.assertThat(download_path.path, matcher)
-        d.addBoth(check)
+        d.addCallback(check)
 
         return d

--- a/flocker/common/functional/test_runner.py
+++ b/flocker/common/functional/test_runner.py
@@ -10,7 +10,7 @@ from twisted.internet import reactor
 from flocker.testtools.ssh import (
     create_ssh_server
 )
-from flocker.common.runner import download_file, upload
+from flocker.common.runner import download, upload
 from flocker.testtools import AsyncTestCase, random_name
 
 
@@ -56,8 +56,8 @@ class UploadTests(AsyncTestCase):
         download_directory = self.make_temporary_directory()
         download_path = download_directory.child('download')
 
-        def download(ignored):
-            return download_file(
+        d.addCallback(
+            lambda ignored: download(
                 reactor=reactor,
                 username=username,
                 host=host,
@@ -66,7 +66,7 @@ class UploadTests(AsyncTestCase):
                 port=self.ssh_server.port,
                 identity_file=self.ssh_server.key_path,
             )
-        d.addCallback(download)
+        )
 
         def check(ignored):
             self.assertThat(download_path.path, matcher)

--- a/flocker/common/functional/test_runner.py
+++ b/flocker/common/functional/test_runner.py
@@ -1,0 +1,51 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.common.runner``.
+"""
+from twisted.internet import reactor
+from twisted.python.filepath import FilePath
+
+from flocker.common.runner import download_file, upload
+from flocker.testtools import AsyncTestCase, random_name
+
+
+class UploadTests(AsyncTestCase):
+    def test_upload_file(self):
+        expected_content = random_name(self)
+        username = u"ubuntu"
+        host = u"54.193.57.202"
+
+        local_file = self.make_temporary_file()
+        local_file.setContent(expected_content)
+        remote_file = FilePath('/home/ubuntu').child(random_name(self))
+
+        d = upload(
+            reactor=reactor,
+            username=username,
+            host=host,
+            local_path=local_file,
+            remote_path=remote_file,
+        )
+
+        download_directory = self.make_temporary_directory()
+        download_path = download_directory.child('download')
+
+        def download(ignored):
+            return download_file(
+                reactor=reactor,
+                username=username,
+                host=host,
+                remote_path=remote_file,
+                local_path=download_path,
+            )
+        d.addCallback(download)
+
+        def check(ignored):
+            self.assertEqual(
+                expected_content,
+                download_path.getContent()
+            )
+        d.addBoth(check)
+
+        return d

--- a/flocker/common/functional/test_runner.py
+++ b/flocker/common/functional/test_runner.py
@@ -3,8 +3,9 @@
 """
 Tests for ``flocker.common.runner``.
 """
-from twisted.internet import reactor
 from testtools.matchers import FileContains, DirContains
+
+from twisted.internet import reactor
 
 from flocker.testtools.ssh import (
     create_ssh_server

--- a/flocker/common/functional/test_runner.py
+++ b/flocker/common/functional/test_runner.py
@@ -4,8 +4,11 @@
 Tests for ``flocker.common.runner``.
 """
 from twisted.internet import reactor
-from twisted.python.filepath import FilePath
+from testtools.matchers import FileContains, DirContains
 
+from flocker.testtools.ssh import (
+    create_ssh_server
+)
 from flocker.common.runner import download_file, upload
 from flocker.testtools import AsyncTestCase, random_name
 
@@ -13,19 +16,40 @@ from flocker.testtools import AsyncTestCase, random_name
 class UploadTests(AsyncTestCase):
     def test_upload_file(self):
         expected_content = random_name(self)
-        username = u"ubuntu"
-        host = u"54.193.57.202"
+        local_path = self.make_temporary_file()
+        local_path.setContent(expected_content)
+        return self.assert_upload(
+            local_path,
+            FileContains(expected_content)
+        )
 
-        local_file = self.make_temporary_file()
-        local_file.setContent(expected_content)
-        remote_file = FilePath('/home/ubuntu').child(random_name(self))
+    def test_upload_directory(self):
+        local_path = self.make_temporary_directory()
+        local_path.child('child1').open('w')
+        return self.assert_upload(
+            local_path,
+            DirContains(["child1"])
+        )
+
+    def assert_upload(self, local_path, matcher):
+        self.ssh_server = create_ssh_server(
+            base_path=self.make_temporary_directory()
+        )
+        self.addCleanup(self.ssh_server.restore)
+
+        username = u"root"
+        host = bytes(self.ssh_server.ip)
+
+        remote_file = self.ssh_server.home.child(random_name(self))
 
         d = upload(
             reactor=reactor,
             username=username,
             host=host,
-            local_path=local_file,
+            local_path=local_path,
             remote_path=remote_file,
+            port=self.ssh_server.port,
+            identity_file=self.ssh_server.key_path,
         )
 
         download_directory = self.make_temporary_directory()
@@ -38,14 +62,14 @@ class UploadTests(AsyncTestCase):
                 host=host,
                 remote_path=remote_file,
                 local_path=download_path,
+                port=self.ssh_server.port,
+                identity_file=self.ssh_server.key_path,
+                recursive=True,
             )
         d.addCallback(download)
 
         def check(ignored):
-            self.assertEqual(
-                expected_content,
-                download_path.getContent()
-            )
+            self.assertThat(download_path.path, matcher)
         d.addBoth(check)
 
         return d

--- a/flocker/common/runner.py
+++ b/flocker/common/runner.py
@@ -209,7 +209,7 @@ def run(reactor, command, handle_stdout=None, handle_stderr=None, **kwargs):
 
 SSH_OPTIONS = [
     b"-C",  # compress traffic
-    b"-vv",  # debug
+    b"-q",  # suppress warnings
     # We're ok with unknown hosts.
     b"-o", b"StrictHostKeyChecking=no",
     # The tests hang if ControlMaster is set, since OpenSSH won't

--- a/flocker/common/runner.py
+++ b/flocker/common/runner.py
@@ -209,7 +209,7 @@ def run(reactor, command, handle_stdout=None, handle_stderr=None, **kwargs):
 
 SSH_OPTIONS = [
     b"-C",  # compress traffic
-    b"-q",  # suppress warnings
+    b"-vv",  # debug
     # We're ok with unknown hosts.
     b"-o", b"StrictHostKeyChecking=no",
     # The tests hang if ControlMaster is set, since OpenSSH won't

--- a/flocker/common/runner.py
+++ b/flocker/common/runner.py
@@ -365,41 +365,23 @@ def scp(reactor, username, host, remote_path, local_path,
         return context.addActionFinish()
 
 
-def download(reactor, username, host, remote_path, local_path,
-             port=22, identity_file=None):
+def download(**kwargs):
     """
     Run the local ``scp`` command to download a file or directory from a remote
     host and kill it if the reactor stops.
 
     See ``scp`` for parameter and return type documentation.
     """
-    return scp(
-        reactor=reactor,
-        username=username,
-        host=host,
-        local_path=local_path,
-        remote_path=remote_path,
-        port=port,
-        identity_file=identity_file,
-        direction=DOWNLOAD,
-    )
+    kwargs["direction"] = DOWNLOAD
+    return scp(**kwargs)
 
 
-def upload(reactor, username, host, local_path, remote_path,
-           port=22, identity_file=None):
+def upload(**kwargs):
     """
     Run the local ``scp`` command to upload a file or directory to a remote
     host and kill it if the reactor stops.
 
     See ``scp`` for parameter and return type documentation.
     """
-    return scp(
-        reactor=reactor,
-        username=username,
-        host=host,
-        local_path=local_path,
-        remote_path=remote_path,
-        port=port,
-        identity_file=identity_file,
-        direction=UPLOAD,
-    )
+    kwargs["direction"] = UPLOAD
+    return scp(**kwargs)

--- a/flocker/common/runner.py
+++ b/flocker/common/runner.py
@@ -371,8 +371,6 @@ def download(reactor, username, host, remote_path, local_path,
         direction=DOWNLOAD,
     )
 
-download_file = download
-
 
 def upload(reactor, username, host, local_path, remote_path,
            port=22, identity_file=None):

--- a/flocker/common/runner.py
+++ b/flocker/common/runner.py
@@ -260,3 +260,33 @@ def download_file(reactor, username, host, remote_path, local_path):
 
     scp_result.addErrback(scp_failed)
     return scp_result
+
+
+def upload(reactor, username, host, local_path, remote_path):
+    """
+    Run the local ``scp`` command to upload a file or directory to a remote
+    host and kill it if the reactor stops.
+
+    :param reactor: Reactor to use.
+    :param username: The username to use when logging into the remote server.
+    :param host: The hostname or IP address of the remote server.
+    :param FilePath local_path: The path of the file on the local host.
+    :param FilePath remote_path: The path of the file on the remote host.
+
+    :return Deferred: Deferred that fires when the process is ended.  If the
+        file isn't found on the remote server, it fires with ``FileNotFound``.
+    """
+    remote_path = username + b'@' + host + b':' + remote_path.path
+    scp_command = [
+        b"scp",
+    ] + SSH_OPTIONS + [
+        local_path.path,
+        remote_path,
+    ]
+
+    scp_result = run(
+        reactor,
+        scp_command,
+    )
+
+    return scp_result

--- a/flocker/common/runner.py
+++ b/flocker/common/runner.py
@@ -267,18 +267,25 @@ class SCPConnectionError(SCPError):
 
 
 def scp(reactor, username, host, remote_path, local_path,
-        port=22, identity_file=None, direction=DOWNLOAD):
+        direction, port=22, identity_file=None):
     """
     :param reactor: A ``twisted.internet.reactor``.
     :param bytes username: The SSH username.
     :param bytes host: The SSH host.
     :param FilePath remote_path: The path to the remote file.
     :param FilePath local_path: The path to the local file.
+    :param direction: One of ``DOWNLOAD`` or ``UPLOAD``.
     :param int port: The SSH TCP port.
     :param FilePath identity_file: The path to an SSH private key.
-    :param direction: One of ``DOWNLOAD`` or ``UPLOAD``.
     :returns: A ``Deferred`` that fires when the process is ended.
     """
+    if direction not in (DOWNLOAD, UPLOAD):
+        raise ValueError(
+            "Invalid direction argument {!r}. "
+            "Must be one of ``runner.DOWNLOAD`` "
+            "or ``runner.UPLOAD``.".format(direction)
+        )
+
     remote_host_path = username + b'@' + host + b':' + remote_path.path
     scp_command = [
         b"scp",

--- a/flocker/common/runner.py
+++ b/flocker/common/runner.py
@@ -60,7 +60,7 @@ SCP_ACTION = ActionType(
         Field.for_types(u"port", [int], u"SSH port."),
         Field(
             u"identity_file",
-            lambda f: f.path,
+            lambda f: f and f.path,
             u"SSH identity file."
         ),
     ],

--- a/flocker/common/test/test_runner.py
+++ b/flocker/common/test/test_runner.py
@@ -11,11 +11,11 @@ from twisted.python.failure import Failure
 from twisted.internet.error import ProcessDone, ProcessTerminated
 
 from flocker.testtools import (
-    MemoryCoreReactor, FakeProcessReactor, TestCase,
+    MemoryCoreReactor, FakeProcessReactor, TestCase, random_name,
 )
 
 from ..runner import (
-    RemoteFileNotFound, run, CommandProtocol, RUN_OUTPUT_MESSAGE,
+    RemoteFileNotFound, run, CommandProtocol, RUN_OUTPUT_MESSAGE, scp
 )
 
 
@@ -211,3 +211,24 @@ class RunTests(TestCase):
 
         reactor.fireSystemEvent('shutdown')
         process.processProtocol.processEnded(Failure(ProcessDone(0)))
+
+
+class SCPTests(TestCase):
+    """
+    Tests for ``scp``.
+    """
+    def test_invalid_direction(self):
+        """
+        The ``direction`` argument must be one of ``DOWNLOAD`` or ``UPLOAD``.
+        """
+        invalid_direction = random_name(self)
+        exception = self.assertRaises(
+            ValueError,
+            scp,
+            reactor=object(),
+            username=u"Joe",
+            host=u"example.com",
+            remote_path=self.make_temporary_path(),
+            local_path=self.make_temporary_path(),
+            direction=invalid_direction)
+        self.assertIn(invalid_direction, unicode(exception))


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4200

* Added a new ``upload`` function based on the existing ``flocker.common.runner.download`` 
* Refactored that function to share a common scp function.
* Added a new error case for parsing SCPs `lost connection` error message into an Exception that we can catch from the retry helpers.