### PR TITLE
[FLOC-4381] Work around the broken lshw encoder in flocker-benchmark hardware-report

### DIFF
--- a/flocker/node/benchmark.py
+++ b/flocker/node/benchmark.py
@@ -50,9 +50,7 @@ def hardware_report(options):
     """
     Print a hardware report to stdout.
     """
-    sys.stdout.write(
-        list_hardware(['processor', 'memory', 'network', 'disk', 'volume'])
-    )
+    sys.stdout.write(list_hardware())
     return succeed(None)
 
 

--- a/flocker/node/diagnostics.py
+++ b/flocker/node/diagnostics.py
@@ -31,26 +31,17 @@ def gzip_file(source_path, archive_path):
                 copyfileobj(source, archive)
 
 
-def list_hardware(classes=()):
+def list_hardware():
     """
     List the hardware on the local machine.
 
-    :param classes: iterable of hardware classes to include in result.
-        Default is to include all classes.
     :returns: ``bytes`` JSON encoded hardware inventory of the current host.
     """
-    command = ['lshw', '-quiet', '-json']
-    for hardware_class in classes:
-        command.append('-class')
-        command.append(hardware_class)
     with open(os.devnull, 'w') as devnull:
-        result = check_output(command, stderr=devnull)
-        if classes:
-            # If classes are named, the result is a sequence of JSON objects,
-            # which need to be wrapped in a JSON array.  Also has a trailing
-            # comma which is invalid JSON.
-            result = '[{}]\n'.format(result.rstrip().rstrip(','))
-        return result
+        return check_output(
+            ['lshw', '-quiet', '-json'],
+            stderr=devnull
+        )
 
 
 class FlockerDebugArchive(object):

--- a/flocker/node/test/test_diagnostics.py
+++ b/flocker/node/test/test_diagnostics.py
@@ -15,14 +15,3 @@ class ListHardwareTests(TestCase):
         ``list_hardware`` returns valid JSON.
         """
         json.loads(list_hardware())
-
-    @skipUnless(which('lshw'), 'Tests require the ``lshw`` command.')
-    def test_list_hardware_classes(self):
-        """
-        ``list_hardware`` with classes only provides named classes.
-        """
-        processors = json.loads(list_hardware(['processor']))
-        self.assertEqual(
-            set(processor['class'] for processor in processors),
-            {'processor'}
-        )


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4381

The problem is described here:
 * https://bugs.launchpad.net/ubuntu/+source/lshw/+bug/1405873

The output is broken in various ways so doesn't seem worth attempting to fix it up.
 * http://www.ezix.org/project/query?status=assigned&status=new&status=reopened&component=lshw&description=~json&order=priority

I'm also not convinced that we need to restrict the information output by the tool. 
It's probably easier to extract the information we need before it gets recorded in the benchmark results database....if we ever get around to deploying that.

I guess it may already be deployed somewhere but I don't know how to access it:
 * https://github.com/ClusterHQ/benchmark-server

Any ideas @avg-I ?