### PR TITLE
[FLOC 4091] Update the CTA information on the docs homepage

### DIFF
--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -909,3 +909,8 @@ a.download:before {
         padding: 0 15px;
     }
 }
+
+/* Docs homepage bullet list */
+div.bulleted-list { text-align: left} 
+div.heading-logo-lockup {min-height: 20rem} 
+div.bulleted-list ul {min-height: 7rem}

--- a/docs/_themes/clusterhq/static/css/docs.css
+++ b/docs/_themes/clusterhq/static/css/docs.css
@@ -81,6 +81,10 @@ Pods
 	background-color: #00a99d;
 }
 
+.pod-boxout .button--manual {
+	background-color: #333333;
+}
+
 .pod-boxout span {
 	height: 70px;
 	margin-bottom: 16px;

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,9 +23,8 @@ For installation and configuration information for using Flocker with a cluster 
 
 	<div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
-			<span>Docker Swarm, with Docker Compose</span>
 			<img src="_static/images/docker2x.png" alt="Docker logo"/>
-	        <span><em>Easiest way to install Flocker</em></span><a href="docker-integration/" class="button button--fast">Using Flocker with Docker</a>
+	        <span>Docker Swarm, with Docker Compose<em>Easiest way to install Flocker</em></span><a href="docker-integration/" class="button button--fast">Using Flocker with Docker</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
@@ -36,8 +35,8 @@ For installation and configuration information for using Flocker with a cluster 
 
 	    <div class="pod-boxout pod-boxout--orchestration">
 			<img src="_static/images/mesos2x.png" alt="mesos logo"/>
-			<span>Mesos</span>
-	        <a href="mesos-integration/" class="button">Using Flocker with Mesos</a>
+	        <span>Mesos</span>
+			<a href="mesos-integration/" class="button">Using Flocker with Mesos</a>
 	    </div>
 	</div>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,43 +21,56 @@ For installation and configuration information for using Flocker with a cluster 
 
 .. raw:: html
 
-	<div class="pods-eq">
-	    <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
-			<p><b>Docker Swarm, with Docker Compose</b></p>
-			<img src="_static/images/docker2x.png" alt="Docker logo"/>
-	        <span><p><em>Easiest way to install Flocker</em></p>
-			<p>Plus:
-			<br />Tutorials
-			<br/>Blog Articles
-			<br/>Advanced Concepts
-			</p></span>
-			<br /><br />
-			<a href="docker-integration/" class="button button--fast">Use Flocker with Docker</a>
-	    </div>
+   <div class="pods-eq">
+        <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
+            <div class="heading-logo-lockup">    
+            <p><strong>Docker Swarm, with Docker Compose</strong></p>
+                <img src="_static/images/docker2x.png" alt="Docker logo"/>
+        </div>
+             <div class="bulleted-list">
+        <p><em>Easiest way to install Flocker</em></p>
+                <p>Plus:</p>
+                <ul>
+            <li>Tutorials</li>
+                    <li>Blog Articles</li>
+                    <li>Advanced Concepts</li>
+           </ul>
+            </div>
+            <a href="docker-integration/" class="button button--fast">Use Flocker with Docker</a>
+        </div>
 
-	    <div class="pod-boxout pod-boxout--orchestration">
-			<p><b>Kubernetes</b></p><br />
-			<img src="_static/images/kubernetes2x.png" alt="Kubernetes logo"/>
-	        <span><p>How to install Flocker</p>
-			<p>Plus:
-			<br />Tutorials
-			<br/>Blog Articles
-			</p></span>
-            <br /><br />
-	        <a href="kubernetes-integration/" class="button">Use Flocker with Kubernetes</a>
-	    </div>
+        <div class="pod-boxout pod-boxout--orchestration">
+        <div class="heading-logo-lockup">             
+            <p><strong>Kubernetes</strong></p>
+                <img src="_static/images/kubernetes2x.png" alt="Kubernetes logo"/>
+        </div>
+            <div class="bulleted-list">
+        <p>How to install Flocker</p>
+            <p>Plus:</p>
+        <ul>
+            <li>Tutorials</li>
+            <li>Blog Articles</li>
+        </ul>
+            </div>
+            <a href="kubernetes-integration/" class="button">Use Flocker with Kubernetes</a>
+        </div>
 
-	    <div class="pod-boxout pod-boxout--orchestration">
-			<p><b>Mesos</b></p><br />
-			<img src="_static/images/mesos2x.png" alt="mesos logo"/>
-	        <span><p>How to install Flocker</p>
-			<p>Plus:
-			<br/>Blog Articles
-			</p></span>
-			<br /><br />
-			<a href="mesos-integration/" class="button">Use Flocker with Mesos</a>
-	    </div>
-	</div>
+        <div class="pod-boxout pod-boxout--orchestration">
+        <div class="heading-logo-lockup">          
+            <p><strong>Mesos</strong></p>
+            <img src="_static/images/mesos2x.png" alt="mesos logo"/>
+        </div>
+             <div class="bulleted-list">
+        <p>How to install Flocker</p>
+            <p>Plus:</p>
+        <ul>
+            <li>Blog Articles</li>
+        </ul>
+            </div>
+            <a href="mesos-integration/" class="button">Use Flocker with Mesos</a>
+        </div>
+   </div>
+
 
 Using Flocker without a Cluster Manager
 =======================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,8 +14,8 @@ Flocker allows you to launch and move stateful containers by integrating with a 
 
 Flocker integrates with a range of Cluster Managers.
 
-Installing Flocker
-==================
+Using Flocker with a Cluster Manager
+====================================
 
 To install Flocker, first choose which Cluster Manager you are using, or intend to use:
 
@@ -25,21 +25,24 @@ To install Flocker, first choose which Cluster Manager you are using, or intend 
 	    <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
 			<img src="_static/images/docker2x.png" alt="Docker logo"/>
 			<span>Docker Swarm, with Docker Compose<em>Try it Now</em></span>
-	        <a href="docker-integration/" class="button button--fast">Install or Learn</a>
+	        <a href="docker-integration/" class="button button--fast">Use Flocker with Docker Swarm</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
 			<img src="_static/images/kubernetes2x.png" alt="Kubernetes logo"/>
 			<span>Kubernetes</span>
-	        <a href="kubernetes-integration/" class="button">Install or Learn</a>
+	        <a href="kubernetes-integration/" class="button">Use Flocker with Kubernetes</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
 			<img src="_static/images/mesos2x.png" alt="mesos logo"/>
 			<span>Mesos</span>
-	        <a href="mesos-integration/" class="button">Install or Learn</a>
+	        <a href="mesos-integration/" class="button">Use Flocker with Mesos</a>
 	    </div>
 	</div>
+
+Using Flocker without a Cluster Manager
+=======================================
 
 Alternatively, if you want to install Flocker without a specific Cluster Manager in mind, that is also possible:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,6 @@ For installation and configuration information for using Flocker with a cluster 
 			<img src="_static/images/mesos2x.png" alt="mesos logo"/>
 	        <span><p>How to install Flocker</p>
 			<p>Plus:
-			<br />Tutorials
 			<br/>Blog Articles
 			</p></span>
 			<br /><br />

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Flocker integrates with a range of Cluster Managers.
 Using Flocker with a Cluster Manager
 ====================================
 
-To install Flocker, first choose which Cluster Manager you are using, or intend to use:
+For installation and configuration information for using Flocker with a cluster manager, first choose which integration you are using, or intend to use:
 
 .. raw:: html
 
@@ -25,33 +25,36 @@ To install Flocker, first choose which Cluster Manager you are using, or intend 
 	    <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
 			<img src="_static/images/docker2x.png" alt="Docker logo"/>
 			<span>Docker Swarm, with Docker Compose<em>Try it Now</em></span>
-	        <a href="docker-integration/" class="button button--fast">Use Flocker with Docker Swarm</a>
+	        <a href="docker-integration/" class="button button--fast">Using Flocker with Docker</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
 			<img src="_static/images/kubernetes2x.png" alt="Kubernetes logo"/>
 			<span>Kubernetes</span>
-	        <a href="kubernetes-integration/" class="button">Use Flocker with Kubernetes</a>
+	        <a href="kubernetes-integration/" class="button">Using Flocker with Kubernetes</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
 			<img src="_static/images/mesos2x.png" alt="mesos logo"/>
 			<span>Mesos</span>
-	        <a href="mesos-integration/" class="button">Use Flocker with Mesos</a>
+	        <a href="mesos-integration/" class="button">Using Flocker with Mesos</a>
 	    </div>
 	</div>
 
 Using Flocker without a Cluster Manager
 =======================================
 
-Alternatively, if you want to install Flocker without a specific Cluster Manager in mind, that is also possible:
+If you want to install Flocker without a specific Cluster Manager in mind, that is also possible:
 
 .. raw:: html
 
-	 <div class="pod-boxout pod-boxout--minor pod-boxout--orchestration">
-		<span><img src="_static/images/icon-question2x.png" aria-hidden="true" alt=""/>&nbsp;Install Flocker without a Cluster Manager</span>
-        <a href="flocker-standalone/" class="button">Install or Learn</a>
-    </div>
+   <div class="pods-eq">
+	    <div class="pod-boxout pod-boxout--2up pod-boxout--short">
+		   <span>Install Flocker without a Cluster Manager
+           </span>
+		     <a href="flocker-standalone/" class="button button--manual">Install Flocker</a>
+	    </div>	
+   </div>
 
 Is your chosen Cluster Manager missing?
 Please let us know with the form below!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,33 +23,53 @@ For installation and configuration information for using Flocker with a cluster 
 
 	<div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
+			<p><b>Docker Swarm, with Docker Compose</b></p>
 			<img src="_static/images/docker2x.png" alt="Docker logo"/>
-	        <span>Docker Swarm, with Docker Compose<em>Easiest way to install Flocker</em></span><a href="docker-integration/" class="button button--fast">Using Flocker with Docker</a>
+	        <span><p><em>Easiest way to install Flocker</em></p>
+			<p>Plus:
+			<br />Tutorials
+			<br/>Blog Articles
+			<br/>Advanced Concepts
+			</p></span>
+			<br /><br />
+			<a href="docker-integration/" class="button button--fast">Use Flocker with Docker</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
+			<p><b>Kubernetes</b></p><br />
 			<img src="_static/images/kubernetes2x.png" alt="Kubernetes logo"/>
-			<span>Kubernetes</span>
-	        <a href="kubernetes-integration/" class="button">Using Flocker with Kubernetes</a>
+	        <span><p>How to install Flocker</p>
+			<p>Plus:
+			<br />Tutorials
+			<br/>Blog Articles
+			</p></span>
+            <br /><br />
+	        <a href="kubernetes-integration/" class="button">Use Flocker with Kubernetes</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
+			<p><b>Mesos</b></p><br />
 			<img src="_static/images/mesos2x.png" alt="mesos logo"/>
-	        <span>Mesos</span>
-			<a href="mesos-integration/" class="button">Using Flocker with Mesos</a>
+	        <span><p>How to install Flocker</p>
+			<p>Plus:
+			<br />Tutorials
+			<br/>Blog Articles
+			</p></span>
+			<br /><br />
+			<a href="mesos-integration/" class="button">Use Flocker with Mesos</a>
 	    </div>
 	</div>
 
 Using Flocker without a Cluster Manager
 =======================================
 
-If you want to install Flocker without a specific Cluster Manager in mind, that is also possible:
+Alternatively, if you want to install Flocker without a specific Cluster Manager in mind, that is also possible:
 
 .. raw:: html
 
    <div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--2up pod-boxout--short">
-		     <a href="flocker-standalone/" class="button button--manual">Using Flocker without a Cluster Manager</a>
+		     <a href="flocker-standalone/" class="button">Use Flocker without a Cluster Manager</a>
 	    </div>	
    </div>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,9 +23,9 @@ For installation and configuration information for using Flocker with a cluster 
 
 	<div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--orchestration pod-boxout--recommended">
+			<span>Docker Swarm, with Docker Compose</span>
 			<img src="_static/images/docker2x.png" alt="Docker logo"/>
-			<span>Docker Swarm, with Docker Compose<em>Try it Now</em></span>
-	        <a href="docker-integration/" class="button button--fast">Using Flocker with Docker</a>
+	        <span><em>Easiest way to install Flocker</em></span><a href="docker-integration/" class="button button--fast">Using Flocker with Docker</a>
 	    </div>
 
 	    <div class="pod-boxout pod-boxout--orchestration">
@@ -50,9 +50,7 @@ If you want to install Flocker without a specific Cluster Manager in mind, that 
 
    <div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--2up pod-boxout--short">
-		   <span>Install Flocker without a Cluster Manager
-           </span>
-		     <a href="flocker-standalone/" class="button button--manual">Install Flocker</a>
+		     <a href="flocker-standalone/" class="button button--manual">Using Flocker without a Cluster Manager</a>
 	    </div>	
    </div>
 


### PR DESCRIPTION
Fixes 4091

Adds new titles to both the section headers, and the buttons - this ensures the user is funnelling down into more specific information as they click into the docs.