### PR TITLE
[FLOC-4464] Get the postgresql and mongodb Integration tests working again

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -653,6 +653,11 @@ IGNORED_WARNINGS = {
         # Fixed upstream, but not released.
         'executable-not-elf-or-script',
 
+        # libffi installs shared libraries with executable bit setContent
+        # '14:59:26 E: clusterhq-python-flocker: shlib-with-executable-bit
+        # opt/flocker/lib/python2.7/site-packages/.libs_cffi_backend/libffi-72499c49.so.6.0.4
+        'shlib-with-executable-bit',
+
         # Our omnibus packages are never going to be used by upstream so
         # there's no bug to close.
         # https://lintian.debian.org/tags/new-package-should-close-itp-bug.html

--- a/requirements/admin.txt
+++ b/requirements/admin.txt
@@ -1,15 +1,15 @@
-apache-libcloud==0.20.1
+apache-libcloud==1.0.0
 # The `aws` command is required by the ``admin.installer``,
 # `admin.test.test_installer` and in the release process.
-awscli==1.10.38
+awscli==1.10.44
 bitmath==1.3.0.2
-boto==2.40.0
+boto==2.41.0
 characteristic==14.3.0
 deb-pkg-tools==1.36
 docker-py==1.8.1
 effect==0.10.1
 eliot==0.11.0
-GitPython==2.0.5
+GitPython==2.0.6
 ipaddr==2.1.11
 # Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
 ndg-httpsclient==0.4.1
@@ -29,9 +29,9 @@ zope.interface==4.2.0
 ## The following requirements were added by pip freeze:
 attrs==16.0.0
 backports.ssl-match-hostname==3.5.0.1
-botocore==1.4.28
+botocore==1.4.34
 cached-property==1.3.0
-cffi==1.6.0
+cffi==1.7.0
 chardet==2.3.0
 colorama==0.3.3
 coloredlogs==5.0
@@ -55,7 +55,7 @@ property-manager==2.1
 pyasn1==0.1.9
 pycparser==2.14
 pyOpenSSL==16.0.0
-python-debian==0.1.23
+python-debian==0.1.28
 python-mimeparse==1.5.2
 rsa==3.4.2
 s3transfer==0.0.1
@@ -63,5 +63,5 @@ six==1.10.0
 smmap==0.9.0
 traceback2==1.4.0
 unittest2==1.1.0
-verboselogs==1.1
+verboselogs==1.4
 websocket-client==0.37.0

--- a/requirements/flocker-dev.txt
+++ b/requirements/flocker-dev.txt
@@ -4,11 +4,15 @@
 # We can't use the "in" marker comparison because it isn't recognised by
 # setuptools, only by pkg_resources.
 nomenclature==0.1.1
+# Required by flocker.acceptance.integration.test_postgres
+pg8000==1.10.6
 pycrypto==2.6.1
 # Sphinx docs dependencies
 # enchant.tokenize is not detected by snakefood
 pyenchant==1.6.6
 pylint==1.5.6
+# Required by flocker.acceptance.integration.test_mongodb
+pymongo==3.2.2
 sphinx-prompt==1.0.0
 sphinxcontrib-spelling==2.1.2
 # XXX: This shouldn't be here. It's only needed by admin.packaging module but

--- a/requirements/flocker-dev.txt
+++ b/requirements/flocker-dev.txt
@@ -18,7 +18,7 @@ virtualenv==15.0.2
 alabaster==0.7.8
 astroid==1.4.6
 Babel==2.3.4
-cffi==1.6.0
+cffi==1.7.0
 colorama==0.3.3
 docutils==0.12
 imagesize==0.7.1

--- a/requirements/flocker-dev.txt.in
+++ b/requirements/flocker-dev.txt.in
@@ -4,11 +4,15 @@
 # We can't use the "in" marker comparison because it isn't recognised by
 # setuptools, only by pkg_resources.
 nomenclature >= "0.1.0"; sys_platform == "linux2"
+# Required by flocker.acceptance.integration.test_postgres
+pg8000
 pycrypto
 # Sphinx docs dependencies
 # enchant.tokenize is not detected by snakefood
 pyenchant
 pylint
+# Required by flocker.acceptance.integration.test_mongodb
+pymongo
 sphinx-prompt
 sphinxcontrib-spelling
 # XXX: This shouldn't be here. It's only needed by admin.packaging module but

--- a/requirements/flocker.txt
+++ b/requirements/flocker.txt
@@ -1,9 +1,9 @@
 # Libcloud is not detected by snakefood
-apache-libcloud==0.20.1
+apache-libcloud==1.0.0
 bitmath==1.3.0.2
-boto==2.40.0
+boto==2.41.0
 boto3==1.3.1
-botocore==1.4.28
+botocore==1.4.34
 characteristic==14.3.0
 python-cinderclient==1.8.0
 docker-py==1.8.1
@@ -36,7 +36,7 @@ oauth2client==1.5.2
 # e.g. nomenclature; sys_platform==linux2 (FLOC-4429)
 pip==8.1.2
 pyOpenSSL==16.0.0
-psutil==4.2.0
+psutil==4.3.0
 --find-links git+https://github.com/ClusterHQ/pyrsistent@v0.11.13+chq5#egg=pyrsistent-0.11.13+chq5
 pyrsistent==0.11.13+chq5
 pytz==2016.4
@@ -60,7 +60,7 @@ alabaster==0.7.8
 attrs==16.0.0
 Babel==2.3.4
 backports.ssl-match-hostname==3.5.0.1
-cffi==1.6.0
+cffi==1.7.0
 cryptography==1.3.4
 debtcollector==1.5.0
 enum34==1.1.6
@@ -81,12 +81,12 @@ MarkupSafe==0.23
 monotonic==1.1
 msgpack-python==0.4.7
 netaddr==0.7.18
-oslo.config==3.11.0
+oslo.config==3.12.0
 oslo.i18n==3.7.0
-oslo.serialization==2.9.0
-oslo.utils==3.13.0
+oslo.serialization==2.10.0
+oslo.utils==3.14.0
 pbr==1.10.0
-positional==1.1.0
+positional==1.1.1
 prettytable==0.7.2
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
@@ -94,6 +94,7 @@ pycparser==2.14
 Pygments==2.1.3
 python-dateutil==2.5.3
 python-mimeparse==1.5.2
+rfc3986==0.3.1
 rsa==3.4.2
 service-identity==16.0.0
 simplejson==3.8.2


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4464

I forgot to include pymongo and pg8000 packages when I updated everything in https://github.com/ClusterHQ/flocker/pull/2792

This should stop the 
 * flocker.acceptance.integration.test_mongodb and
 * flocker.acceptance.integration.test_postgres

...being skipped.

As usual, in running `admin/update-requirements` I've pulled in some unrelated updates. But they all seem to be minor or micro version changes so hopefully shouldn't cause any problems. 


Here are some of the test results, showing that the integration tests for postgres and mongo are no longer skipped:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/integration-tests-again-FLOC-4464/view/cron/job/_run_acceptance_on_GCE_Ubuntu_Trusty_with_GCE/lastSuccessfulBuild/testReport/