### PR TITLE
[FLOC-4327] Use `PSet` for `required_config` in `BackendDescription`

### DIFF
--- a/docs/gettinginvolved/plugins/building-driver.rst
+++ b/docs/gettinginvolved/plugins/building-driver.rst
@@ -126,7 +126,7 @@ Here's what the module could look like:
         name=u"mystorage_flocker_plugin",
         needs_reactor=False, needs_cluster_id=True,
         api_factory=api_factory,
-        required_config=set("username", "password",),
+        required_config={u"username", u"password"},
         deployer_type=DeployerType.block)
 
 The ``required_config`` set in a ``BackendDescription`` is an optional set of configuration keys that must be present in your backend's ``agent.yml`` for your driver to successfully initialize.

--- a/docs/gettinginvolved/plugins/building-driver.rst
+++ b/docs/gettinginvolved/plugins/building-driver.rst
@@ -131,6 +131,7 @@ Here's what the module could look like:
 
 The ``required_config`` set in a ``BackendDescription`` is an optional set of configuration keys that must be present in your backend's ``agent.yml`` for your driver to successfully initialize.
 If you specify ``required_config``, the dataset agent will validate that all of these keys are present in the user's ``dataset`` configuration when starting.
+The specified keys must be a set of :py:obj:`unicode` objects.
 
 The ``cluster_id`` parameter is a Python :py:obj:`uuid.UUID` instance uniquely identifying the cluster.
 This is useful if you want to build a system that supports multiple Flocker clusters talking to a shared storage backend.

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -438,7 +438,7 @@ class BackendDescription(PClass):
     # out.
     needs_cluster_id = field(type=bool, mandatory=True)
     # Config "dataset" keys required to initialize this backend.
-    required_config = pset_field(str)
+    required_config = pset_field(unicode)
     api_factory = field(mandatory=True)
     deployer_type = field(
         mandatory=True,
@@ -469,15 +469,15 @@ _DEFAULT_BACKENDS = [
         name=u"openstack", needs_reactor=False, needs_cluster_id=True,
         api_factory=cinder_from_configuration,
         deployer_type=DeployerType.block,
-        required_config=set(["region", ]),
+        required_config={u"region"},
     ),
     BackendDescription(
         name=u"aws", needs_reactor=False, needs_cluster_id=True,
         api_factory=aws_from_configuration,
         deployer_type=DeployerType.block,
-        required_config=set(
-            ["region", "zone", "access_key_id", "secret_access_key", ]
-        ),
+        required_config={
+            u"region", u"zone", u"access_key_id", u"secret_access_key",
+        },
     ),
 ]
 

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -426,8 +426,9 @@ class BackendDescription(PClass):
     :ivar api_factory: An object which can be called with some simple
         configuration data and which returns the API object implementing this
         storage backend.
-    :ivar required_config: A ``set`` of the dataset configuration keys
+    :ivar required_config: A set of the dataset configuration keys
         required to initialize this backend.
+    :type required_config: ``PSet`` of ``unicode``
     :ivar deployer_type: A constant from ``DeployerType`` indicating which kind
         of ``IDeployer`` the API object returned by ``api_factory`` is usable
         with.

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -14,7 +14,7 @@ import yaml
 
 from jsonschema import FormatChecker, Draft4Validator
 
-from pyrsistent import PClass, field, PMap, pmap, pvector
+from pyrsistent import PClass, field, PMap, pmap, pvector, pset_field
 
 from eliot import ActionType, fields
 
@@ -438,7 +438,7 @@ class BackendDescription(PClass):
     # out.
     needs_cluster_id = field(type=bool, mandatory=True)
     # Config "dataset" keys required to initialize this backend.
-    required_config = field(type=set, mandatory=True, initial=set())
+    required_config = pset_field(str)
     api_factory = field(mandatory=True)
     deployer_type = field(
         mandatory=True,

--- a/flocker/node/test/test_script.py
+++ b/flocker/node/test/test_script.py
@@ -414,7 +414,7 @@ class AgentServiceGetAPITests(TestCase):
                     name=self.agent_service.backend_name,
                     needs_reactor=False, needs_cluster_id=False,
                     api_factory=API, deployer_type=DeployerType.p2p,
-                    required_config=set(["region", "api_key", ]),
+                    required_config={u"region", u"api_key"},
                 ),
             ],
         )


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-4237

This also makes it require unicode. I don't think anybody has started using this.