### PR TITLE
avoid recreating already deleted dataset

### DIFF
--- a/flocker/node/_p2p.py
+++ b/flocker/node/_p2p.py
@@ -354,7 +354,8 @@ def find_dataset_changes(uuid, current_state, desired_state):
                             # datasets; this is wrong. See FLOC-2060.
                             in (node.manifestations or {}).values())
                         for node in current_state.nodes}
-    local_desired_datasets = desired_datasets.get(uuid, set())
+    local_desired_datasets = set(dataset for dataset in desired_datasets.get(uuid, set())
+                                 if dataset.deleted is False)
     local_desired_dataset_ids = set(dataset.dataset_id for dataset in
                                     local_desired_datasets)
     local_current_dataset_ids = set(dataset.dataset_id for dataset in


### PR DESCRIPTION
when use p2p type storage backend. we notice that on primary node of deleted dataset. dataset will be created and then deleted constantly.

this exclude already deleted dataset in local_desired_datasets