### PR TITLE
[FLOC-4425] Upgrade virtualenv package requirement

### DIFF
--- a/flocker/restapi/docs/publicapi.py
+++ b/flocker/restapi/docs/publicapi.py
@@ -12,7 +12,7 @@ from yaml import safe_load
 from docutils import nodes
 
 from sphinxcontrib import httpdomain
-from sphinxcontrib.autohttp.flask import translate_werkzeug_rule
+from sphinxcontrib.autohttp.flask_base import translate_werkzeug_rule
 from sphinxcontrib.autohttp.common import http_directive
 
 from sphinx.util.compat import Directive

--- a/requirements/admin.txt
+++ b/requirements/admin.txt
@@ -9,7 +9,7 @@ deb-pkg-tools==1.36
 docker-py==1.8.1
 effect==0.10.1
 eliot==0.11.0
-GitPython==2.0.3
+GitPython==2.0.5
 ipaddr==2.1.11
 # Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
 ndg-httpsclient==0.4.0
@@ -24,7 +24,7 @@ testtools==2.2.0
 troposphere==1.6.0
 Twisted==16.2.0
 txeffect==0.9
-virtualenv==15.0.1
+virtualenv==15.0.2
 zope.interface==4.1.3
 ## The following requirements were added by pip freeze:
 attrs==16.0.0
@@ -51,7 +51,7 @@ jmespath==0.9.0
 linecache2==1.0.0
 monotonic==1.1
 pbr==1.10.0
-property-manager==1.3
+property-manager==1.6
 pyasn1==0.1.9
 pycparser==2.14
 pyOpenSSL==16.0.0
@@ -63,4 +63,5 @@ six==1.10.0
 smmap==0.9.0
 traceback2==1.4.0
 unittest2==1.1.0
+verboselogs==1.1
 websocket-client==0.37.0

--- a/requirements/flocker-dev.txt
+++ b/requirements/flocker-dev.txt
@@ -13,7 +13,7 @@ sphinx-prompt==1.0.0
 sphinxcontrib-spelling==2.1.2
 # XXX: This shouldn't be here. It's only needed by admin.packaging module but
 # buildbot doesn't install the admin dependencies
-virtualenv==15.0.1
+virtualenv==15.0.2
 ## The following requirements were added by pip freeze:
 alabaster==0.7.8
 astroid==1.4.5
@@ -30,5 +30,5 @@ Pygments==2.1.3
 pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.4.1
+Sphinx==1.4.2
 wrapt==1.10.8

--- a/requirements/flocker.txt
+++ b/requirements/flocker.txt
@@ -39,8 +39,8 @@ requests==2.10.0
 # See: https://github.com/pyca/cryptography/issues/2838#issuecomment-221838467
 setuptools==21.0.0
 six==1.10.0
-Sphinx==1.4.1
-sphinxcontrib-httpdomain==1.4.0
+Sphinx==1.4.2
+sphinxcontrib-httpdomain==1.5.0
 testtools==2.2.0
 treq==15.1.0
 Twisted==16.2.0


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4425

Upgraded to virtualenv-15.0.2
 * https://virtualenv.pypa.io/en/latest/changes/#id1

Which has the latest version of pkg_resources (vendored into setuptools) which is able to parse the so called environment markers in package version strings e.g.

``nomenclature >= "0.1.0"; sys_platform == "linux2"``