### PR TITLE
[FLOC-3404] Update cffi and cryptography dependencies

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -16,6 +16,7 @@ Next Release
   This could lead to the appearance of data loss, as different volumes get used.
   Now, even if multiple volumes are created, only a single volume will be used.
   This was particularly likely to occur on AWS.
+* Fixed brew tap for flocker client tools on OSX, which had regressed on Yosemite.
 
 This Release
 ============

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ bitmath==1.2.3-4
 boto==2.38.0
 boto3==1.2.2
 botocore==1.3.17
-cffi==1.1.2
+cffi==1.5.2
 characteristic==14.3.0
-cryptography==1.1.2
+cryptography==1.2.3
 debtcollector==0.5.0
 docker-py==1.6.0
 docutils==0.12


### PR DESCRIPTION
This fixes installing on OSX which is currently broken on El Capitan.

Verified fix manually in a VirtualBox VM on my machine. (Built an sdist, uploaded it to S3, made a new tap ruby file, uploaded that to S3, installed using brew from that file).

I do not know why the automated OSX builder did not catch this. If I was crossing all of my t's and dotting all of my i's I would look into it, but I think that's probably lower priority than getting the fix in (and some of the other work I'm working on presently).