### PR TITLE
[FLOC-4330] Re-enable the Pyrsistent C extension

### DIFF
--- a/flocker/__init__.py
+++ b/flocker/__init__.py
@@ -11,27 +11,6 @@ from ._version import get_versions
 REST_API_PORT = 4523
 
 
-def _disable_pyrsistent_c_extensions():
-    """
-    Pyrsistent sometimes segfaults. Disabling the C extension reduces the
-    likelihood of this happening.
-
-    We do this first so it happens before pyrsistent is imported.
-
-    In theory this bug is fixed in pyrsistent 0.11.7, so this may no
-    longer be necessary and is likely worth risking for higher
-    performance. Once we have benchmarking framework we can assess
-    risk/benefit ratio better.
-
-    The mechanism for disabling extensions is documented at
-    https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt#L17-L19.
-    """
-    import os
-    os.environ[b"PYRSISTENT_NO_C_EXTENSION"] = b"1"
-_disable_pyrsistent_c_extensions()
-del _disable_pyrsistent_c_extensions
-
-
 def _suppress_warnings():
     """
     Suppress warnings when not running under trial.


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4330


I started some parallel builds to see if we can trigger the segfault:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/re-enable-pyrsistent-c-extension-FLOC-4330-parallel-testing-1
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/re-enable-pyrsistent-c-extension-FLOC-4330-parallel-testing-2
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/re-enable-pyrsistent-c-extension-FLOC-4330-parallel-testing-3
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/re-enable-pyrsistent-c-extension-FLOC-4330-parallel-testing-4
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/re-enable-pyrsistent-c-extension-FLOC-4330-parallel-testing-5

See also:
 * #1891 (the PR where we disabled the C extension)
 * https://github.com/tobgu/pyrsistent/issues/52 (the bug that we were originally encountering)