### PR TITLE
[FLOC-4336] Update pyrsistent to a version with __eq__ and __hash__ optimizations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ClusterHQ/pyrsistent@53c1abf20b7c07f0e36b5c0cf6891e161740fa8e#egg=pyrsistent-0.11.13chq
+git+https://github.com/ClusterHQ/pyrsistent@5b722c3ad75ed2da414a40e6d27af373a8610018#egg=pyrsistent-0.11.13chq
 argparse==1.3.0
 attrs==15.1.0
 Babel==1.3


### PR DESCRIPTION
Now that we have a mechanism to use our own fork of pyrsistent, this is the commit to use the latest hash of master.

By policy this hash matches exactly a valid hash from ClusterHQ/pyrsistent/master, specifically:

https://github.com/ClusterHQ/pyrsistent/commit/5b722c3ad75ed2da414a40e6d27af373a8610018