### PR TITLE
[FLOC-4310] Increase all acceptance test timeouts.

### DIFF
--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -27,7 +27,7 @@ from ...node import backends
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset,
     skip_backend, get_backend_api, verify_socket,
-    get_default_volume_size,
+    get_default_volume_size, ACCEPTANCE_TEST_TIMEOUT
 )
 
 
@@ -35,6 +35,8 @@ class DatasetAPITests(AsyncTestCase):
     """
     Tests for the dataset API.
     """
+
+    run_test_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
 
     @flaky(u'FLOC-3207')
     @require_cluster(1)
@@ -210,8 +212,6 @@ class DatasetAPITests(AsyncTestCase):
 
     @flaky(u'FLOC-3341')
     @require_moving_backend
-    # GCE sometimes takes 1 full minute to detach a disk.
-    @run_test_with(async_runner(timeout=timedelta(minutes=4)))
     @require_cluster(2)
     def test_dataset_move(self, cluster):
         """

--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -36,7 +36,7 @@ class DatasetAPITests(AsyncTestCase):
     Tests for the dataset API.
     """
 
-    run_test_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
+    run_tests_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
 
     @flaky(u'FLOC-3207')
     @require_cluster(1)

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -4,7 +4,6 @@
 Tests for the Flocker Docker plugin.
 """
 
-from datetime import timedelta
 from distutils.version import LooseVersion  # pylint: disable=import-error
 
 from testtools import run_test_with
@@ -24,7 +23,7 @@ from ...common.runner import run_ssh
 from ...dockerplugin.test.test_api import volume_expression
 
 from ...testtools import (
-    AsyncTestCase, random_name, flaky, async_runner,
+    AsyncTestCase, random_name, flaky, async_runner, ACCEPTANCE_TEST_TIMEOUT
 )
 from ..testtools import (
     require_cluster, post_http_server, assert_http_server,
@@ -43,6 +42,9 @@ class DockerPluginTests(AsyncTestCase):
     """
     Tests for the Docker plugin.
     """
+
+    run_test_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
+
     def require_docker(self, required_version, cluster):
         """
         Check for a specific minimum version of Docker on a remote node.
@@ -471,8 +473,6 @@ class DockerPluginTests(AsyncTestCase):
 
     @require_moving_backend
     @flaky(u'FLOC-3346')
-    # Test is very slow on Rackspace, it seems:
-    @run_test_with(async_runner(timeout=timedelta(minutes=4)))
     @require_cluster(2)
     def test_move_volume_different_node(self, cluster):
         """
@@ -505,8 +505,6 @@ class DockerPluginTests(AsyncTestCase):
         return d
 
     @require_cluster(1)
-    # Test can be slow on GCE.
-    @run_test_with(async_runner(timeout=timedelta(minutes=4)))
     def test_listed(self, cluster):
         """
         A volume created outside of Docker can be listed via the Docker

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -20,14 +20,12 @@ from ...common.runner import run_ssh
 
 from ...dockerplugin.test.test_api import volume_expression
 
-from ...testtools import (
-    AsyncTestCase, random_name, flaky, async_runner, ACCEPTANCE_TEST_TIMEOUT
-)
+from ...testtools import AsyncTestCase, random_name, flaky, async_runner
 from ..testtools import (
     require_cluster, post_http_server, assert_http_server,
     get_docker_client, verify_socket, check_http_server,
     extract_external_port,
-    create_dataset, require_moving_backend,
+    create_dataset, require_moving_backend, ACCEPTANCE_TEST_TIMEOUT
 )
 
 from ..scripts import SCRIPTS

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -6,8 +6,6 @@ Tests for the Flocker Docker plugin.
 
 from distutils.version import LooseVersion  # pylint: disable=import-error
 
-from testtools import run_test_with
-
 from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
 
@@ -43,7 +41,7 @@ class DockerPluginTests(AsyncTestCase):
     Tests for the Docker plugin.
     """
 
-    run_test_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
+    run_tests_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
 
     def require_docker(self, required_version, cluster):
         """

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -14,7 +14,9 @@ from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
 
 from ...common import loop_until
-from ...testtools import AsyncTestCase, async_runner, flaky, random_name
+from ...testtools import (
+    AsyncTestCase, async_runner, flaky, random_name, ACCEPTANCE_TEST_TIMEOUT
+)
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset,
     create_python_container, verify_socket, post_http_server,
@@ -27,6 +29,9 @@ class ContainerAPITests(AsyncTestCase):
     """
     Tests for the container API.
     """
+
+    run_test_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
+
     def _create_container(self, cluster, script):
         """
         Create a container listening on port 8080.
@@ -340,8 +345,6 @@ class ContainerAPITests(AsyncTestCase):
             lambda _: assert_http_server(self, origin.public_address, port))
         return running
 
-    # Unfortunately this test is very very slow.
-    @run_test_with(async_runner(timeout=timedelta(minutes=5)))
     @require_cluster(2, require_container_agent=True)
     def test_reboot(self, cluster):
         """

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -14,13 +14,12 @@ from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
 
 from ...common import loop_until
-from ...testtools import (
-    AsyncTestCase, async_runner, flaky, random_name, ACCEPTANCE_TEST_TIMEOUT
-)
+from ...testtools import AsyncTestCase, async_runner, flaky, random_name
 from ..testtools import (
     require_cluster, require_moving_backend, create_dataset,
     create_python_container, verify_socket, post_http_server,
     assert_http_server, query_http_server, is_process_running,
+    ACCEPTANCE_TEST_TIMEOUT
 )
 from ..scripts import SCRIPTS
 

--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -30,7 +30,7 @@ class ContainerAPITests(AsyncTestCase):
     Tests for the container API.
     """
 
-    run_test_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
+    run_tests_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
 
     def _create_container(self, cluster, script):
         """

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -3,6 +3,7 @@
 """
 Testing utilities for ``flocker.acceptance``.
 """
+from datetime import timedelta
 from functools import wraps
 from json import dumps
 from os import environ, close

--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -66,8 +66,15 @@ __all__ = [
     'require_cluster',
     'MONGO_APPLICATION', 'MONGO_IMAGE', 'get_mongo_application',
     'require_flocker_cli', 'create_application',
-    'create_attached_volume', 'get_docker_client'
+    'create_attached_volume', 'get_docker_client', 'ACCEPTANCE_TEST_TIMEOUT'
     ]
+
+
+# GCE sometimes takes up to a minute and a half to do a single operation,
+# safer to wait at least 5 minutes per test, as most tests have to do at
+# least 2 operations in series (cleanup then run test).
+ACCEPTANCE_TEST_TIMEOUT = timedelta(minutes=5)
+
 
 # XXX This assumes that the desired version of flocker-cli has been installed.
 # Instead, the testing environment should do this automatically.

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -64,7 +64,6 @@ __all__ = [
     'FakeSysModule',
     'MemoryCoreReactor',
     'REALISTIC_BLOCKDEVICE_SIZE',
-    'ACCEPTANCE_TEST_TIMEOUT',
     'make_standard_options_test',
     'TestCase',
     'assertContainsAll',
@@ -88,12 +87,6 @@ __all__ = [
 ]
 
 REALISTIC_BLOCKDEVICE_SIZE = RACKSPACE_MINIMUM_VOLUME_SIZE
-
-
-# GCE sometimes takes up to a minute and a half to do a single operation,
-# safer to wait at least 5 minutes per test, as most tests have to do at
-# least 2 operations in series (cleanup then run test).
-ACCEPTANCE_TEST_TIMEOUT = timedelta(minutes=5)
 
 
 @implementer(IProcessTransport)

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -12,6 +12,7 @@ import socket
 import sys
 import os
 import pwd
+from datetime import timedelta
 from collections import namedtuple
 from contextlib import contextmanager
 from random import randrange

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -12,7 +12,6 @@ import socket
 import sys
 import os
 import pwd
-from datetime import timedelta
 from collections import namedtuple
 from contextlib import contextmanager
 from random import randrange

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     'FakeSysModule',
     'MemoryCoreReactor',
     'REALISTIC_BLOCKDEVICE_SIZE',
+    'ACCEPTANCE_TEST_TIMEOUT',
     'make_standard_options_test',
     'TestCase',
     'assertContainsAll',
@@ -86,6 +87,12 @@ __all__ = [
 ]
 
 REALISTIC_BLOCKDEVICE_SIZE = RACKSPACE_MINIMUM_VOLUME_SIZE
+
+
+# GCE sometimes takes up to a minute and a half to do a single operation,
+# safer to wait at least 5 minutes per test, as most tests have to do at
+# least 2 operations in series (cleanup then run test).
+ACCEPTANCE_TEST_TIMEOUT = timedelta(minutes=5)
 
 
 @implementer(IProcessTransport)


### PR DESCRIPTION
GCE unfortunately can be very slow at doing volume operations (specifically attach and detach) (O(90 seconds)). Most of our tests have to do 2 operations in series (First they have to delete old volumes, then the have to create a volume for their own test). Thus, it sort of makes sense to me to have a much larger default timeout on our acceptance tests (I had been going through 1 by 1 and identified tests that needed a longer timeout experimentally, but after seeing 1 test that had an 80 second detach in cleanup followed by a 70 second attach in the actual test itself, it seems like this will be a quicker solution.)

Decided to make the change in three places:

1) test_dataset
2) test_container
3) test_dockerplugin

removed old timeout extensions that were less than 5 minutes. 