### PR TITLE
[FLOC-4379] Allow more time for the stateful container reboot test

### DIFF
--- a/flocker/acceptance/obsolete/test_containers.py
+++ b/flocker/acceptance/obsolete/test_containers.py
@@ -344,6 +344,7 @@ class ContainerAPITests(AsyncTestCase):
             lambda _: assert_http_server(self, origin.public_address, port))
         return running
 
+    @run_test_with(async_runner(timeout=timedelta(minutes=20)))
     @require_cluster(2, require_container_agent=True)
     def test_reboot(self, cluster):
         """


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4379

I'm going to trigger a bunch of builds to verify that this fixes the test and to get an idea of how long they actually take.
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-1/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-2/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-3/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-4/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-5/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-6/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-7/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-8/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/reboot-test-timeout-9/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/