### PR TITLE
[FLOC-4442] Move the postgres database to node2 along with the web container in the tutorial 

### DIFF
--- a/docs/docker-integration/tutorial-downloads/flocker-swarm-tutorial-node2.yml
+++ b/docs/docker-integration/tutorial-downloads/flocker-swarm-tutorial-node2.yml
@@ -25,7 +25,7 @@ services:
      ports:
         -  "5432:5432"
      environment:
-        - "constraint:flocker-node==1"
+        - "constraint:flocker-node==2"
         - "POSTGRES_USER=flocker"
         - "POSTGRES_PASSWORD=flockerdemo"
         - "POSTGRES_DB=postgres"


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4442 

Merging https://github.com/ClusterHQ/flocker/pull/2827 in to master.