### PR TITLE
[FLOC-4309] Gce blockdevice threadsafe.

### DIFF
--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -911,6 +911,13 @@ class Cluster(PClass):
                 d.addBoth(
                     lambda _: async_api.destroy_volume(volume.blockdevice_id)
                 )
+                # Consume failures and write them out. Failures might just
+                # indicate that the cluster beat us to deleting the volume
+                # which should not cause the test to fail, we only want the
+                # test to fail if list_volumes still returns a non-empty list.
+                # The construction of api_clean_state should prevent this from
+                # masking significant failures to clean up volumes.
+                d.addErrback(write_failure)
                 return d
 
             cleaning_volumes = api_clean_state(

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -656,8 +656,13 @@ class GCEBlockDeviceAPI(PClass):
 
                 if potentially_detaching_error is not None:
                     try:
+                        # We want to poll until _get_attached_to no longer
+                        # returns a compute_instance_id, and instead raises an
+                        # UnattachedVolume exception.
                         poll_until(
-                            lambda: self._get_attached_to(blockdevice_id),
+                            lambda: not bool(
+                                self._get_attached_to(blockdevice_id)
+                            ),
                             [1] * VOLUME_DETATCH_TIMEOUT
                         )
                         raise GCEVolumeException(

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -899,7 +899,7 @@ class GCEOperations(PClass):
 
         # A custom sleep function that drops the lock while the actual sleeping
         # is going on.
-        def custom_sleep(*args, **kwargs):
+        def lock_dropped_sleep(*args, **kwargs):
             self._lock.release()
             try:
                 return sleep(*args, **kwargs)
@@ -912,7 +912,7 @@ class GCEOperations(PClass):
         try:
             operation = function(**args).execute()
             return wait_for_operation(
-                self._compute, operation, [1]*timeout_sec, sleep)
+                self._compute, operation, [1]*timeout_sec, lock_dropped_sleep)
         finally:
             self._lock.release()
 


### PR DESCRIPTION
In reviewing logs, @justnoise and I noticed that we had some concurrent GCE requests that appeared to come back mangled (or hang abnormally long).

The GCE python bindings are based on httplib2, which is not threadsafe, so we either need to create 1 backend per thread or add some other serialization method.  To me it seemed most simple to just add a mutex around all calls to the GCE API.

I'm still debugging some failures that I'm seeing in the acceptance tests, but it seems as if this change does not make thing worse, so I consider this ready for review.