### PR TITLE
[FLOC-4399] Only lookup the value once in the cache.

### DIFF
--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -248,8 +248,9 @@ def _cached_dfs_serialize(input_object):
     else:
         if _is_pyrsistent(input_object):
             is_pyrsistent = True
-            if input_object in _cached_dfs_serialize_cache:
-                return _cached_dfs_serialize_cache[input_object]
+            cached_value = _cached_dfs_serialize_cache.get(input_object)
+            if cached_value is not None:
+                return cached_value
         obj = _to_serializables(input_object)
 
     result = obj


### PR DESCRIPTION
`bool(key in dict)` is one lookup in the dictionary, and `dict[key]` is another lookup.  We have already determined that looking up a large PClass in a dict is a slow operation, so we should avoid that. Using `dict.get` and then checking for None (or using `try...except IndexError`) should eliminate one of the checks.