### PR TITLE
Acceptance Test Provisioner: SSH Client spawns a tty

### DIFF
--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -7,7 +7,6 @@ AWS provisioner.
 import logging
 
 from itertools import izip_longest, repeat
-from textwrap import dedent
 
 from pyrsistent import PClass, field
 

--- a/flocker/provision/_aws.py
+++ b/flocker/provision/_aws.py
@@ -380,10 +380,6 @@ class AWSProvisioner(PClass):
                 # On some operating systems a tty is requried for sudo.
                 # Since AWS systems have a non-root user as the login,
                 # disable this, so we can use sudo with conch.
-                user_data=dedent("""\
-                    #!/bin/sh
-                    sed -i '/Defaults *requiretty/d' /etc/sudoers
-                    """),
             )
             return reservation.instances
 

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -536,10 +536,6 @@ class GCEProvisioner(PClass):
                       u"json-description",
                       _GCE_FIREWALL_TAG]),
             delete_disk_on_terminate=True,
-            startup_script=dedent("""\
-                #!/bin/sh
-                sed -i '/Defaults *requiretty/d' /etc/sudoers
-                """),
         )
 
         return GCENode(

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -23,7 +23,6 @@ import json
 
 from eliot import start_action
 from pyrsistent import PClass, field
-from textwrap import dedent
 from twisted.conch.ssh.keys import Key
 from zope.interface import implementer
 from googleapiclient import discovery

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -269,19 +269,8 @@ def ensure_minimal_setup(package_manager):
     :return: a sequence of commands to run on the distribution
     """
     if package_manager in ('dnf', 'yum'):
-        # Fedora/CentOS sometimes configured to require tty for sudo
-        # ("sorry, you must have a tty to run sudo"). Disable that to
-        # allow automated tests to run.
-        return sequence([
-            run_network_interacting_from_args([
-                'su', 'root', '-c', [package_manager, '-y', 'install', 'sudo']
-            ]),
-            run_from_args([
-                'su', 'root', '-c', [
-                    'sed', '--in-place', '-e',
-                    's/Defaults.*requiretty/Defaults !requiretty/',
-                    '/etc/sudoers'
-                ]]),
+        return run_network_interacting_from_args([
+            'su', 'root', '-c', [package_manager, '-y', 'install', 'sudo']
         ])
     elif package_manager == 'apt':
         return sequence([

--- a/flocker/provision/_ssh/_conch.py
+++ b/flocker/provision/_ssh/_conch.py
@@ -95,7 +95,7 @@ class CommandChannelWithTTY(_CommandChannel):
     CentOS/RHEL wants us to have a pty in order to run commands with sudo.
     Create a pty that won't be used when creating the channel.
     """
-    def ttyChannelOpen(self, ignored):
+    def channelOpen(self, ignored):
         """
         Create a pty by sending a pty-req to the server
         """

--- a/flocker/provision/_ssh/_conch.py
+++ b/flocker/provision/_ssh/_conch.py
@@ -20,8 +20,11 @@ from twisted.conch.endpoints import (
     _NewConnectionHelper,
     # https://twistedmatrix.com/trac/ticket/7862
     _ReadFile, ConsoleUI,
+    _CommandChannel,
 )
 
+from twisted.conch.ssh.common import NS
+import twisted.conch.ssh.session as session
 from twisted.conch.client.knownhosts import KnownHostsFile
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.endpoints import UNIXClientEndpoint, connectProtocol
@@ -87,6 +90,58 @@ class CommandProtocol(LineOnlyReceiver, object):
         ).write()
 
 
+class CommandChannelWithTTY(_CommandChannel):
+    """
+    CentOS/RHEL wants us to have a pty in order to run commands with sudo.
+    Create a pty that won't be used when creating the channel.
+    """
+    def ttyChannelOpen(self, ignored):
+        """
+        Create a pty by sending a pty-req to the server
+        """
+        term = 'xterm'
+        winSize = (25,80,0,0)
+        ptyReqData = session.packRequest_pty_req(term, winSize, '')
+        self.conn.sendRequest(self, 'pty-req', ptyReqData)
+        command = self.conn.sendRequest(
+            self, 'exec', NS(self._command), wantReply=True)
+        command.addCallbacks(self._execSuccess, self._execFailure)
+
+
+class SSHCommandClientEndpointWithTTY(SSHCommandClientEndpoint):
+    """
+    Subclass that spawns a TTY when connecting.
+    """
+    def _executeCommand(self, connection, protocolFactory):
+        """
+        Given a secured SSH connection, try to execute a command in a new
+        channel created on it and associate the result with a protocol from the
+        given factory.
+
+        @param connection: See L{SSHCommandClientEndpoint.existingConnection}'s
+            C{connection} parameter.
+
+        @param protocolFactory: See L{SSHCommandClientEndpoint.connect}'s
+            C{protocolFactory} parameter.
+
+        @return: See L{SSHCommandClientEndpoint.connect}'s return value.
+        """
+        from twisted.internet.defer import Deferred, CancelledError
+        commandConnected = Deferred()
+        def disconnectOnFailure(passthrough):
+            # Close the connection immediately in case of cancellation, since
+            # that implies user wants it gone immediately (e.g. a timeout):
+            immediate =  passthrough.check(CancelledError)
+            self._creator.cleanupConnection(connection, immediate)
+            return passthrough
+        commandConnected.addErrback(disconnectOnFailure)
+
+        channel = CommandChannelWithTTY(
+            self._creator, self._command, protocolFactory, commandConnected)
+        connection.openChannel(channel)
+        return commandConnected
+
+
 def get_ssh_dispatcher(connection, context):
     """
     :param Message context: The eliot message context to log.
@@ -99,7 +154,7 @@ def get_ssh_dispatcher(connection, context):
             message_type="flocker.provision.ssh:run",
             command=intent.log_command_filter(intent.command),
         ).write()
-        endpoint = SSHCommandClientEndpoint.existingConnection(
+        endpoint = SSHCommandClientEndpointWithTTY.existingConnection(
             connection, intent.command)
         d = Deferred()
         connectProtocol(endpoint, CommandProtocol(


### PR DESCRIPTION
This is the first in a set of two PRs that'll allow the acceptance tests to run as the default user.  Running acceptance tests without a tty cause flakes on rackspace.  Running the tests as the root user requires us to modify the root account and sshd.  This has slowed down development on GCE.

In the future these changes will be used to allow the provisioning code to be reused to build a better flocker installer.