### PR TITLE
[FLOC-4358] Release Flocker 1.11.0

### DIFF
--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -28,7 +28,7 @@ v1.11.0
   Now, even if multiple volumes are created, only a single volume will be used.
   This was particularly likely to occur on AWS.
 * The Flocker client tools can once again be installed on OSX Yosemite.
-  A regression in the Flocker homebrew tap file has been fixed.
+  A regression in the Flocker Homebrew tap file has been fixed.
 
 Previous Releases
 =================

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -9,22 +9,26 @@ You can learn more about where we might be going with future releases by:
 * Stopping by the ``#clusterhq`` channel on ``irc.freenode.net``.
 * Visiting our GitHub repository at https://github.com/ClusterHQ/flocker.
 
-Next Release
-============
-
-* Fixed a race condition where multiple volumes for a given dataset could be created and used.
-  This could lead to the appearance of data loss, as different volumes get used.
-  Now, even if multiple volumes are created, only a single volume will be used.
-  This was particularly likely to occur on AWS.
-* Dataset backend support for :ref:`Google Compute Engine <gce-dataset-backend>`.
-* Fixed brew tap for flocker client tools on OSX, which had regressed on Yosemite.
-* Added documentation for the :ref:`Open vStorage <open-vstorage-backend>` driver.
-
 This Release
 ============
 
+v1.11.0
+-------
+
+* The dataset agent now has backend support for :ref:`Google Compute Engine <gce-dataset-backend>`.
+* Flocker is now significantly more efficient.
+  The control and agent services use far less CPU time when idle and far less CPU time when converging on a configuration change.
+  This allows larger clusters containing more datasets and supporting more frequent configuration changes.
+* Flocker can now be :ref:`installed on Redhat Enterprise Linux 7 <rhel-7-install-standalone-flocker>`.
 * The container agent is now optional and can be safely disabled if you don't expect to be using Flocker's deprecated container API or ``flocker-deploy``.
   The :ref:`Flocker plugin for Docker<plugin>` allows you to use Flocker from Docker without using Flocker's container API.
+* The dataset agent now has backend support for :ref:`Open vStorage <open-vstorage-backend>`.
+* A race condition where multiple volumes for a given dataset could be created and used has been fixed.
+  This could lead to the appearance of data loss, as different volumes get used.
+  Now, even if multiple volumes are created, only a single volume will be used.
+  This was particularly likely to occur on AWS.
+* The Flocker client tools can once again be installed on OSX Yosemite.
+  A regression in the Flocker homebrew tap file has been fixed.
 
 Previous Releases
 =================

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -27,7 +27,7 @@ v1.11.0
   This could lead to the appearance of data loss, as different volumes get used.
   Now, even if multiple volumes are created, only a single volume will be used.
   This was particularly likely to occur on AWS.
-* The Flocker client tools can once again be installed on OSX Yosemite.
+* The Flocker client tools can once again be installed on OS X 10.10.
   A regression in the Flocker Homebrew tap file has been fixed.
 
 Previous Releases


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4358

See: http://doc-dev.clusterhq.com/gettinginvolved/infrastructure/release-process.html#pre-tag-review-process