### PR TITLE
[FLOC-4342] Add support for building and testing Ubuntu 16.04 packages

### DIFF
--- a/admin/build_targets/ubuntu-16.04/Dockerfile
+++ b/admin/build_targets/ubuntu-16.04/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright ClusterHQ Inc. See LICENSE file for details.
 #
-# A Docker image for building packages in a clean Ubuntu 15.10 build
+# A Docker image for building packages in a clean Ubuntu 16.04 build
 # environment.
 #
 

--- a/admin/build_targets/ubuntu-16.04/Dockerfile
+++ b/admin/build_targets/ubuntu-16.04/Dockerfile
@@ -1,0 +1,15 @@
+# Copyright ClusterHQ Inc. See LICENSE file for details.
+#
+# A Docker image for building packages in a clean Ubuntu 15.10 build
+# environment.
+#
+
+FROM clusterhqci/fpm-ubuntu-xenial
+MAINTAINER ClusterHQ <contact@clusterhq.com>
+COPY requirements/*.txt /requirements/
+RUN ["pip", "install", "--upgrade", "pip==8.1.2", "setuptools==23.0.0"]
+RUN ["pip", "install",\
+     "--requirement", "/requirements/all.txt",\
+     "--constraint", "/requirements/constraints.txt"]
+VOLUME /flocker
+ENTRYPOINT ["/flocker/admin/build-package-entrypoint", "--destination-path=/output"]

--- a/admin/client.py
+++ b/admin/client.py
@@ -36,6 +36,7 @@ DOCKER_IMAGES = {
     'fedora-22': DockerImage(image='fedora:22', package_manager='dnf'),
     'ubuntu-14.04': DockerImage(image='ubuntu:14.04', package_manager='apt'),
     'ubuntu-15.10': DockerImage(image='ubuntu:15.10', package_manager='apt'),
+    'ubuntu-16.04': DockerImage(image='ubuntu:16.04', package_manager='apt'),
 }
 
 # No distribution is officially supported using pip, but the code can
@@ -45,7 +46,12 @@ PIP_DISTRIBUTIONS = DOCKER_IMAGES.keys()
 # Some distributions have packages created for them.
 # Although CentOS 7 is not a supported client distribution, the client
 # packages get built, and can be tested.
-PACKAGED_CLIENT_DISTRIBUTIONS = ('centos-7', 'ubuntu-14.04', 'ubuntu-15.10')
+PACKAGED_CLIENT_DISTRIBUTIONS = (
+    'centos-7',
+    'ubuntu-14.04',
+    'ubuntu-15.10',
+    'ubuntu-16.04',
+)
 
 
 class ScriptBuilder(TypeDispatcher):

--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -111,6 +111,7 @@ DISTRIBUTION_NAME_MAP = {
     'centos-7': Distribution(name="centos", version="7"),
     'ubuntu-14.04': Distribution(name="ubuntu", version="14.04"),
     'ubuntu-15.10': Distribution(name="ubuntu", version="15.10"),
+    'ubuntu-16.04': Distribution(name="ubuntu", version="16.04"),
 }
 
 CURRENT_DISTRIBUTION = Distribution._get_current_distribution()

--- a/build.yaml
+++ b/build.yaml
@@ -588,6 +588,18 @@ common_cli:
     echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
     echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==23.0.0"]' >> Dockerfile
 
+  build_dockerfile_ubuntu_xenial: &build_dockerfile_ubuntu_xenial |
+    # don't waste time installing ruby or fpm, use an image containing fpm
+    # https://github.com/alanfranz/fpm-within-docker
+    echo "FROM alanfranz/fwd-ubuntu-xenial:latest" > Dockerfile
+    echo "MAINTAINER ClusterHQ <contact@clusterhq.com>" >> Dockerfile
+    echo "RUN apt-get update" >> Dockerfile
+    echo "RUN apt-get install --no-install-recommends -y \
+          git ruby-dev libffi-dev libssl-dev build-essential \
+          python2.7-dev lintian python" >> Dockerfile
+    echo "ADD https://bootstrap.pypa.io/get-pip.py /tmp/" >> Dockerfile
+    echo 'RUN ["python", "/tmp/get-pip.py", "pip==8.1.2", "setuptools==23.0.0"]' >> Dockerfile
+
   do_not_abort_on_errors: &do_not_abort_on_errors |
     # make sure we don't abort the job on the first error we find.
     #
@@ -1124,6 +1136,21 @@ job_type:
             cli: [ *hashbang, *add_shell_functions,
                    'export DOCKER_IMAGE=clusterhqci/fpm-ubuntu-wily',
                    *build_dockerfile_ubuntu_wily,
+                   *build_docker_image,
+                   *push_image_to_dockerhub ]
+          }
+      timeout: 30
+      directories_to_delete: []
+      notify_slack: '#nightly-builds'
+
+    run_docker_build_ubuntu_xenial_fpm:
+      at: '0 3 * * *'
+      on_nodes_with_labels: 'aws-centos-7-SELinux-T2Medium'
+      with_steps:
+        - { type: 'shell',
+            cli: [ *hashbang, *add_shell_functions,
+                   'export DOCKER_IMAGE=clusterhqci/fpm-ubuntu-xenial',
+                   *build_dockerfile_ubuntu_xenial,
                    *build_docker_image,
                    *push_image_to_dockerhub ]
           }

--- a/build.yaml
+++ b/build.yaml
@@ -1054,6 +1054,24 @@ job_type:
       timeout: 30
       directories_to_delete: *run_acceptance_directories_to_delete
 
+    run_client_installation_on_Ubuntu_Xenial:
+      on_nodes_with_labels: 'aws-ubuntu-trusty-T2Medium'
+      with_steps:
+        - { type: 'shell',
+            cli: [ *hashbang, *add_shell_functions,
+                   *cleanup, *setup_venv, *setup_flocker_modules,
+                   'export DISTRIBUTION_NAME=ubuntu-16.04',
+                   *setup_aws_env_vars, *check_version,
+                   *build_sdist, *build_package,
+                   *build_repo_metadata,
+                   *run_client_tests,
+                   *clean_packages,
+                   *exit_with_return_code_from_test ]
+          }
+      clean_repo: true
+      timeout: 30
+      directories_to_delete: *run_acceptance_directories_to_delete
+
   run_lint:
     run_lint:
       on_nodes_with_labels: 'aws-centos-7-T2Medium'

--- a/build.yaml
+++ b/build.yaml
@@ -501,15 +501,18 @@ common_cli:
     sudo cp repo/* ${DOC_ROOT}/${REPO_PATH}
     cd ${DOC_ROOT}/${REPO_PATH}
     # create a repo on either centos or ubuntu
-    if [ "${DISTRIBUTION_NAME}" == "ubuntu-14.04" ]; then
-      sudo sh -c 'dpkg-scanpackages --multiversion . | gzip > Packages.gz'
-    fi
-    if [ "${DISTRIBUTION_NAME}" == "ubuntu-15.10" ]; then
-      sudo sh -c 'dpkg-scanpackages --multiversion . | gzip > Packages.gz'
-    fi
-    if [ "${DISTRIBUTION_NAME}" == "centos-7" ]; then
-      sudo createrepo .
-    fi
+    case "${DISTRIBUTION_NAME}" in
+        ubuntu*)
+            sudo sh -c 'dpkg-scanpackages --multiversion . | gzip > Packages.gz'
+            ;;
+        centos*)
+            sudo createrepo .
+            ;;
+        *)
+            echo "ERROR: Unsupported distribution '${DISTRIBUTION_NAME}'." >&2
+            exit 1
+            ;;
+    esac
     cd -
 
   clean_packages: &clean_packages |

--- a/build.yaml
+++ b/build.yaml
@@ -1486,6 +1486,9 @@ views:
   Ubuntu_Wily_15_10:
     description: 'All Ubuntu Wily (15.10) jobs'
     regex: '.*_(?i)wily_.*.*'
+  Ubuntu_Xenial_16_04:
+    description: 'All Ubuntu Xenial (16.04) jobs'
+    regex: '.*_(?i)xenial_.*.*'
   cron:
     description: 'All Nightly Cron jobs'
     regex: '^_[^_](?i)[a-z]*.*'

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -225,6 +225,13 @@ def get_repository_url(distribution, flocker_version):
                             key='ubuntu' + get_package_key_suffix(
                                 flocker_version),
                         ),
+
+        'ubuntu-16.04': 'https://{archive_bucket}.s3.amazonaws.com/{key}/'
+                        '$(lsb_release --release --short)/\\$(ARCH)'.format(
+                            archive_bucket=ARCHIVE_BUCKET,
+                            key='ubuntu' + get_package_key_suffix(
+                                flocker_version),
+                        ),
     }
 
     try:

--- a/flocker/provision/_install.py
+++ b/flocker/provision/_install.py
@@ -447,10 +447,6 @@ def install_commands_ubuntu(package_name, distribution, package_source,
         # is available, and HTTPS URLs are supported.
         apt_get_update(),
         apt_get_install(["apt-transport-https", "software-properties-common"]),
-
-        # Add ClusterHQ repo for installation of Flocker packages.
-        # XXX This needs retry
-        run(command='add-apt-repository -y "deb {} /"'.format(repository_url))
         ]
 
     pinned_host = urlparse(repository_url).hostname
@@ -464,6 +460,17 @@ def install_commands_ubuntu(package_name, distribution, package_source,
         # server. Thus, in all cases we pin precisely which url we want to
         # install flocker from.
         pinned_host = urlparse(package_source.build_server).hostname
+    else:
+        # Add ClusterHQ repo for installation of Flocker packages.
+        # XXX This needs retry
+        commands.append(
+            run(
+                command='add-apt-repository -y "deb {} /"'.format(
+                    repository_url
+                )
+            )
+        )
+
     commands.append(put(dedent('''\
         Package: *
         Pin: origin {}


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4342

The build results are available on this staging server:
 * http://52.40.233.218/boxes-flocker?branch=xenial-packages-FLOC-4342

Packages available here:
 * http://52.40.233.218/results/omnibus/xenial-packages-FLOC-4342/ubuntu-16.04/

You can run the client installation tests as follows:

```
./admin/run-client-tests  --distribution ubuntu-16.04 --branch xenial-packages-FLOC-4342 --build-server http://52.40.233.218/
```

...but Jenkins should also run them for this branch....let's see.