### PR TITLE
[FLOC-4400] Change the default machine size in GCE tests.

### DIFF
--- a/flocker/provision/_gce.py
+++ b/flocker/provision/_gce.py
@@ -41,7 +41,8 @@ from ._ssh import sudo_from_args, run_remotely
 
 # Defaults for some of the instance construction parameters.
 _GCE_MINIMUM_DISK_SIZE_GIB = 10
-_GCE_INSTANCE_TYPE = u"n1-standard-1"
+# 2 CPUs and 7.5 GiB of RAM, similar to m3.large on AWS.
+_GCE_INSTANCE_TYPE = u"n1-standard-2"
 _GCE_ACCEPTANCE_USERNAME = u"flocker-acceptance"
 
 # The network used must have firewall rules such that the node running
@@ -189,7 +190,7 @@ def _create_gce_instance_config(instance_name,
                                 project,
                                 zone,
                                 image,
-                                machine_type=u"n1-standard-1",
+                                machine_type=_GCE_INSTANCE_TYPE,
                                 disk_size=_GCE_MINIMUM_DISK_SIZE_GIB,
                                 description=u"",
                                 tags=frozenset(),
@@ -204,7 +205,7 @@ def _create_gce_instance_config(instance_name,
         configuration for.
     :param unicode zone: The name of the gce zone to spin the instance up in.
     :param unicode machine_type: The name of the machine type, e.g.
-        'n1-standard-1'.
+        'n1-standard-2'.
     :param unicode image: The name of the image to base the disk off of.
     :param login_credentials: An iterable of :class:`_LoginCredentials` to be
         installed on the image.


### PR DESCRIPTION
This is a change that I've done locally for all of the benchmarking clusters that I've run. Decided it was probably safe to push to master and it puts GCE at par with the AWS instances that we spin up for tests.

On AWS we have the default set to m3.large, which is 2 CPU and 7.5 GiB of RAM. The n1-standard-2 on GCE is the equivalent machine. The n1-standard-1 was chosen previously because I incorrectly thought that flocker should never use more than 1 CPU. Turns out the control node on large clusters easily consumes an entire CPU and then some, and we need the spare for the agents and the journalctl daemon.