### PR TITLE
[FLOC-4443] Add diff to the spelling list

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -26,6 +26,7 @@ deduplication
 Deis
 devel
 DevStack
+diff
 DigitalOcean
 Dockerized
 dropdown


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4443

* http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/view/releases/job/release-maintenance-flocker-1.13.0-diff-spelling-FLOC-4443/job/run_sphinx/

vs

* http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/view/master/job/master/job/run_sphinx/

I also tried to see if the `apt-get install wamerican-{large,huge,insane}` word lists package had it ...they don't.
But it does seem to be present in the  Fedora23 `words` package.
Oh well.