### PR TITLE
[FLOC-4199] Verify that the version.html value matches the version being published

### DIFF
--- a/admin/aws.py
+++ b/admin/aws.py
@@ -548,13 +548,18 @@ class FakeAWS(object):
         """
         See :class:`UploadToS3`.
         """
-        bucket = self.s3_buckets[intent.target_bucket]
+
         with intent.file.open() as source_file:
             content = source_file.read()
+        # XXX: Need to think about this.
+        # The fake currently only allows unicode content.
         content_type = intent.content_type
         if content_type is not None:
             content = ContentTypeUnicode(content, content_type)
-        bucket[intent.target_key] = content
+        self.state = self.state.transform(
+            ['s3_buckets', intent.target_bucket, intent.target_key],
+            content
+        )
 
     def get_dispatcher(self):
         """

--- a/admin/aws.py
+++ b/admin/aws.py
@@ -10,6 +10,7 @@ from effect import Effect, sync_performer, TypeDispatcher
 from effect.do import do, do_return
 
 import boto
+from boto.s3.website import RoutingRules
 from pyrsistent import PClass, pmap_field, PMap, field, discard, freeze
 from twisted.python.filepath import FilePath
 
@@ -438,7 +439,7 @@ class FakeAWSState(PClass):
     """
     routing_rules = pmap_field(
         key_type=unicode,
-        value_type=boto.s3.website.RoutingRules
+        value_type=RoutingRules
     )
     s3_buckets = pmap_field(
         key_type=unicode,

--- a/admin/aws.py
+++ b/admin/aws.py
@@ -283,6 +283,8 @@ def perform_download_s3_key(dispatcher, intent):
 
     bucket = s3.get_bucket(intent.source_bucket)
     key = bucket.get_key(intent.source_key)
+    if key is None:
+        raise KeyError(intent.source_key)
     with intent.target_path.open('w') as target_file:
         key.get_contents_to_file(target_file)
 

--- a/admin/aws.py
+++ b/admin/aws.py
@@ -407,6 +407,7 @@ boto_dispatcher = TypeDispatcher({
     CopyS3Keys: perform_copy_s3_keys,
     DownloadS3KeyRecursively: perform_download_s3_key_recursively,
     DownloadS3Key: perform_download_s3_key,
+    ReadS3Key: perform_read_s3_key,
     UploadToS3Recursively: perform_upload_s3_key_recursively,
     UploadToS3: perform_upload_s3_key,
     CreateCloudFrontInvalidation: perform_create_cloudfront_invalidation,

--- a/admin/release.py
+++ b/admin/release.py
@@ -51,8 +51,8 @@ from .aws import (
     ListS3Keys,
     DeleteS3Keys,
     CopyS3Keys,
-    DownloadS3Key,
     DownloadS3KeyRecursively,
+    ReadS3Key,
     UploadToS3,
     UploadToS3Recursively,
     CreateCloudFrontInvalidation,
@@ -242,20 +242,12 @@ def publish_docs(flocker_version, doc_version, environment, routing_config):
     else:
         stable_prefix = "en/latest/"
 
-    version_number_file = FilePath('/tmp/bucket').temporarySibling()
-    version_number_file.requireCreate(False)
-    try:
-        yield Effect(
-            DownloadS3Key(
-                source_bucket=configuration.dev_bucket,
-                source_key=dev_prefix + u"version.html",
-                target_path=version_number_file,
-            )
+    found_version_number = yield Effect(
+        ReadS3Key(
+            source_bucket=configuration.dev_bucket,
+            source_key=dev_prefix + u"version.html",
         )
-        found_version_number = version_number_file.getContent()
-    finally:
-        if version_number_file.exists():
-            version_number_file.remove()
+    )
 
     if found_version_number != doc_version:
         raise UnexpectedDocumentationVersion(

--- a/admin/release.py
+++ b/admin/release.py
@@ -10,6 +10,7 @@ https://clusterhq.atlassian.net/browse/FLOC-397
 
 import yaml
 import os
+import re
 import sys
 import tempfile
 import virtualenv
@@ -162,6 +163,14 @@ DOCUMENTATION_CONFIGURATIONS = {
 }
 
 
+def strip_html_tags(html):
+    """
+    :param unicode html: The HTML content.
+    :returns: ``html`` with all HTML tags removed.
+    """
+    return re.sub(r"</?[^>]+>", "", html)
+
+
 def parse_routing_rules(routing_config, hostname):
     """
     Parse routing rule description.
@@ -242,13 +251,13 @@ def publish_docs(flocker_version, doc_version, environment, routing_config):
     else:
         stable_prefix = "en/latest/"
 
-    found_version_number = yield Effect(
+    found_version_html = yield Effect(
         ReadS3Key(
             source_bucket=configuration.dev_bucket,
             source_key=dev_prefix + u"version.html",
         )
     )
-
+    found_version_number = strip_html_tags(found_version_html).strip()
     if found_version_number != doc_version:
         raise UnexpectedDocumentationVersion(
             documentation_version=found_version_number,

--- a/admin/release.py
+++ b/admin/release.py
@@ -99,6 +99,8 @@ class UnexpectedDocumentationVersion(Exception):
     Raised if the source documentation is found to have a different version
     than is being published.
     """
+    def __str__(self):
+        return self.__repr__()
 
 
 class Environments(Names):

--- a/admin/test/test_release.py
+++ b/admin/test/test_release.py
@@ -1185,15 +1185,18 @@ class UploadPythonPackagesTests(TestCase):
 
     def setUp(self):
         super(UploadPythonPackagesTests, self).setUp()
-        self.target_bucket = 'test-target-bucket'
+        self.target_bucket = u'test-target-bucket'
         self.scratch_directory = FilePath(self.mktemp())
         self.top_level = FilePath(self.mktemp())
         self.top_level.makedirs()
         self.aws = FakeAWS(
-            routing_rules={},
-            s3_buckets={
-                self.target_bucket: {},
-            })
+            state=FakeAWSState(
+                routing_rules=freeze({}),
+                s3_buckets=freeze({
+                    self.target_bucket: {},
+                })
+            )
+        )
 
     def upload_python_packages(self):
         """
@@ -1237,7 +1240,7 @@ class UploadPythonPackagesTests(TestCase):
 
         self.upload_python_packages()
 
-        aws_keys = self.aws.s3_buckets[self.target_bucket].keys()
+        aws_keys = self.aws.state.s3_buckets[self.target_bucket].keys()
         self.assertEqual(
             sorted(aws_keys),
             ['python/Flocker-0.3.0-py2-none-any.whl',

--- a/admin/test/test_release.py
+++ b/admin/test/test_release.py
@@ -1450,14 +1450,16 @@ class UploadPipIndexTests(TestCase):
         """
         An index file is uploaded to S3.
         """
-        bucket = 'clusterhq-archive'
+        bucket = u'clusterhq-archive'
         aws = FakeAWS(
-            routing_rules={},
-            s3_buckets={
-                bucket: {
-                    'python/Flocker-0.3.1-py2-none-any.whl': '',
-                },
-            })
+            state=FakeAWSState(
+                s3_buckets=freeze({
+                    bucket: {
+                        u'python/Flocker-0.3.1-py2-none-any.whl': u'',
+                    },
+                })
+            )
+        )
 
         scratch_directory = FilePath(self.mktemp())
         scratch_directory.makedirs()
@@ -1469,11 +1471,11 @@ class UploadPipIndexTests(TestCase):
                 target_bucket=bucket))
 
         self.assertEqual(
-            aws.s3_buckets[bucket]['python/index.html'],
+            aws.state.s3_buckets[bucket][u'python/index.html'],
             (
-                '<html>\nThis is an index for pip\n<div>'
-                '<a href="Flocker-0.3.1-py2-none-any.whl">'
-                'Flocker-0.3.1-py2-none-any.whl</a><br />\n</div></html>'
+                u'<html>\nThis is an index for pip\n<div>'
+                u'<a href="Flocker-0.3.1-py2-none-any.whl">'
+                u'Flocker-0.3.1-py2-none-any.whl</a><br />\n</div></html>'
             ))
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,11 +13,8 @@
 
 from twisted.python.filepath import FilePath
 
-import atexit
 import sys
 import os
-import json
-from tempfile import mkdtemp
 
 sys.path.insert(0, FilePath(__file__).parent().parent().path)
 
@@ -343,17 +340,3 @@ linkcheck_ignore = [
 def setup(app):
     # This allows us to ignore spelling in any particular file
     app.add_config_value('is_spelling_check', 'spelling' in sys.argv, True)
-
-
-version_file = FilePath(mkdtemp()).child('version.json')
-atexit.register(version_file.parent().remove)
-with version_file.open('w') as fp:
-    json.dump(
-        obj=dict(
-            version=version,
-            release=release,
-        ),
-        fp=fp
-    )
-
-html_extra_path = [version_file.path]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,11 @@
 
 from twisted.python.filepath import FilePath
 
+import atexit
 import sys
 import os
+import json
+from tempfile import mkdtemp
 
 sys.path.insert(0, FilePath(__file__).parent().parent().path)
 
@@ -340,3 +343,17 @@ linkcheck_ignore = [
 def setup(app):
     # This allows us to ignore spelling in any particular file
     app.add_config_value('is_spelling_check', 'spelling' in sys.argv, True)
+
+
+version_file = FilePath(mkdtemp()).child('version.json')
+atexit.register(version_file.parent().remove)
+with version_file.open('w') as fp:
+    json.dump(
+        obj=dict(
+            version=version,
+            release=release,
+        ),
+        fp=fp
+    )
+
+html_extra_path = [version_file.path]


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4199

Sorry this branch grew so big.
I added the check for version and was faced with updating dozens of tests with fixed dictionaries of fake S3 keys.
So instead I modified FakeAWS to use an immutable FakeAWSState and added some canned states to test_release.
The tests can then transform the canned state, adding modifying keys, route and redirection rules.
Trouble is that that then broke a bunch of other test modules that also use FakeAWS so I had to go and update those too.

I also deleted a bunch of ``publish_docs`` which are concerned with publishing to a staging bucket. That is no longer part of the release process. We only ever use ``admin/publish_docs --production``.

