### PR TITLE
[FLOC-4376] Fix client on Ubuntu Wily tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -587,8 +587,10 @@ common_cli:
           --assumeyes epel-release" >> Dockerfile
     echo "RUN env URLGRABBER_DEBUG=1 yum install --assumeyes \
           git ruby-devel python-devel libffi-devel openssl-devel \
-          python-pip rpmlint" >> Dockerfile
+          rpmlint" >> Dockerfile
     echo "RUN env URLGRABBER_DEBUG=1 yum update --assumeyes" >> Dockerfile
+    echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
+    echo 'RUN ["/usr/bin/env", "python2.7", "/tmp/get-pip.py"]' >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
     # Is this unused? --process-depency-links added but sort of untested.
     echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile
@@ -603,8 +605,10 @@ common_cli:
     echo "MAINTAINER ClusterHQ <contact@clusterhq.com>" >> Dockerfile
     echo "RUN apt-get update" >> Dockerfile
     echo "RUN apt-get install --no-install-recommends -y git ruby-dev \
-          libffi-dev libssl-dev build-essential python-pip \
+          libffi-dev libssl-dev build-essential \
           python2.7-dev lintian" >> Dockerfile
+    echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
+    echo 'RUN ["/usr/bin/env", "python2.7", "/tmp/get-pip.py"]' >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
     # Is this unused? --process-depency-links added but sort of untested.
     echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile
@@ -619,8 +623,10 @@ common_cli:
     echo "MAINTAINER ClusterHQ <contact@clusterhq.com>" >> Dockerfile
     echo "RUN apt-get update" >> Dockerfile
     echo "RUN apt-get install --no-install-recommends -y \
-          git ruby-dev libffi-dev libssl-dev build-essential python-pip \
+          git ruby-dev libffi-dev libssl-dev build-essential \
           python2.7-dev lintian" >> Dockerfile
+    echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
+    echo 'RUN ["/usr/bin/env", "python2.7", "/tmp/get-pip.py"]' >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
     # Is this unused? --process-depency-links added but sort of untested.
     echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile

--- a/build.yaml
+++ b/build.yaml
@@ -590,7 +590,7 @@ common_cli:
           rpmlint" >> Dockerfile
     echo "RUN env URLGRABBER_DEBUG=1 yum update --assumeyes" >> Dockerfile
     echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
-    echo 'RUN ["/usr/bin/env", "python2.7", "/tmp/get-pip.py"]' >> Dockerfile
+    echo 'RUN ["python", "/tmp/get-pip.py"]' >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
     # Is this unused? --process-depency-links added but sort of untested.
     echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile
@@ -606,9 +606,9 @@ common_cli:
     echo "RUN apt-get update" >> Dockerfile
     echo "RUN apt-get install --no-install-recommends -y git ruby-dev \
           libffi-dev libssl-dev build-essential \
-          python2.7-dev lintian" >> Dockerfile
+          python2.7-dev lintian python" >> Dockerfile
     echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
-    echo 'RUN ["/usr/bin/env", "python2.7", "/tmp/get-pip.py"]' >> Dockerfile
+    echo 'RUN ["python", "/tmp/get-pip.py"]' >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
     # Is this unused? --process-depency-links added but sort of untested.
     echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile
@@ -624,9 +624,9 @@ common_cli:
     echo "RUN apt-get update" >> Dockerfile
     echo "RUN apt-get install --no-install-recommends -y \
           git ruby-dev libffi-dev libssl-dev build-essential \
-          python2.7-dev lintian" >> Dockerfile
+          python2.7-dev lintian python" >> Dockerfile
     echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
-    echo 'RUN ["/usr/bin/env", "python2.7", "/tmp/get-pip.py"]' >> Dockerfile
+    echo 'RUN ["python", "/tmp/get-pip.py"]' >> Dockerfile
     echo "COPY requirements.txt /tmp/" >> Dockerfile
     # Is this unused? --process-depency-links added but sort of untested.
     echo "RUN pip install --process-dependency-links -r /tmp/requirements.txt" >> Dockerfile


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4376

The Ubuntu 15.10 `pip` works (with the Ubuntu packaged python-requests) until you use it to install a newer version of requests, which no longer has the required `from requests.compat import IncompleteRead` API.

See:
 * https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991/comments/47

My solution is to install the latest version of Pip in the package build images and never install the Ubuntu or Centos packaged `pip`.

We should probably do the same in the Jenkins slave images...except there, we'd need to install the latest version of virtualenv in order to get the latest version of pip for the slaves to install Flocker during tests.

Note that since building and pushing `clusterhqci/fpm-ubuntu-wily` here: 
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/fix-client-wily-tests-FLOC-4376/view/cron/job/_run_docker_build_ubuntu_wily_fpm/

The Ubuntu wily client installation tests now pass on master here: 
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/view/master/job/master/view/client/job/run_client_installation_on_Ubuntu_Wily/lastSuccessfulBuild/