### PR TITLE
[FLOC-4276] Add hooks to support provisioning external backends.

### DIFF
--- a/flocker/node/backends.py
+++ b/flocker/node/backends.py
@@ -101,6 +101,12 @@ class BackendDescription(PClass):
         nodes.
     :type acceptance_provision_node: Callable that takes a
         ``flocker.provision.INode``.
+    :ivar acceptance_configure_cluster: Function that will configure
+        a cluster for use with this backend. This should configure
+        and start any servcies required by the backend. This will be
+        called before configuring the flocker cluster.
+    :type acceptance_configure_cluster: Callable that takes a
+        ``flocker.provision.Cluster``.
     """
     name = field(type=unicode, mandatory=True)
     needs_reactor = field(type=bool, mandatory=True)
@@ -120,6 +126,10 @@ class BackendDescription(PClass):
     acceptance_provision_node = field(
         mandatory=True,
         initial=(lambda node: None),
+    )
+    acceptance_configure_cluster = field(
+        mandatory=True,
+        initial=(lambda cluster: None),
     )
 
 

--- a/flocker/provision/__init__.py
+++ b/flocker/provision/__init__.py
@@ -4,7 +4,7 @@
 Provisioning for acceptance tests.
 """
 
-from ._common import PackageSource, Variants, INode, IProvisioner
+from ._common import PackageSource, Variants, INode, IProvisioner, Cluster
 from ._install import (
     provision, configure_cluster, reinstall_flocker_from_package_source
 )
@@ -21,7 +21,7 @@ CLOUD_PROVIDERS = {
 
 __all__ = [
     'PackageSource', 'Variants',
-    'INode', 'IProvisioner',
+    'INode', 'IProvisioner', 'Cluster',
     'provision',
     'CLOUD_PROVIDERS',
     'configure_cluster',

--- a/flocker/provision/_common.py
+++ b/flocker/provision/_common.py
@@ -50,11 +50,9 @@ class Variants(Values):
     :ivar DISTRO_TESTING: Install packages from the distribution's
         proposed-updates repository.
     :ivar DOCKER_HEAD: Install docker from a repository tracking docker HEAD.
-    :ivar ZFS_TESTING: Install latest zfs build.
     """
     DISTRO_TESTING = ValueConstant("distro-testing")
     DOCKER_HEAD = ValueConstant("docker-head")
-    ZFS_TESTING = ValueConstant("zfs-testing")
 
 
 class Cluster(PClass):

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -1179,7 +1179,7 @@ def task_create_flocker_pool_file():
     ])
 
 
-def task_install_zfs(distribution, variants=set()):
+def task_install_zfs(distribution):
     """
     Install ZFS on a node.
 
@@ -1210,12 +1210,6 @@ def task_install_zfs(distribution, variants=set()):
         if distribution == 'centos-7':
             commands.append(yum_install(["epel-release"]))
 
-        if Variants.ZFS_TESTING in variants:
-            commands += [
-                yum_install(['yum-utils']),
-                run_from_args([
-                    'yum-config-manager', '--enable', 'zfs-testing'])
-            ]
         commands.append(yum_install(["zfs"]))
     else:
         raise DistributionNotSupported(distribution)
@@ -1223,12 +1217,11 @@ def task_install_zfs(distribution, variants=set()):
     return sequence(commands)
 
 
-def configure_zfs(node, variants):
+def configure_zfs(node):
     """
     Configure ZFS for use as a Flocker backend.
 
     :param INode node: The node to configure ZFS on.
-    :param set variants: The set of variant configurations to use when
 
     :return Effect:
     """
@@ -1244,9 +1237,7 @@ def configure_zfs(node, variants):
             username='root',
             address=node.address,
             commands=sequence([
-                task_install_zfs(
-                    distribution=node.distribution,
-                    variants=variants),
+                task_install_zfs(distribution=node.distribution),
                 task_create_flocker_pool_file(),
             ]),
         ),


### PR DESCRIPTION
https://clusterhq.atlassian.net/browse/FLOC-4276

I have a couple of questions:
- should the new configuration be at the top-level, or should there be a separate description of the acceptance testing configuration. I suspect there will need to be more configuration related to tests in the future ([this](https://github.com/ClusterHQ/flocker/blob/61a38a5124e28834e172ac12912424b152660b04/flocker/acceptance/testtools.py#L230) for example will need to be parameterized for ceph).
- Should these variables be actual functions, or fully-qualified names? Both here and in the [ceph driver](https://github.com/ClusterHQ/ceph-flocker-driver/compare/ceph-provision#diff-ed1a3ddb9abeaaaae06d9a573081f693R37) to avoid having to import test-code at runtime (either to avoid potential for import loops or bringing in additional run-time dependencies).