### PR TITLE
[FLOC-4491] Close the Cinder client persistent connection instead of flaky monkey patching of the server side.

### DIFF
--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -842,7 +842,7 @@ class CinderFromConfigurationTests(AsyncTestCase):
         try:
             result = api.list_volumes()
         except ConnectFailure:
-            # Can't use self.asserRaises here because that would call the
+            # Can't use self.assertRaises here because that would call the
             # function in the main thread.
             pass
         else:
@@ -874,7 +874,7 @@ class CinderFromConfigurationTests(AsyncTestCase):
          .session
          .session.close())
 
-    def test_no_retry_authentication(self):
+    def test_retry_authentication(self):
         """
         The API object returned by ``cinder_from_configuration`` will retry
         authentication even when initial authentication attempts fail.


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4491

The original test monkey patches twisted.web.http, aiming to force the server to make all HTTP connections non-persistent.
The reason for that was to avoid lingering persistent  HTTPChannels  in the reactor after the test....leading to Unclean reactor errors in the test.
But that doesn't work because the client has negotiated a persistent connection and thinks it can re-use it.
The client interprets the empty response which results from server TCP RESET as a ``BadStatusLine`` and aborts the connection...but only if the RST is received slowly...after the client has sent a subsequent HTTP request.
I *think* that's why this test was especially flaky on my devstack environment where the host machine is over loaded and the network packets are delayed.

```
  File "/home/ubuntu/.venvs/4489/local/lib/python2.7/site-packages/keystoneclient/session.py", line 449, in _send_request
    raise exceptions.ConnectionRefused(msg)
keystoneauth1.exceptions.connection.ConnectFailure: Unable to establish connection to http://127.0.0.1:53813/mimicking/CinderApi-0ea185/ORD/v2/5062690
87629312/volumes/detail?limit=2. (ConnectionError(ProtocolError('Connection aborted.', BadStatusLine("''",)),))


flocker.node.agents.functional.test_cinder.CinderFromConfigurationTests.test_no_retry_authentication
-------------------------------------------------------------------------------
Ran 1 tests in 0.042s
```


The test now passes reliably (>1000) times on my devstack system

```
PASSED (successes=1)
Test Pass 1004
flocker.node.agents.functional.test_cinder
  CinderFromConfigurationTests
    test_no_retry_authentication ... Version 1 is deprecated, use alternative version 2 instead.
WARNING:cinderclient.api_versions:Version 1 is deprecated, use alternative version 2 instead.
Version 1 is deprecated, use alternative version 2 instead.
WARNING:cinderclient.api_versions:Version 1 is deprecated, use alternative version 2 instead.
                                      [OK]

-------------------------------------------------------------------------------
Ran 1 tests in 0.046s

PASSED (successes=1)
Test Pass 1005

```

Previously the test failed on the second attempt.