### PR TITLE
[FLOC-4457] Allow ami-search-ubuntu to find non-ebs images

### DIFF
--- a/admin/ubuntu.py
+++ b/admin/ubuntu.py
@@ -192,27 +192,34 @@ def reduce_to_map(records, key_field, value_field):
     text file changes or includes unexpected fields.
     """
     map_fields = {key_field, value_field}
-    map = {}
+    result_map = {}
     first_record = None
-    for r in records:
-        r = r.serialize()
+    for record in records:
+        r = record.serialize()
         if first_record is None:
-            first_record = set(r.items())
+            first_record = record
+            first_record_items = set(r.items())
             continue
-        diff = dict(first_record.difference(r.items()))
-        unexpected_differences = set(
+        diff = dict(first_record_items.difference(r.items()))
+        different_keys = set(
             diff.keys()
         ).difference(map_fields)
-        if unexpected_differences:
+        if different_keys:
             raise ValueError(
-                "Unexpected differences in record. "
-                "Record: {}, "
-                "Differences: {}".format(r, unexpected_differences)
+                "Unexpected related record found. \n"
+                "Reference Record: {}, \n"
+                "Different Record: {}, \n"
+                "Different Keys: {}".format(
+                    first_record,
+                    record,
+                    different_keys,
+                )
             )
-        key_value = r[key_field]
-        assert key_value not in map
-        map[key_value] = r[value_field]
-    return map
+        key = r[key_field]
+        value = r[value_field]
+        assert key not in result_map
+        result_map[key] = value
+    return result_map
 
 
 def ami_search_ubuntu_main(args, top_level, base_path):

--- a/admin/ubuntu.py
+++ b/admin/ubuntu.py
@@ -182,6 +182,15 @@ class AMISearchUbuntuOptions(Options):
 
 
 def reduce_to_map(records, key_field, value_field):
+    """
+    Reduce the ``records`` to a ``dict`` of ``key_field``: ``value_field``
+    extracted from each record.
+    The ``key_field`` is expected to be unique amongst ``records`` and all
+    other fields are expected to be identical. If not, ValueError is raised
+    with details of the unexpected differences.
+    This is to ensure that the tool will fail if the format of the downloaded
+    text file changes or includes unexpected fields.
+    """
     map_fields = {key_field, value_field}
     map = {}
     first_record = None

--- a/admin/ubuntu.py
+++ b/admin/ubuntu.py
@@ -150,6 +150,22 @@ def latest(**kwargs):
     )
 
 
+EC2_IMAGE_TYPES = (u"ebs", u"ebs-ssd", u"instance-store")
+
+
+def _validate_ec2_image_type(supplied_type):
+    supplied_type = supplied_type.decode('ascii')
+    if supplied_type not in EC2_IMAGE_TYPES:
+        raise UsageError(
+            "Unrecognized option value for --ec2-image-type: '{}'. "
+            "Must be one of: '{}'".format(
+                supplied_type,
+                "', '".join(EC2_IMAGE_TYPES),
+            )
+        )
+    return supplied_type
+
+
 class AMISearchUbuntuOptions(Options):
     """
     Options.
@@ -159,6 +175,9 @@ class AMISearchUbuntuOptions(Options):
          'One of `daily` or `release`.', unicode],
         ['ubuntu-name', None, u"trusty",
          'An Ubuntu release name.', unicode],
+        ['ec2-image-type', None, EC2_IMAGE_TYPES[0],
+         'One of {}.'.format(", ".join(EC2_IMAGE_TYPES)),
+         _validate_ec2_image_type],
     ]
 
 
@@ -201,7 +220,7 @@ def ami_search_ubuntu_main(args, top_level, base_path):
         ubuntu_variant=u"server",
         architecture=u'amd64',
         hypervisor=u'hvm',
-        ec2_image_type=u'ebs',
+        ec2_image_type=options["ec2-image-type"],
     )
 
     ami_map = reduce_to_map(


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4457

I need this to get the regional AMI IDs for Ubuntu Xenial.
(see https://clusterhq.atlassian.net/browse/FLOC-4456)

There are no Xenial `ebs` images, only `ebs-ssd` , as shown by 

```
./admin/ami-search-ubuntu  --ubuntu-name xenial
{}
```

So we'll have to base the new jenkins images off ebs-ssd or instance-store images.

You can now run the tool as follows:

```

$ ./admin/ami-search-ubuntu  --ubuntu-name xenial --ec2-image-type ebs-ssd | jq . 
{
  "ap-southeast-1": "ami-1932e07a",
  "ap-southeast-2": "ami-bc8ba3df",
  "eu-central-1": "ami-26ed0649",
  "eu-west-1": "ami-3628b345",
  "sa-east-1": "ami-cca431a0",
  "us-east-1": "ami-47dd132a",
  "us-west-1": "ami-5af9bd3a",
  "us-west-2": "ami-83e82ee3"
}

```

