### PR TITLE
[FLOC-4383] Ignore lintian hardening-no-relro warnings

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -678,7 +678,14 @@ IGNORED_WARNINGS = {
         "systemd-service-file-outside-lib",
 
         # The binaries in ManyLinux wheel files are not compiled using Debian
-        # compile flags (dpkg-buildflags  --export).
+        # compile flags especially those related to hardening:
+        # https://wiki.debian.org/Hardening
+        # These are important security precautions which we should enforce in
+        # our packages.
+        # Remove this once binary wheel files have been hardened upstream or
+        # alternatively consider compiling from source rather than installing
+        # wheels from PyPI:
+        # https://github.com/pypa/manylinux/issues/59
         "hardening-no-relro",
     ),
 }

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -676,6 +676,10 @@ IGNORED_WARNINGS = {
         "netaddr/eui/oui.txt",
         "package-contains-timestamped-gzip",
         "systemd-service-file-outside-lib",
+
+        # The binaries in ManyLinux wheel files are not compiled using Debian
+        # compile flags (dpkg-buildflags  --export).
+        "hardening-no-relro",
     ),
 }
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4383

I think these warnings may have started appearing since we upgraded to pip 8.1.1 which is able to install `manylinux` wheel files.
And the `msgpack` `manylinux` wheel files are not  compiled with the CC and LDFLAGs that are expected for debian binaries (`dpkg-buildflags --export`)

This should allow the packages to be built:
 * http://build.clusterhq.com/boxes-flocker?branch=lintian-FLOC-4383

And the acceptance tests to *run*:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/lintian-FLOC-4383/view/cron/

They may not pass until #2771 gets merged.

I merged this branch into #2771 and re-ran the Ubuntu acceptance tests:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/lsblk-FLOC-4382/view/cron/

Those *should* all now pass.