### PR TITLE
[FLOC 4361] Update the label on the Supported Platforms/RHEL box 

### DIFF
--- a/docs/supported/index.rst
+++ b/docs/supported/index.rst
@@ -188,16 +188,15 @@ Supported Operating Systems
 	        <a href="../index.html" class="button">Learn more</a>
 	    </div>
 	    <div class="pod-boxout pod-boxout--4up pod-boxout--orchestration">
+			<img src="../_static/images/rhel72x.png" alt="RHEL 7 logo"/>
+			<span>RHEL 7</span>
+	        <a href="../index.html" class="button">Learn more</a>
+	    </div>
+	    <div class="pod-boxout pod-boxout--4up pod-boxout--orchestration">
 			<img src="../_static/images/coreos2x.png" alt="CoreOS Logo"/>
 			<span>CoreOS</span>
 			<img class="icon-key-assign" src="../_static/images/icon-labs2x.png" aria-hidden="true" alt=""/>
 	        <a href="../flocker-standalone/installer.html#experimental-configurations" class="button">Learn more</a>
-	    </div>
-	    <div class="pod-boxout pod-boxout--4up pod-boxout--orchestration">
-			<img src="../_static/images/rhel72x.png" alt="RHEL 7 logo"/>
-			<span>RHEL 7</span>
-			<img class="icon-key-assign" src="../_static/images/icon-soon2x.png" aria-hidden="true" alt=""/>
-	        <div class="button button--disabled">Coming soon</div>
 	    </div>
 	</div>
 


### PR DESCRIPTION
Fixes 4361

This moves RHEL before the experimental CentOS box, and removes the coming soon label.

It was noted during this work that the CTA on the supported platform links (to Learn More) directs the user to a rather unhelpful homepage destination. This has been raised as a bug (FLOC 4362)