### PR TITLE
[FLOC-4445] Redirect obsolete documentation to latest

### DIFF
--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -35,3 +35,47 @@
     "0.3.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "0.3.1.post1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "0.3.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.3.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.3.3dev6/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.3.3dev7/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.3.3dev8/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.4.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.4.0pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.4.1dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.4.1dev3/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.4.1dev4/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.4.1dev5/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.4.1dev6/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.9.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "0.9.0pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.0pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.1pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.2pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.3/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.0.3pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.1.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.1.0.dev2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.1.0rc1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.2.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.2.0.dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.3.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.3.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.4.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.4.0.dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.4.0.dev2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.5.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.6.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.7.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.7.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.7.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.8.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.9.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.9.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.10.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.10.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.10.3.dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.10.3.dev2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    "1.11.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}

--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -18,54 +18,19 @@
     # Changed in 1.4.0
     "labs/docker-plugin.html": {replace_key: "docker-integration/"}
 "en/":
-    # Redirects for version of the documentation not published to S3.
-    "0.0.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.0.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.0.4/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.0.5/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.0.6/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.0.7/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.1.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.1.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.1.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.1.3/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.1.4/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.2.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.2.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.3.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.3.1.post1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.3.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
+    # Redirects for obsolete versions of the documentation.
     "0.3.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.3.3dev6/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.3.3dev7/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.3.3dev8/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "0.4.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.4.0pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.4.1dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.4.1dev3/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.4.1dev4/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.4.1dev5/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.4.1dev6/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "0.9.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "0.9.0pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.0.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.0.0pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.0.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.0.1pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.0.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.0.2pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.0.3/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.0.3pre1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.1.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.1.0.dev2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.1.0rc1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.2.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.2.0.dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.3.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.3.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.4.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.4.0.dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.4.0.dev2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.5.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.6.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.7.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
@@ -76,6 +41,4 @@
     "1.9.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.10.1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.10.2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.10.3.dev1/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
-    "1.10.3.dev2/": {replace_key_prefix: "latest/", http_redirect_code: '301'}
     "1.11.0/": {replace_key_prefix: "latest/", http_redirect_code: '301'}


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4445

I set up Google webmaster tools and that confirms that people are searching for "install flocker" and getting a load of ancient pages;

![screenshot from 2016-06-15 17-32-40](https://cloud.githubusercontent.com/assets/978965/16088492/4641c014-331f-11e6-91b7-84edcc8a5d4d.png)


I considered adding a robots.txt to "Dissallow"  crawlers from finding all those  old docs, but am nervous whether that might spoil our search ranking.
 * https://en.wikipedia.org/wiki/Robots_exclusion_standard
 * https://support.google.com/webmasters/topic/4598466

We could just delete some of those *really* old docs. Google would then remove them from it's index.
That might have the same negative effect on our search ranking.

And finally I investigated "sitemap" files.....but that doesn't really seem to buy us much...assuming that Google can follow all our links.
 * https://support.google.com/webmasters/answer/156184?hl=en

So I've updated the redirect rules and done a test publication of the docs here:
You should see a 301 redirect for each of the versions in the PR:

```
[richard@richardw-pet-instance-1 flocker]$ curl --insecure -v https://docs.staging.clusterhq.com/en/1.11.0/
* About to connect() to docs.staging.clusterhq.com port 443 (#0)
*   Trying 52.85.178.188...
* Connected to docs.staging.clusterhq.com (52.85.178.188) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
* skipping SSL peer certificate verification
* SSL connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate:
*       subject: CN=docs.staging.clusterhq.com,OU=Gandi Standard SSL,OU=Domain Control Validated
*       start date: Jan 22 00:00:00 2015 GMT
*       expire date: Jan 22 23:59:59 2016 GMT
*       common name: docs.staging.clusterhq.com
*       issuer: CN=Gandi Standard SSL CA 2,O=Gandi,L=Paris,ST=Paris,C=FR
> GET /en/1.11.0/ HTTP/1.1
> User-Agent: curl/7.29.0
> Host: docs.staging.clusterhq.com
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Content-Length: 0
< Connection: keep-alive
< Date: Wed, 15 Jun 2016 16:37:48 GMT
< Location: https://docs.staging.clusterhq.com/en/latest/
< Server: AmazonS3
< X-Cache: Miss from cloudfront
< Via: 1.1 de7a549023f0ea5ae15f58d27aeb67c7.cloudfront.net (CloudFront)
< X-Amz-Cf-Id: qEq-NUmDdcDpPE0sT2zU7Kln01WKmdRs1dLJ6Hvb25iOukfnshsqlA==
< 

```

Ignore the SSL error....apparently certificate expired for `docs.staging.clusterhq.com`


If this is approved, I can re-publish the 1.13.0 docs and make these new redirects live on the `docs.clusterhq.com` site.