### PR TITLE
[FLOC-4334] Cache flocker-control responses.

### DIFF
--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -143,7 +143,7 @@ def _extract_containers_state(deployment_state):
     container in the deployment state.
 
     N.B.: Callers of this function should not mutate the returned value as this
-    function uses an lru_cache.
+    function uses an lru_cache (FLOC-4345 to clean up).
 
     :param DeploymentState deployment_state: The deployment state to extract
         the containers from.
@@ -152,9 +152,7 @@ def _extract_containers_state(deployment_state):
     """
     result = []
     for node in deployment_state.nodes:
-        if node.applications is None:
-            continue
-        for application in node.applications:
+        for application in (node.applications or ()):
             container = container_configuration_response(
                 application, node.uuid)
             container[u"running"] = application.running
@@ -1257,7 +1255,7 @@ def _containers_from_deployment(deployment):
     Extract the containers from the supplied deployment instance.
 
     N.B.: Callers of this function should not mutate the returned value as this
-    function uses an lru_cache.
+    function uses an lru_cache (FLOC-4345 to clean up).
 
     :param Deployment deployment: A ``Deployment`` describing the state
         of the cluster.

--- a/flocker/control/httpapi.py
+++ b/flocker/control/httpapi.py
@@ -142,6 +142,9 @@ def _extract_containers_state(deployment_state):
     Turn the deployment state into serializable simple types for every
     container in the deployment state.
 
+    N.B.: Callers of this function should not mutate the returned value as this
+    function uses an lru_cache.
+
     :param DeploymentState deployment_state: The deployment state to extract
         the containers from.
 
@@ -548,7 +551,8 @@ class ConfigurationAPIUserV1(object):
         :return: A ``list`` of ``dict`` representing each of the containers
             that are configured to exist anywhere on the cluster.
         """
-        return list(containers_from_deployment(self.persistence_service.get()))
+        return list(
+            _containers_from_deployment(self.persistence_service.get()))
 
     @app.route("/state/containers", methods=['GET'])
     @user_documentation(
@@ -1248,9 +1252,12 @@ def datasets_from_deployment(deployment):
 
 
 @lru_cache(1)
-def containers_from_deployment(deployment):
+def _containers_from_deployment(deployment):
     """
     Extract the containers from the supplied deployment instance.
+
+    N.B.: Callers of this function should not mutate the returned value as this
+    function uses an lru_cache.
 
     :param Deployment deployment: A ``Deployment`` describing the state
         of the cluster.


### PR DESCRIPTION
In order to speed up response times from the control agent, this PR adds a simple cache to be used in the case where the deployment state or configuration has not changed since the last time it was requested over the API.

Note: This assumes that the callers of the caching functions are well-behaved and don't mutate the values they receive. If they mutate the values they receive they will be mutating the value in the cache. I believe this is true, and that it is fairly easy to reason about it being true in the future.