### PR TITLE
[FLOC-4501] Skip upgrade tests on Openstack backends

### DIFF
--- a/flocker/acceptance/endtoend/test_dataset.py
+++ b/flocker/acceptance/endtoend/test_dataset.py
@@ -102,9 +102,14 @@ class DatasetAPITests(AsyncTestCase):
         ),
     )
     @skip_backend(
-        unsupported={backends.LOOPBACK},
-        reason="Does not maintain compute_instance_id across restarting "
-               "flocker (and didn't as of most recent release).")
+        unsupported={backends.LOOPBACK, backends.OPENSTACK},
+        reason=(
+            "Loopback backend does not maintain compute_instance_id across "
+            "restarting flocker (and didn't as of most recent release). "
+            "OpenStack backend (as of 1.15.0) cannot reliably identify "
+            "the compute node if it has floating IP addresses."
+        )
+    )
     @run_test_with(async_runner(timeout=timedelta(minutes=6)))
     @require_cluster(1)
     def test_upgrade(self, cluster):


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4501

``test_upgrade`` downgrades to a version of Flocker where `compute_instance_id` fails because it can't deal with floating IP addresses on  Rackspace + Ubuntu 14.04.

The test times out and Flocker is never upgraded again and all remaining tests time out.

Once we've released 1.16.0 we can re-enable this test and also remove the skip for Ubuntu 16.04