### PR TITLE
[FLOC-4451] Bundle eliot-tree in the Flocker package

### DIFF
--- a/admin/build_targets/centos-7/Dockerfile
+++ b/admin/build_targets/centos-7/Dockerfile
@@ -6,7 +6,7 @@
 FROM clusterhqci/fpm-centos-7
 MAINTAINER ClusterHQ <contact@clusterhq.com>
 COPY requirements/*.txt /requirements/
-RUN ["pip", "install", "--upgrade", "pip==8.1.2", "setuptools==22.0.5"]
+RUN ["pip", "install", "--upgrade", "pip==8.1.2", "setuptools==23.0.0"]
 RUN ["pip", "install",\
      "--requirement", "/requirements/all.txt",\
      "--constraint", "/requirements/constraints.txt"]

--- a/admin/build_targets/ubuntu-14.04/Dockerfile
+++ b/admin/build_targets/ubuntu-14.04/Dockerfile
@@ -8,7 +8,7 @@ FROM clusterhqci/fpm-ubuntu-trusty
 MAINTAINER ClusterHQ <contact@clusterhq.com>
 COPY requirements/*.txt /requirements/
 RUN echo UMASK 022 >> /etc/logins.defs
-RUN ["pip", "install", "--upgrade", "pip==8.1.2", "setuptools==22.0.5"]
+RUN ["pip", "install", "--upgrade", "pip==8.1.2", "setuptools==23.0.0"]
 RUN ["pip", "install",\
      "--requirement", "/requirements/all.txt",\
      "--constraint", "/requirements/constraints.txt"]

--- a/admin/build_targets/ubuntu-15.10/Dockerfile
+++ b/admin/build_targets/ubuntu-15.10/Dockerfile
@@ -7,7 +7,7 @@
 FROM clusterhqci/fpm-ubuntu-wily
 MAINTAINER ClusterHQ <contact@clusterhq.com>
 COPY requirements/*.txt /requirements/
-RUN ["pip", "install", "--upgrade", "pip==8.1.2", "setuptools==22.0.5"]
+RUN ["pip", "install", "--upgrade", "pip==8.1.2", "setuptools==23.0.0"]
 RUN ["pip", "install",\
      "--requirement", "/requirements/all.txt",\
      "--constraint", "/requirements/constraints.txt"]

--- a/build.yaml
+++ b/build.yaml
@@ -252,7 +252,7 @@ common_cli:
     virtualenv -p python2.7 --clear ${venv}
     . ${venv}/bin/activate
     # Upgrade Python packaging tools.
-    ${venv}/bin/pip install pip==8.1.2 setuptools==22.0.5
+    ${venv}/bin/pip install pip==8.1.2 setuptools==23.0.0
     # Report the versions to aid debugging.
     ${venv}/bin/python --version
     ${venv}/bin/pip --version
@@ -562,7 +562,7 @@ common_cli:
           rpmlint" >> Dockerfile
     echo "RUN env URLGRABBER_DEBUG=1 yum update --assumeyes" >> Dockerfile
     echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
-    echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==22.0.5"]' >> Dockerfile
+    echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==23.0.0"]' >> Dockerfile
 
   build_dockerfile_ubuntu_trusty: &build_dockerfile_ubuntu_trusty |
     # don't waste time installing ruby or fpm, use an image containing fpm
@@ -574,7 +574,7 @@ common_cli:
           libffi-dev libssl-dev build-essential \
           python2.7-dev lintian python" >> Dockerfile
     echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
-    echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==22.0.5"]' >> Dockerfile
+    echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==23.0.0"]' >> Dockerfile
 
   build_dockerfile_ubuntu_wily: &build_dockerfile_ubuntu_wily |
     # don't waste time installing ruby or fpm, use an image containing fpm
@@ -586,7 +586,7 @@ common_cli:
           git ruby-dev libffi-dev libssl-dev build-essential \
           python2.7-dev lintian python" >> Dockerfile
     echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
-    echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==22.0.5"]' >> Dockerfile
+    echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==23.0.0"]' >> Dockerfile
 
   do_not_abort_on_errors: &do_not_abort_on_errors |
     # make sure we don't abort the job on the first error we find.

--- a/requirements/admin.txt
+++ b/requirements/admin.txt
@@ -1,7 +1,7 @@
 apache-libcloud==0.20.1
 # The `aws` command is required by the ``admin.installer``,
 # `admin.test.test_installer` and in the release process.
-awscli==1.10.36
+awscli==1.10.38
 bitmath==1.3.0.2
 boto==2.40.0
 characteristic==14.3.0
@@ -25,11 +25,11 @@ troposphere==1.6.0
 Twisted==16.2.0
 txeffect==0.9
 virtualenv==15.0.2
-zope.interface==4.1.3
+zope.interface==4.2.0
 ## The following requirements were added by pip freeze:
 attrs==16.0.0
 backports.ssl-match-hostname==3.5.0.1
-botocore==1.4.26
+botocore==1.4.28
 cached-property==1.3.0
 cffi==1.6.0
 chardet==2.3.0
@@ -51,7 +51,7 @@ jmespath==0.9.0
 linecache2==1.0.0
 monotonic==1.1
 pbr==1.10.0
-property-manager==1.6
+property-manager==2.1
 pyasn1==0.1.9
 pycparser==2.14
 pyOpenSSL==16.0.0

--- a/requirements/flocker-dev.txt
+++ b/requirements/flocker-dev.txt
@@ -30,5 +30,5 @@ Pygments==2.1.3
 pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.4.3
+Sphinx==1.4.4
 wrapt==1.10.8

--- a/requirements/flocker.txt
+++ b/requirements/flocker.txt
@@ -3,7 +3,7 @@ apache-libcloud==0.20.1
 bitmath==1.3.0.2
 boto==2.40.0
 boto3==1.3.1
-botocore==1.4.26
+botocore==1.4.28
 characteristic==14.3.0
 python-cinderclient==1.8.0
 docker-py==1.8.1
@@ -11,6 +11,7 @@ docutils==0.12
 effect==0.10.1
 eliot==0.11.0
 google-api-python-client==1.5.1
+google-compute-engine==2.0.0
 hypothesis==3.4.0
 ipaddr==2.1.11
 jsonschema==2.5.1
@@ -41,16 +42,16 @@ requests==2.10.0
 # Add a setuptools dependency to ensure that `pip` installs the latest version
 # instead of settling for the OS packaged version.
 # See: https://github.com/pyca/cryptography/issues/2838#issuecomment-221838467
-setuptools==22.0.5
+setuptools==23.0.0
 six==1.10.0
-Sphinx==1.4.3
+Sphinx==1.4.4
 sphinxcontrib-httpdomain==1.5.0
 testtools==2.2.0
 treq==15.1.0
 Twisted==16.2.0
 txeffect==0.9
 PyYAML==3.11
-zope.interface==4.1.3
+zope.interface==4.2.0
 ## The following requirements were added by pip freeze:
 alabaster==0.7.8
 attrs==16.0.0
@@ -58,7 +59,7 @@ Babel==2.3.4
 backports.ssl-match-hostname==3.5.0.1
 cffi==1.6.0
 cryptography==1.3.4
-debtcollector==1.4.0
+debtcollector==1.5.0
 enum34==1.1.6
 extras==1.0.0
 fixtures==3.0.0
@@ -77,10 +78,10 @@ MarkupSafe==0.23
 monotonic==1.1
 msgpack-python==0.4.7
 netaddr==0.7.18
-oslo.config==3.10.0
-oslo.i18n==3.6.0
-oslo.serialization==2.7.0
-oslo.utils==3.11.0
+oslo.config==3.11.0
+oslo.i18n==3.7.0
+oslo.serialization==2.9.0
+oslo.utils==3.13.0
 pbr==1.10.0
 positional==1.1.0
 prettytable==0.7.2
@@ -94,7 +95,7 @@ rsa==3.4.2
 service-identity==16.0.0
 simplejson==3.8.2
 snowballstemmer==1.2.1
-stevedore==1.14.0
+stevedore==1.15.0
 traceback2==1.4.0
 unittest2==1.1.0
 uritemplate==0.6

--- a/requirements/flocker.txt
+++ b/requirements/flocker.txt
@@ -10,7 +10,10 @@ docker-py==1.8.1
 docutils==0.12
 effect==0.10.1
 eliot==0.11.0
+# Included in the Flocker package to assist with debugging.
+eliot-tree==15.3.0
 google-api-python-client==1.5.1
+# Not used directly by Flocker, but allows boto GCE plugins to load.
 google-compute-engine==2.0.0
 hypothesis==3.4.0
 ipaddr==2.1.11
@@ -25,7 +28,7 @@ mmh3==2.3.1
 # Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
 ndg-httpsclient==0.4.1
 netifaces==0.10.4
-python-novaclient==4.0.0
+python-novaclient==4.1.0
 # FLOC-4411 oauth2client 2 no longer exports SignedJwtAssertionCredentials
 oauth2client==1.5.2
 # XXX This is here to ensure that buildbot installs a version of pip and
@@ -96,6 +99,7 @@ service-identity==16.0.0
 simplejson==3.8.2
 snowballstemmer==1.2.1
 stevedore==1.15.0
+toolz==0.8.0
 traceback2==1.4.0
 unittest2==1.1.0
 uritemplate==0.6

--- a/requirements/flocker.txt.in
+++ b/requirements/flocker.txt.in
@@ -11,6 +11,8 @@ docutils
 effect
 eliot
 google-api-python-client
+# Not used directly by Flocker, but allows boto GCE plugins to load.
+google-compute-engine
 hypothesis
 ipaddr
 jsonschema

--- a/requirements/flocker.txt.in
+++ b/requirements/flocker.txt.in
@@ -10,6 +10,8 @@ docker-py
 docutils
 effect
 eliot
+# Included in the Flocker package to assist with debugging.
+eliot-tree
 google-api-python-client
 # Not used directly by Flocker, but allows boto GCE plugins to load.
 google-compute-engine


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4451
Stacked on #2833 (review that one first)

We always used to bundle it but I missed  it out when I landed #2792

Unfortunately in re-running the `update-requirments` tool I've pulled in a just released version of python-novaclient.
Their release notes are non-existent but the changes I can see, look minor;
 * https://github.com/openstack/python-novaclient

I'll run all the acceptance tests to ensure that it hasn't broken anything.
If I have, I'll pin to the previous version.


