### PR TITLE
[FLOC-4473] Retry the node UUID lookup on network failure

### DIFF
--- a/flocker/common/_retry.py
+++ b/flocker/common/_retry.py
@@ -11,7 +11,8 @@ from sys import exc_info
 from datetime import timedelta
 from functools import partial
 from inspect import getfile, getsourcelines
-from itertools import repeat
+from itertools import chain, count, imap, repeat, takewhile
+from random import uniform
 import time
 
 from eliot import (
@@ -26,6 +27,65 @@ from twisted.internet.defer import maybeDeferred
 
 from effect import Effect, Constant, Delay
 from effect.retry import retry
+
+
+def backoff(step=5.0, maximum_step=60.0, timeout=10*60.0, jitter=0.2):
+    """
+    Generate increasingly large values for use as the ``steps`` argument to
+    retry functions.
+
+    :param float step: The amount by which to increase successive values.
+    :param float maximum_step: The maximum value that will be
+        generated. ``None`` means no maximum.
+    :param float timeout: No further values will be generated when the sum of
+        the generated steps is greater than ``timeout``. ``None`` means no
+        timeout.
+    :param float jitter: If not ``None``, the generated values will be adjusted
+        by a random amount between +/- ``jitter.
+    :returns: A generator of floats.
+    """
+    if step <= 0.0:
+        raise ValueError("Invalid ``step`` ({!r}). "
+                         "Must be > 0.0.".format(step))
+    steps = imap(
+        lambda x: x * step,
+        count(start=1)
+    )
+    if maximum_step is not None:
+        if maximum_step <= 0.0:
+            raise ValueError(
+                "Invalid ``maximum_step`` ({!r}). "
+                "Must be > 0.0.".format(
+                    maximum_step
+                )
+            )
+
+        steps = takewhile(
+            lambda x: x < maximum_step,
+            steps
+        )
+        steps = chain(
+            steps,
+            repeat(maximum_step)
+        )
+    if jitter is not None:
+        steps = imap(
+            lambda x: x + uniform(-jitter, jitter),
+            steps,
+        )
+    if timeout is not None:
+        total_time = [0]
+
+        def maybe_timeout(values):
+            for value in values:
+                total_time[0] += value
+                if total_time[0] > timeout:
+                    break
+                yield value
+
+        steps = maybe_timeout(steps)
+
+    return steps
 
 
 def function_serializer(function):

--- a/flocker/dockerplugin/_script.py
+++ b/flocker/dockerplugin/_script.py
@@ -3,8 +3,9 @@
 """
 Command to start up the Docker plugin.
 """
-
+from itertools import repeat
 from os import umask
+from random import uniform
 from stat import S_IRUSR, S_IWUSR, S_IXUSR
 
 from twisted.python.usage import Options
@@ -13,6 +14,7 @@ from twisted.application.internet import StreamServerEndpointService
 from twisted.web.server import Site
 from twisted.python.filepath import FilePath
 
+from ..common import retry_failure
 from ..common.script import (
     flocker_standard_options, FlockerScriptRunner, main_for_service)
 from ._api import VolumePlugin
@@ -73,7 +75,17 @@ class DockerPluginScript(object):
         self._create_listening_directory(PLUGIN_PATH.parent())
 
         # Get the node UUID, and then start up:
-        getting_id = flocker_client.this_node_uuid()
+        # Retry on  *all* errors.
+        getting_id = retry_failure(
+            reactor=reactor,
+            function=flocker_client.this_node_uuid,
+            # Keep trying with +5 second backoff up to a 60 second maximum
+            # delay, with jitter
+            steps=(
+                min(60, i * delay) + uniform(-0.2, 0.2)
+                for i, delay in enumerate(repeat(5))
+            )
+        )
 
         def run_service(node_id):
             endpoint = serverFromString(

--- a/flocker/dockerplugin/_script.py
+++ b/flocker/dockerplugin/_script.py
@@ -83,7 +83,7 @@ class DockerPluginScript(object):
             # delay, with jitter
             steps=(
                 min(60, i * delay) + uniform(-0.2, 0.2)
-                for i, delay in enumerate(repeat(5))
+                for i, delay in enumerate(repeat(5), start=1)
             )
         )
 


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4473

This change causes the `flocker-docker-plugin` process to retry the ``this_node_uuid`` procedure indefinitely.
* *All* failures will be logged and cause a retry.
*  And specifically, the ``twisted.internet.error.NoRouteError`` that was causing systemd to give up restarting the unit.

I've merged this branch into the Ubuntu 16.04 acceptance tests branch and you can see that this change has made the Ubuntu16.04 on Rackspace tests pass:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/xenial-acceptance-tests-FLOC-4341/view/cron/job/_run_acceptance_on_Rackspace_Ubuntu_Xenial_with_Cinder/


