### PR TITLE
[FLOC-4528] Remove zendesk from flocker-docs

### DIFF
--- a/docs/_themes/clusterhq/layout_docs.html
+++ b/docs/_themes/clusterhq/layout_docs.html
@@ -41,11 +41,6 @@
     </script>
     <link rel="top" title="{{ docstitle|e }}" href="{{ pathto('index') }}"/>
 
-    <!-- Snippet from https://clusterhq.zendesk.com/agent/apps/zopim-chat -->
-    <!-- Start of clusterhq Zendesk Widget script -->
-    <script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(c){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var o=this.createElement("script");n&&(this.domain=n),o.id="js-iframe-async",o.src=e,this.t=+new Date,this.zendeskHost=t,this.zEQueue=a,this.body.appendChild(o)},o.write('<body onload="document._l();">'),o.close()}("//assets.zendesk.com/embeddable_framework/main.js","clusterhq.zendesk.com");/*]]>*/</script>
-    <!-- End of clusterhq Zendesk Widget script -->
-
     <link rel="shortcut icon" href="https://clusterhq.com/assets/favicon.ico"/>
     <!-- Algolia doc search -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4528

(cherry picked from commit dd96abaf946f489cb676ffa67e522b340d3d2267)

Replaces: #2944

Rendered docs: http://clusterhq-staging-docs.s3-website-us-east-1.amazonaws.com/release-maintenance/flocker-1.15.0/remove-zendesk-FLOC-4528/