### PR TITLE
add ID to Mount / Unmount for docker 1.12

### DIFF
--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -197,11 +197,12 @@ class VolumePlugin(object):
 
     @app.route("/VolumeDriver.Unmount", methods=["POST"])
     @_endpoint(u"Unmount")
-    def volumedriver_unmount(self, Name):
+    def volumedriver_unmount(self, Name, ID):
         """
         The Docker container is no longer using the given volume.
 
         :param unicode Name: The name of the volume.
+        :param string ID: A unique ID for caller that requested the mount
 
         For now this does nothing. In FLOC-2755 this will release the
         lease acquired for the dataset by the ``VolumeDriver.Mount``
@@ -313,7 +314,7 @@ class VolumePlugin(object):
 
     @app.route("/VolumeDriver.Mount", methods=["POST"])
     @_endpoint(u"Mount")
-    def volumedriver_mount(self, Name):
+    def volumedriver_mount(self, Name, ID):
         """
         Move a volume with the given name to the current node and mount it.
 
@@ -321,6 +322,11 @@ class VolumePlugin(object):
         dataset is mounted locally.
 
         :param unicode Name: The name of the volume.
+        :param string ID: A unique ID for caller that requested the mount
+
+        Right now we do nothing with ID, but it can be used to track
+        the mount calls when multiple containers are trying to mount
+        the same volume.
 
         :return: Result that includes the mountpoint.
         """

--- a/flocker/dockerplugin/_api.py
+++ b/flocker/dockerplugin/_api.py
@@ -197,7 +197,7 @@ class VolumePlugin(object):
 
     @app.route("/VolumeDriver.Unmount", methods=["POST"])
     @_endpoint(u"Unmount")
-    def volumedriver_unmount(self, Name, ID):
+    def volumedriver_unmount(self, Name, ID=None):
         """
         The Docker container is no longer using the given volume.
 
@@ -314,7 +314,7 @@ class VolumePlugin(object):
 
     @app.route("/VolumeDriver.Mount", methods=["POST"])
     @_endpoint(u"Mount")
-    def volumedriver_mount(self, Name, ID):
+    def volumedriver_mount(self, Name, ID=None):
         """
         Move a volume with the given name to the current node and mount it.
 

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -119,7 +119,8 @@ class APITestsMixin(APIAssertionsMixin):
         unmount_id = ''.join(random.choice(
             '0123456789abcdef') for n in xrange(64))
         return self.assertResult(b"POST", b"/VolumeDriver.Unmount",
-                                 {u"Name": u"vol", unicode(unmount_id): u""},
+                                 {u"Name": u"vol",
+                                  u"ID": unicode(unmount_id)},
                                  OK, {u"Err": u""})
 
     def test_create_with_profile(self):

--- a/flocker/dockerplugin/test/test_api.py
+++ b/flocker/dockerplugin/test/test_api.py
@@ -4,6 +4,7 @@
 Tests for the Volumes Plugin API provided by the plugin.
 """
 
+import random
 from uuid import uuid4
 
 from bitmath import TiB, GiB, MiB, KiB, Byte
@@ -115,8 +116,11 @@ class APITestsMixin(APIAssertionsMixin):
         """
         ``/VolumeDriver.Unmount`` returns a successful result.
         """
+        unmount_id = ''.join(random.choice(
+            '0123456789abcdef') for n in xrange(64))
         return self.assertResult(b"POST", b"/VolumeDriver.Unmount",
-                                 {u"Name": u"vol"}, OK, {u"Err": u""})
+                                 {u"Name": u"vol", unicode(unmount_id): u""},
+                                 OK, {u"Err": u""})
 
     def test_create_with_profile(self):
         """
@@ -320,6 +324,8 @@ class APITestsMixin(APIAssertionsMixin):
         """
         name = u"myvol"
         dataset_id = uuid4()
+        mount_id = ''.join(random.choice(
+            '0123456789abcdef') for n in xrange(64))
 
         # Create dataset on a different node:
         d = self.flocker_client.create_dataset(
@@ -337,7 +343,7 @@ class APITestsMixin(APIAssertionsMixin):
         d.addCallback(lambda _:
                       self.assertResult(
                           b"POST", b"/VolumeDriver.Mount",
-                          {u"Name": name}, OK,
+                          {u"Name": name, u"ID": unicode(mount_id)}, OK,
                           {u"Err": u"",
                            u"Mountpoint": u"/flocker/{}".format(dataset_id)}))
         d.addCallback(lambda _: self.flocker_client.list_datasets_state())
@@ -363,6 +369,8 @@ class APITestsMixin(APIAssertionsMixin):
         """
         name = u"myvol"
         dataset_id = uuid4()
+        mount_id = ''.join(random.choice(
+            '0123456789abcdef') for n in xrange(64))
         # Create dataset on a different node:
         d = self.flocker_client.create_dataset(
             self.NODE_B, int(DEFAULT_SIZE.to_Byte()),
@@ -379,7 +387,7 @@ class APITestsMixin(APIAssertionsMixin):
         d.addCallback(lambda _:
                       self.assertResult(
                           b"POST", b"/VolumeDriver.Mount",
-                          {u"Name": name}, OK,
+                          {u"Name": name, u"ID": unicode(mount_id)}, OK,
                           {u"Err": u"Timed out waiting for dataset to mount.",
                            u"Mountpoint": u""}))
         return d
@@ -392,6 +400,8 @@ class APITestsMixin(APIAssertionsMixin):
         don't have a special dataset ID.
         """
         name = u"myvol"
+        mount_id = ''.join(random.choice(
+            '0123456789abcdef') for n in xrange(64))
 
         d = self.flocker_client.create_dataset(
             self.NODE_A, int(DEFAULT_SIZE.to_Byte()),
@@ -401,7 +411,7 @@ class APITestsMixin(APIAssertionsMixin):
             self.flocker_client.synchronize_state()
             result = self.assertResult(
                 b"POST", b"/VolumeDriver.Mount",
-                {u"Name": name}, OK,
+                {u"Name": name, u"ID": unicode(mount_id)}, OK,
                 {u"Err": u"",
                  u"Mountpoint": u"/flocker/{}".format(
                      dataset.dataset_id)})
@@ -420,9 +430,11 @@ class APITestsMixin(APIAssertionsMixin):
         non-existent volume.
         """
         name = u"myvol"
+        mount_id = ''.join(random.choice(
+            '0123456789abcdef') for n in xrange(64))
         return self.assertResult(
             b"POST", b"/VolumeDriver.Mount",
-            {u"Name": name}, OK,
+            {u"Name": name, u"ID": unicode(mount_id)}, OK,
             {u"Err": u"Could not find volume with given name."})
 
     def test_path(self):


### PR DESCRIPTION
Because docker added IDs to Mount() / Unmount()

Right now we choose to do nothing with the ID but add it to our plugin layer so that calls will continue to work with docker 1.12

https://clusterhq.atlassian.net/browse/FLOC-4480
https://github.com/ClusterHQ/flocker/issues/2854