### PR TITLE
[FLOC-4164] Increase retry of first run of sudo on GCE instances

### DIFF
--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -392,7 +392,7 @@ class GCENode(PClass):
                     address=self.address,
                     commands=enable_root_ssh,
                 ),
-                30
+                120
             ))
 
         commands.append(provision_for_any_user(self, package_source, variants))


### PR DESCRIPTION
Once on master the first sudo to a CentOS GCE machine failed for 30 seconds claiming that you cannot sudo if you don't have a tty. This is consistent with the google init script that comes in from metadata (userData for you AWS folks) taking a long time to run (This is where we turn on sudo from non-tty).

In no other run was this even needed to retry once, so there would be fair criticism that this might not fix the problem.

However, it is cheaper than launching a deeper investigation (even improving logging would be a bit tricky), and it is a bug in provisioning code, not production code, so I wanted to try this and then wait to see if the error repeated itself.