### PR TITLE
[FLOC-3829] Have the GCE driver implement ICloudAPI

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1137,6 +1137,9 @@ class ICloudAPI(Interface):
         This is only used by acceptance tests, so has no direct functional
         tests.
 
+        This is done on a best effort basis. Error conditions are not tested
+        for or even necessarily raised if they occur.
+
         :param unicode node_id: The compute node ID to startup.
         """
 

--- a/flocker/node/agents/functional/test_gce.py
+++ b/flocker/node/agents/functional/test_gce.py
@@ -92,7 +92,7 @@ class GCEComputeTestObjects(Fixture):
                 else:
                     raise e
 
-        self.addCleanup(destroy_best_effort(instance))
+        self.addCleanup(lambda: destroy_best_effort(instance))
         return instance
 
 

--- a/flocker/node/agents/functional/test_gce.py
+++ b/flocker/node/agents/functional/test_gce.py
@@ -90,7 +90,7 @@ class GCEComputeTestObjects(Fixture):
                     # The test must have already destroyed the instance.
                     pass
                 else:
-                    raise e
+                    raise
 
         self.addCleanup(lambda: destroy_best_effort(instance))
         return instance
@@ -172,7 +172,18 @@ class GCEBlockDeviceAPITests(TestCase):
     def test_list_live_nodes_pagination_and_removal(self):
         """
         list_live_nodes should be able to walk pages to get all live nodes and
-        should not have nodes after they are destroyed.
+        should not have nodes after they are destroyed or stopped.
+
+        Also, _stop_node and start_node should be able to take a node off-line
+        and bring it back online.
+
+        Sorry for testing two things in this test.
+
+        Unfortunately, to verify pagination is working there must be two nodes
+        running. Also, to test start_node and _stop_node, there must be a
+        second instance started up. Since starting and stopping a node is time
+        consuming, I decided to combine these into the same test. My apologies
+        to future maintainers if this makes debugging failures less pleasant.
         """
         api = gceblockdeviceapi_for_test(self)
 
@@ -197,7 +208,7 @@ class GCEBlockDeviceAPITests(TestCase):
             )
         )
 
-        api.stop_node(other_instance_name)
+        api._stop_node(other_instance_name)
 
         self.assertThat(
             api.list_live_nodes(),

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -353,7 +353,7 @@ class GCEBlockDeviceAPI(object):
         """
         return u"flocker-v1-cluster-id: " + unicode(self._cluster_id)
 
-    def _do_blocking_operation(self, function, max_wait=60, **kwargs):
+    def _do_blocking_operation(self, function, timeout_sec=60, **kwargs):
         """
         Perform a GCE operation, blocking until the operation completes.
 
@@ -370,8 +370,8 @@ class GCEBlockDeviceAPI(object):
         :param function: Callable that takes keyword arguments project and
             zone, and returns an executable that results in a GCE operation
             resource dict as described above.
-        :param int max_wait: The maximum amount of time to wait in seconds for
-            the operation to complete.
+        :param int timeout_sec: The maximum amount of time to wait in seconds
+            for the operation to complete.
         :param kwargs: Additional keyword arguments to pass to function.
 
         :returns dict: A dict representing the concluded GCE operation
@@ -389,7 +389,7 @@ class GCEBlockDeviceAPI(object):
         # operations within GCE and use that information to determine
         # an appropriate timeout. Until that is done, use the
         # following arbitrary timeout.
-        return wait_for_operation(self._compute, operation, [1]*max_wait)
+        return wait_for_operation(self._compute, operation, [1]*timeout_sec)
 
     def allocation_unit(self):
         """
@@ -570,7 +570,7 @@ class GCEBlockDeviceAPI(object):
     def start_node(self, node_id):
         self._do_blocking_operation(
             self._compute.instances().start,
-            max_wait=5*60,
+            timeout_sec=5*60,
             instance=node_id
         )
 
@@ -585,6 +585,6 @@ class GCEBlockDeviceAPI(object):
         """
         self._do_blocking_operation(
             self._compute.instances().stop,
-            max_wait=5*60,
+            timeout_sec=5*60,
             instance=node_id
         )

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -353,7 +353,7 @@ class GCEBlockDeviceAPI(object):
         """
         return u"flocker-v1-cluster-id: " + unicode(self._cluster_id)
 
-    def _do_blocking_operation(self, function, max_wait=35, **kwargs):
+    def _do_blocking_operation(self, function, max_wait=60, **kwargs):
         """
         Perform a GCE operation, blocking until the operation completes.
 

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -562,10 +562,10 @@ class GCEBlockDeviceAPI(object):
                 pageToken=page_token
             ).execute()
             page_token = result.get('nextPageToken')
-            nodes.extend(result.get('items', []))
+            nodes.extend(result['items'])
             done = not page_token
-        return set(node.get("name") for node in nodes
-                   if node.get("status") == "RUNNING")
+        return set(node["name"] for node in nodes
+                   if node["status"] == "RUNNING")
 
     def start_node(self, node_id):
         self._do_blocking_operation(
@@ -574,7 +574,7 @@ class GCEBlockDeviceAPI(object):
             instance=node_id
         )
 
-    def stop_node(self, node_id):
+    def _stop_node(self, node_id):
         """
         Stops a node. This shuts the node down, but leaves the boot disk
         available so that it can be started again using ``start_node``.


### PR DESCRIPTION
Implement the ICloudAPI in the GCE IBlockDeviceAPI.

Also, actually test all of the endpoints at the functional level.

The GCE functional tests now are considerably slower to run since they actually spin up 2nd instances for some tests.  Since they are only run nightly on Jenkins this seemed reasonable.