### PR TITLE
[FLOC 4306] fix broken link

### DIFF
--- a/docs/kubernetes-integration/about.rst
+++ b/docs/kubernetes-integration/about.rst
@@ -6,7 +6,7 @@ About the Kubernetes Integration
 
 Kubernetes 1.1 and later has native support for Flocker volumes.
 
-See `Kubernetes Flocker docs <http://kubernetes.io/v1.1/examples/flocker/>`_ for more details and example usage.
+See `Kubernetes Flocker docs <http://kubernetes.io/docs/user-guide/volumes/#flocker>`_ for more details and example usage.
 
 .. _concepts-kubernetes-integration:
 

--- a/docs/kubernetes-integration/index.rst
+++ b/docs/kubernetes-integration/index.rst
@@ -45,7 +45,7 @@ Tutorial
     <div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--2up pod-boxout--tutorial">
 		   <span>Tutorial: Using Flocker volumes, provided by Kubernetes</span>
-		     <a href="http://kubernetes.io/v1.1/examples/flocker/" target="_blank" class="button">Open the Kubernetes Tutorial</a>
+		     <a href="http://kubernetes.io/docs/user-guide/volumes/#flocker" target="_blank" class="button">Open the Kubernetes Tutorial</a>
 	    </div>
 	</div>
 


### PR DESCRIPTION
Fixes 4306

The URL for the Kubernetes Flocker information has changed from:

`http://kubernetes.io/v1.1/examples/flocker/`

to

`http://kubernetes.io/docs/user-guide/volumes/#flocker`
