### PR TITLE
[FLOC-4397] Amortize updates some more

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -532,8 +532,8 @@ class ControlAMPService(Service):
         currently pending getting an update of state and configuration. An
         empty set indicates that there is no update pending.
     :ivar IDelayedCall _current_pending_update_delayed_call: The
-        ``IDelayedCall`` provider for the currently pending call to broadcast a
-        state/configuration update.
+        ``IDelayedCall`` provider for the currently pending call to update
+        state/configuration on connected nodes.
     """
     logger = Logger()
 
@@ -731,7 +731,7 @@ class ControlAMPService(Service):
 
     def _execute_update_connections(self):
         """
-        Actually executes a broadcast update to all current connections.
+        Actually executes an update to all pending connections.
         """
         connections_to_update = self._connections_pending_update
         self._connections_pending_update = set()
@@ -754,7 +754,7 @@ class ControlAMPService(Service):
         # pending an update, we must schedule the delayed call to update
         # connections.
         if (self._current_pending_update_delayed_call is None
-            and self._connections_pending_update):
+                and self._connections_pending_update):
             self._current_pending_update_delayed_call = (
                 self._reactor.callLater(
                     CONTROL_SERVICE_BATCHING_DELAY,

--- a/flocker/control/test/test_protocol.py
+++ b/flocker/control/test/test_protocol.py
@@ -815,7 +815,7 @@ class ControlAMPServiceTests(ControlTestCase):
 
         for server in delayed_servers:
             service.connected(server)
-        service_clock.advance(10.0)
+        service_clock.advance(CONTROL_SERVICE_BATCHING_DELAY*2)
         (server.respond() for server in delayed_servers)
 
         configuration = service.configuration_service.get()
@@ -823,12 +823,12 @@ class ControlAMPServiceTests(ControlTestCase):
         # Update configuration:
         service.configuration_service.save(
             arbitrary_transformation(configuration))
-        service_clock.advance(10.0)
+        service_clock.advance(CONTROL_SERVICE_BATCHING_DELAY*2)
 
         # Before any of the nodes respond, update configuration again
         service.configuration_service.save(
             arbitrary_transformation(configuration))
-        service_clock.advance(10.0)
+        service_clock.advance(CONTROL_SERVICE_BATCHING_DELAY*2)
 
         initial_update_counts = list(
             agent.cluster_updated_count for agent in agents
@@ -848,7 +848,7 @@ class ControlAMPServiceTests(ControlTestCase):
                 for agent, c in zip(agents, initial_update_counts)
             )
         )
-        service_clock.advance(10.0)
+        service_clock.advance(CONTROL_SERVICE_BATCHING_DELAY*2)
         self.assertEqual(
             [2] * len(agents),
             list(


### PR DESCRIPTION
This PR makes it so that the control node will only ever send updates to nodes once every second even when it is recovering from a delayed update for a node that took awhile to acknowledge the original update.