### PR TITLE
[FLOC-4183] Increase COMPOSE_HTTP_TIMEOUT for installer tests.

### DIFF
--- a/admin/test/test_installer.py
+++ b/admin/test/test_installer.py
@@ -87,7 +87,8 @@ def remote_docker_compose(client_ip, docker_host, compose_file_path, *args):
     """
     return remote_command(
         client_ip,
-        ('DOCKER_TLS_VERIFY=1', 'DOCKER_HOST={}'.format(docker_host),
+        ('COMPOSE_HTTP_TIMEOUT=360', 'DOCKER_TLS_VERIFY=1',
+         'DOCKER_HOST={}'.format(docker_host),
          'docker-compose', '--file', compose_file_path) + args,
     )
 


### PR DESCRIPTION
Increase COMPOSE_HTTP_TIMEOUT for CloudFormation installer tests from default of 60 seconds to 360 seconds. This addresses intermittent test failures due to 60 second timeout being hit 18% of nightly runs on master over 30 day period.
________

COMPOSE_HTTP_TIMEOUT defintion (from https://docs.docker.com/compose/reference/envvars/ ):
Configures the time (in seconds) a request to the Docker daemon is allowed to hang before Compose considers it failed. Defaults to 60 seconds.
________

Verification: 5 out of 5 runs passed (http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/set-docker-client-timeout-FLOC-4183/job/_run_admin_test_test_installer/).

Run #1: http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/set-docker-client-timeout-FLOC-4183/job/_run_admin_test_test_installer/lastSuccessfulBuild/artifact/_trial_temp/test.log

> 2016-03-16 23:11:54+0000 [-] ELIOT: {"task_uuid": "c4460ad2-d48b-49fd-893f-83f0d6f29103", "command": ["ssh", "-C", "-q", "-o", "StrictHostKeyChecking=no", "-o", "ControlMaster=no", "-o", "PreferredAuthentications=publickey", "-l", "ubuntu", "54.153.58.130", "COMPOSE_HTTP_TIMEOUT=360 DOCKER_TLS_VERIFY=1 DOCKER_HOST=tcp://54.215.208.134:2376 docker-compose --file /home/ubuntu/admin_test_test_installer_DockerComposeTests_test_docker_compose_up_postgres-593238/docker-compose-node1.yml up -d"], "task_level": [1], "action_type": "flocker.common.runner:run", "timestamp": 1458169914.191637, "action_status": "started"}
