### PR TITLE
[FLOC-4363] Increase other acceptance test timeouts

### DIFF
--- a/flocker/acceptance/endtoend/test_benchmark.py
+++ b/flocker/acceptance/endtoend/test_benchmark.py
@@ -7,14 +7,16 @@ Tests for ``flocker-benchmark``.
 import json
 
 from ...common.runner import run_ssh
-from ...testtools import AsyncTestCase
-from ..testtools import require_cluster
+from ...testtools import AsyncTestCase, async_runner
+from ..testtools import require_cluster, ACCEPTANCE_TEST_TIMEOUT
 
 
 class BenchmarkTests(AsyncTestCase):
     """
     Tests for ``flocker-benchmark``.
     """
+
+    run_tests_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
 
     @require_cluster(1)
     def test_export(self, cluster):

--- a/flocker/acceptance/endtoend/test_diagnostics.py
+++ b/flocker/acceptance/endtoend/test_diagnostics.py
@@ -11,8 +11,8 @@ from twisted.internet import reactor
 from twisted.python.filepath import FilePath
 
 from ...common.runner import run_ssh, download
-from ...testtools import AsyncTestCase
-from ..testtools import require_cluster
+from ...testtools import AsyncTestCase, async_runner
+from ..testtools import require_cluster, ACCEPTANCE_TEST_TIMEOUT
 from testtools.matchers import MatchesAny, Equals
 
 
@@ -20,6 +20,9 @@ class DiagnosticsTests(AsyncTestCase):
     """
     Tests for ``flocker-diagnostics``.
     """
+
+    run_tests_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
+
     # This only requires the container agent to check
     # that its log is collected. We still care about
     # that working, so we run it. We should stop

--- a/flocker/acceptance/integration/test_platform.py
+++ b/flocker/acceptance/integration/test_platform.py
@@ -4,8 +4,8 @@
 Tests for integration with the host operating system which runs Flocker.
 """
 
-from ..testtools import require_cluster
-from ...testtools import AsyncTestCase
+from ..testtools import require_cluster, ACCEPTANCE_TEST_TIMEOUT
+from ...testtools import AsyncTestCase, async_runner
 from ...common.runner import RemoteFileNotFound
 
 from twisted.python.filepath import FilePath
@@ -15,6 +15,9 @@ class SyslogTests(AsyncTestCase):
     """
     Tests for Flocker's integration with syslog.
     """
+
+    run_tests_with = async_runner(timeout=ACCEPTANCE_TEST_TIMEOUT)
+
     def _assert_not_logged(self, cluster, fragment):
         """
         Assert that the given fragment of a log line does not appear in the


### PR DESCRIPTION
Now that we restart the nodes every time we toggle running the container agent or not, our tests take a lot longer to run.

Thus, we should increase all acceptance test timeouts rather than just the ones that GCE was slow on.