### PR TITLE
[FLOC-4331] Restore some logging

### DIFF
--- a/flocker/common/logging.py
+++ b/flocker/common/logging.py
@@ -1,0 +1,75 @@
+# -*- test-case-name: flocker.common.test.test_logging -*-
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Simple logging utilities for flocker.
+"""
+
+from inspect import getmodule, stack
+
+from eliot import Message
+
+
+_ERROR_TOKEN = u'ERROR'
+
+
+def _compute_message_type(frame_tuple):
+    """
+    Constructs a human readable message type from a frame of a traceback.
+
+    The resulting string should have the module name, function name, and line
+    number encoded so that it is trivial to figure out where the log came from.
+
+    Format of output:
+
+    <module>:<function name>:<line number>
+
+    :param frame_tuple: The stack frame tuple to turn into a message type.
+        Should normally be one stack level higher than the function that calls
+        this. (i.e. ``inspect.stack()[1]`` )
+
+    :returns unicode: The human readable message_type for a log originating at
+        the given stack frame.
+    """
+    frame, _, line, func, _, _ = frame_tuple
+    return u':'.join([getmodule(frame).__name__, func, unicode(line)])
+
+
+def log_info(**kwargs):
+    """
+    Simple logging wrapper around Eliot messages.
+
+    This fills in the message type and passes all other arguments on to
+    ``Message.log``.
+    """
+    Message.log(
+        message_type=_compute_message_type(stack()[1]),
+        **kwargs
+    )
+
+
+def log_error(**kwargs):
+    """
+    Simple logging wrapper around Eliot messages that should cause acceptance
+    tests to fail.
+
+    This fills in the message type, adds a token to indicate it is an error,
+    and passes all other arguments on to ``Message.log``.
+    """
+    Message.log(
+        message_type=_compute_message_type(stack()[1]),
+        level=_ERROR_TOKEN,
+        **kwargs
+    )
+
+
+def is_error(message):
+    """
+    Determines if the passed in Eliot message was an error message.
+
+    :param dict message: The Eliot message to examine.
+
+    :returns bool: If the passed in message is an error that should fail the
+        acceptance tests.
+    """
+    return message.get('level') == _ERROR_TOKEN

--- a/flocker/common/test/test_logging.py
+++ b/flocker/common/test/test_logging.py
@@ -11,7 +11,6 @@ from testtools.matchers import (
     AfterPreprocessing,
     AnyMatch,
     ContainsAll,
-    Contains,
     Equals,
     MatchesAll,
     MatchesSetwise,
@@ -50,8 +49,9 @@ class LoggingTests(TestCase):
         message_type, and passes other keyword arguments onto the message
         structure.
         """
-        frame = getframeinfo(currentframe()); log_info(key='VAL')  # noqa
-        line_no = frame.lineno
+        frame = getframeinfo(currentframe())
+        log_info(key='VAL')
+        line_no = frame.lineno + 1
 
         self.assertThat(
             logger.messages,
@@ -71,8 +71,9 @@ class LoggingTests(TestCase):
         message_type, and passes other keyword arguments onto the message
         structure.
         """
-        frame = getframeinfo(currentframe()); log_error(key='VAL')  # noqa
-        line_no = frame.lineno
+        frame = getframeinfo(currentframe())
+        log_error(key='VAL')
+        line_no = frame.lineno + 1
 
         self.assertThat(
             logger.messages,

--- a/flocker/common/test/test_logging.py
+++ b/flocker/common/test/test_logging.py
@@ -1,0 +1,111 @@
+# -*- test-case-name: flocker.common.test.test_logging -*-
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Tests for ``flocker.common.logging``
+"""
+
+from eliot.testing import capture_logging
+from ...testtools import TestCase
+from testtools.matchers import (
+    AfterPreprocessing,
+    AnyMatch,
+    ContainsAll,
+    Contains,
+    Equals,
+    MatchesAll,
+    MatchesSetwise,
+)
+from inspect import currentframe, getframeinfo
+
+from ..logging import log_info, log_error, is_error
+
+
+def _dict_values_match(*args, **kwargs):
+    """
+    Matcher that matches a dict where each of they keys match the matcher
+    passed in. Similar to ``MatchesStructure``, but for dictionaries rather
+    than python objects.
+    """
+    matchers = dict(*args, **kwargs)
+
+    def extract_val(key):
+
+        def extract_val_for_key(d):
+            return d.get(key)
+        return extract_val_for_key
+    return MatchesAll(*list(AfterPreprocessing(extract_val(key), value)
+                            for key, value in matchers.iteritems()))
+
+
+class LoggingTests(TestCase):
+    """
+    Tests for ``flocker.common.logging``.
+    """
+
+    @capture_logging(None)
+    def test_log_info(self, logger):
+        """
+        ``log_info`` encodes module, function, and line number in the
+        message_type, and passes other keyword arguments onto the message
+        structure.
+        """
+        frame = getframeinfo(currentframe()); log_info(key='VAL')  # noqa
+        line_no = frame.lineno
+
+        self.assertThat(
+            logger.messages,
+            AnyMatch(
+                _dict_values_match(
+                    message_type=ContainsAll(
+                        [__name__, u'test_log_info', unicode(line_no)]),
+                    key=Equals('VAL')
+                )
+            )
+        )
+
+    @capture_logging(None)
+    def test_log_error(self, logger):
+        """
+        ``log_error`` encodes module, function, and line number in the
+        message_type, and passes other keyword arguments onto the message
+        structure.
+        """
+        frame = getframeinfo(currentframe()); log_error(key='VAL')  # noqa
+        line_no = frame.lineno
+
+        self.assertThat(
+            logger.messages,
+            AnyMatch(
+                _dict_values_match(
+                    message_type=ContainsAll(
+                        [__name__, u'test_log_error', unicode(line_no)]),
+                    key=Equals('VAL')
+                )
+            )
+        )
+
+    @capture_logging(None)
+    def test_errors_identifiable(self, logger):
+        """
+        Errors can be identified by ``is_error``.
+        """
+        log_info(info='message')
+        log_error(error='message')
+        self.assertThat(
+            logger.messages,
+            MatchesSetwise(
+                MatchesAll(
+                    _dict_values_match(
+                        info=Equals('message')
+                    ),
+                    AfterPreprocessing(is_error, Equals(False)),
+                ),
+                MatchesAll(
+                    _dict_values_match(
+                        error=Equals('message')
+                    ),
+                    AfterPreprocessing(is_error, Equals(True)),
+                )
+            )
+        )

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -564,8 +564,8 @@ class ConvergenceLoop(object):
                     action.sleep.total_seconds())
             else:
                 # Log the Node configuration that we are converging upon:
-                log_info(desired_config=self.desired_configuration.get_node(
-                    self.node_uuid
+                log_info(desired_config=to_unserialized_json(
+                    self.configuration.get_node(self.deployer.node_uuid)
                 ))
                 # We're going to do some work, we should do another
                 # iteration, but chances are that if, for any reason,

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -516,11 +516,6 @@ class ConvergenceLoop(object):
             return succeed(None)
 
     def output_CONVERGE(self, context):
-        # XXX: We stopped logging configuration and cluster state here for
-        # performance reasons.
-        # But without some limited logging it'll be difficult to debug problems
-        # all the way from a configuration change to the failed convergence
-        # operation. FLOC-4331.
         with LOG_CONVERGE(self.fsm.logger).context():
             log_discovery = LOG_DISCOVERY(self.fsm.logger)
             with log_discovery.context():
@@ -567,6 +562,9 @@ class ConvergenceLoop(object):
                 sleep_duration = _Sleep.with_jitter(
                     action.sleep.total_seconds())
             else:
+                # Log the Node configuration that we are converging upon:
+                Message.log(
+                    self.desired_configuration.get_node(self.node_uuid))
                 # We're going to do some work, we should do another
                 # iteration, but chances are that if, for any reason,
                 # the backend is saturated, by looping too fast, we

--- a/flocker/node/_loop.py
+++ b/flocker/node/_loop.py
@@ -47,6 +47,7 @@ from twisted.python.reflect import safe_repr
 from . import run_state_change, NoOp
 
 from ..common import gather_deferreds
+from ..common.logging import log_info
 from ..control import (
     NodeStateCommand, IConvergenceAgent, AgentAMP, SetNodeEraCommand,
     IStatePersister, SetBlockDeviceIdForDatasetId,
@@ -563,8 +564,9 @@ class ConvergenceLoop(object):
                     action.sleep.total_seconds())
             else:
                 # Log the Node configuration that we are converging upon:
-                Message.log(
-                    self.desired_configuration.get_node(self.node_uuid))
+                log_info(desired_config=self.desired_configuration.get_node(
+                    self.node_uuid
+                ))
                 # We're going to do some work, we should do another
                 # iteration, but chances are that if, for any reason,
                 # the backend is saturated, by looping too fast, we


### PR DESCRIPTION
We turned a lot of logging off in order to meet Swisscom benchmarking requirements.

This turns back on only the node configuration log in the agents during convergence.

The bad news is that this does log all datasets that this node has deleted (since the beginning of time). Although from preliminary benchmarking the additional CPU usage of adding this logging back is negligible (spun up 280 containers on 20 nodes with and without this PR, and couldn't see any real difference in CPU usage with the write benchmark). Although, it is probably worth mentioning that from master I was able to delete all of them all at once, whereas with this  PR I started to get timeout errors.

Nevertheless this PR will make our acceptance tests diagnosable once more.