### PR TITLE
[FLOC-4271] Make the P2P deployer not require the container agent running.

### DIFF
--- a/flocker/node/_p2p.py
+++ b/flocker/node/_p2p.py
@@ -274,10 +274,6 @@ class P2PManifestationDeployer(object):
         better solution.
         """
         local_state = cluster_state.get_node(self.node_uuid)
-        # We need to know applications (for now) to see if we should delay
-        # deletion or handoffs. Eventually this will rely on leases instead.
-        if local_state.applications is None:
-            return sequentially(changes=[])
         phases = []
 
         not_in_use_datasets = NotInUseDatasets(

--- a/flocker/node/test/test_p2p.py
+++ b/flocker/node/test/test_p2p.py
@@ -518,7 +518,7 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
 
         changes = api.calculate_changes(desired, current,
                                         NodeLocalState(node_state=node_state))
-        self.assertEqual(NoOp(sleep=timedelta(seconds=60)), changes)
+        self.assertEqual(NO_CHANGES, changes)
 
     def test_volume_handoff(self):
         """
@@ -758,32 +758,6 @@ class P2PManifestationDeployerCalculateChangesTests(TestCase):
                     dataset=dataset,
                     hostname=u'node2.example.com')]
             )])
-        self.assertEqual(expected, changes)
-
-    def test_unknown_applications(self):
-        """
-        If applications are unknown, no changes are calculated.
-        """
-        node_state = NodeState(
-            hostname=u"10.1.1.1",
-            manifestations={MANIFESTATION.dataset_id:
-                            MANIFESTATION},
-            devices={}, paths={},
-            applications=None,
-        )
-
-        api = P2PManifestationDeployer(
-            node_state.hostname, create_volume_service(self)
-        )
-        current = DeploymentState(nodes=[node_state])
-        desired = Deployment(nodes=[
-            Node(hostname=api.hostname,
-                 manifestations=node_state.manifestations.transform(
-                     (DATASET_ID, "dataset", "deleted"), True))])
-
-        changes = api.calculate_changes(desired, current,
-                                        NodeLocalState(node_state=node_state))
-        expected = NoOp(sleep=timedelta(seconds=60))
         self.assertEqual(expected, changes)
 
     def test_different_node_is_ignorant(self):


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-4271

This is a follow up to #2272 for the obsolete ZFS backend.

I'm doing this so I can test the code-paths for provisioning hooks with in-tree code.