### PR TITLE
[FLOC-4188] Only cleanup available volumes

### DIFF
--- a/admin/cleanup.py
+++ b/admin/cleanup.py
@@ -22,6 +22,7 @@ from dateutil.parser import parse as parse_date
 from dateutil.tz import tzutc
 
 from libcloud.compute.base import NodeState, StorageVolume, Node
+from libcloud.compute.types import StorageVolumeState
 from libcloud.compute.providers import get_driver, Provider
 
 from twisted.python.filepath import FilePath
@@ -254,7 +255,11 @@ class CleanVolumes(object):
         keep = []
         for volume in volumes:
             created = _get_volume_creation_time(volume)
-            if self._is_test_volume(volume) and now - created > maximum_age:
+            if (
+                volume.state is StorageVolumeState.AVAILABLE and
+                self._is_test_volume(volume) and
+                now - created > maximum_age
+            ):
                 destroy.append(volume)
             else:
                 keep.append(volume)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.6
-apache-libcloud==0.17.0
+apache-libcloud==0.20.1
 astroid==1.4.4
 awscli==1.9.17
 backports.ssl-match-hostname==3.4.0.2


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4188

I originally thought that the script should ignore volumes that are attached to nodes that it has decided to keep.

Instead, I've it's far simpler to only attempt to delete volumes that are available.

This should prevent the script attempting to delete volumes that are attached to non-buildbot / jenkins acceptance test nodes.
It should also prevent the errors that we see when it attempts to delete volumes that are in other transient states....eg detaching as we can see in these build results

http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/view/master/job/master/job/_cleanup_cloud_resources/10/artifact/cleanup_cloud_resources.stderr/*view*/

```
Destroying resource.
Traceback (most recent call last):
  File "admin/cleanup_cloud_resources", line 13, in <module>
    main(sys.argv[1:], BASEPATH, TOPLEVEL)
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 531, in cleanup_cloud_resources_main
    perform_all_actions(all_actions)
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 557, in perform_all_actions
    destroy_resource(resource)
--- <exception caught here> ---
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 544, in destroy_resource
    resource.destroy()
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/base.py", line 537, in destroy
    return self.driver.destroy_volume(volume=self)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/drivers/openstack.py", line 173, in destroy_volume
    method='DELETE').success()
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/openstack.py", line 200, in request
    raw=raw)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/base.py", line 736, in request
    response = responseCls(**kwargs)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/drivers/openstack.py", line 956, in __init__
    super(OpenStack_1_1_Response, self).__init__(*args, **kwargs)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/base.py", line 117, in __init__
    raise Exception(self.parse_error())
exceptions.Exception: 400 Bad Request Invalid input received: Invalid volume: Volume status must be available or error, but current status is: detaching (HTTP 400) (Request-ID: req-e0fc1d5c-84bb-401e-bdc5-7bb29cbab416)

Destroying resource.
Traceback (most recent call last):
  File "admin/cleanup_cloud_resources", line 13, in <module>
    main(sys.argv[1:], BASEPATH, TOPLEVEL)
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 531, in cleanup_cloud_resources_main
    perform_all_actions(all_actions)
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 557, in perform_all_actions
    destroy_resource(resource)
--- <exception caught here> ---
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 544, in destroy_resource
    resource.destroy()
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/base.py", line 537, in destroy
    return self.driver.destroy_volume(volume=self)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/drivers/openstack.py", line 173, in destroy_volume
    method='DELETE').success()
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/openstack.py", line 200, in request
    raw=raw)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/base.py", line 736, in request
    response = responseCls(**kwargs)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/drivers/openstack.py", line 956, in __init__
    super(OpenStack_1_1_Response, self).__init__(*args, **kwargs)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/base.py", line 117, in __init__
    raise Exception(self.parse_error())
exceptions.Exception: 400 Bad Request Invalid input received: Invalid volume: Volume status must be available or error, but current status is: detaching (HTTP 400) (Request-ID: req-afcc978c-c66c-4188-96e8-5755b6565876)

Destroying resource.
Traceback (most recent call last):
  File "admin/cleanup_cloud_resources", line 13, in <module>
    main(sys.argv[1:], BASEPATH, TOPLEVEL)
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 531, in cleanup_cloud_resources_main
    perform_all_actions(all_actions)
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 557, in perform_all_actions
    destroy_resource(resource)
--- <exception caught here> ---
  File "/tmp/workspace/ClusterHQ-flocker/master/_cleanup_cloud_resources/admin/cleanup.py", line 544, in destroy_resource
    resource.destroy()
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/base.py", line 537, in destroy
    return self.driver.destroy_volume(volume=self)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/compute/drivers/ec2.py", line 2378, in destroy_volume
    response = self.connection.request(self.path, params=params).object
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/base.py", line 736, in request
    response = responseCls(**kwargs)
  File "/tmp/5637/local/lib/python2.7/site-packages/libcloud/common/base.py", line 117, in __init__
    raise Exception(self.parse_error())
exceptions.Exception: VolumeInUse: Volume vol-fd3d6f05 is currently attached to i-24e9f996
```


You can run the script manually and see that the output now starts with

```
./admin/cleanup_cloud_resources --dry-run --config-file=$PWD/acceptance.yml
...
[
    {
        "category": "NodeActions",
        "destroy": [],
        "keep": []
    },
    {
        "category": "VolumeActions",
        "destroy": [],
        "keep": [
...
```
