### PR TITLE
Split title on CloudFormation document [FLOC 4286]

### DIFF
--- a/docs/docker-integration/cloudformation.rst
+++ b/docs/docker-integration/cloudformation.rst
@@ -6,9 +6,12 @@
         .toctree-wrapper { display:none; }
     </style>
 
-================================================================
-Installing Flocker with Docker Swarm on AWS using CloudFormation
-================================================================
+====================================
+Installing Flocker with Docker Swarm 
+====================================
+
+on AWS using CloudFormation
+===========================
 
 In this guide you will learn how to quickly deploy a cluster of servers running Flocker and Docker Swarm.
 You will launch four EC2 instances in your AWS account, as illustrated below:

--- a/docs/docker-integration/cloudformation.rst
+++ b/docs/docker-integration/cloudformation.rst
@@ -6,12 +6,12 @@
         .toctree-wrapper { display:none; }
     </style>
 
-====================================
-Installing Flocker with Docker Swarm 
-====================================
-
-on AWS using CloudFormation
-===========================
+==================
+Installing Flocker 
+==================
+---------------------------------------------
+with Docker Swarm on AWS using CloudFormation
+---------------------------------------------
 
 In this guide you will learn how to quickly deploy a cluster of servers running Flocker and Docker Swarm.
 You will launch four EC2 instances in your AWS account, as illustrated below:


### PR DESCRIPTION
Fixes 4286

Following feedback from the designers, this splits the long title on the CloudFormation doc into a main header and sub header.