### PR TITLE
[FLOC-4530] Pass the swappiness configuration value to the Docker API

### DIFF
--- a/flocker/node/_container.py
+++ b/flocker/node/_container.py
@@ -111,6 +111,7 @@ class StartApplication(PClass):
             # The only supported policy is "never".  See FLOC-2449.
             restart_policy=RestartNever(),
             command_line=application.command_line,
+            swappiness=application.swappiness,
         )
 
 

--- a/flocker/node/_container.py
+++ b/flocker/node/_container.py
@@ -316,6 +316,7 @@ class ApplicationNodeDeployer(object):
                 restart_policy=container.restart_policy,
                 running=(container.activation_state == u"active"),
                 command_line=container.command_line,
+                swappiness=container.swappiness,
             ))
         return applications
 

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -724,10 +724,6 @@ class DockerClient(object):
             if command_line_values is not None:
                 command_line_values = list(command_line_values)
 
-            memswap_limit = -1
-            if swappiness != 0:
-                memswap_limit = mem_limit + mem_limit * swappiness
-
             self._client.create_container(
                 name=container_name,
                 image=image_name,
@@ -737,7 +733,6 @@ class DockerClient(object):
                 mem_limit=mem_limit,
                 cpu_shares=cpu_shares,
                 host_config=host_config,
-                memswap_limit=memswap_limit,
             )
 
         def _add():

--- a/flocker/node/_docker.py
+++ b/flocker/node/_docker.py
@@ -717,6 +717,7 @@ class DockerClient(object):
                 binds=binds,
                 port_bindings=port_bindings,
                 restart_policy=restart_policy_dict,
+                mem_limit=mem_limit,
                 mem_swappiness=swappiness,
             )
             # We're likely to get e.g. pvector, so make sure we're passing
@@ -731,7 +732,6 @@ class DockerClient(object):
                 command=command_line_values,
                 environment=environment,
                 ports=[p.internal_port for p in ports],
-                mem_limit=mem_limit,
                 cpu_shares=cpu_shares,
                 host_config=host_config,
             )

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -371,8 +371,8 @@ class DeployerTests(AsyncTestCase):
     @if_docker_configured
     def test_swappiness_introspection(self):
         """
-        The swappiness value discovered by the ApplicationDeployer is the same
-        as was passed in.
+        The swappiness value discovered by the ``ApplicationDeployer`` is the
+        same as was passed in.
         """
         swappiness = 98
         d = self._start_container_for_introspection(swappiness=swappiness)

--- a/flocker/node/functional/test_deploy.py
+++ b/flocker/node/functional/test_deploy.py
@@ -369,6 +369,21 @@ class DeployerTests(AsyncTestCase):
         return d
 
     @if_docker_configured
+    def test_swappiness_introspection(self):
+        """
+        The swappiness value discovered by the ApplicationDeployer is the same
+        as was passed in.
+        """
+        swappiness = 98
+        d = self._start_container_for_introspection(swappiness=swappiness)
+        d.addCallback(
+            lambda results: self.assertEqual(
+                [swappiness],
+                [app.swappiness for app in
+                 results.node_state.applications.values()]))
+        return d
+
+    @if_docker_configured
     def test_memory_limit(self):
         """
         The memory limit number specified in an ``Application`` is passed to

--- a/flocker/node/test/test_container.py
+++ b/flocker/node/test/test_container.py
@@ -460,6 +460,34 @@ class StartApplicationTests(TestCase):
             pvector(command_line),
         )
 
+    def test_swappiness(self):
+        """
+        ``StartApplication.run()`` passes ``swappiness`` to
+        ``DockerClient.add`` which is used when creating a Unit.
+        """
+        expected_swappiness = 99
+        fake_docker = FakeDockerClient()
+        deployer = ApplicationNodeDeployer(u'example.com', fake_docker)
+
+        application_name = u'site-example.com'
+        application = Application(
+            name=application_name,
+            image=DockerImage(repository=u'clusterhq/postgresql',
+                              tag=u'9.3.5'),
+            swappiness=expected_swappiness,
+        )
+
+        StartApplication(
+            application=application,
+            node_state=EMPTY_NODESTATE,
+        ).run(deployer, state_persister=InMemoryStatePersister())
+
+        [unit] = self.successResultOf(fake_docker.list())
+        self.assertEqual(
+            expected_swappiness,
+            unit.swappiness,
+        )
+
 
 class LinkEnviromentTests(TestCase):
     """

--- a/flocker/node/test/test_container.py
+++ b/flocker/node/test/test_container.py
@@ -705,6 +705,17 @@ class ApplicationNodeDeployerDiscoverNodeConfigurationTests(
         applications = [APP.set("memory_limit", memory_limit)]
         self._verify_discover_state_applications(units, applications)
 
+    def test_discover_application_with_swappiness(self):
+        """
+        An ``Application`` with a swappiness value is discovered from a
+        ``Unit`` with a swappiness value.
+        """
+        swappiness = 99
+        unit1 = UNIT_FOR_APP.set("swappiness", swappiness)
+        units = {unit1.name: unit1}
+        applications = [APP.set("swappiness", swappiness)]
+        self._verify_discover_state_applications(units, applications)
+
     def test_discover_application_with_environment(self):
         """
         An ``Application`` with ``Environment`` objects is discovered from a


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4530

In https://github.com/ClusterHQ/flocker/pull/2818 we added swappiness parameter to the container API but the implementation wasn't complete.
The swappiness was not passed through to the Docker API.
And the swappiness was not inspected by the ApplicationDeployer.

This branch adds that missing piece and a functional test that demonstrates that swappiness is set and discovered.