### PR TITLE
[FLOC-4255] Add documentation for Flocker deploy on RHEL 7.2

### DIFF
--- a/docs/docker-integration/install-client.rst
+++ b/docs/docker-integration/install-client.rst
@@ -24,6 +24,12 @@ Installing the Flocker Client
 
 .. note:: If you are using a 32-bit Ubuntu platform, see the instructions for  :ref:`installing-flocker-cli-linux-docker`.
 
+.. _installing-flocker-cli-rhel-7.2-docker:
+
+.. include:: ../installation/install-client.rst
+   :start-after: .. begin-body-installing-client-rhel-7.2
+   :end-before: .. end-body-installing-client-rhel-7.2
+
 .. _installing-flocker-cli-linux-docker:
 
 .. include:: ../installation/install-client.rst

--- a/docs/docker-integration/install-node.rst
+++ b/docs/docker-integration/install-node.rst
@@ -21,6 +21,12 @@ Installing the Flocker Node Services
 * :ref:`aws-install-docker`
 * :ref:`rackspace-install-docker`
 
+.. _rhel-7-install-docker:
+
+.. include:: ../installation/install-node.rst
+   :start-after: .. begin-body-installing-node-rhel
+   :end-before: .. end-body-installing-node-rhel
+
 .. _centos-7-install-docker:
 
 .. include:: ../installation/install-node.rst

--- a/docs/flocker-standalone/enabling-agent-service.rst
+++ b/docs/flocker-standalone/enabling-agent-service.rst
@@ -9,7 +9,7 @@ Enabling the Flocker Agent Service
    :end-before: .. end-body-enable-agent-intro
 
 .. include:: ../installation/enabling-agent-service.rst
-   :start-after: .. begin-body-enable-agent-kubernetes
-   :end-before: .. end-body-enable-agent-kubernetes
+   :start-after: .. begin-body-enable-agent-other
+   :end-before: .. end-body-enable-agent-other
 
 This completes the manual installation and configuration of Flocker.

--- a/docs/flocker-standalone/install-client.rst
+++ b/docs/flocker-standalone/install-client.rst
@@ -24,6 +24,12 @@ Installing the Flocker Client
 
 .. note:: If you are using a 32-bit Ubuntu platform, see the instructions for  :ref:`installing-flocker-cli-linux-standalone-flocker`.
 
+.. _installing-flocker-cli-rhel-7.2-standalone-flocker:
+
+.. include:: ../installation/install-client.rst
+   :start-after: .. begin-body-installing-client-rhel-7.2
+   :end-before: .. end-body-installing-client-rhel-7.2
+
 .. _installing-flocker-cli-linux-standalone-flocker:
 
 .. include:: ../installation/install-client.rst

--- a/docs/flocker-standalone/install-node.rst
+++ b/docs/flocker-standalone/install-node.rst
@@ -21,6 +21,12 @@ Installing the Flocker Node Services
 * :ref:`aws-install-standalone-flocker`
 * :ref:`rackspace-install-standalone-flocker`
 
+.. _rhel-7-install-standalone-flocker:
+
+.. include:: ../installation/install-node.rst
+   :start-after: .. begin-body-installing-node-rhel
+   :end-before: .. end-body-installing-node-rhel
+
 .. _centos-7-install-standalone-flocker:
 
 .. include:: ../installation/install-node.rst

--- a/docs/installation/enabling-agent-service.rst
+++ b/docs/installation/enabling-agent-service.rst
@@ -49,7 +49,7 @@ Ubuntu
 
 .. end-body-enable-agent-main
 
-.. begin-body-enable-agent-kubernetes
+.. begin-body-enable-agent-other
 
 .. note::
    Flocker's container management features depend on Docker.
@@ -57,8 +57,8 @@ Ubuntu
 
 .. _Docker (at least 1.8) is installed: https://docs.docker.com/installation/
 
-CentOS 7
-========
+CentOS 7, RHEL 7.2
+==================
 
 Run the following commands to enable the agent service:
 
@@ -73,4 +73,4 @@ Run the following commands to enable the agent service:
 .. task:: enable_flocker_agent ubuntu-14.04
       :prompt: [root@agent-node]#
 
-.. end-body-enable-agent-kubernetes
+.. end-body-enable-agent-other

--- a/docs/installation/enabling-agent-service.rst
+++ b/docs/installation/enabling-agent-service.rst
@@ -18,8 +18,8 @@ The Flocker agents, the ``flocker-dataset-agent`` and the ``flocker-container-ag
 
 .. _Docker (at least 1.8) is installed: https://docs.docker.com/installation/
 
-CentOS 7
-========
+CentOS 7, RHEL 7.2
+==================
 
 #. Run the following commands to enable the agent service:
 

--- a/docs/installation/enabling-control-service.rst
+++ b/docs/installation/enabling-control-service.rst
@@ -32,10 +32,10 @@ On AWS, an external firewall is used instead, which will need to be configured s
 RHEL 7.2
 ========
 
-   .. prompt:: bash root@rhel:~$
+.. prompt:: bash root@rhel:~$
       
-      systemctl enable flocker-control
-      systemctl start flocker-control
+   systemctl enable flocker-control
+   systemctl start flocker-control
 
 The control service needs to be accessible remotely.
 You will need to configure FirewallD to allow access to the control service HTTP API and for agent connections.

--- a/docs/installation/enabling-control-service.rst
+++ b/docs/installation/enabling-control-service.rst
@@ -32,7 +32,7 @@ On AWS, an external firewall is used instead, which will need to be configured s
 RHEL 7.2
 ========
 
-.. prompt:: bash root@rhel:~$
+.. prompt:: bash [root@rhel]#
       
    systemctl enable flocker-control
    systemctl start flocker-control

--- a/docs/installation/enabling-control-service.rst
+++ b/docs/installation/enabling-control-service.rst
@@ -29,6 +29,27 @@ For more details on configuring the firewall, see the `FirewallD documentation`_
 
 On AWS, an external firewall is used instead, which will need to be configured similarly.
 
+RHEL 7.2
+========
+
+   .. prompt:: bash root@rhel:~$
+      
+      systemctl enable flocker-control
+      systemctl start flocker-control
+
+The control service needs to be accessible remotely.
+You will need to configure FirewallD to allow access to the control service HTTP API and for agent connections.
+Note that on some environments, in particular AWS, the ``firewalld`` package is not installed and the ``firewall-cmd`` program will not be found.
+If that is the case then just skip these commands.
+Otherwise run:
+
+.. task:: open_control_firewall centos-7
+   :prompt: [root@control-node]#
+
+For more details on configuring the firewall, see the `FirewallD documentation`_.
+
+On AWS, an external firewall is used instead, which will need to be configured similarly.
+
 Ubuntu
 ======
 

--- a/docs/installation/install-client.rst
+++ b/docs/installation/install-client.rst
@@ -53,9 +53,9 @@ On Ubuntu 14.04 (64-bit), the Flocker CLI can be installed from the ClusterHQ re
 
 .. end-body-installing-client-Ubuntu-14.04
 
-.. _installing-flocker-cli-linux:
+.. _installing-flocker-cli-rhel-7.2:
 
-.. begin-body-installing-client-linux
+.. begin-body-installing-client-rhel-7.2
 
 Installing on RHEL 7.2
 ======================
@@ -69,6 +69,13 @@ On RHEL 7.2, the Flocker CLI can be installed from the ClusterHQ repository:
 .. prompt:: bash root@rhel:~$
 
    yum install -y clusterhq-flocker-cli
+
+.. end-body-installing-client-rhel-7.2
+
+.. _installing-flocker-cli-linux:
+
+.. begin-body-installing-client-linux
+
 
 Installing on Other Linux Distributions
 =======================================

--- a/docs/installation/install-client.rst
+++ b/docs/installation/install-client.rst
@@ -66,9 +66,9 @@ Installing on RHEL 7.2
 
 On RHEL 7.2, the Flocker CLI can be installed from the ClusterHQ repository:
 
-   .. prompt:: bash root@rhel:~$
+.. prompt:: bash root@rhel:~$
 
-      yum install -y clusterhq-flocker-cli
+   yum install -y clusterhq-flocker-cli
 
 Installing on Other Linux Distributions
 =======================================

--- a/docs/installation/install-client.rst
+++ b/docs/installation/install-client.rst
@@ -57,6 +57,19 @@ On Ubuntu 14.04 (64-bit), the Flocker CLI can be installed from the ClusterHQ re
 
 .. begin-body-installing-client-linux
 
+Installing on RHEL 7.2
+======================
+
+.. note:: 
+   These instructions require that you have ``sudo`` access.
+
+
+On RHEL 7.2, the Flocker CLI can be installed from the ClusterHQ repository:
+
+   .. prompt:: bash root@rhel:~$
+
+      yum install -y clusterhq-flocker-cli
+
 Installing on Other Linux Distributions
 =======================================
 

--- a/docs/installation/install-node.rst
+++ b/docs/installation/install-node.rst
@@ -81,7 +81,7 @@ Installing on RHEL 7
    
       yum install -y clusterhq-flocker-docker-plugin
 
-.. XXX FLOC-3454 to create a task directive for installing the plugin
+   .. XXX FLOC-3454 to create a task directive for installing the plugin
 
 #. **Repeat the previous steps for all other nodes:**
 
@@ -124,7 +124,7 @@ Installing on CentOS 7
    
       yum install -y clusterhq-flocker-docker-plugin
 
-.. XXX FLOC-3454 to create a task directive for installing the plugin
+   .. XXX FLOC-3454 to create a task directive for installing the plugin
 
 #. **Repeat the previous steps for all other nodes:**
 
@@ -167,7 +167,7 @@ Installing on Ubuntu 14.04
    
       apt-get install -y clusterhq-flocker-docker-plugin
 
-.. XXX FLOC-3454 to create a task directive for installing the plugin
+   .. XXX FLOC-3454 to create a task directive for installing the plugin
 
 #. **Repeat the previous steps for all other nodes:**
 

--- a/docs/installation/install-node.rst
+++ b/docs/installation/install-node.rst
@@ -64,7 +64,7 @@ Installing on RHEL 7
    
    Run the following commands as root on the target node:
 
-   .. prompt:: bash root@rhel:~$
+   .. prompt:: bash [root@rhel]#
 
       yum list installed clusterhq-release || yum install -y https://clusterhq-archive.s3.amazonaws.com/centos/clusterhq-release$(rpm -E %dist).centos.noarch.rpm
 

--- a/docs/installation/install-node.rst
+++ b/docs/installation/install-node.rst
@@ -44,6 +44,49 @@ If you do not have any nodes, the following guides will help you set some up, wi
 
 .. XXX In the integration specific documentation, links to the guides appear here
 
+.. begin-body-installing-node-rhel
+
+Installing on RHEL 7
+====================
+
+.. note:: You should ensure your nodes are Flocker-ready, either by checking the prerequisites above, or by following our guides on using Amazon Web Services or Rackspace.
+
+#. **Log into the first node as root:**
+
+   .. prompt:: bash alice@mercury:~$
+
+      ssh root@<your-first-node>
+
+#. **Install the** ``clusterhq-flocker-node`` **package:**
+
+   To install ``clusterhq-flocker-node`` on RHEL 7 you must install the RPM package provided by the ClusterHQ repository.
+   The commands below will install the two repositories and the ``clusterhq-flocker-node`` package.
+   
+   Run the following commands as root on the target node:
+
+   .. task:: install_flocker rhel-7
+      :prompt: [root@rhel]#
+
+#. **Install the** ``clusterhq-flocker-docker-plugin`` **package:**
+
+   At this point you can choose to install the Flocker plugin for Docker.
+   Run the following command as root on the target node:
+
+   .. prompt:: bash [root@rhel]#
+   
+      yum install -y clusterhq-flocker-docker-plugin
+
+.. XXX FLOC-3454 to create a task directive for installing the plugin
+
+#. **Repeat the previous steps for all other nodes:**
+
+   Log into your other nodes as root, and then complete step 2 and 3 until all the nodes in your cluster have installed the ``clusterhq-flocker-node`` and the optional ``clusterhq-flocker-docker-plugin`` package.
+
+.. note:: Flocker's container management features depend on Docker.
+          You will need to make sure `Docker (at least 1.8) is installed`_ and running.
+
+.. end-body-installing-node-rhel
+
 .. begin-body-installing-node-centos
 
 Installing on CentOS 7

--- a/docs/installation/install-node.rst
+++ b/docs/installation/install-node.rst
@@ -68,6 +68,10 @@ Installing on RHEL 7
 
       yum list installed clusterhq-release || yum install -y https://clusterhq-archive.s3.amazonaws.com/centos/clusterhq-release$(rpm -E %dist).centos.noarch.rpm
 
+      sed -i 's/$releasever/7/g' /etc/yum.repos.d/clusterhq.repo
+      sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/clusterhq.repo
+      yum install -y clusterhq-flocker-node
+
 #. **Install the** ``clusterhq-flocker-docker-plugin`` **package:**
 
    At this point you can choose to install the Flocker plugin for Docker.

--- a/docs/installation/install-node.rst
+++ b/docs/installation/install-node.rst
@@ -64,8 +64,9 @@ Installing on RHEL 7
    
    Run the following commands as root on the target node:
 
-   .. task:: install_flocker rhel-7
-      :prompt: [root@rhel]#
+   .. prompt:: bash root@rhel:~$
+
+      yum list installed clusterhq-release || yum install -y https://clusterhq-archive.s3.amazonaws.com/centos/clusterhq-release$(rpm -E %dist).centos.noarch.rpm
 
 #. **Install the** ``clusterhq-flocker-docker-plugin`` **package:**
 

--- a/docs/installation/install-node.rst
+++ b/docs/installation/install-node.rst
@@ -69,7 +69,7 @@ Installing on RHEL 7
       yum list installed clusterhq-release || yum install -y https://clusterhq-archive.s3.amazonaws.com/centos/clusterhq-release$(rpm -E %dist).centos.noarch.rpm
 
       sed -i 's/$releasever/7/g' /etc/yum.repos.d/clusterhq.repo
-      sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/clusterhq.repo
+      yum-config-manager --enable clusterhq
       yum install -y clusterhq-flocker-node
 
 #. **Install the** ``clusterhq-flocker-docker-plugin`` **package:**

--- a/docs/kubernetes-integration/enabling-agent-service.rst
+++ b/docs/kubernetes-integration/enabling-agent-service.rst
@@ -9,8 +9,8 @@ Enabling the Flocker Agent Service
    :end-before: .. end-body-enable-agent-intro
 
 .. include:: ../installation/enabling-agent-service.rst
-   :start-after: .. begin-body-enable-agent-kubernetes
-   :end-before: .. end-body-enable-agent-kubernetes
+   :start-after: .. begin-body-enable-agent-other
+   :end-before: .. end-body-enable-agent-other
 
 Next Step
 =========

--- a/docs/kubernetes-integration/install-client.rst
+++ b/docs/kubernetes-integration/install-client.rst
@@ -24,6 +24,12 @@ Installing the Flocker Client
 
 .. note:: If you are using a 32-bit Ubuntu platform, see the instructions for  :ref:`installing-flocker-cli-linux-kubernetes`.
 
+.. _installing-flocker-cli-rhel-7.2-kubernetes:
+
+.. include:: ../installation/install-client.rst
+   :start-after: .. begin-body-installing-client-rhel-7.2
+   :end-before: .. end-body-installing-client-rhel-7.2
+
 .. _installing-flocker-cli-linux-kubernetes:
 
 .. include:: ../installation/install-client.rst

--- a/docs/kubernetes-integration/install-node.rst
+++ b/docs/kubernetes-integration/install-node.rst
@@ -21,6 +21,12 @@ Installing the Flocker Node Services
 * :ref:`aws-install-kubernetes`
 * :ref:`rackspace-install-kubernetes`
 
+.. _rhel-7-install-kubernetes:
+
+.. include:: ../installation/install-node.rst
+   :start-after: .. begin-body-installing-node-rhel
+   :end-before: .. end-body-installing-node-rhel
+
 .. _centos-7-install-kubernetes:
 
 .. include:: ../installation/install-node.rst


### PR DESCRIPTION
Add documentation for installing flocker node and flocker cli on RHEL 7.2. Relevant sections start at http://clusterhq-staging-docs.s3-website-us-east-1.amazonaws.com/add-rhel-documentation-FLOC-4255/docker-integration/manual-install.html

Setting up RHEL CI environment will follow this PR.