### PR TITLE
[FLOC-4533] Pipe tox output directly to file

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -692,7 +692,7 @@ common_cli:
       s3://clusterhq-staging-docs/master s3://doc-dev.clusterhq.com
 
   run_lint: &run_lint |
-    tox -e lint | tee lint.txt
+    tox -e lint > lint.txt
 
 #-----------------------------------------------------------------------------#
 # Job Definitions below this point

--- a/flocker/node/agents/functional/test_cinder.py
+++ b/flocker/node/agents/functional/test_cinder.py
@@ -1155,7 +1155,7 @@ def webserver_for_test(test, url_path, response_content):
     app = Klein()
 
     @app.route(url_path)
-    def respond(request):
+    def _respond(request):
         return response_content
     factory = Site(app.resource())
     endpoint = serverFromString(reactor, b"tcp:0")


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4533

In #2928 I changed the lint builder to use tox and pipe the output to a file so that the output is visible both in the console output and in an archived build result.

Problem is that the build step always exits with the return code of the tee command rather than the tox command.

Here's an example:
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/master/view/code_quality/job/run_lint/lastSuccessfulBuild/artifact/lint.txt/*view*/

There are some bash specific tricks to have the pipeline fail with the exit code of the first failing command:
 * http://www.tldp.org/LDP/abs/html/bashver3.html#PIPEFAILREF

...and to get the exit code of each pipeline component:
 * http://www.tldp.org/LDP/abs/html/internalvariables.html#PIPESTATUSREF

I decided to keep it simple.