### PR TITLE
[FLOC-4428] Guard against a pyrsistent.tranform call.

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -380,16 +380,21 @@ class ControlServiceLocator(CommandLocator):
     @SetBlockDeviceIdForDatasetId.responder
     def set_blockdevice_id(self, dataset_id, blockdevice_id):
         deployment = self.control_amp_service.configuration_service.get()
-        self.control_amp_service.configuration_service.save(
-            deployment.transform(
-                ["persistent_state", "blockdevice_ownership"],
-                partial(
-                    BlockDeviceOwnership.record_ownership,
-                    dataset_id=UUID(dataset_id),
-                    blockdevice_id=blockdevice_id,
-                ),
-            )
+        dataset_uuid = UUID(dataset_id)
+        current_val = deployment.persistent_state.blockdevice_ownership.get(
+            dataset_uuid
         )
+        if current_val != blockdevice_id:
+            self.control_amp_service.configuration_service.save(
+                deployment.transform(
+                    ["persistent_state", "blockdevice_ownership"],
+                    partial(
+                        BlockDeviceOwnership.record_ownership,
+                        dataset_id=dataset_uuid,
+                        blockdevice_id=blockdevice_id,
+                    ),
+                )
+            )
         return {}
 
 


### PR DESCRIPTION
In profiling I discovered that there is a specific pyrsistent.transform call that takes quite a bit of time.

I have reason to believe that a simple guard might assist in speeding up some of the performance.