### PR TITLE
Use forked version of Pyrsistent

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -857,6 +857,10 @@ def omnibus_package_builder(
         steps=(
             InstallVirtualEnv(virtualenv=virtualenv),
             InstallApplication(virtualenv=virtualenv,
+                               package_uri='pip==8.1.1'),
+            InstallApplication(virtualenv=virtualenv,
+                               package_uri='-r/flocker/requirements.txt'),
+            InstallApplication(virtualenv=virtualenv,
                                package_uri=package_uri),
             # get_package_version_step must be run before steps that reference
             # rpm_version

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -893,11 +893,15 @@ class OmnibusPackageBuilderTests(TestCase):
 
         package_files = FilePath('/package-files')
 
+        virtualenv = VirtualEnv(root=expected_virtualenv_path)
         expected = BuildSequence(
             steps=(
                 # clusterhq-python-flocker steps
-                InstallVirtualEnv(
-                    virtualenv=VirtualEnv(root=expected_virtualenv_path)),
+                InstallVirtualEnv(virtualenv=virtualenv),
+                InstallApplication(virtualenv=virtualenv,
+                                   package_uri='pip==8.1.1'),
+                InstallApplication(virtualenv=virtualenv,
+                                   package_uri='-r/flocker/requirements.txt'),
                 InstallApplication(
                     virtualenv=VirtualEnv(root=expected_virtualenv_path),
                     package_uri=b'https://www.example.com/foo/Bar-1.2.3.whl',

--- a/build.yaml
+++ b/build.yaml
@@ -624,7 +624,8 @@ common_cli:
           python-pip rpmlint" >> Dockerfile
     echo "RUN env URLGRABBER_DEBUG=1 yum update --assumeyes" >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
-    echo "RUN pip install -r /tmp/requirements.txt" >> Dockerfile
+    # Is this unused? --process-depency-links added but sort of untested.
+    echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile
 
   build_dockerfile_ubuntu_trusty: &build_dockerfile_ubuntu_trusty |
     # Download the latest pip requirements file from flocker
@@ -639,7 +640,8 @@ common_cli:
           libffi-dev libssl-dev build-essential python-pip \
           python2.7-dev lintian" >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
-    echo "RUN pip install -r /tmp/requirements.txt" >> Dockerfile
+    # Is this unused? --process-depency-links added but sort of untested.
+    echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile
 
   build_dockerfile_ubuntu_wily: &build_dockerfile_ubuntu_wily |
     # Download the latest pip requirements file from flocker
@@ -654,7 +656,8 @@ common_cli:
           git ruby-dev libffi-dev libssl-dev build-essential python-pip \
           python2.7-dev lintian" >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
-    echo "RUN pip install -r /tmp/requirements.txt" >> Dockerfile
+    # Is this unused? --process-depency-links added but sort of untested.
+    echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile
 
   do_not_abort_on_errors: &do_not_abort_on_errors |
     # make sure we don't abort the job on the first error we find.

--- a/build.yaml
+++ b/build.yaml
@@ -318,8 +318,9 @@ common_cli:
 
     # using the caching-layer, install all the dependencies
     pip install --upgrade pip
-    pip install . ${PIP_ADDITIONAL_OPTIONS}
-    pip install ".[dev]" ${PIP_ADDITIONAL_OPTIONS}
+    # Use --process-dependency-links so we can use the pyrsistent fork.
+    pip install --process-dependency-links . ${PIP_ADDITIONAL_OPTIONS}
+    pip install --process-dependency-links ".[dev]" ${PIP_ADDITIONAL_OPTIONS}
     # install junix for our coverage report
     pip install python-subunit junitxml ${PIP_ADDITIONAL_OPTIONS}
 

--- a/docs/gettinginvolved/client-testing.rst
+++ b/docs/gettinginvolved/client-testing.rst
@@ -15,7 +15,7 @@ Flocker includes client installation tests and a tool for running them in Docker
    .. prompt:: bash $
 
       brew install libffi openssl
-      env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install -e .[dev]
+      env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install --process-dependency-links -e .[dev]
       mkvirtualenv --python=/usr/bin/python new_virtualenv
 
 The client tests are called like this:

--- a/docs/gettinginvolved/functional-testing.rst
+++ b/docs/gettinginvolved/functional-testing.rst
@@ -49,7 +49,7 @@ To install this environment on CentOS, run the following commands:
    mkvirtualenv flocker
    git clone https://github.com/ClusterHQ/flocker
    cd flocker/
-   pip install -e .[dev]
+   pip install --process-dependency-links -e .[dev]
 
 Or for Ubuntu:
 
@@ -61,7 +61,7 @@ Or for Ubuntu:
    mkvirtualenv flocker
    git clone https://github.com/ClusterHQ/flocker
    cd flocker/
-   pip install -e .[dev]
+   pip install --process-dependency-links -e .[dev]
 
 AWS
 ===

--- a/docs/gettinginvolved/infrastructure/packaging.rst
+++ b/docs/gettinginvolved/infrastructure/packaging.rst
@@ -12,8 +12,8 @@ To build omnibus packages, create a VirtualEnv and install Flocker then its rele
 
    cd /path/to/flocker
    mkvirtualenv flocker-packaging
-   pip install .
-   pip install .[dev]
+   pip install --process-dependency-links .
+   pip install --process-dependency-links .[dev]
 
 Then run the following command from a clean checkout of the Flocker repository:
 

--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -173,7 +173,7 @@ class _ConfigurationEncoder(JSONEncoder):
             result[_CLASS_MARKER] = obj.__class__.__name__
             return result
         elif isinstance(obj, PClass):
-            result = obj.evolver().data
+            result = obj._to_dict()
             result[_CLASS_MARKER] = obj.__class__.__name__
             return result
         elif isinstance(obj, PMap):

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -294,7 +294,7 @@ class AgentServiceFactory(PClass):
     # This should have an explicit interface:
     # https://clusterhq.atlassian.net/browse/FLOC-1929
     deployer_factory = field(mandatory=True)
-    get_external_ip = field(initial=_get_external_ip, mandatory=True)
+    get_external_ip = field(initial=(lambda: _get_external_ip), mandatory=True)
 
     def get_service(self, reactor, options):
         """
@@ -420,12 +420,12 @@ class AgentService(PClass):
     backends = field(
         PluginLoader,
         mandatory=True,
-        initial=backend_loader,
+        initial=(lambda: backend_loader),
     )
     deployers = field(factory=pmap, initial=_DEFAULT_DEPLOYERS, mandatory=True)
     reactor = field(initial=reactor, mandatory=True)
 
-    get_external_ip = field(initial=_get_external_ip, mandatory=True)
+    get_external_ip = field(initial=(lambda: _get_external_ip), mandatory=True)
 
     control_service_host = field(type=bytes, mandatory=True)
     control_service_port = field(type=int, mandatory=True)
@@ -561,8 +561,9 @@ class DatasetServiceFactory(PClass):
     A helper for creating most of the pieces that go into a dataset convergence
     agent.
     """
-    agent_service_factory = field(initial=AgentService.from_configuration)
-    configuration_factory = field(initial=get_configuration)
+    agent_service_factory = field(
+        initial=(lambda: AgentService.from_configuration))
+    configuration_factory = field(initial=(lambda: get_configuration))
 
     def get_service(self, reactor, options):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/ClusterHQ/pyrsistent@53c1abf20b7c07f0e36b5c0cf6891e161740fa8e#egg=pyrsistent-0.11.13chq
 argparse==1.3.0
 attrs==15.1.0
 Babel==1.3
@@ -38,7 +39,6 @@ oslo.i18n==1.7.0
 oslo.serialization==1.6.0
 oslo.utils==1.6.0
 pbr==0.11.1
-pip==7.1.0
 prettytable==0.7.2
 psutil==2.1.2
 pyasn1==0.1.9
@@ -46,7 +46,6 @@ pyasn1-modules==0.0.8
 pycparser==2.14
 pycrypto==2.6.1
 pyOpenSSL==0.15.1
-pyrsistent==0.11.9
 python-cinderclient==1.1.1
 python-dateutil==2.4.2
 python-keystoneclient==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.rst") as readme:
     description = readme.read()
 
 with open("requirements.txt") as requirements:
-    install_requires = requirements.readlines()
+    install_requires = [req for req in requirements.readlines() if 'git+https' not in req]
 with open("dev-requirements.txt") as dev_requirements:
     dev_requires = dev_requirements.readlines()
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ minversion = 1.6
 
 [testenv]
 commands =
-    pip install -r requirements.txt
-    pip install .[dev]
+    pip install --process-dependency-links -r requirements.txt
+    pip install --process-dependency-links .[dev]
     trial --rterrors {posargs:flocker}
 setenv =
     PYTHONHASHSEED=random
@@ -17,8 +17,8 @@ basepython = python2.7
 basepython = python2.7
 changedir = {toxinidir}
 commands =
-    pip install -r requirements.txt
-    pip install .[dev]
+    pip install --process-dependency-links -r requirements.txt
+    pip install --process-dependency-links .[dev]
     flake8 admin benchmark flocker
     pylint admin benchmark flocker
 
@@ -26,8 +26,8 @@ commands =
 basepython = python2.7
 changedir = {toxinidir}
 commands =
-    pip install -r requirements.txt
-    pip install .[dev]
+    pip install --process-dependency-links -r requirements.txt
+    pip install --process-dependency-links .[dev]
     rm -rf docs/_build/html
     sphinx-build -a -b spelling docs/ docs/_build/spelling
     sphinx-build -a -b html docs/ docs/_build/html
@@ -37,6 +37,6 @@ basepython = python2.7
 usedevelop = True
 changedir = {toxinidir}
 commands =
-    pip install -r requirements.txt
-    pip install .[dev]
+    pip install --process-dependency-links -r requirements.txt
+    pip install --process-dependency-links .[dev]
     trial --rterrors admin


### PR DESCRIPTION
This allows us to use a forked version
of Pyrsistent. Currently, it points
to a CHQ fork that has nothing in it
but a "forking stamp". This should be
updated to a hash that has the speed-ups
we need.