### PR TITLE
[FLOC-4357] Removed one of the points of logging

### DIFF
--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -47,7 +47,7 @@ from ...control import (
     NodeState, NonManifestDatasets, Dataset as ModelDataset, ChangeSource,
     DockerImage, UpdateNodeStateEra,
 )
-from ...restapi._logging import JSON_REQUEST
+from ...restapi._logging import REQUEST
 from ...restapi import _infrastructure as rest_api
 from ... import __version__
 
@@ -809,7 +809,7 @@ class FlockerClientTests(make_clientv1_tests()):
 
         def got_response(_):
             parent = LoggedAction.ofType(logger.messages, my_action)[0]
-            child = LoggedAction.ofType(logger.messages, JSON_REQUEST)[0]
+            child = LoggedAction.ofType(logger.messages, REQUEST)[0]
             self.assertIn(child, list(parent.descendants()))
         d.addCallback(got_response)
         return d

--- a/flocker/restapi/_logging.py
+++ b/flocker/restapi/_logging.py
@@ -7,7 +7,6 @@ This module defines the Eliot log events emitted by the API implementation.
 from eliot import Field, ActionType
 
 __all__ = [
-    "JSON_REQUEST",
     "REQUEST",
     ]
 
@@ -26,20 +25,9 @@ RESPONSE_CODE = Field.forTypes(
     u"The response code for the request.")
 
 
-# It would be nice if RESPONSE_CODE was in REQUEST instead of
-# JSON_REQUEST; see FLOC-1586.
+# It would be nice if RESPONSE_CODE was in REQUEST; see FLOC-1586.
 REQUEST = ActionType(
     LOG_SYSTEM + u":request",
     [REQUEST_PATH, METHOD],
     [],
     u"A request was received on the public HTTP interface.")
-
-# NB we deliberately do not log the entire JSON response body because the
-# volume of log that it generates for state and configuration requests in a
-# cluster with large numbers of datasets and nodes causes high CPU usage in the
-# control service and in the logging daemon. (FLOC-4327)
-JSON_REQUEST = ActionType(
-    LOG_SYSTEM + u":json_request",
-    [JSON],
-    [RESPONSE_CODE],
-    u"A request containing JSON request body and HTTP response code.")


### PR DESCRIPTION
Flocker had a lot of nested logging on API requests. This drives CPU usage higher than it should be for high numbers of requests per second.

Removing one of these layers in an attempt to reduce CPU usage.

After spinning up 2 15 node clusters, one with this change and one without this change, I observed the following when I ran the 10 QPS read benchmark:

Without this PR:

flocker-control CPU: 25%

With this PR:

flocker-control CPU: 23%

This was on ubuntu rather than CentOS, but now that we neutered the JSON logs, it seems to me that these are adding no value, and getting the extra 2 percent back is sort of a big deal.