### PR TITLE
[FLOC-4326] Do not log configuration and deployment state during CONVERGE

### DIFF
--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -379,21 +379,13 @@ LOG_SEND_TO_CONTROL_SERVICE = ActionType(
     [_FIELD_CONNECTION, _FIELD_LOCAL_CHANGES], [],
     u"Send the local state to the control service.")
 
-_FIELD_CLUSTERSTATE = Field(
-    u"cluster_state", to_unserialized_json,
-    u"The state of the cluster, according to control service.")
-
-_FIELD_CONFIGURATION = Field(
-    u"desired_configuration", to_unserialized_json,
-    u"The configuration of the cluster according to the control service.")
-
 _FIELD_ACTIONS = Field(
     u"calculated_actions", repr,
     u"The actions we decided to take to converge with configuration.")
 
 LOG_CONVERGE = ActionType(
     u"flocker:agent:converge",
-    [_FIELD_CLUSTERSTATE, _FIELD_CONFIGURATION], [],
+    [], [],
     u"The convergence action within the loop.")
 
 LOG_DISCOVERY = ActionType(
@@ -524,8 +516,7 @@ class ConvergenceLoop(object):
             return succeed(None)
 
     def output_CONVERGE(self, context):
-        with LOG_CONVERGE(self.fsm.logger, cluster_state=self.cluster_state,
-                          desired_configuration=self.configuration).context():
+        with LOG_CONVERGE(self.fsm.logger).context():
             log_discovery = LOG_DISCOVERY(self.fsm.logger)
             with log_discovery.context():
                 discover = DeferredContext(maybeDeferred(

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -516,6 +516,11 @@ class ConvergenceLoop(object):
             return succeed(None)
 
     def output_CONVERGE(self, context):
+        # XXX: We stopped logging configuration and cluster state here for
+        # performance reasons.
+        # But without some limited logging it'll be difficult to debug problems
+        # all the way from a configuration change to the failed convergence
+        # operation. FLOC-4331.
         with LOG_CONVERGE(self.fsm.logger).context():
             log_discovery = LOG_DISCOVERY(self.fsm.logger)
             with log_discovery.context():

--- a/flocker/node/test/test_loop.py
+++ b/flocker/node/test/test_loop.py
@@ -644,10 +644,7 @@ class ConvergenceLoopFSMTests(TestCase):
         logging.
         """
         transition = assertHasAction(self, logger, LOG_FSM_TRANSITION, True)
-        converge = assertHasAction(
-            self, logger, LOG_CONVERGE, True,
-            {u"cluster_state": self.cluster_state,
-             u"desired_configuration": self.configuration})
+        converge = assertHasAction(self, logger, LOG_CONVERGE, True)
         self.assertIn(converge, transition.children)
         send = assertHasAction(self, logger, LOG_SEND_TO_CONTROL_SERVICE, True,
                                {u"local_changes": [self.local_state]})


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4326

Copied from #2720 with some additional test fixes.