### PR TITLE
[FLOC-4368] Simpler Cinder HTTPs tests

### DIFF
--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -196,17 +196,20 @@ class CinderHttpsTests(TestCase):
     """
     Test connections to HTTPS-enabled OpenStack.
     """
+    def setUp(self):
+        super(CinderHttpsTests, self).setUp()
+        try:
+            self.config = get_blockdevice_config(ProviderType.openstack)
+        except InvalidConfig as e:
+            self.skipTest(str(e))
+
     def test_verify_false(self):
         """
         With the peer_verify field set to False, connection to the
         OpenStack servers always succeeds.
         """
-        try:
-            config = get_blockdevice_config(ProviderType.openstack)
-        except InvalidConfig as e:
-            self.skipTest(str(e))
-        config['peer_verify'] = False
-        session = get_keystone_session(**config)
+        self.config['peer_verify'] = False
+        session = get_keystone_session(**self.config)
         session.invalidate()
         # This will fail if authentication fails.
         session.get_token()
@@ -218,14 +221,11 @@ class CinderHttpsTests(TestCase):
         """
         path = self.make_temporary_directory()
         RootCredential.initialize(path, b"mycluster")
-        try:
-            config = get_blockdevice_config(ProviderType.openstack)
-        except InvalidConfig as e:
-            self.skipTest(str(e))
-        config['peer_verify'] = True
-        config['peer_ca_path'] = path.child(
-            AUTHORITY_CERTIFICATE_FILENAME).path
-        session = get_keystone_session(**config)
+        self.config['peer_verify'] = True
+        self.config['peer_ca_path'] = path.child(
+            AUTHORITY_CERTIFICATE_FILENAME
+        ).path
+        session = get_keystone_session(**self.config)
         session.invalidate()
         self.assertRaises(Unauthorized, session.get_token)
 

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -196,20 +196,6 @@ class CinderHttpsTests(TestCase):
     """
     Test connections to HTTPS-enabled OpenStack.
     """
-
-    @staticmethod
-    def _authenticates_ok(cinder_client):
-        """
-        Check connection is authorized.
-
-        :return: True if client connected OK, False otherwise.
-        """
-        try:
-            cinder_client.authenticate()
-            return True
-        except Unauthorized:
-            return False
-
     def test_verify_false(self):
         """
         With the peer_verify field set to False, connection to the
@@ -221,32 +207,27 @@ class CinderHttpsTests(TestCase):
             self.skipTest(str(e))
         config['peer_verify'] = False
         session = get_keystone_session(**config)
-        region = get_openstack_region_for_test()
-        cinder_client = get_cinder_v1_client(session, region)
-        self.assertTrue(self._authenticates_ok(cinder_client))
+        session.invalidate()
+        # This will fail if authentication fails.
+        session.get_token()
 
     def test_verify_ca_path_no_match_fails(self):
         """
         With a CA file that does not match any CA, connection to the
         OpenStack servers fails.
         """
-        path = FilePath(self.mktemp())
-        path.makedirs()
+        path = self.make_temporary_directory()
         RootCredential.initialize(path, b"mycluster")
         try:
             config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
             self.skipTest(str(e))
-        config['backend'] = 'openstack'
-        config['auth_plugin'] = 'password'
-        config['password'] = 'password'
         config['peer_verify'] = True
         config['peer_ca_path'] = path.child(
             AUTHORITY_CERTIFICATE_FILENAME).path
         session = get_keystone_session(**config)
-        region = get_openstack_region_for_test()
-        cinder_client = get_cinder_v1_client(session, region)
-        self.assertFalse(self._authenticates_ok(cinder_client))
+        session.invalidate()
+        self.assertRaises(Unauthorized, session.get_token)
 
 
 class VirtIOClient:

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -14,6 +14,7 @@ See https://github.com/rackerlabs/mimic/issues/218
 """
 
 from unittest import skipIf
+from urlparse import urlsplit
 from uuid import uuid4
 
 from bitmath import Byte
@@ -202,6 +203,13 @@ class CinderHttpsTests(TestCase):
             self.config = get_blockdevice_config(ProviderType.openstack)
         except InvalidConfig as e:
             self.skipTest(str(e))
+        auth_url = self.config['auth_url']
+        if not urlsplit(auth_url).scheme == u"https":
+            self.skipTest(
+                "Tests require a TLS auth_url endpoint "
+                "beginning with https://. "
+                "Found auth_url: {}".format(auth_url)
+            )
 
     def test_verify_false(self):
         """

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -196,6 +196,10 @@ class CinderCloudAPIInterfaceTests(
 class CinderHttpsTests(TestCase):
     """
     Test connections to HTTPS-enabled OpenStack.
+
+    XXX: These tests can only be run against a keystone server endpoint that
+    has SSL and that supports the "password" auth_plugin.
+    Which means that these tests are not run on any of our build servers.
     """
     def session_for_test(self, config_override):
         """


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4368

Stacked on #2752

These tests were using region dependent, but needn't be.
Instead they now only create a keystone session, which is not tied to a region.

The tests were also broken, in so far as the "rackspace" keystone auth driver doesn't support the peer_verify or peer_ca_path options. 

I now skip the tests unless the driver supports those options.

