### PR TITLE
[FLOC-4489] Use detailed volume list and update to a version of mimic that supports that endpoint

### DIFF
--- a/flocker/node/agents/cinder.py
+++ b/flocker/node/agents/cinder.py
@@ -530,7 +530,7 @@ class CinderBlockDeviceAPI(object):
         http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/GET_getVolumesDetail_v1__tenant_id__volumes_detail_volumes.html
         """
         flocker_volumes = []
-        for cinder_volume in self.cinder_volume_manager.list(detailed=False):
+        for cinder_volume in self.cinder_volume_manager.list(detailed=True):
             if _is_cluster_volume(self.cluster_id, cinder_volume):
                 flocker_volume = _blockdevicevolume_from_cinder_volume(
                     cinder_volume

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -868,6 +868,7 @@ class CinderFromConfigurationTests(AsyncTestCase):
         (api
          .cinder_volume_manager
          ._original
+         ._client_v2
          ._cinder_volumes
          .api
          .client

--- a/requirements/flocker-dev.txt
+++ b/requirements/flocker-dev.txt
@@ -1,4 +1,5 @@
-mimic==2.1.0
+--find-links git+https://github.com/ClusterHQ/mimic@2.1.0+chq2#egg=mimic-2.1.0+chq2
+mimic==2.1.0+chq2
 # The test suite uses network namespaces
 # nomenclature can only be installed on Linux
 # The "linux2" marker value is specific to Python2

--- a/requirements/flocker-dev.txt.in
+++ b/requirements/flocker-dev.txt.in
@@ -1,3 +1,4 @@
+--find-links git+https://github.com/ClusterHQ/mimic@2.1.0+chq2#egg=mimic-2.1.0+chq2
 mimic
 # The test suite uses network namespaces
 # nomenclature can only be installed on Linux


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4489
Depends on: https://github.com/ClusterHQ/mimic/pull/1

I re-instated the use of detailed volume list.
This ensures that volume attachment information is returned, even when interacting with Cinder v2 API.

One of our tests attempts to hit the volumes/detail endpoint with a mimic based fake REST server.
So I also had to fork andupdate mimic to support that endpoint.

I'll post devstack based test results shortly.