### PR TITLE
[DO NOT MERGE] Add flocker volumes to cluster

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -925,6 +925,8 @@ def omnibus_package_builder(
                      flocker_cli_path),
                     (FilePath('/opt/flocker/bin/flocker-ca'),
                      flocker_cli_path),
+                    (FilePath('/opt/flocker/bin/flocker-migrator'),
+                     flocker_cli_path),
                 ]
             ),
             BuildPackage(

--- a/flocker/cli/script.py
+++ b/flocker/cli/script.py
@@ -304,7 +304,10 @@ class ListAllVolumesOptions(Options):
         bdapi = backend_description.api_factory(
             **config
         )
-        print bdapi.list_volumes()
+        if provides(bdapi, IListBlockDevices):
+            print bdapi.list_all_blockdevices()
+        else:
+            print "Your backend does not provide list_all_blockdevices."
 
 
 @flocker_standard_options

--- a/flocker/node/agents/blockdevice.py
+++ b/flocker/node/agents/blockdevice.py
@@ -1423,6 +1423,23 @@ class IListBlockDevices(Interface):
             available from the storage backend.
         """
 
+class ISetBlockDeviceCluster(Interface):
+    """
+    An interface for drivers that are capable of setting the Flocker cluster
+    for an existing volume. This allows an existing volume to be added to the
+    specified flocker cluster.
+    """
+
+    def set_blockdevice_cluster(blockdevice_id, dataset_id, cluster_id):
+        """
+        Set the dataset id and cluster id for a given blockdevice_id.
+
+        :param unicode blockdevice_id: The unique identifier for a blockdevice
+            in the backing storage platform.
+        :param UUID dataset_id: The new dataset_id for the blockdevice.
+        :param UUID cluster_id: The new cluster_id for the blockdevice.
+        """
+
 
 @implementer(IBlockDeviceAsyncAPI)
 @auto_threaded(IBlockDeviceAPI, "_reactor", "_sync", "_threadpool")

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.rst") as readme:
     description = readme.read()
 
 with open("requirements.txt") as requirements:
-    install_requires = [req for req in requirements.readlines() if 'git+https' not in req]
+    install_requires = [req for req in requirements.readlines() if 'git+https' not in req]  # noqa
 with open("dev-requirements.txt") as dev_requirements:
     dev_requires = dev_requirements.readlines()
 
@@ -85,6 +85,7 @@ setup(
             'flocker-benchmark = ' +
             'flocker.node.benchmark:flocker_benchmark_main',
             'flocker-node-era = flocker.common._era:era_main',
+            'flocker-migrator = flocker.cli.script:flocker_migrator_main',
         ],
     },
 


### PR DESCRIPTION
Totally hacky implementation  of a command line utility that lets you list all volumes your backend can see (not just the flocker ones), and add some to a flocker cluster of your choice.

This definitely needs some work, but is useful to play around with the workflows.
