### PR TITLE
[FLOC-4495] Catch a circular call to cancel the AMP protocol inactivity timeout

### DIFF
--- a/flocker/control/_protocol.py
+++ b/flocker/control/_protocol.py
@@ -57,6 +57,7 @@ from twisted.protocols.amp import (
     Argument, Command, Integer, CommandLocator, AMP, Unicode,
     MAX_VALUE_LENGTH,
 )
+from twisted.internet.error import AlreadyCalled
 from twisted.internet.task import LoopingCall
 from twisted.internet.protocol import ServerFactory
 from twisted.application.internet import StreamServerEndpointService
@@ -350,7 +351,12 @@ class Timeout(object):
         """
         Cancel the delayed call to this ``Timeout``'s ``action``.
         """
-        self._delay_call.cancel()
+        try:
+            self._delay_call.cancel()
+        except AlreadyCalled:
+            # This Timeout may have triggered protocol.abortConnection which
+            # will attempt to cancel...this timeout...
+            pass
 
 
 class ControlServiceLocator(CommandLocator):


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4495

What seems to happen is that if a blocking agent operation takes too long, the AMP connection pings are not responded to this means that the unresponsive peer timeout is reached and the connection is aborted.
And in aborting the connection we attempt to cancel the timer....which has already fired.

Putting this up for review now, to see if it fixes the Ubuntu 14.04 errors and meanwhile I'll see if I can figure out a unit test for this.

This may have been caused by #2836
