### PR TITLE
[FLOC 4166] update mesos page with better CTAs

### DIFF
--- a/docs/mesos-integration/index.rst
+++ b/docs/mesos-integration/index.rst
@@ -10,28 +10,29 @@ Mesos
         <p>This page describes one of our experimental projects, developed to less rigorous quality and testing standards than the mainline Flocker distribution. It is not built with production-readiness in mind.</p>
 	</div>
 
-Flocker works with Mesos via two different integration paths.
+Flocker works with Mesos via two different integration paths:
 
-* With the `Mesos-Flocker Isolator <http://flocker.mesosframeworks.com/>`_ to provide storage to any Mesos framework and any application, whether Dockerized or not.
+* Using the Mesos-Flocker Isolator to provide storage to any Mesos framework and any application, whether Dockerized or not.
   Currently experimental.
-* With Marathon and the Flocker plugin for Docker to provide storage to Dockerized applications running on Marathon.
-  `See our blog post for details <https://clusterhq.com/2015/10/06/marathon-ha-demo/>`_.
-
-.. _mesos-tutorials:
-
-Tutorial
-========
-
-.. XXX this title should be renamed to "Tutorials" when there are more than one tutorial
+* Using Marathon and the Flocker plugin for Docker to provide storage to Dockerized applications running on Marathon.
+  See our `blog post below <https://clusterhq.com/2015/10/06/marathon-ha-demo/>`_ for details.
 
 .. raw:: html
 
     <div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--tutorial pod-boxout--2up">
-		   <span>Using Mesos isolator for Flocker</span>
-		     <a href="https://github.com/ClusterHQ/mesos-module-flocker" class="button" target="_blank">GitHub Readme</a>
+		   <span>Using the Mesos-Flocker Isolator</span>
+		     <a href="http://flocker.mesosframeworks.com/" class="button" target="_blank">Launch the Mesos-Flocker Isolator</a>
+	    </div>
+	    <div class="pod-boxout pod-boxout--tutorial pod-boxout--2up">
+		   <span>View the Mesos-Flocker isolator on GitHub</span>
+		     <a href="https://github.com/ClusterHQ/mesos-module-flocker" class="button" target="_blank">Open the GitHub repo</a>
 	    </div>
 	</div>
+
+.. _mesos-tutorials:
+
+.. XXX this section should be returned when there are tutorials
 
 Related Blog Articles
 =====================

--- a/docs/mesos-integration/index.rst
+++ b/docs/mesos-integration/index.rst
@@ -22,7 +22,7 @@ Flocker works with Mesos via two different integration paths:
     <div class="pods-eq">
 	    <div class="pod-boxout pod-boxout--tutorial pod-boxout--2up">
 		   <span>Using the Mesos-Flocker Isolator</span>
-		     <a href="http://flocker.mesosframeworks.com/" class="button" target="_blank">Launch the Mesos-Flocker Isolator</a>
+		     <a href="http://flocker.mesosframeworks.com/" class="button" target="_blank">Open the Mesos-Flocker Isolator</a>
 	    </div>
 	    <div class="pod-boxout pod-boxout--tutorial pod-boxout--2up">
 		   <span>View the Mesos-Flocker isolator on GitHub</span>


### PR DESCRIPTION
Fixes 4166

Corrects some UX issues highlighted in 4166. This includes removing the tutorial title, as we don't provide a mesos tutorial, and adding a CTA for launching the Mesos/Flocker isolator.