### PR TITLE
[FLOC-4299] Ignore deleted datasets once they've been deleted

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ The following people and organizations contributed to its development; please ad
 * Scotch Media (Base for documentation theme)
 * Wentao Zhang (zhangwentao234@huaewi.com, Huawei Ltd.)
 * Sean McGinnis (Dell SC Series storage configuration documentation)
+* Huai Cheng Zheng <huaicheng.zheng@transwarp.io>

--- a/flocker/node/_p2p.py
+++ b/flocker/node/_p2p.py
@@ -354,8 +354,11 @@ def find_dataset_changes(uuid, current_state, desired_state):
                             # datasets; this is wrong. See FLOC-2060.
                             in (node.manifestations or {}).values())
                         for node in current_state.nodes}
-    local_desired_datasets = set(dataset for dataset in desired_datasets.get(uuid, set())
-                                 if dataset.deleted is False)
+
+    local_desired_datasets = set(
+        dataset for dataset in desired_datasets.get(uuid, set())
+        if dataset.deleted is False
+    )
     local_desired_dataset_ids = set(dataset.dataset_id for dataset in
                                     local_desired_datasets)
     local_current_dataset_ids = set(dataset.dataset_id for dataset in
@@ -408,6 +411,7 @@ def find_dataset_changes(uuid, current_state, desired_state):
                    if dataset.dataset_id in creating_dataset_ids)
 
     deleting = set(dataset for dataset in chain(*desired_datasets.values())
-                   if dataset.deleted)
+                   if dataset.deleted
+                   and dataset.dataset_id in local_current_dataset_ids)
     return DatasetChanges(going=going, deleting=deleting,
                           creating=creating, resizing=resizing)

--- a/flocker/node/_p2p.py
+++ b/flocker/node/_p2p.py
@@ -354,7 +354,8 @@ def find_dataset_changes(uuid, current_state, desired_state):
                             # datasets; this is wrong. See FLOC-2060.
                             in (node.manifestations or {}).values())
                         for node in current_state.nodes}
-    local_desired_datasets = desired_datasets.get(uuid, set())
+    local_desired_datasets = set(dataset for dataset in desired_datasets.get(uuid, set())
+                                 if dataset.deleted is False)
     local_desired_dataset_ids = set(dataset.dataset_id for dataset in
                                     local_desired_datasets)
     local_current_dataset_ids = set(dataset.dataset_id for dataset in


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4299

Based on https://github.com/ClusterHQ/flocker/pull/2685 by @zhenghc (Thank you).

With an additional test which in turn revealed a bug in the calculation of DeleteDataset changes.