### PR TITLE
[FLOC-4281] publish-installer-images now prints image ID map

### DIFF
--- a/admin/installer/_images.py
+++ b/admin/installer/_images.py
@@ -355,7 +355,7 @@ def publish_installer_images_effects(options):
     )
     yield Effect(
         intent=StandardOut(
-            content=json.dumps(thaw(ami_map), encoding="utf-8")
+            content=json.dumps(thaw(ami_map), encoding="utf-8") + b"\n"
         )
     )
 

--- a/admin/installer/_images.py
+++ b/admin/installer/_images.py
@@ -311,8 +311,6 @@ class PublishInstallerImagesOptions(Options):
          "Copy images to all regions. [default: False]"]
     ]
     optParameters = [
-        ["target_bucket", None, DEFAULT_IMAGE_BUCKET,
-         "The bucket to upload installer AMI names to.\n", unicode],
         ["build_region", None, DEFAULT_BUILD_REGION.value,
          "A region where the image will be built.\n", unicode],
         ["distribution", None, DEFAULT_DISTRIBUTION,

--- a/admin/installer/_images.py
+++ b/admin/installer/_images.py
@@ -8,8 +8,6 @@ import json
 import sys
 from tempfile import mkdtemp
 
-import boto3
-
 from effect import (
     Effect, ComposedDispatcher, TypeDispatcher,
     sync_performer, base_dispatcher,
@@ -186,18 +184,13 @@ class PackerBuild(PClass):
     sys_module = field(initial=sys)
 
 
-class WriteToS3(PClass):
+class StandardOut(PClass):
     """
-    The attributes necessary to write bytes to an S3 bucket.
+    The attributes necessary to write bytes to stdout.
 
     :ivar content: The bytes to write.
-    :ivar target_bucket: The name of the S3 bucket.
-    :ivar target_key: The name of the object which will be created in the S3
-        bucket.
     """
     content = field(type=bytes, mandatory=True)
-    target_bucket = field(type=unicode, mandatory=True)
-    target_key = field(type=unicode, mandatory=True)
 
 
 class RealPerformers(object):
@@ -275,17 +268,11 @@ class RealPerformers(object):
         return d
 
     @sync_performer
-    def perform_write_to_s3(self, dispatcher, intent):
+    def perform_standard_out(self, dispatcher, intent):
         """
-        Create a new object in an existing S3 bucket with the key and content
-        in ``intent``.
+        Print the content in ``intent`` to stdout.
         """
-        client = boto3.client("s3")
-        client.put_object(
-            Bucket=intent.target_bucket,
-            Key=intent.target_key,
-            Body=intent.content
-        )
+        self.sys_module.stdout.write(intent.content)
 
     # Map intents to performers.
     def dispatcher(self):
@@ -294,7 +281,7 @@ class RealPerformers(object):
                 {
                     PackerConfigure: self.perform_packer_configure,
                     PackerBuild: self.perform_packer_build,
-                    WriteToS3: self.perform_write_to_s3,
+                    StandardOut: self.perform_standard_out,
                 }
             ),
             base_dispatcher
@@ -366,12 +353,9 @@ def publish_installer_images_effects(options):
             configuration_path=configuration_path,
         )
     )
-    # Publish the regional AMI map to S3
     yield Effect(
-        intent=WriteToS3(
-            content=json.dumps(thaw(ami_map), encoding="utf-8"),
-            target_bucket=options['target_bucket'],
-            target_key=options["template"],
+        intent=StandardOut(
+            content=json.dumps(thaw(ami_map), encoding="utf-8")
         )
     )
 

--- a/admin/test/test_images.py
+++ b/admin/test/test_images.py
@@ -8,9 +8,6 @@ from subprocess import check_call, CalledProcessError
 from unittest import skipIf
 
 import boto3
-from botocore.exceptions import (
-    ClientError, NoCredentialsError, EndpointConnectionError
-)
 from botocore.vendored.requests.packages.urllib3.contrib.pyopenssl import (
     extract_from_urllib3,
 )
@@ -26,8 +23,6 @@ from testtools.matchers import StartsWith
 from testtools.content import text_content, content_from_file, ContentType
 from testtools.matchers import Contains
 
-from fixtures import Fixture
-
 from twisted.internet.error import ProcessTerminated
 from twisted.python.filepath import FilePath
 
@@ -36,7 +31,7 @@ from flocker.testtools import (
 )
 
 from ..installer._images import (
-    WriteToS3, PackerBuild,
+    StandardOut, PackerBuild,
     _PackerOutputParser, PackerConfigure,
     AWS_REGIONS, publish_installer_images_effects, RealPerformers,
     PublishInstallerImagesOptions, PACKER_PATH
@@ -46,22 +41,6 @@ from ..installer._images import (
 # exception when we try an API call on an idled persistent connection.
 # See https://github.com/boto/boto3/issues/220
 extract_from_urllib3()
-
-try:
-    boto3.session.Session().client('s3').list_buckets()
-except (ClientError, NoCredentialsError, EndpointConnectionError) as e:
-    S3_INACCESSIBLE = True
-    S3_INACCESSIBLE_REASON = (
-        "S3 is not accessible. "
-        "Check AWS credentials in ~/.aws/credentials. "
-        "Error was: {!r}"
-    ).format(e)
-    del e
-else:
-    S3_INACCESSIBLE = False
-    S3_INACCESSIBLE_REASON = ""
-
-require_s3_credentials = skipIf(S3_INACCESSIBLE, S3_INACCESSIBLE_REASON)
 
 try:
     import flocker as _flocker
@@ -290,74 +269,28 @@ class PackerBuildIntegrationTests(AsyncTestCase):
         return d.addCallback(check_error)
 
 
-class S3BucketFixture(Fixture):
+class StandardOutTests(TestCase):
     """
-    Create a temporary S3 bucket for the duration of a test.
+    Tests for ``StandardOut``.
     """
-    def __init__(self, test_case):
-        super(S3BucketFixture, self).__init__()
-        self.test_case = test_case
-        # Bucket names must be a valid DNS label
-        # https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
-        self.bucket_name = random_name(
-            test_case
-        ).lower().replace("_", "")[-63:]
-
-    def _setUp(self):
-        self.s3client = boto3.client("s3")
-        self.s3client.create_bucket(Bucket=self.bucket_name)
-
-        def cleanup():
-            self.empty_bucket()
-            self.s3client.delete_bucket(Bucket=self.bucket_name)
-        self.addCleanup(cleanup)
-
-    def empty_bucket(self):
-        """
-        Delete all the objects in the temporary bucket.
-        """
-        bucket = self.s3client.list_objects(Bucket=self.bucket_name)
-        for s3object in bucket.get("Contents", []):
-            self.s3client.delete_object(
-                Bucket=self.bucket_name,
-                Key=s3object["Key"],
-            )
-
-    def get_object_content(self, key):
-        """
-        :param unicode key: The key name of an object in the bucket.
-        :returns: The content of the object with ``key``
-        """
-        return self.s3client.get_object(
-            Bucket=self.bucket_name,
-            Key=key
-        )["Body"].read()
-
-
-class WriteToS3Tests(TestCase):
-    """
-    Tests for ``WriteToS3``.
-    """
-    @require_s3_credentials
     def test_perform(self):
         """
-        ``WriteToS3`` has a performer that creates a new object with
-        ``target_key`` and ``content`` in ``target_bucket``
+        ``StandardOut`` has a performer that writes content to sys.stdout.
         """
-        s3 = self.useFixture(S3BucketFixture(test_case=self))
-        intent = WriteToS3(
+        fake_sys_module = FakeSysModule()
+        intent = StandardOut(
             content=random_name(self).encode('ascii'),
-            target_key=random_name(self),
-            target_bucket=s3.bucket_name,
         )
         result = sync_perform(
-            dispatcher=RealPerformers().dispatcher(),
+            dispatcher=RealPerformers(
+                sys_module=fake_sys_module
+            ).dispatcher(),
             effect=Effect(intent=intent)
         )
         self.assertIs(None, result)
         self.assertEqual(
             intent.content,
-            s3.get_object_content(key=intent.target_key),
+            fake_sys_module.stdout.getvalue()
         )
 
 
@@ -385,13 +318,11 @@ class PublishInstallerImagesEffectsTests(TestCase):
                 (PackerBuild(
                     configuration_path=configuration_path,
                 ), lambda intent: ami_map),
-                (WriteToS3(
+                (StandardOut(
                     content=json.dumps(
                         thaw(ami_map),
                         encoding='utf-8',
                     ),
-                    target_bucket=options["target_bucket"],
-                    target_key=options["template"],
                 ), lambda intent: None),
             ],
             eff=publish_installer_images_effects(options=options)
@@ -468,8 +399,7 @@ class PublishInstallerImagesIntegrationTests(TestCase):
         )
 
     @require_packer
-    @require_s3_credentials
-    def test_build_both(self):
+    def foo_test_build_both(self):
         """
         ``publish-installer-images`` can be called twice to first generate
         Docker images and then Flocker images built on the Docker images.
@@ -479,10 +409,8 @@ class PublishInstallerImagesIntegrationTests(TestCase):
         swarm_version = u"1.0.1"
         flocker_version = u"1.10.1"
         build_region = u"us-west-1"
-        s3 = self.useFixture(S3BucketFixture(test_case=self))
         returncode, stdout, stderr = self.publish_installer_images(
-            args=['--target_bucket', s3.bucket_name,
-                  '--template', 'docker',
+            args=['--template', 'docker',
                   '--copy_to_all_regions',
                   '--build_region', build_region],
             extra_enviroment={
@@ -490,18 +418,16 @@ class PublishInstallerImagesIntegrationTests(TestCase):
                 u'SWARM_VERSION': swarm_version,
             }
         )
-        # The script should have uploaded AMI map to an object called "docker"
-        docker_object_content = s3.get_object_content(key=u'docker')
         self.addDetail(
-            'docker_object_content', text_content(docker_object_content)
+            'docker_object_content', text_content(stdout)
         )
 
         # It should be valid JSON.
-        docker_ami_map = json.loads(docker_object_content)
+        docker_ami_map = json.loads(stdout)
+
         # We can use that image as the source for the Flocker image
         returncode, stdout, stderr = self.publish_installer_images(
-            args=['--target_bucket', s3.bucket_name,
-                  '--template', 'flocker',
+            args=['--template', 'flocker',
                   '--build_region', build_region,
                   '--copy_to_all_regions',
                   '--source_ami', docker_ami_map[build_region]],
@@ -509,13 +435,11 @@ class PublishInstallerImagesIntegrationTests(TestCase):
                 u'FLOCKER_VERSION': flocker_version
             }
         )
-        # And now we should have a "flocker" AMI map
-        flocker_object_content = s3.get_object_content(key=u'flocker')
         self.addDetail(
-            'flocker_object_content', text_content(flocker_object_content)
+            'flocker_object_content', text_content(stdout)
         )
         # It should be valid JSON.
-        flocker_ami_map = json.loads(flocker_object_content)
+        flocker_ami_map = json.loads(stdout)
 
         ec2 = boto3.resource('ec2', region_name=build_region)
         # Get a list of all the related images and tags in case of errors.

--- a/admin/test/test_images.py
+++ b/admin/test/test_images.py
@@ -322,7 +322,7 @@ class PublishInstallerImagesEffectsTests(TestCase):
                     content=json.dumps(
                         thaw(ami_map),
                         encoding='utf-8',
-                    ),
+                    ) + b"\n",
                 ), lambda intent: None),
             ],
             eff=publish_installer_images_effects(options=options)

--- a/docs/gettinginvolved/infrastructure/maintaining-cloudformation.rst
+++ b/docs/gettinginvolved/infrastructure/maintaining-cloudformation.rst
@@ -80,7 +80,7 @@ Follow these steps to build the virtual machine images:
 
    A new AMI image will be built in the ``us-west-1`` region.
    That image will be copied to all available AWS regions.
-   The region specific AMI image IDs will be uploaded to the ``clusterhq-installer-images`` S3 bucket in an object matching the template name ``docker`` in JSON format.
+   The region specific AMI image IDs will be printed to ``stdout`` in JSON format.
    Make a note of the ``us-west-1`` AMI image ID because you'll use it for building the Flocker AMI in the next step.
 
    .. note::
@@ -117,10 +117,9 @@ Follow these steps to build the virtual machine images:
 
    A new AMI image will be built in the ``us-west-1`` region.
    That image will be copied to all available AWS regions.
-   The region specific AMI image IDs will be uploaded to the ``clusterhq-installer-images`` S3 bucket in an object matching the template name ``flocker`` in JSON format.
+   The region specific AMI image IDs will be printed to ``stdout`` in JSON format.
 
-   .. XXX: Now that I document it, it's going to be easier if the command just prints the JSON AMI map to ``stdout``.
-      We can then add a new option to consume that JSON in line or from a URL.
+   .. XXX: We need a new option to consume that JSON in line or from a URL.
       E.g. ``--source_ami_map_url <S3 URL>`` and ``--source_ami_map_body <inline JSON>``
 
 4. Add the new images to the CloudFormation template.


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4281

Publishing to S3 is unnecessary complication.
I've removed all that code and replaced with printing the AMI map to stdout.

We're aiming for a process that looks something like this: #2672

Here's a sample output

```
(4281)(print-image-ids-FLOC-4281 ? =)[~/.../HybridLogic/flocker]$ DOCKER_VERSION=1.10.0       SWARM_VERSION=1.1.3       ./admin/publish-installer-images         --template=docker 2>stderr.log | tee stdout.log
{"us-west-1": "ami-916b18f1"}
(4281)(print-image-ids-FLOC-4281 ? =)[~/.../HybridLogic/flocker]$ jq . stdout.log 
{
  "us-west-1": "ami-916b18f1"
}

```