### PR TITLE
[FLOC-4315] Release Flocker 1.10.3

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,18 +9,17 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
-Next Release
+This Release
 ============
+
+v1.10.3
+-------
 
 * Fixed a race condition where multiple volumes for a given dataset could be created and used.
   This could lead to the appearance of data loss, as different volumes get used.
   Now, even if multiple volumes are created, only a single volume will be used.
   This was particularly likely to occur on AWS.
 * Fixed brew tap for flocker client tools on OSX, which had regressed on Yosemite.
-
-This Release
-============
-
 * The container agent is now optional and can be safely disabled if you don't expect to be using Flocker's deprecated container API or ``flocker-deploy``.
   The :ref:`Flocker plugin for Docker<plugin>` allows you to use Flocker from Docker without using Flocker's container API.
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4315
Build results: http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/view/releases/job/release-release-flocker-1.10.3/
Release process for reviewer: http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html?highlight=release%20process#pre-tag-review-process