### PR TITLE
[FLOC-4441] Move the postgres database to node2 along with the web container in the tutorial

### DIFF
--- a/docs/docker-integration/tutorial-downloads/flocker-swarm-tutorial-node2.yml
+++ b/docs/docker-integration/tutorial-downloads/flocker-swarm-tutorial-node2.yml
@@ -25,7 +25,7 @@ services:
      ports:
         -  "5432:5432"
      environment:
-        - "constraint:flocker-node==1"
+        - "constraint:flocker-node==2"
         - "POSTGRES_USER=flocker"
         - "POSTGRES_PASSWORD=flockerdemo"
         - "POSTGRES_DB=postgres"


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4441

This fixes something I broke in #2778 (specifically https://github.com/ClusterHQ/flocker/pull/2778/files#diff-0bba9631d532bd8773436a553e257fe0R28)

# To Test

* Start a cloudformation stack using the (as yet unreleased) 1.13.0 template: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?templateURL=https:%2F%2Fs3.amazonaws.com%2Finstaller.downloads.clusterhq.com%2Fflocker-cluster.cloudformation.1.13.0.json

* Follow the tutorial documentation built from this branch: http://clusterhq-staging-docs.s3-website-us-east-1.amazonaws.com/release-maintenance/flocker-1.13.0/move-postgres-too-FLOC-4441/docker-integration/tutorial-swarm-compose.html

