### PR TITLE
[FLOC-4497] Move run_process to a public module

### DIFF
--- a/flocker/common/process.py
+++ b/flocker/common/process.py
@@ -1,0 +1,63 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Subprocess utilities.
+"""
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen
+
+from eliot import Message, start_action
+from pyrsistent import PClass, field
+
+
+class _CalledProcessError(CalledProcessError):
+    """
+    Just like ``CalledProcessError`` except output is included in the string
+    representation.
+    """
+    def __str__(self):
+        base = super(_CalledProcessError, self).__str__()
+        lines = "\n".join("    |" + line for line in self.output.splitlines())
+        return base + " and output:\n" + lines
+
+
+class _ProcessResult(PClass):
+    """
+    The return type for ``run_process`` representing the outcome of the process
+    that was run.
+    """
+    command = field(type=list, mandatory=True)
+    output = field(type=bytes, mandatory=True)
+    status = field(type=int, mandatory=True)
+
+
+def run_process(command, *args, **kwargs):
+    """
+    Run a child process, capturing its stdout and stderr.
+
+    :param list command: An argument list to use to launch the child process.
+
+    :raise CalledProcessError: If the child process has a non-zero exit status.
+
+    :return: A ``_ProcessResult`` instance describing the result of the child
+         process.
+    """
+    kwargs["stdout"] = PIPE
+    kwargs["stderr"] = STDOUT
+    action = start_action(
+        action_type="run_process", command=command, args=args, kwargs=kwargs)
+    with action:
+        process = Popen(command, *args, **kwargs)
+        output = process.stdout.read()
+        status = process.wait()
+        result = _ProcessResult(command=command, output=output, status=status)
+        # TODO: We should be using a specific logging type for this.
+        Message.new(
+            command=result.command,
+            output=result.output,
+            status=result.status,
+        ).write()
+        if result.status:
+            raise _CalledProcessError(
+                returncode=status, cmd=command, output=output,
+            )
+    return result

--- a/flocker/common/test/sample_script.py
+++ b/flocker/common/test/sample_script.py
@@ -1,0 +1,30 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+import os
+import sys
+
+from twisted.python.usage import Options
+
+
+class ScriptOptions(Options):
+    optParameters = [
+        ["returncode", None, None, "Exit with this status", int],
+        ["stdout", None, None, "Print this to stdout"],
+        ["stderr", None, None, "Print this to stderr"],
+    ]
+
+
+def main():
+    options = ScriptOptions()
+    options.parseOptions(sys.argv[1:])
+    sys.stdout.write(options["stdout"])
+    sys.stdout.flush()
+    sys.stderr.write(options["stderr"])
+    sys.stderr.flush()
+    returncode = options["returncode"]
+    if returncode < 0:
+        os.kill(os.getpid(), abs(returncode))
+    else:
+        return returncode
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/flocker/common/test/sample_script.py
+++ b/flocker/common/test/sample_script.py
@@ -1,6 +1,17 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+A script which is called by ``run_process`` in the ``test_process` module.
+The returncode, stdout and stderr can all be supplied as command line arguments
+so that we can test how ``run_process`` captures process output and how it
+behaves when sub-processes exit with different return codes.
+If the supplied returncode is < 0 the script will send that integer as a signal
+to its own PID.
+"""
+
 import os
 import sys
+import time
 
 from twisted.python.usage import Options
 
@@ -23,8 +34,8 @@ def main():
     returncode = options["returncode"]
     if returncode < 0:
         os.kill(os.getpid(), abs(returncode))
-    else:
-        return returncode
+        time.sleep(10)
+    return returncode
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/flocker/common/test/sample_script.py
+++ b/flocker/common/test/sample_script.py
@@ -6,7 +6,7 @@ The returncode, stdout and stderr can all be supplied as command line arguments
 so that we can test how ``run_process`` captures process output and how it
 behaves when sub-processes exit with different return codes.
 If the supplied returncode is < 0 the script will send that integer as a signal
-to its own PID.
+to its own PID and then sleep until we receive the signal.
 """
 
 import os
@@ -34,7 +34,8 @@ def main():
     returncode = options["returncode"]
     if returncode < 0:
         os.kill(os.getpid(), abs(returncode))
-        time.sleep(10)
+        # Sleep for a short time or until we receive the signal.
+        time.sleep(5)
     return returncode
 
 if __name__ == "__main__":

--- a/flocker/common/test/test_process.py
+++ b/flocker/common/test/test_process.py
@@ -5,39 +5,78 @@ Tests for ``flocker.common.runner``.
 from subprocess import CalledProcessError
 import sys
 
+from pyrsistent import PClass, field
 from twisted.python.filepath import FilePath
 
-from flocker.testtools import TestCase, random_name
-
+from ...testtools import TestCase, random_name
 from ..process import run_process, _ProcessResult
+
+SAMPLE_SCRIPT_FILE = FilePath(__file__).sibling('sample_script.py')
+
+
+class SampleScript(PClass):
+    """
+    The parameters which will be supplied when calling ``SAMPLE_SCRIPT_FILE``
+    in tests.
+    """
+    returncode = field(type=int)
+    stdout = field(type=bytes)
+    stderr = field(type=bytes)
+
+    def commandline(self):
+        """
+        :returns: A ``list`` suitable for passing to ``run_process`` in tests.
+        """
+        return [
+            sys.executable,
+            SAMPLE_SCRIPT_FILE.path,
+            "--returncode", bytes(self.returncode),
+            "--stdout", self.stdout,
+            "--stderr", self.stderr,
+        ]
 
 
 class RunProcessTests(TestCase):
+    """
+    Tests for ``run_process``.
+    """
+    def command_for_test(self, returncode):
+        return SampleScript(
+            returncode=returncode,
+            stdout=random_name(self).encode("utf8"),
+            stderr=random_name(self).encode("utf8"),
+        )
+
     def test_success(self):
         """
         ``run_process`` returns a `__ProcessResult`` object with the status,
         command and combined stdout and stderr if the exit status is 0.
         """
-        expected_returncode = 0
-        expected_stdout = random_name(self).encode("utf8")
-        expected_stderr = random_name(self).encode("utf8")
-        sample_script = FilePath(__file__).sibling('sample_script.py')
-        command = [
-            sys.executable,
-            sample_script.path,
-            "--returncode", bytes(expected_returncode),
-            "--stdout", expected_stdout,
-            "--stderr", expected_stderr,
-        ]
-        result = run_process(command)
+        command = self.command_for_test(returncode=0)
+        result = run_process(command.commandline())
         self.assertEqual(
             _ProcessResult(
-                command=command,
-                status=expected_returncode,
-                output=expected_stdout + expected_stderr,
+                command=command.commandline(),
+                status=command.returncode,
+                output=command.stdout + command.stderr,
             ),
             result
         )
+
+    def check_run_process_error(self, expected_returncode):
+        command = self.command_for_test(returncode=expected_returncode)
+        e = self.assertRaises(
+            CalledProcessError,
+            run_process,
+            command.commandline()
+        )
+        self.assertEqual(
+            (command.commandline(),
+             command.returncode,
+             command.stdout + command.stderr),
+            (e.cmd, e.returncode, e.output)
+        )
+        self.assertIn(command.stdout + command.stderr, unicode(e))
 
     def test_error(self):
         """
@@ -45,47 +84,11 @@ class RunProcessTests(TestCase):
         The string representation of the raised error includes the combined
         stdout and stderr.
         """
-        expected_returncode = 1
-        expected_stdout = random_name(self).encode("utf8")
-        expected_stderr = random_name(self).encode("utf8")
-        sample_script = FilePath(__file__).sibling('sample_script.py')
-        command = [
-            sys.executable,
-            sample_script.path,
-            "--returncode", bytes(expected_returncode),
-            "--stdout", expected_stdout,
-            "--stderr", expected_stderr,
-        ]
+        self.check_run_process_error(expected_returncode=1)
 
-        e = self.assertRaises(CalledProcessError, run_process, command)
-
-        self.assertEqual(
-            (command, expected_returncode, expected_stdout + expected_stderr),
-            (e.cmd, e.returncode, e.output)
-        )
-        self.assertIn(expected_stdout + expected_stderr, unicode(e))
-
-    def test_signal(self):
+    def test_error_signal(self):
         """
         ``run_process`` raises CalledProcessError when it exits due to a signal
         and the signal is included in the exception.
         """
-        expected_returncode = -1
-        expected_stdout = random_name(self).encode("utf8")
-        expected_stderr = random_name(self).encode("utf8")
-        sample_script = FilePath(__file__).sibling('sample_script.py')
-        command = [
-            sys.executable,
-            sample_script.path,
-            "--returncode", bytes(expected_returncode),
-            "--stdout", expected_stdout,
-            "--stderr", expected_stderr,
-        ]
-
-        e = self.assertRaises(CalledProcessError, run_process, command)
-
-        self.assertEqual(
-            (command, expected_returncode, expected_stdout + expected_stderr),
-            (e.cmd, e.returncode, e.output)
-        )
-        self.assertIn(expected_stdout + expected_stderr, unicode(e))
+        self.check_run_process_error(expected_returncode=-1)

--- a/flocker/common/test/test_process.py
+++ b/flocker/common/test/test_process.py
@@ -41,6 +41,11 @@ class RunProcessTests(TestCase):
     Tests for ``run_process``.
     """
     def command_for_test(self, returncode):
+        """
+        Construct a ``SampleScript`` which generates a command line for
+        ``SAMPLE_SCRIPT_FILE`` with test case specific stdout and stderr and
+        the supplied ``returncode``.
+        """
         return SampleScript(
             returncode=returncode,
             stdout=random_name(self).encode("utf8"),
@@ -64,6 +69,10 @@ class RunProcessTests(TestCase):
         )
 
     def check_run_process_error(self, expected_returncode):
+        """
+        Run ``SAMPLE_SCRIPT_FILE`` with ``run_process`` and assert that
+        ``CalledProcessError`` is raised.
+        """
         command = self.command_for_test(returncode=expected_returncode)
         e = self.assertRaises(
             CalledProcessError,

--- a/flocker/common/test/test_process.py
+++ b/flocker/common/test/test_process.py
@@ -1,0 +1,91 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Tests for ``flocker.common.runner``.
+"""
+from subprocess import CalledProcessError
+import sys
+
+from twisted.python.filepath import FilePath
+
+from flocker.testtools import TestCase, random_name
+
+from ..process import run_process, _ProcessResult
+
+
+class RunProcessTests(TestCase):
+    def test_success(self):
+        """
+        ``run_process`` returns a `__ProcessResult`` object with the status,
+        command and combined stdout and stderr if the exit status is 0.
+        """
+        expected_returncode = 0
+        expected_stdout = random_name(self).encode("utf8")
+        expected_stderr = random_name(self).encode("utf8")
+        sample_script = FilePath(__file__).sibling('sample_script.py')
+        command = [
+            sys.executable,
+            sample_script.path,
+            "--returncode", bytes(expected_returncode),
+            "--stdout", expected_stdout,
+            "--stderr", expected_stderr,
+        ]
+        result = run_process(command)
+        self.assertEqual(
+            _ProcessResult(
+                command=command,
+                status=expected_returncode,
+                output=expected_stdout + expected_stderr,
+            ),
+            result
+        )
+
+    def test_error(self):
+        """
+        ``run_process`` raises CalledProcessError when status !=0.
+        The string representation of the raised error includes the combined
+        stdout and stderr.
+        """
+        expected_returncode = 1
+        expected_stdout = random_name(self).encode("utf8")
+        expected_stderr = random_name(self).encode("utf8")
+        sample_script = FilePath(__file__).sibling('sample_script.py')
+        command = [
+            sys.executable,
+            sample_script.path,
+            "--returncode", bytes(expected_returncode),
+            "--stdout", expected_stdout,
+            "--stderr", expected_stderr,
+        ]
+
+        e = self.assertRaises(CalledProcessError, run_process, command)
+
+        self.assertEqual(
+            (command, expected_returncode, expected_stdout + expected_stderr),
+            (e.cmd, e.returncode, e.output)
+        )
+        self.assertIn(expected_stdout + expected_stderr, unicode(e))
+
+    def test_signal(self):
+        """
+        ``run_process`` raises CalledProcessError when it exits due to a signal
+        and the signal is included in the exception.
+        """
+        expected_returncode = -1
+        expected_stdout = random_name(self).encode("utf8")
+        expected_stderr = random_name(self).encode("utf8")
+        sample_script = FilePath(__file__).sibling('sample_script.py')
+        command = [
+            sys.executable,
+            sample_script.path,
+            "--returncode", bytes(expected_returncode),
+            "--stdout", expected_stdout,
+            "--stderr", expected_stderr,
+        ]
+
+        e = self.assertRaises(CalledProcessError, run_process, command)
+
+        self.assertEqual(
+            (command, expected_returncode, expected_stdout + expected_stderr),
+            (e.cmd, e.returncode, e.output)
+        )
+        self.assertIn(expected_stdout + expected_stderr, unicode(e))

--- a/flocker/common/test/test_process.py
+++ b/flocker/common/test/test_process.py
@@ -1,6 +1,6 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 """
-Tests for ``flocker.common.runner``.
+Tests for ``flocker.common.process``.
 """
 from subprocess import CalledProcessError
 import sys

--- a/flocker/testtools/__init__.py
+++ b/flocker/testtools/__init__.py
@@ -19,14 +19,13 @@ import shutil
 from functools import wraps
 from unittest import skipIf, skipUnless
 from StringIO import StringIO
-from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 
 from bitmath import MiB
 
 from pyrsistent import PClass, field
 
 from docker import Client as DockerClient
-from eliot import ActionType, Message, MessageType, start_action, fields
+from eliot import ActionType, MessageType, fields
 from eliot.twisted import DeferredContext
 
 from zope.interface import implementer
@@ -54,6 +53,9 @@ from ._flaky import flaky
 from .. import __version__
 from ..common import RACKSPACE_MINIMUM_VOLUME_SIZE
 from ..common.script import FlockerScriptRunner, ICommandLineScript
+from ..common.process import (
+    _ProcessResult, _CalledProcessError, run_process
+)
 
 __all__ = [
     'AsyncTestCase',
@@ -81,6 +83,7 @@ __all__ = [
     'make_with_init_tests',
     'not_root',
     'random_name',
+    # XXX Refactor code that imports run_process from here.
     'run_process',
     'skip_on_broken_permissions',
 ]
@@ -864,27 +867,6 @@ PROCESS_ENDED = MessageType(
     u'The process terminated')
 
 
-class _ProcessResult(PClass):
-    """
-    The return type for ``run_process`` representing the outcome of the process
-    that was run.
-    """
-    command = field(type=list, mandatory=True)
-    output = field(type=bytes, mandatory=True)
-    status = field(type=int, mandatory=True)
-
-
-class _CalledProcessError(CalledProcessError):
-    """
-    Just like ``CalledProcessError`` except output is included in the string
-    representation.
-    """
-    def __str__(self):
-        base = super(_CalledProcessError, self).__str__()
-        lines = "\n".join("    |" + line for line in self.output.splitlines())
-        return base + " and output:\n" + lines
-
-
 class _LoggingProcessProtocol(ProcessProtocol):
     """
     A ``ProcessProtocol`` that both stores and logs output from the
@@ -958,36 +940,3 @@ def logged_run_process(reactor, command):
         d2.addCallback(process_ended)
         d2.addActionFinish()
         return d2.result
-
-
-def run_process(command, *args, **kwargs):
-    """
-    Run a child process, capturing its stdout and stderr.
-
-    :param list command: An argument list to use to launch the child process.
-
-    :raise CalledProcessError: If the child process has a non-zero exit status.
-
-    :return: A ``_ProcessResult`` instance describing the result of the child
-         process.
-    """
-    kwargs["stdout"] = PIPE
-    kwargs["stderr"] = STDOUT
-    action = start_action(
-        action_type="run_process", command=command, args=args, kwargs=kwargs)
-    with action:
-        process = Popen(command, *args, **kwargs)
-        output = process.stdout.read()
-        status = process.wait()
-        result = _ProcessResult(command=command, output=output, status=status)
-        # TODO: We should be using a specific logging type for this.
-        Message.new(
-            command=result.command,
-            output=result.output,
-            status=result.status,
-        ).write()
-        if result.status:
-            raise _CalledProcessError(
-                returncode=status, cmd=command, output=output,
-            )
-    return result


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4497

I need this for running the mount and blkid commands in  #2908

We can also use this in block_device_manager which has its own, less useful sub process runner.