### PR TITLE
[FLOC 4354] Move enabling the container agent to the deprecated API info

### DIFF
--- a/docs/installation/enabling-agent-service.rst
+++ b/docs/installation/enabling-agent-service.rst
@@ -6,25 +6,24 @@ Enabling the Flocker Agent Service
 
 .. begin-body-enable-agent-intro
 
-The Flocker agents, the ``flocker-dataset-agent`` and the ``flocker-container-agent``, are the workhorses of Flocker; you have them on each node in your cluster, and enabling them is an essential step in setting up your cluster.
+The ``flocker-dataset-agent`` is the workhorse of Flocker; you install an agent on each node in your cluster, and enabling them is an essential step in setting up your cluster.
+
+.. note:: The ``flocker-container-agent`` is now deprecated, but it can still be enabled.
+   For more information, see :ref:`deprecated-endpoints`.
 
 .. end-body-enable-agent-intro
 
 .. begin-body-enable-agent-main
-
-.. note::
-   Flocker's container management features depend on Docker.
-   You will need to make sure `Docker (at least 1.8) is installed`_ and running before you enable ``flocker-container-agent``.
-
-.. _Docker (at least 1.8) is installed: https://docs.docker.com/installation/
 
 CentOS 7, RHEL 7.2
 ==================
 
 #. Run the following commands to enable the agent service:
 
-   .. task:: enable_flocker_agent centos-7
-      :prompt: [root@agent-node]#
+   .. prompt:: bash [root@agent-node]#
+   
+      systemctl enable flocker-dataset-agent
+      systemctl start flocker-dataset-agent
 
 #. Run the following commands to enable the Flocker plugin for Docker:
 
@@ -38,8 +37,9 @@ Ubuntu
 
 #. Run the following commands to enable the agent service:
 
-   .. task:: enable_flocker_agent ubuntu-14.04
-      :prompt: [root@agent-node]#
+   .. prompt:: bash [root@agent-node]#
+
+      service flocker-dataset-agent start
 
 #. Run the following command to enable the Flocker plugin for Docker:
 
@@ -51,26 +51,23 @@ Ubuntu
 
 .. begin-body-enable-agent-other
 
-.. note::
-   Flocker's container management features depend on Docker.
-   You will need to make sure `Docker (at least 1.8) is installed`_ and running before you enable ``flocker-container-agent``.
-
-.. _Docker (at least 1.8) is installed: https://docs.docker.com/installation/
-
 CentOS 7, RHEL 7.2
 ==================
 
 Run the following commands to enable the agent service:
 
-.. task:: enable_flocker_agent centos-7
-      :prompt: [root@agent-node]#
+.. prompt:: bash [root@agent-node]#
+   
+   systemctl enable flocker-dataset-agent
+   systemctl start flocker-dataset-agent
 
 Ubuntu
 ======
 
-Run the following commands to enable the agent service:
+Run the following command to enable the agent service:
 
-.. task:: enable_flocker_agent ubuntu-14.04
-      :prompt: [root@agent-node]#
+.. prompt:: bash [root@agent-node]#
+
+   service flocker-dataset-agent start
 
 .. end-body-enable-agent-other

--- a/docs/reference/deprecated_api.rst
+++ b/docs/reference/deprecated_api.rst
@@ -1,3 +1,5 @@
+.. _deprecated-endpoints:
+
 ====================
 Deprecated Endpoints
 ====================
@@ -7,13 +9,38 @@ Deprecated Endpoints
 .. warning:: 
    The endpoints listed in this document are deprecated, and they will not be available in future versions of the Flocker API.
 
+The Flocker Container API
+=========================
+
 The Flocker Container API enables you to manage containers in your cluster.
 However, ClusterHQ is no longer developing any future features in this area, as you can now use Flocker with 3rd party orchestration tools.
 
-The deprecated endpoints listed below are still available for use, but please be aware that they will not be available in future versions of the Flocker API:
+.. note::
+   Flocker's container management features depend on Docker.
+   You will need to make sure `Docker (at least 1.8) is installed`_ and running before you enable ``flocker-container-agent``.
+
+.. _Docker (at least 1.8) is installed: https://docs.docker.com/installation/
+
+Enabling the Container Agent Service
+------------------------------------
+
+* On CentOS 7 and RHEL 7.2, run the following commands:
+  
+  .. prompt:: bash [root@agent-node]#
+  
+     systemctl enable flocker-container-agent
+     systemctl start flocker-container-agent
+
+* On Ubuntu, run the following command:
+
+  .. prompt:: bash [root@agent-node]#
+  
+     service flocker-container-agent start
 
 Deprecated Endpoints
 ====================
+
+The deprecated endpoints listed below are still available for use, but please be aware that they will not be available in future versions of the Flocker API:
 
 .. contents::
         :local:


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4354