### PR TITLE
[FLOC-4398] use murmur hash instead of sha

### DIFF
--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -4,11 +4,12 @@
 Persistence of cluster configuration.
 """
 
-from json import dumps, loads
-from uuid import UUID
+from base64 import b16encode
 from calendar import timegm
 from datetime import datetime
-from hashlib import sha256
+from json import dumps, loads
+from mmh3 import hash_bytes
+from uuid import UUID
 
 from eliot import Logger, write_traceback, MessageType, Field, ActionType
 
@@ -515,7 +516,7 @@ class ConfigurationPersistenceService(MultiService):
         """
         config = Configuration(version=_CONFIG_VERSION, deployment=deployment)
         data = wire_encode(config)
-        self._hash = sha256(data).hexdigest()
+        self._hash = b16encode(hash_bytes(data)).lower()
         self._config_path.setContent(data)
 
     def save(self, deployment):

--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -8,7 +8,7 @@ from base64 import b16encode
 from calendar import timegm
 from datetime import datetime
 from json import dumps, loads
-from mmh3 import mmh3_hash_bytes
+from mmh3 import hash_bytes as mmh3_hash_bytes
 from uuid import UUID
 
 from eliot import Logger, write_traceback, MessageType, Field, ActionType

--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -8,7 +8,7 @@ from base64 import b16encode
 from calendar import timegm
 from datetime import datetime
 from json import dumps, loads
-from mmh3 import hash_bytes
+from mmh3 import mmh3_hash_bytes
 from uuid import UUID
 
 from eliot import Logger, write_traceback, MessageType, Field, ActionType
@@ -516,7 +516,7 @@ class ConfigurationPersistenceService(MultiService):
         """
         config = Configuration(version=_CONFIG_VERSION, deployment=deployment)
         data = wire_encode(config)
-        self._hash = b16encode(hash_bytes(data)).lower()
+        self._hash = b16encode(mmh3_hash_bytes(data)).lower()
         self._config_path.setContent(data)
 
     def save(self, deployment):

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ jsonschema==2.4.0
 keystoneauth1==2.4.0
 klein==0.2.3
 machinist==0.2.0
+mmh3==2.3.1
 monotonic==1.0
 msgpack-python==0.4.7
 ndg-httpsclient==0.4.0


### PR DESCRIPTION
In profiling the control agent I got to a point where it was clear that using a secure hashing function to attempt to uniquely identify a configuration was consuming a significant amount of our time. This specifically happens in workloads with a lot of configuration changes (like deleting all datasets at the end of a benchmarking run). These might not be particularly relevant workloads in the real world, but one could make an argument that since the flocker control node requires making individual requests for creating or deleting datasets there are situations where this should be faster; if anyone wants to delete N disks, they have to make N requests in quick succession.

Given that our specific use case does not require that the hash be cryptographically secure, we can get a lot of CPU back by simply using a faster hashing algorithm.