### PR TITLE
[FLOC 4367] Update the flockercontainers.rst document

### DIFF
--- a/docs/reference/deprecated_api.rst
+++ b/docs/reference/deprecated_api.rst
@@ -1,3 +1,5 @@
+.. _deprecated-endpoints:
+
 ====================
 Deprecated Endpoints
 ====================

--- a/docs/supported/flockercontainers.rst
+++ b/docs/supported/flockercontainers.rst
@@ -63,12 +63,9 @@ Use the following steps to install Flocker using Docker containers:
 
 #. Run the following command where you want to be able to run the Docker ``--volume-driver=flocker`` command, this will start Flocker's Docker plugin:
 
-   * ``Control-Service-Host-DNS-or-IP`` is your control service host.
-   * ``Host-IP-Address`` is the current hosts local IP address.
-
    .. prompt:: bash $
 
-      docker run --restart=always -d --net=host -e FLOCKER_CONTROL_SERVICE_BASE_URL=<Control-Service-Host-DNS-or-IP>:4523/v1 -e MY_NETWORK_IDENTITY=<Host-IP-Address> -v /etc/flocker:/etc/flocker -v /run/docker:/run/docker --name=flocker-docker-plugin clusterhq/flocker-docker-plugin
+      docker run --restart=always -d --net=host -v /etc/flocker:/etc/flocker -v /run/docker:/run/docker --name=flocker-docker-plugin clusterhq/flocker-dockerplugin:<version>
 
 Example
 =======

--- a/docs/supported/flockercontainers.rst
+++ b/docs/supported/flockercontainers.rst
@@ -63,7 +63,7 @@ Use the following steps to install Flocker using Docker containers:
 
 #. Run the following command where you want to be able to run the Docker ``--volume-driver=flocker`` command, this will start Flocker's Docker plugin:
 
-   .. prompt:: bash $
+   .. version-prompt:: bash $
 
       docker run --restart=always -d --net=host -v /etc/flocker:/etc/flocker -v /run/docker:/run/docker --name=flocker-docker-plugin clusterhq/flocker-dockerplugin:|latest-installable|
 

--- a/docs/supported/flockercontainers.rst
+++ b/docs/supported/flockercontainers.rst
@@ -65,7 +65,7 @@ Use the following steps to install Flocker using Docker containers:
 
    .. prompt:: bash $
 
-      docker run --restart=always -d --net=host -v /etc/flocker:/etc/flocker -v /run/docker:/run/docker --name=flocker-docker-plugin clusterhq/flocker-dockerplugin:<version>
+      docker run --restart=always -d --net=host -v /etc/flocker:/etc/flocker -v /run/docker:/run/docker --name=flocker-docker-plugin clusterhq/flocker-dockerplugin:|latest-installable|
 
 Example
 =======

--- a/docs/supported/flockercontainers.rst
+++ b/docs/supported/flockercontainers.rst
@@ -15,9 +15,12 @@ For some environments, such as CoreOS, and ECS you must install Flocker inside a
 You can find the relevant Docker Hub images here:
 
 * `Dataset Agent <https://hub.docker.com/r/clusterhq/flocker-dataset-agent/>`_
-* `Container Agent <https://hub.docker.com/r/clusterhq/flocker-container-agent/>`_
+* `Container Agent <https://hub.docker.com/r/clusterhq/flocker-container-agent/>`_ (deprecated - see note below)
 * `Control Service <https://hub.docker.com/r/clusterhq/flocker-control-service/>`_
-* `Docker Plugin <https://hub.docker.com/r/clusterhq/flocker-docker-plugin/>`_
+* `Docker Plugin <https://hub.docker.com/r/clusterhq/flocker-dockerplugin/builds/>`_
+
+.. note:: The Container Agent should only be used if you intend on using the :ref:`deprecated container API <deprecated-endpoints>`.
+   If you are using the Docker CLI, or any other cluster manager, it is not required.
 
 Before you install Flocker in containers, you must have generated the cluster certificate and key, any node certificates and keys, and API certificates and keys for the Docker plugin.
 


### PR DESCRIPTION
Fixes 4367

This updates this doc with a new Docker Hub link for the Docker Plugin, specifies that the Container agent is deprecated, and updates the start the plugin command (step 3)