### PR TITLE
[FLOC-3142] Enable profiling of agent services.

### DIFF
--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -340,7 +340,7 @@ def main_for_service(reactor, service):
 
 def enable_profiling(profile, signal, frame):
     """
-    Enable profiling of the control service.
+    Enable profiling of a Flocker service.
 
     :param profile: A cProfile Profile object for a Flocker service.
     :param int signal: See ``signal.signal``.
@@ -351,7 +351,7 @@ def enable_profiling(profile, signal, frame):
 
 def disable_profiling(profile, service, signal, frame):
     """
-    Disable profiling of the control service.
+    Disable profiling of a Flocker service.
     Dump profiling statistics to a file.
 
     :param profile: A cProfile Profile object for a Flocker service.

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -360,11 +360,10 @@ def disable_profiling(profile, service, signal, frame):
     :param frame: None or frame object. See ``signal.signal``.
     """
     current_time = strftime("%Y%m%d%H%M%S")
-    path = FilePath(
-        '/var/lib/flocker/profile-{service}-{current_time}'.format(
-            service=service,
-            current_time=current_time
-        )
+    path = FilePath('/var/lib/flocker')
+    path = path.child('profile-{service}-{current_time}'.format(
+        service=service,
+        current_time=current_time)
     )
     # This dumps the current profiling statistics and disables the
     # collection of profiling data. When the profiler is next enabled

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -342,7 +342,7 @@ def enable_profiling(profile, signal, frame):
     """
     Enable profiling of a Flocker service.
 
-    :param profile: A cProfile Profile object for a Flocker service.
+    :param profile: A ``cProfile.Profile`` object for a Flocker service.
     :param int signal: See ``signal.signal``.
     :param frame: None or frame object. See ``signal.signal``.
     """
@@ -354,7 +354,7 @@ def disable_profiling(profile, service, signal, frame):
     Disable profiling of a Flocker service.
     Dump profiling statistics to a file.
 
-    :param profile: A cProfile Profile object for a Flocker service.
+    :param profile: A ``cProfile.Profile`` object for a Flocker service.
     :param str service: Name of or identifier for a Flocker service.
     :param int signal: See ``signal.signal``.
     :param frame: None or frame object. See ``signal.signal``.

--- a/flocker/common/script.py
+++ b/flocker/common/script.py
@@ -3,6 +3,7 @@
 """Helpers for flocker shell commands."""
 
 import sys
+from time import strftime
 
 from bitmath import MiB
 
@@ -335,3 +336,37 @@ def main_for_service(reactor, service):
     reactor.addSystemEventTrigger(
         "before", "shutdown", _chain_stop_result, service, stop)
     return stop
+
+
+def enable_profiling(profile, signal, frame):
+    """
+    Enable profiling of the control service.
+
+    :param profile: A cProfile Profile object for a Flocker service.
+    :param int signal: See ``signal.signal``.
+    :param frame: None or frame object. See ``signal.signal``.
+    """
+    profile.enable()
+
+
+def disable_profiling(profile, service, signal, frame):
+    """
+    Disable profiling of the control service.
+    Dump profiling statistics to a file.
+
+    :param profile: A cProfile Profile object for a Flocker service.
+    :param str service: Name of or identifier for a Flocker service.
+    :param int signal: See ``signal.signal``.
+    :param frame: None or frame object. See ``signal.signal``.
+    """
+    current_time = strftime("%Y%m%d%H%M%S")
+    path = FilePath(
+        '/var/lib/flocker/profile-{service}-{current_time}'.format(
+            service=service,
+            current_time=current_time
+        )
+    )
+    # This dumps the current profiling statistics and disables the
+    # collection of profiling data. When the profiler is next enabled
+    # the new statistics are added to existing data.
+    profile.dump_stats(path.path)

--- a/flocker/control/script.py
+++ b/flocker/control/script.py
@@ -104,7 +104,9 @@ def flocker_control_main():
         :param frame: None or frame object. See ``signal.signal``.
         """
         current_time = time.strftime("%Y%m%d%H%M%S")
-        path = FilePath('/var/lib/flocker/profile-{}'.format(current_time))
+        path = FilePath(
+            '/var/lib/flocker/profile-control-{}'.format(current_time)
+        )
         # This dumps the current profiling statistics and disables the
         # collection of profiling data. When the profiler is next enabled
         # the new statistics are added to existing data.

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -7,8 +7,10 @@ The command-line ``flocker-*-agent`` tools.
 
 from socket import socket
 from contextlib import closing
+import cProfile
+import signal
 import sys
-from time import sleep
+from time import sleep, clock, strftime
 
 import yaml
 
@@ -66,6 +68,40 @@ def flocker_dataset_agent_main():
     agent_script = AgentScript(service_factory=service_factory.get_service)
     options = DatasetAgentOptions()
 
+    # Use CPU time instead of wallclock time.
+    # The control service does a lot of waiting and we do not
+    # want the profiler to include that.
+    pr = cProfile.Profile(clock)
+
+    def enable_profiling(signal, frame):
+        """
+        Enable profiling of the control service.
+
+        :param int signal: See ``signal.signal``.
+        :param frame: None or frame object. See ``signal.signal``.
+        """
+        pr.enable()
+
+    def disable_profiling(signal, frame):
+        """
+        Disable profiling of the control service.
+        Dump profiling statistics to a file.
+
+        :param int signal: See ``signal.signal``.
+        :param frame: None or frame object. See ``signal.signal``.
+        """
+        current_time = strftime("%Y%m%d%H%M%S")
+        path = FilePath(
+            '/var/lib/flocker/profile-dataset-{}'.format(current_time)
+        )
+        # This dumps the current profiling statistics and disables the
+        # collection of profiling data. When the profiler is next enabled
+        # the new statistics are added to existing data.
+        pr.dump_stats(path.path)
+
+    signal.signal(signal.SIGUSR1, enable_profiling)
+    signal.signal(signal.SIGUSR2, disable_profiling)
+
     return FlockerScriptRunner(
         script=agent_script,
         options=options,
@@ -84,6 +120,41 @@ def flocker_container_agent_main():
         deployer_factory=deployer_factory
     ).get_service
     agent_script = AgentScript(service_factory=service_factory)
+
+    # Use CPU time instead of wallclock time.
+    # The control service does a lot of waiting and we do not
+    # want the profiler to include that.
+    pr = cProfile.Profile(clock)
+
+    def enable_profiling(signal, frame):
+        """
+        Enable profiling of the control service.
+
+        :param int signal: See ``signal.signal``.
+        :param frame: None or frame object. See ``signal.signal``.
+        """
+        pr.enable()
+
+    def disable_profiling(signal, frame):
+        """
+        Disable profiling of the control service.
+        Dump profiling statistics to a file.
+
+        :param int signal: See ``signal.signal``.
+        :param frame: None or frame object. See ``signal.signal``.
+        """
+        current_time = strftime("%Y%m%d%H%M%S")
+        path = FilePath(
+            '/var/lib/flocker/profile-container-{}'.format(current_time)
+        )
+        # This dumps the current profiling statistics and disables the
+        # collection of profiling data. When the profiler is next enabled
+        # the new statistics are added to existing data.
+        pr.dump_stats(path.path)
+
+    signal.signal(signal.SIGUSR1, enable_profiling)
+    signal.signal(signal.SIGUSR2, disable_profiling)
+
     return FlockerScriptRunner(
         script=agent_script,
         options=ContainerAgentOptions()

--- a/flocker/node/script.py
+++ b/flocker/node/script.py
@@ -71,8 +71,6 @@ def flocker_dataset_agent_main():
     options = DatasetAgentOptions()
 
     # Use CPU time instead of wallclock time.
-    # The control service does a lot of waiting and we do not
-    # want the profiler to include that.
     pr = cProfile.Profile(clock)
 
     signal.signal(signal.SIGUSR1, partial(enable_profiling, pr))
@@ -98,8 +96,6 @@ def flocker_container_agent_main():
     agent_script = AgentScript(service_factory=service_factory)
 
     # Use CPU time instead of wallclock time.
-    # The control service does a lot of waiting and we do not
-    # want the profiler to include that.
     pr = cProfile.Profile(clock)
 
     signal.signal(signal.SIGUSR1, partial(enable_profiling, pr))


### PR DESCRIPTION
Fixes: [FLOC-3142](https://clusterhq.atlassian.net/browse/FLOC-3142)

This changes moves the code added for [FLOC-3039](https://clusterhq.atlassian.net/browse/FLOC-3039) and allows it to be used by other flocker services.

Sending `SIGUSR1` and `SIGUSR2` to a flocker service results in a profile dump being written to `/var/lib/flocker`. The profile files are named according to which service they correspond to, one of `control`, `dataset`, or `container`.