### PR TITLE
[FLOC-4274] Document how to run Cinder functional tests on Devstack

### DIFF
--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -134,7 +134,49 @@ To run the functional tests, run the following command:
 OpenStack
 =========
 
-The configuration stanza for an private OpenStack deployment is the same as Rackspace above, but ``auth_plugin`` should be included, which refers to an authentication plugin provided by ``python-keystoneclient``.
+The configuration stanza for a private OpenStack deployment is similar to Rackspace (above), with a few notable differences:
+
+* ``auth_plugin`` should be included, which refers to an authentication plugin provided by ``python-keystoneclient``, and
+* ``provider: "openstack"`` should be included, if the top level key is not ``openstack``.
 
 If required, you may need to add additional fields.
 For more information, see :ref:`openstack-dataset-backend`.
+
+Devstack
+--------
+
+It is assumed that you have a working ``Devstack`` environment.
+Refer to document "Setting up a devstack instance" on Google Drive.
+
+To run the Cinder functional tests on ``devstack``:
+
+* boot a supported guest operating system in ``devstack``,
+* log into the guest and clone your branch of the Flocker source code and
+* install the Flocker dependencies in a ``virtualenv``.
+* Create ``$HOME/acceptance.yml`` containing:
+
+.. code:: yaml
+
+   # It is important to use ``devstack-openstack`` as the top-level name
+   # because this limits the size of the Cinder volumes created in the tests to
+   # 1 GiB.
+   devstack-openstack:
+     auth_plugin: password
+     username: "<devstack username e.g. admin>"
+     password: "<devstack password>"
+     tenant_name: "<devstack project name e.g. demo>"
+     region_name: "<devstack region e.g. RegionOne>"
+     auth_url: "<devstack keystone server endpoint e.g. http://192.0.2.100:5000/v2.0>"
+     # This is important, so that the tests know to load the OpenStack Cinder
+     # driver despite not using ``openstack`` as the top-level name.
+     provider: "openstack"
+
+* Run trial as ``root``:
+
+.. prompt:: bash #
+
+   FLOCKER_FUNCTIONAL_TEST=TRUE \
+   FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE=$HOME/acceptance.yml \
+   FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=devstack-openstack \
+   FLOCKER_FUNCTIONAL_TEST_OPENSTACK_REGION=<devstack region e.g. RegionOne> \
+   trial --testmodule flocker/node/agents/cinder.py

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -165,7 +165,6 @@ To run the Cinder functional tests on DevStack:
      username: "<DevStack username e.g. admin>"
      password: "<DevStack password>"
      tenant_name: "<DevStack project name e.g. demo>"
-     region_name: "<DevStack region e.g. RegionOne>"
      auth_url: "<DevStack keystone server endpoint e.g. http://192.0.2.100:5000/v2.0>"
      # This is important, so that the tests know to load the OpenStack Cinder
      # driver despite not using ``openstack`` as the top-level name.
@@ -178,5 +177,4 @@ To run the Cinder functional tests on DevStack:
    FLOCKER_FUNCTIONAL_TEST=TRUE \
    FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE=$HOME/acceptance.yml \
    FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=devstack-openstack \
-   FLOCKER_FUNCTIONAL_TEST_OPENSTACK_REGION=<devstack region e.g. RegionOne> \
    trial --testmodule flocker/node/agents/cinder.py

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -136,7 +136,7 @@ OpenStack
 
 The configuration stanza for a private OpenStack deployment is similar to Rackspace (above), with a few notable differences:
 
-* ``auth_plugin`` should be included, which refers to an authentication plugin provided by ``python-keystoneclient``, and
+* ``auth_plugin`` should be included, which refers to an authentication plugin provided by ``python-keystoneclient``.
 * ``provider: "openstack"`` should be included, if the top level key is not ``openstack``.
 
 If required, you may need to add additional fields.
@@ -150,9 +150,9 @@ Refer to document "Setting up a DevStack instance" on Google Drive.
 
 To run the Cinder functional tests on DevStack:
 
-* boot a supported guest operating system in DevStack,
-* log into the guest and clone your branch of the Flocker source code and
-* install the Flocker dependencies in a ``virtualenv``.
+* Boot a supported guest operating system in DevStack.
+* Log into the guest and clone your branch of the Flocker source code.
+* Install the Flocker dependencies in a ``virtualenv``.
 * Create ``$HOME/acceptance.yml`` containing:
 
 .. code:: yaml

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -142,15 +142,15 @@ The configuration stanza for a private OpenStack deployment is similar to Racksp
 If required, you may need to add additional fields.
 For more information, see :ref:`openstack-dataset-backend`.
 
-Devstack
+DevStack
 --------
 
-It is assumed that you have a working ``Devstack`` environment.
-Refer to document "Setting up a devstack instance" on Google Drive.
+It is assumed that you have a working DevStack environment.
+Refer to document "Setting up a DevStack instance" on Google Drive.
 
-To run the Cinder functional tests on ``devstack``:
+To run the Cinder functional tests on DevStack:
 
-* boot a supported guest operating system in ``devstack``,
+* boot a supported guest operating system in DevStack,
 * log into the guest and clone your branch of the Flocker source code and
 * install the Flocker dependencies in a ``virtualenv``.
 * Create ``$HOME/acceptance.yml`` containing:
@@ -162,11 +162,11 @@ To run the Cinder functional tests on ``devstack``:
    # 1 GiB.
    devstack-openstack:
      auth_plugin: password
-     username: "<devstack username e.g. admin>"
-     password: "<devstack password>"
-     tenant_name: "<devstack project name e.g. demo>"
-     region_name: "<devstack region e.g. RegionOne>"
-     auth_url: "<devstack keystone server endpoint e.g. http://192.0.2.100:5000/v2.0>"
+     username: "<DevStack username e.g. admin>"
+     password: "<DevStack password>"
+     tenant_name: "<DevStack project name e.g. demo>"
+     region_name: "<DevStack region e.g. RegionOne>"
+     auth_url: "<DevStack keystone server endpoint e.g. http://192.0.2.100:5000/v2.0>"
      # This is important, so that the tests know to load the OpenStack Cinder
      # driver despite not using ``openstack`` as the top-level name.
      provider: "openstack"

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -23,6 +23,7 @@ Debian
 deduplication
 Deis
 devel
+DevStack
 DigitalOcean
 dropdown
 Dockerized

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -39,9 +39,7 @@ from ..test.blockdevicefactory import (
     get_blockdeviceapi_with_cleanup, get_device_allocation_unit,
     get_minimum_allocatable_size, get_openstack_region_for_test,
 )
-from ....testtools import (
-    REALISTIC_BLOCKDEVICE_SIZE, TestCase, flaky, run_process,
-)
+from ....testtools import TestCase, flaky, run_process
 
 from ..cinder import (
     get_keystone_session, get_cinder_v1_client, get_nova_v2_client,
@@ -638,7 +636,7 @@ class BlockDeviceAPIDestroyTests(TestCase):
         """
         new_volume = self.api.create_volume(
             dataset_id=uuid4(),
-            size=int(REALISTIC_BLOCKDEVICE_SIZE.to_Byte()),
+            size=get_minimum_allocatable_size(),
         )
 
         expected_timeout = 8

--- a/flocker/node/agents/functional/test_cinder_behaviour.py
+++ b/flocker/node/agents/functional/test_cinder_behaviour.py
@@ -7,6 +7,8 @@ basic assumptions/understandings of how Cinder works in the real world.
 
 from unittest import SkipTest
 
+from bitmath import Byte
+
 from ..cinder import (
     get_keystone_session, get_cinder_v1_client, wait_for_volume_state
 )
@@ -15,6 +17,7 @@ from ..test.blockdevicefactory import (
     ProviderType,
     get_openstack_region_for_test,
     get_blockdevice_config,
+    get_minimum_allocatable_size,
 )
 from ....testtools import TestCase, random_name
 
@@ -56,7 +59,7 @@ class VolumesCreateTests(TestCase):
         expected_metadata = {random_name(self): "bar"}
 
         new_volume = self.cinder_volumes.create(
-            size=100,
+            size=int(Byte(get_minimum_allocatable_size()).to_GiB().value),
             metadata=expected_metadata
         )
         CINDER_VOLUME(id=new_volume.id).write()
@@ -94,7 +97,9 @@ class VolumesSetMetadataTests(TestCase):
         """
         expected_metadata = {random_name(self): u"bar"}
 
-        new_volume = self.cinder_volumes.create(size=100)
+        new_volume = self.cinder_volumes.create(
+            size=int(Byte(get_minimum_allocatable_size()).to_GiB().value),
+        )
         CINDER_VOLUME(id=new_volume.id).write()
         self.addCleanup(self.cinder_volumes.delete, new_volume)
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4274

I also had to modify some of the tests that were still using `REALISTIC_BLOCKDEVICE_SIZE` .

All Cinder functional test now pass:

```
(flocker)[centos@centos7-1 flocker]$ sudo /usr/bin/env FLOCKER_FUNCTIONAL_TEST=TRUE FLOCKER_FUNCTIONAL_TEST_CLOUD_CONFIG_FILE=$PWD/acceptance.yml FLOCKER_FUNCTIONAL_TEST_CLOUD_PROVIDER=devstack-openstack $(type -p trial) --testmodule $PWD/flocker/node/agents/cinder.py
flocker.node.agents.functional.test_cinder
  BlockDeviceAPIDestroyTests
    test_destroy_timesout ...                                              [OK]
  CinderAttachmentTests
    test_get_device_path_no_attached_disks ...                             [OK]
  CinderBlockDeviceAPIInterfaceTests
    test_attach_attached_volume ...                                        [OK]
    test_attach_destroyed_volume ...                                       [OK]
    test_attach_elsewhere_attached_volume ...                              [OK]
    test_attach_unattached_volume ...                                      [OK]
    test_attach_unknown_volume ...                                         [OK]
    test_attached_volume_listed ...                                        [OK]
    test_compute_instance_id_nonempty ...                                  [OK]
    test_compute_instance_id_unicode ...                                   [OK]
    test_created_is_listed ...                                             [OK]
    test_created_volume_attributes ...                                     [OK]
    test_destroy_destroyed_volume ...                                      [OK]
    test_destroy_unknown_volume ...                                        [OK]
    test_destroy_volume ...                                                [OK]
    test_detach_detached_volume ...                                        [OK]
    test_detach_unknown_volume ...                                         [OK]
    test_detach_volume ...                                                 [OK]
    test_device_size ...                                                   [OK]
    test_foreign_cluster_volume ...                                        [OK]
    test_foreign_volume ...                                                [OK]
    test_get_device_path_device ...                                        [OK]
    test_get_device_path_device_repeatable_results ...                     [OK]
    test_get_device_path_unattached_volume ...                             [OK]
    test_get_device_path_unknown_volume ...                                [OK]
    test_interface ...                                                     [OK]
    test_list_attached_and_unattached ...                                  [OK]
    test_list_volume_empty ...                                             [OK]
    test_listed_volume_attributes ...                                      [OK]
    test_multiple_volumes_attached_to_host ...                             [OK]
    test_name ...                                                          [OK]
    test_reattach_detached_volume ...                                      [OK]
  CinderCloudAPIInterfaceTests
    test_current_machine_is_live ...                                       [OK]
    test_interface ...                                                     [OK]
    test_list_live_nodes ...                                               [OK]
  CinderHttpsTests
    test_verify_ca_path_no_match_fails ...                                 [OK]
    test_verify_false ...                                                  [OK]
  VirtIOCinderAttachmentTests
    test_disk_attachment_fails_with_conflicting_disk ...              [SKIPPED]
    test_get_device_path_correct_with_attached_disk ...               [SKIPPED]
    test_get_device_path_virtio_blk_error_without_udev ...            [SKIPPED]
    test_get_device_path_virtio_blk_symlink ...                       [SKIPPED]
flocker.node.agents.functional.test_cinder_behaviour
  VolumesCreateTests
    test_create_metadata_is_listed ...                                     [OK]
  VolumesSetMetadataTests
    test_updated_metadata_is_listed ...                                    [OK]

===============================================================================
[SKIPPED]
Tests require the ``virsh`` command.

flocker.node.agents.functional.test_cinder.VirtIOCinderAttachmentTests.test_disk_attachment_fails_with_conflicting_disk
flocker.node.agents.functional.test_cinder.VirtIOCinderAttachmentTests.test_get_device_path_correct_with_attached_disk
flocker.node.agents.functional.test_cinder.VirtIOCinderAttachmentTests.test_get_device_path_virtio_blk_error_without_udev
flocker.node.agents.functional.test_cinder.VirtIOCinderAttachmentTests.test_get_device_path_virtio_blk_symlink
-------------------------------------------------------------------------------
Ran 43 tests in 424.593s

PASSED (skips=4, successes=39)
```