### PR TITLE
[FLOC-4382] Docker plugin tests now wait for test volumes to be mounted

### DIFF
--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -215,7 +215,9 @@ class DockerPluginTests(AsyncTestCase):
         Docker can run a container with a provisioned volumes with a
         specific size.
         """
-        self.require_docker('1.9.0', cluster)
+        # Requires docker volume list which was introduced in 1.10.0.
+        # https://github.com/docker/docker/blob/master/CHANGELOG.md#volumes-3
+        self.require_docker('1.10.0', cluster)
         return self._test_sized_vol_container(cluster, cluster.nodes[0])
 
     def _test_create_container(self, cluster, volume_name=None):

--- a/flocker/acceptance/endtoend/test_dockerplugin.py
+++ b/flocker/acceptance/endtoend/test_dockerplugin.py
@@ -135,13 +135,14 @@ class DockerPluginTests(AsyncTestCase):
     def _create_volume(self, client, name, driver_opts):
         """
         Create a volume with the given name and driver options on the passed in
-        docker client.
+        docker client and block until the ``docker volume ls`` API reports that
+        the volume has been mounted.
 
         :param client: The docker.Client object to use.
         :param name: The name of the volume to create.
         :param opts: The options to pass through to the Flocker Plugin for
             Docker.
-        :returns: The result of the API call.
+        :returns: The result of the API call when the volume has been mounted.
         """
         result = client.create_volume(name, u'flocker', driver_opts)
         self.addCleanup(client.remove_volume, name)

--- a/flocker/acceptance/scripts/lsblkhttp.py
+++ b/flocker/acceptance/scripts/lsblkhttp.py
@@ -3,9 +3,41 @@ HTTP server that returns the size of the mounted volume.
 """
 
 from sys import argv
-from subprocess import check_output
+from subprocess import check_output, STDOUT, CalledProcessError
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+
+
+class CalledProcessErrorWithOutput(CalledProcessError):
+    """
+    Like ``CalledProcessError`` but includes the suppied ``output`` when
+    coerced to ``str``.
+    """
+    def __str__(self):
+        return (
+            "Command '%s' "
+            "returned non-zero exit status %d "
+            "and output %r" % (
+                self.cmd, self.returncode, self.output,
+            )
+        )
+
+
+def check_output_and_error(*args, **kwargs):
+    """
+    Like ``check_output`` but captures the ``stderr`` and raises an exception
+    that incudes all the ``stdout`` and ``stderr`` output when coerced to
+    ``str``.
+    """
+    kwargs["stderr"] = STDOUT
+    try:
+        return check_output(*args, **kwargs)
+    except CalledProcessError as e:
+        raise CalledProcessErrorWithOutput(
+            returncode=e.returncode,
+            cmd=e.cmd,
+            output=e.output,
+        )
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -17,17 +49,20 @@ class Handler(BaseHTTPRequestHandler):
                 # format output is </dev/id>[/mount/point]
                 # so we filter the mountpoint
                 # returned device is '/dev/xvdb\\n'
-                device_path = check_output([
-                    'findmnt', '-n', '-m', '%s' % argv[1], '-o',
-                    'SOURCE']).split('[')[0].split('\n')[0]
+                output = check_output_and_error(
+                    ['findmnt', '-n', '-m', '%s' % argv[1], '-o', 'SOURCE'],
+                )
+                device_path = output.split('[')[0].split('\n')[0]
 
-                command = ["/bin/lsblk", "--noheadings", "--bytes",
-                           "--output", "SIZE", device_path]
                 # lskblk is filtered to just return the size of the
                 # underlying device in filtered columns, we grab the
                 # specific one which contains the size in bytes.
-                command_output = check_output(command).split('\n')[0]
-                device_size = str(int(command_output.strip()))
+                output = check_output_and_error(
+                    ["/bin/lsblk", "--noheadings", "--bytes",
+                     "--output", "SIZE",
+                     device_path]
+                )
+                device_size = str(int(output.split('\n')[0].strip()))
             # generally this will only fail if lsblk fails,
             # becuase we run in a stable container environment
             # so catching 'Exception' here is preceived as OK.


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4382

The `docker volume create` API returns immediately and the `docker create --volume-plugin=flocker ...`  && `docker start` APIs don't wait for the *existing* flocker volume to be mounted before starting the container.

The test has been failing since 2016-04-12....around the time of the Docker 1.11.0 release so perhaps that's a change in Docker behaviour.

 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/view/master/job/master/view/cron/job/_run_acceptance_on_AWS_CentOS_7_with_EBS/lastCompletedBuild/testReport/flocker.acceptance.endtoend.test_dockerplugin/DockerPluginTests/test_create_sized_volume_with_v2_plugin_api/

```
Failing for the past 12 builds (Since Failed#120 )
Took 8 ms.
```
And build #120 was for revision 312403043142d0119ee43fb1e110325241bda47b on April 12.

 * https://github.com/docker/docker/blob/master/CHANGELOG.md#1110-2016-04-13

So I've added a poll_until after the Docker volume create step which waits until ``docker volume ls`` reports a mountpoint for the volume.

Also added some better error reporting to the `lsblk` command since that was failing with stderr message "/dev/xvdf is not a block device" but that was  missing from the test data.