### PR TITLE
[FLOC-4323] Gce benchmarking

### DIFF
--- a/docs/gettinginvolved/cluster-setup.rst
+++ b/docs/gettinginvolved/cluster-setup.rst
@@ -129,6 +129,17 @@ To create a cluster on AWS, see :ref:`acceptance-testing-aws-config`.
 
   admin/setup-cluster --distribution centos-7 --provider aws --config-file config.yml --number-of-nodes 2
 
+.. _cluster-setup-gce-config:
+
+GCE
+===
+
+To create a cluster on GCE, see :ref:`acceptance-testing-gce-config`.
+
+.. prompt:: bash $
+
+  admin/setup-cluster --distribution centos-7 --provider gce --dataset-backend gce --config-file config.yml --number-of-nodes 2
+
 .. _cluster-setup-managed-config:
 
 Managed
@@ -292,7 +303,7 @@ An example of how to run :program:`add-cluster-nodes` would be:
 
 .. prompt:: bash $
 
-  admin/add-cluster-node \
+  admin/add-cluster-nodes \
     --distribution centos-7 \
     --branch master \
     --config-file ~/clusters/test0/managed.yaml \
@@ -375,7 +386,7 @@ An example of how to use it, without specifying any optional argument would be:
 
 .. prompt:: bash $
 
-  admin/setup-cluster-containers \
+  benchmark/setup-cluster-containers \
     --image "clusterhq/mongodb" \
     --mountpoint "/data/db" \
     --apps-per-node 5 \
@@ -394,12 +405,12 @@ so that it can be re-used for testing a different configuration.
 
 .. prompt:: bash $
 
-   admin/cleanup-cluster <options>
+   benchmark/cleanup-cluster <options>
 
 
-The :program:`admin/cleanup-cluster` script has several options:
+The :program:`benchmark/cleanup-cluster` script has several options:
 
-.. program:: admin/cleanup-cluster
+.. program:: benchmark/cleanup-cluster
 
 .. option:: --control-node <address>
 

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -631,7 +631,11 @@ class GCEBlockDeviceAPI(PClass):
             errors = result.get('error', {}).get('errors', [])
             for e in errors:
                 if e.get('code') == u"RESOURCE_IN_USE_BY_ANOTHER_RESOURCE":
+                    write_traceback()
                     raise AlreadyAttachedVolume(blockdevice_id)
+                elif e.get('code') == u'RESOURCE_NOT_FOUND':
+                    write_traceback()
+                    raise UnknownVolume(blockdevice_id)
             disk = self._operations.get_disk_details(blockdevice_id)
             result = BlockDeviceVolume(
                 blockdevice_id=blockdevice_id,
@@ -700,7 +704,10 @@ class GCEBlockDeviceAPI(PClass):
             if 'error' in result:
                 potentially_detaching_error = None
                 for error in result['error']['errors']:
-                    if error.get('code') == 'INVALID_FIELD_VALUE':
+                    if (
+                        error.get('code') == 'INVALID_FIELD_VALUE' or
+                        error.get('code') == 'INVALID_USAGE'
+                    ):
                         potentially_detaching_error = error
 
                 if potentially_detaching_error is not None:

--- a/flocker/node/agents/gce.py
+++ b/flocker/node/agents/gce.py
@@ -246,7 +246,7 @@ def wait_for_operation_async(reactor, compute, operation, timeout_steps):
         the operation.
 
     :returns Deferred: A Deferred firing with the concluded GCE operation
-        resource or calling its errback operation times out.
+        resource or calling its errback if it times out.
     """
     poller = _create_poller(operation)
 

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -460,6 +460,16 @@ class GCEInstanceBuilder(PClass):
         ).execute()
 
     def _make_gce_instance(self, instance_name):
+        """
+        Queries the GCE API to to get information about the named instance to
+        construct an object of type ``GCEInstance``.
+
+        :param unicode instance_name: The unique name of the GCE instance
+            resource.
+
+        :returns GCEInstance: A ``GCEInstance`` object that represents the
+            GCE instance resource with name ``instance_name``.
+        """
         instance_resource = self.compute.instances().get(
             project=self.project, zone=self.zone, instance=instance_name
         ).execute()
@@ -599,16 +609,6 @@ class GCEProvisioner(PClass):
         )
 
     def create_nodes(self, reactor, names, distribution, metadata=None):
-        """
-        Create nodes with the given names.
-
-        This method is not implemented as it is not used yet.
-        As of this time create_nodes is only used by setup-cluster
-        which does not support GCE.
-        One way to implement this method would be to use a variant of
-        wait_for_operation that uses loop_until instead of poll_until
-        to perform the waiting.
-        """
         if metadata is None:
             metadata = {}
 

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -445,7 +445,7 @@ class GCEInstanceBuilder(PClass):
         if image is None:
             image = get_latest_gce_image_for_distribution('centos-7',
                                                           self.compute)
-        body =  _create_gce_instance_config(
+        body = _create_gce_instance_config(
             instance_name=instance_name,
             project=self.project,
             zone=self.zone,
@@ -459,7 +459,6 @@ class GCEInstanceBuilder(PClass):
             body=body
         ).execute()
 
-    
     def _make_gce_instance(self, instance_name):
         instance_resource = self.compute.instances().get(
             project=self.project, zone=self.zone, instance=instance_name
@@ -501,7 +500,6 @@ class GCEInstanceBuilder(PClass):
             )
 
         return self._make_gce_instance(instance_name)
-
 
     def create_instance_async(
             self, reactor, instance_name, image=None, **kwargs):

--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -28,7 +28,11 @@ from twisted.conch.ssh.keys import Key
 from zope.interface import implementer
 from googleapiclient import discovery
 
-from ..node.agents.gce import wait_for_operation, gce_credentials_from_config
+from ..node.agents.gce import (
+    gce_credentials_from_config,
+    wait_for_operation,
+    wait_for_operation_async,
+)
 from ..common import retry_effect_with_timeout
 
 from ._common import IProvisioner, INode
@@ -431,44 +435,32 @@ class GCEInstanceBuilder(PClass):
     project = field(type=unicode)
     compute = field()
 
-    def create_instance(self, instance_name, image=None, **kwargs):
+    def _execute_create_instance(self, instance_name, image=None, **kwargs):
         """
-        Create a GCE instance.
+        Executes a create instance request on GCE and returns the operation.
 
-        :param unicode instance: The name of the instance to create.
-        :param unicode image: The link to the GCE image to use for the base
-            disk. Defaults to the latest CentOS 7 image if unspecified.
-        :param **kwargs: Other keyword arguments for the creation of the
-            instance. See documentation of ``_create_gce_instance_config`` for
-            keyword argument values.
-        :returns GCEInstance: The instance that was started.
+        :returns dict: A GCE operation resource object, suitable for use with
+            ``wait_for_operation``.
         """
         if image is None:
             image = get_latest_gce_image_for_distribution('centos-7',
                                                           self.compute)
-        config = _create_gce_instance_config(
+        body =  _create_gce_instance_config(
             instance_name=instance_name,
             project=self.project,
             zone=self.zone,
             image=image,
             **kwargs
         )
-        operation = self.compute.instances().insert(
+
+        return self.compute.instances().insert(
             project=self.project,
             zone=self.zone,
-            body=config
+            body=body
         ).execute()
 
-        operation_result = wait_for_operation(
-            self.compute, operation, timeout_steps=[5]*60)
-
-        if not operation_result:
-            raise ValueError(
-                "Timed out waiting for creation of VM: {}".format(
-                    instance_name
-                )
-            )
-
+    
+    def _make_gce_instance(self, instance_name):
         instance_resource = self.compute.instances().get(
             project=self.project, zone=self.zone, instance=instance_name
         ).execute()
@@ -482,6 +474,60 @@ class GCEInstanceBuilder(PClass):
             name=instance_name,
             compute=self.compute,
         )
+
+    def create_instance(self, instance_name, image=None, **kwargs):
+        """
+        Create a GCE instance.
+
+        :param unicode instance: The name of the instance to create.
+        :param unicode image: The link to the GCE image to use for the base
+            disk. Defaults to the latest CentOS 7 image if unspecified.
+        :param **kwargs: Other keyword arguments for the creation of the
+            instance. See documentation of ``_create_gce_instance_config`` for
+            keyword argument values.
+        :returns GCEInstance: The instance that was started.
+        """
+        operation = self._execute_create_instance(
+            instance_name, image=image, **kwargs)
+
+        operation_result = wait_for_operation(
+            self.compute, operation, timeout_steps=[5]*60)
+
+        if not operation_result:
+            raise ValueError(
+                "Timed out waiting for creation of VM: {}".format(
+                    instance_name
+                )
+            )
+
+        return self._make_gce_instance(instance_name)
+
+
+    def create_instance_async(
+            self, reactor, instance_name, image=None, **kwargs):
+        """
+        Create a GCE instance.
+
+        :param reactor: The twisted ``IReactorTime`` provider to use to
+            schedule delays.
+        :param unicode instance: The name of the instance to create.
+        :param unicode image: The link to the GCE image to use for the base
+            disk. Defaults to the latest CentOS 7 image if unspecified.
+        :param **kwargs: Other keyword arguments for the creation of the
+            instance. See documentation of ``_create_gce_instance_config`` for
+            keyword argument values.
+        :returns Deferred: Fires with the ``GCEInstance`` that was started.
+        """
+        operation = self._execute_create_instance(
+            instance_name, image=image, **kwargs)
+
+        operation_deferred = wait_for_operation_async(
+            reactor, self.compute, operation, timeout_steps=[5]*60)
+
+        operation_deferred.addCallback(
+            lambda _: self._make_gce_instance(instance_name))
+
+        return operation_deferred
 
 
 @implementer(IProvisioner)
@@ -500,11 +546,10 @@ class GCEProvisioner(PClass):
     def get_ssh_key(self):
         return self.ssh_public_key
 
-    def create_node(self, name, distribution, metadata={}):
+    def _create_instance_kwargs(self, name, distribution, metadata, username):
         instance_name = _clean_to_gce_name(name)
         ssh_key = unicode(self.ssh_public_key.toString('OPENSSH'))
-        username = _GCE_ACCEPTANCE_USERNAME
-        instance = self.instance_builder.create_instance(
+        return dict(
             instance_name=instance_name,
             machine_type=_GCE_INSTANCE_TYPE,
             image=get_latest_gce_image_for_distribution(
@@ -539,13 +584,23 @@ class GCEProvisioner(PClass):
                 """),
         )
 
+    def create_node(self, name, distribution, metadata=None):
+        if metadata is None:
+            metadata = {}
+        username = _GCE_ACCEPTANCE_USERNAME
+
+        instance = self.instance_builder.create_instance(
+            **self._create_instance_kwargs(name, distribution, metadata,
+                                           username)
+        )
+
         return GCENode(
             instance=instance,
             distribution=bytes(distribution),
             username=bytes(username)
         )
 
-    def create_nodes(self, reactor, names, distribution, metadata={}):
+    def create_nodes(self, reactor, names, distribution, metadata=None):
         """
         Create nodes with the given names.
 
@@ -556,8 +611,28 @@ class GCEProvisioner(PClass):
         wait_for_operation that uses loop_until instead of poll_until
         to perform the waiting.
         """
-        raise NotImplementedError(
-            "GCE does not have create_nodes implemented yet.")
+        if metadata is None:
+            metadata = {}
+
+        username = _GCE_ACCEPTANCE_USERNAME
+
+        results = []
+
+        for name in names:
+            instance_deferred = self.instance_builder.create_instance_async(
+                reactor,
+                **self._create_instance_kwargs(name, distribution, metadata,
+                                               username)
+            )
+
+            instance_deferred.addCallback(lambda instance: GCENode(
+                instance=instance,
+                distribution=bytes(distribution),
+                username=bytes(username)
+            ))
+
+            results.append(instance_deferred)
+        return results
 
 
 def gce_provisioner(


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4323

This puts GCE the rest of the way into our provisioning code so you can now quickly spin up instances in parallel.

The approach was to pull out code that could be re-used from the GCE provisioner, and add an async version of wait_for_operation. The API calls to GCE are still syncronous, but we wait in parallel for the nodes to be brought up.