### PR TITLE
[FLOC-4463] Run unit tests on Ubuntu 16.04

### DIFF
--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -766,7 +766,7 @@ class LintPackageTests(TestCase):
             vendor="Acme Corporation",
             maintainer='Someone <noreply@example.com>',
             architecture="all",
-            description="A Test Package.\n\n" + ("Lorum ipsum. " * 100),
+            description="A Test Package\n\nThe description.",
             category="none",
             dependencies=[]
         ).run()

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -766,7 +766,7 @@ class LintPackageTests(TestCase):
             vendor="Acme Corporation",
             maintainer='Someone <noreply@example.com>',
             architecture="all",
-            description="Description\n\nExtended",
+            description="Description\n\n" + ("Lorum ipsum. " * 100),
             category="none",
             dependencies=[]
         ).run()

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -766,7 +766,7 @@ class LintPackageTests(TestCase):
             vendor="Acme Corporation",
             maintainer='Someone <noreply@example.com>',
             architecture="all",
-            description="A Test Package\n\nThe description.",
+            description="Test Package\n\nThe description.",
             category="none",
             dependencies=[]
         ).run()

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -766,7 +766,7 @@ class LintPackageTests(TestCase):
             vendor="Acme Corporation",
             maintainer='Someone <noreply@example.com>',
             architecture="all",
-            description="Description\n\n" + ("Lorum ipsum. " * 100),
+            description="A Test Package.\n\n" + ("Lorum ipsum. " * 100),
             category="none",
             dependencies=[]
         ).run()

--- a/admin/test/test_packaging.py
+++ b/admin/test/test_packaging.py
@@ -199,7 +199,7 @@ def assert_deb_content(test_case, expected_paths, package_path):
             continue
         actual_paths.add(FilePath('/').descendant(f.segmentsFrom(output_dir)))
 
-    test_case.assertEqual(expected_paths, actual_paths)
+    test_case.assertEqual(set(), expected_paths.difference(actual_paths))
 
 
 def assert_deb_headers(test_case, expected_headers, package_path):
@@ -670,9 +670,6 @@ class BuildPackageTests(TestCase):
             expected_prefix.child('Foo'),
             expected_prefix.child('Bar'),
             FilePath('/other/file'),
-            # This is added automatically by fpm despite not supplying the
-            # --deb-changelog option
-            FilePath('/usr/share/doc/foobar/changelog.Debian.gz'),
         ])
         expected_name = 'FooBar'.lower()
         expected_epoch = b'3'

--- a/build.yaml
+++ b/build.yaml
@@ -850,6 +850,30 @@ job_type:
       timeout: 30
       directories_to_delete: *run_trial_directories_to_delete
 
+    run_trial_on_AWS_Ubuntu_Xenial:
+      on_nodes_with_labels: 'aws-ubuntu-xenial-T2Medium'
+      with_modules: *run_trial_modules
+      with_steps:
+        - { type: 'shell', cli: *run_trial_cli }
+      archive_artifacts: *flocker_artifacts
+      publish_test_results: true
+      coverage_report: true
+      clean_repo: true
+      timeout: 30
+      directories_to_delete: *run_trial_directories_to_delete
+
+    run_trial_on_AWS_Ubuntu_Xenial_as_root:
+      on_nodes_with_labels: 'aws-ubuntu-xenial-T2Medium'
+      with_modules: *run_trial_as_root_modules
+      with_steps:
+        - { type: 'shell', cli: *run_trial_cli_as_root }
+      archive_artifacts: *flocker_artifacts
+      publish_test_results: true
+      coverage_report: true
+      clean_repo: true
+      timeout: 30
+      directories_to_delete: *run_trial_directories_to_delete
+
     run_trial_on_AWS_CentOS_7_flocker.node.functional.test_docker:
       # FLOC-3903: docker on centos use loop-devmapper
       # by default. That makes it much slower than Ubuntu


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4463

This fixes a couple of `admin.tests` and updates build.yaml to run all our standard unit tests on the xenial build slave.

The lintian error is that the package description must have more than one word:
 * https://lintian.debian.org/tags/description-too-short.html

Once this is merged I'll merge forward https://github.com/ClusterHQ/flocker/pull/2845 (the remaining tests) and put it up for review 