### PR TITLE
[FLOC-4328] Don't wake up for datasets that have been deleted on other nodes

### DIFF
--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1577,11 +1577,8 @@ DATASET_TRANSITIONS = TransitionTable.create({
         Discovered.NON_EXISTENT: CreateBlockDeviceDataset,
         # Other node will detach:
         Discovered.ATTACHED_ELSEWHERE: DoNothing,
-        # Some backends (AWS in particular) are only eventually consistent, so
-        # list_volumes might not report the volume even after it has already
-        # been created. We poll waiting for the backend to start reporting the
-        # created volume.
-        Discovered.REGISTERED: Poll,
+        # We reach this state when a dataset has been deleted.
+        Discovered.REGISTERED: DoNothing,
         Discovered.UNREGISTERED: RegisterVolume,
         Discovered.ATTACHED_NO_FILESYSTEM: DetachVolume,
         Discovered.ATTACHED: DetachVolume,

--- a/flocker/node/agents/test/test_blockdevice.py
+++ b/flocker/node/agents/test/test_blockdevice.py
@@ -1864,7 +1864,7 @@ class CalculateDesiredStateTests(TestCase):
 def assert_calculated_changes(
         case, node_state, node_config, nonmanifest_datasets, expected_changes,
         additional_node_states=frozenset(), leases=Leases(),
-        discovered_datasets=None
+        discovered_datasets=None,
 ):
     """
     Assert that ``BlockDeviceDeployer`` calculates certain changes in a certain
@@ -2144,9 +2144,17 @@ class BlockDeviceDeployerAlreadyConvergedCalculateChangesTests(
             )
         )
 
-        # Add a registered volume to discovered dataset. Upon deletion datasets
-        # to not get unregistered. This also should not result in any
-        # convergence operations.
+        # Upon deletion, datasets to not get unregistered, so they will still
+        # be in the discovered datasets.
+
+        registered_dataset = DiscoveredDataset(
+            dataset_id=self.DATASET_ID,
+            blockdevice_id=self.BLOCKDEVICE_ID,
+            state=DatasetStates.REGISTERED,
+        )
+
+        # Foreign deleted datasets show up as REGISTERED, but they are not in
+        # our config.
         foreign_registered_dataset_id = uuid4()
         foreign_registered_dataset = DiscoveredDataset(
             dataset_id=foreign_registered_dataset_id,
@@ -2161,6 +2169,7 @@ class BlockDeviceDeployerAlreadyConvergedCalculateChangesTests(
             nonmanifest_datasets={},
             expected_changes=in_parallel(changes=[]),
             discovered_datasets=[
+                registered_dataset,
                 foreign_registered_dataset
             ],
         )

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -368,7 +368,7 @@ def compute_cluster_state(node_state, additional_node_states,
 def assert_calculated_changes_for_deployer(
     case, deployer, node_state, node_config, nonmanifest_datasets,
     additional_node_states, additional_node_config, expected_changes,
-    local_state, leases=Leases()
+    local_state, leases=Leases(), persistent_state=None,
 ):
     """
     Assert that ``calculate_changes`` returns certain changes when it is
@@ -391,6 +391,7 @@ def assert_calculated_changes_for_deployer(
         ``calculate_changes``. Must be the correct type for the type of
         ``IDeployer`` being tested.
     :param Leases leases: Currently configured leases. By default none exist.
+    :param PersistentState persistent_state: Agent state which is persisted.
     """
     cluster_state = compute_cluster_state(node_state, additional_node_states,
                                           nonmanifest_datasets)
@@ -398,6 +399,10 @@ def assert_calculated_changes_for_deployer(
         nodes={node_config} | additional_node_config,
         leases=leases,
     )
+    if persistent_state is not None:
+        cluster_configuration = cluster_configuration.set(
+            'persistent_state', persistent_state
+        )
     changes = deployer.calculate_changes(
         cluster_configuration, cluster_state, local_state
     )

--- a/flocker/node/testtools.py
+++ b/flocker/node/testtools.py
@@ -368,7 +368,7 @@ def compute_cluster_state(node_state, additional_node_states,
 def assert_calculated_changes_for_deployer(
     case, deployer, node_state, node_config, nonmanifest_datasets,
     additional_node_states, additional_node_config, expected_changes,
-    local_state, leases=Leases(), persistent_state=None,
+    local_state, leases=Leases()
 ):
     """
     Assert that ``calculate_changes`` returns certain changes when it is
@@ -391,7 +391,6 @@ def assert_calculated_changes_for_deployer(
         ``calculate_changes``. Must be the correct type for the type of
         ``IDeployer`` being tested.
     :param Leases leases: Currently configured leases. By default none exist.
-    :param PersistentState persistent_state: Agent state which is persisted.
     """
     cluster_state = compute_cluster_state(node_state, additional_node_states,
                                           nonmanifest_datasets)
@@ -399,10 +398,6 @@ def assert_calculated_changes_for_deployer(
         nodes={node_config} | additional_node_config,
         leases=leases,
     )
-    if persistent_state is not None:
-        cluster_configuration = cluster_configuration.set(
-            'persistent_state', persistent_state
-        )
     changes = deployer.calculate_changes(
         cluster_configuration, cluster_state, local_state
     )


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4328

Copied from #2720 with a test.

It took me ages to figure out that the problem was only occurring when the deleted dataset had been attached to some other volume.
For now I've modified one of the existing tests. Perhaps this case deserves a separate test though.