### PR TITLE
[FLOC-4507] Disallow installation of pycparser wheel file. 

### DIFF
--- a/admin/packaging.py
+++ b/admin/packaging.py
@@ -679,6 +679,11 @@ IGNORED_WARNINGS = {
         # Cryptography hazmat bindings
         'package-installs-python-pycache-dir opt/flocker/lib/python2.7/site-packages/cryptography/hazmat/bindings/__pycache__/',  # noqa
 
+        # Pycparser is installed from an sdist as of FLOC-4507 which seems to
+        # result in these cache directories.
+        'package-installs-python-pycache-dir opt/flocker/lib/python2.7/site-packages/pycparser/__pycache__/',  # noqa
+        'package-installs-python-pycache-dir opt/flocker/lib/python2.7/site-packages/pycparser/ply/__pycache__/',  # noqa
+
         # files included by netaddr - we put the whole python we need in the
         # flocker package, and lint complains. See:
         # https://lintian.debian.org/tags/package-installs-ieee-data.html

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,7 @@
+# Do not install the broken pycparser-2.14-py2.py3-none-any.whl
+# Workaround for:
+# https://github.com/eliben/pycparser/issues/148
+--no-binary pycparser
 # Install everything required for local development.
 --requirement requirements/all.txt
 --editable .

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,3 +1,7 @@
+# Do not install the broken pycparser-2.14-py2.py3-none-any.whl
+# Workaround for:
+# https://github.com/eliben/pycparser/issues/148
+--no-binary pycparser
 # awscli has very specific colarama requirements while pylint doesn't
 colorama<=0.3.3,>=0.2.5
 # docker-py requirement since https://github.com/docker/docker-py/pull/1127


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4507
Workaround for: https://github.com/eliben/pycparser/issues/148

This is a quick fix.

Long term we should:
 * Include hashes in our requirements files - so that pip wouldn't even attempt to install the broken file.
 * Monitor: https://github.com/pypa/pip/issues/3996 which would make pip not attempt to install the wheel file if the hash was for an sdist.
 * Have our own wheelhouse of verified dependencies and only install from there.