### PR TITLE
[FLOC-4364] Restart the dataset agent after we reboot a node.

### DIFF
--- a/flocker/acceptance/testtools.py
+++ b/flocker/acceptance/testtools.py
@@ -1197,6 +1197,15 @@ def set_container_agent_enabled_on_node(node, enabled):
         d.addCallback(lambda _: loop_until(
             reactor, lambda: is_process_running(
                 node, b'flocker-dataset-agent')))
+        d.addCallback(
+            lambda _:
+            node.run_script("disable_service", "flocker-dataset-agent"))
+        d.addCallback(
+            lambda _:
+            node.run_script("enable_service", "flocker-dataset-agent"))
+        d.addCallback(lambda _: loop_until(
+            reactor, lambda: is_process_running(
+                node, b'flocker-dataset-agent')))
     # Hide the value in the callback as it could come from
     # different places and shouldn't be used.
     d.addCallback(lambda _: None)


### PR DESCRIPTION
If you don't restart the dataset agent after you reboot a node, flocker doesn't work on CentOS on Rackspace.

I did not root-cause the issue.

Should we root-cause it rather than working around it? Should we open a new FLOC to root cause, but in the meantime merge this so that we can test for other regressions? These are the questions I leave for the reviewer.