### PR TITLE
[FLOC-4486] Retry apt-get operations

### DIFF
--- a/admin/installer/cloudformation.py
+++ b/admin/installer/cloudformation.py
@@ -272,8 +272,7 @@ def flocker_docker_template(cluster_size, client_ami_map, node_ami_map):
         'stack_name="', Ref("AWS::StackName"), '"\n',
         'volumehub_token="', Ref(volumehub_token), '"\n',
         'node_count="{}"\n'.format(cluster_size),
-        'apt-get update\n',
-    ]
+    ] + _sibling_lines("common.sh")
 
     # XXX Flocker agents are indexed from 1 while the nodes overall are indexed
     # from 0.

--- a/admin/installer/cloudformation.py
+++ b/admin/installer/cloudformation.py
@@ -272,7 +272,9 @@ def flocker_docker_template(cluster_size, client_ami_map, node_ami_map):
         'stack_name="', Ref("AWS::StackName"), '"\n',
         'volumehub_token="', Ref(volumehub_token), '"\n',
         'node_count="{}"\n'.format(cluster_size),
-    ] + _sibling_lines("common.sh")
+    ] + _sibling_lines("common.sh") + [
+        'retry_command apt-get update\n'
+    ]
 
     # XXX Flocker agents are indexed from 1 while the nodes overall are indexed
     # from 0.

--- a/admin/installer/cloudformation.py
+++ b/admin/installer/cloudformation.py
@@ -272,8 +272,9 @@ def flocker_docker_template(cluster_size, client_ami_map, node_ami_map):
         'stack_name="', Ref("AWS::StackName"), '"\n',
         'volumehub_token="', Ref(volumehub_token), '"\n',
         'node_count="{}"\n'.format(cluster_size),
+        'set -ex\n',
     ] + _sibling_lines("common.sh") + [
-        'retry_command apt-get update\n'
+        'retry_command apt-get update\n',
     ]
 
     # XXX Flocker agents are indexed from 1 while the nodes overall are indexed

--- a/admin/installer/common.sh
+++ b/admin/installer/common.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Shared helper functions.
+#
+# set -ex
+
+# Retry a command line until it succeeds.
+# With a delay between attempts and a limited number of attempts.
+
+RETRY_COMMAND_SLEEP_INTERVAL=5
+RETRY_COMMAND_RETRY_LIMIT=5
+
+function retry_command () {
+    local count=0
+    local last_return_code=1
+    echo "RETRY_COMMAND_SLEEP_INTERVAL=${RETRY_COMMAND_SLEEP_INTERVAL}" >&2
+    echo "RETRY_COMMAND_RETRY_LIMIT=${RETRY_COMMAND_RETRY_LIMIT}" >&2
+
+    while true; do
+        count=$((count+1))
+        "${@}"
+        last_return_code=$?
+        if [[ "${last_return_code}" -eq 0 ]]; then
+            return 0
+        fi
+        if [[ "${count}" -eq "${RETRY_COMMAND_RETRY_LIMIT}" ]]; then
+            break
+        fi
+
+        echo "RETRY_COMMAND: command '${@}' failed with exit_code '${last_return_code}'" >&2
+        echo "RETRY_COMMAND: failure_count: ${count}"
+        echo "RETRY_COMMAND: sleeping for ${RETRY_COMMAND_SLEEP_INTERVAL}s" >&2
+        sleep "${RETRY_COMMAND_SLEEP_INTERVAL}"
+    done
+    echo "RETRY_COMMAND: stopping after '${RETRY_COMMAND_RETRY_LIMIT}' failed attempts" >&2
+    return ${last_return_code}
+}

--- a/admin/installer/common.sh
+++ b/admin/installer/common.sh
@@ -7,7 +7,7 @@
 # With a delay between attempts and a limited number of attempts.
 
 RETRY_COMMAND_SLEEP_INTERVAL=5
-RETRY_COMMAND_RETRY_LIMIT=5
+RETRY_COMMAND_RETRY_LIMIT=10
 
 function retry_command () {
     local count=0

--- a/admin/installer/common.sh
+++ b/admin/installer/common.sh
@@ -24,7 +24,7 @@ function retry_command () {
             last_return_code=$?
         fi
         echo "RETRY_COMMAND: command '${@}' failed with exit_code '${last_return_code}'" >&2
-        echo "RETRY_COMMAND: failure_count: ${count}"
+        echo "RETRY_COMMAND: failure_count: ${count}" >&2
         if [[ "${count}" -eq "${RETRY_COMMAND_RETRY_LIMIT}" ]]; then
             break
         fi

--- a/admin/installer/common.sh
+++ b/admin/installer/common.sh
@@ -2,7 +2,6 @@
 #
 # Shared helper functions.
 #
-# set -ex
 
 # Retry a command line until it succeeds.
 # With a delay between attempts and a limited number of attempts.
@@ -18,20 +17,19 @@ function retry_command () {
 
     while true; do
         count=$((count+1))
-        "${@}"
-        last_return_code=$?
-        if [[ "${last_return_code}" -eq 0 ]]; then
+        if "${@}"; then
             return 0
+        else
+            last_return_code=$?
         fi
+        echo "RETRY_COMMAND: command '${@}' failed with exit_code '${last_return_code}'" >&2
+        echo "RETRY_COMMAND: failure_count: ${count}"
         if [[ "${count}" -eq "${RETRY_COMMAND_RETRY_LIMIT}" ]]; then
             break
         fi
-
-        echo "RETRY_COMMAND: command '${@}' failed with exit_code '${last_return_code}'" >&2
-        echo "RETRY_COMMAND: failure_count: ${count}"
         echo "RETRY_COMMAND: sleeping for ${RETRY_COMMAND_SLEEP_INTERVAL}s" >&2
         sleep "${RETRY_COMMAND_SLEEP_INTERVAL}"
     done
-    echo "RETRY_COMMAND: stopping after '${RETRY_COMMAND_RETRY_LIMIT}' failed attempts" >&2
+    echo "RETRY_COMMAND: stopping after '${count}' failed attempts" >&2
     return ${last_return_code}
 }

--- a/admin/installer/common.sh
+++ b/admin/installer/common.sh
@@ -2,6 +2,7 @@
 #
 # Shared helper functions.
 #
+set -ex
 
 # Retry a command line until it succeeds.
 # With a delay between attempts and a limited number of attempts.

--- a/admin/installer/docker-swarm-ca-setup.sh
+++ b/admin/installer/docker-swarm-ca-setup.sh
@@ -5,7 +5,7 @@ set -ex
 : ${s3_bucket:?}
 
 # Get expect to autofill openssl inputs
-sudo apt-get install -y expect
+retry_command apt-get install -y expect
 
 PASSPHRASE=$(dd bs=18 count=1 if=/dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 

--- a/admin/installer/setup_client.sh
+++ b/admin/installer/setup_client.sh
@@ -9,8 +9,7 @@ UBUNTU_HOME="/home/ubuntu"
 SUCCESS_SIGNAL_URL="http://check.clusterhq.com/cloudformation-complete.txt"
 
 # Get Postgres image.
-apt-get update
-sudo apt-get install -y postgresql-client
+retry_command apt-get install -y postgresql-client
 
 # Get docker-compose.
 curl -L https://github.com/docker/compose/releases/download/1.7.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
@@ -30,7 +29,7 @@ s3cmd_wrapper get --force --config=/root/.s3cfg s3://${s3_bucket}/docker-swarm-t
 PASSPHRASE=`eval cat ${DOCKER_CERT_HOME}/passphrase.txt`
 
 # Get expect to autofill openssl inputs.
-sudo apt-get install -y expect
+retry_command apt-get install -y expect
 
 # Generate Docker Swarm client certificates.
 pushd ${DOCKER_CERT_HOME}

--- a/admin/installer/setup_docker.sh
+++ b/admin/installer/setup_docker.sh
@@ -6,7 +6,7 @@ set -ex
 : ${s3_bucket:?}
 
 # Get expect to autofill openssl inputs.
-sudo apt-get install -y expect
+retry_command apt-get install -y expect
 
 # Get CA from S3 bucket.
 DOCKER_CERT_HOME="/root/.docker"

--- a/admin/installer/setup_s3.sh
+++ b/admin/installer/setup_s3.sh
@@ -12,13 +12,10 @@ access_key = ${access_key_id}
 secret_key = ${secret_access_key}
 EOF
 
-apt-get -y install s3cmd
+retry_command apt-get --yes install s3cmd
 
 # Wrapper around S3 command to allow retry until
 # bucket of interest is available and populated.
-s3cmd_wrapper ()
-{
-    while ! /usr/bin/s3cmd --force $@; do
-        sleep 5
-    done
+s3cmd_wrapper () {
+    retry_command /usr/bin/s3cmd --force $@
 }

--- a/admin/installer/setup_swarm_manager.sh
+++ b/admin/installer/setup_swarm_manager.sh
@@ -11,10 +11,10 @@ DOCKER_CERT_HOME='/root/.docker'
 # Create Swarm cluster, and publish Swarm cluster ID to S3 bucket.
 rm -rf /tmp/swarm-config
 mkdir -p /tmp/swarm-config
-docker pull swarm:1.2.3
-docker run --rm -v ${DOCKER_CERT_HOME}:${DOCKER_CERT_HOME} swarm:1.2.3 create > /tmp/swarm-config/swarm_cluster_id
+docker pull swarm:1.2.5
+docker run --rm -v ${DOCKER_CERT_HOME}:${DOCKER_CERT_HOME} swarm:1.2.5 create > /tmp/swarm-config/swarm_cluster_id
 /usr/bin/s3cmd put --config=/root/.s3cfg --recursive /tmp/swarm-config/ s3://${s3_bucket}/swarm-config/
 
 # Start Swarm Manager.
 swarm_cluster_id=$(cat /tmp/swarm-config/swarm_cluster_id)
-docker run -d -v ${DOCKER_CERT_HOME}:${DOCKER_CERT_HOME} -p 2376:2375 swarm:1.2.3 manage --tlsverify --tlscacert=${DOCKER_CERT_HOME}/ca.pem --tlskey=${DOCKER_CERT_HOME}/key.pem --tlscert=${DOCKER_CERT_HOME}/cert.pem token://$swarm_cluster_id
+docker run -d -v ${DOCKER_CERT_HOME}:${DOCKER_CERT_HOME} -p 2376:2375 swarm:1.2.5 manage --tlsverify --tlscacert=${DOCKER_CERT_HOME}/ca.pem --tlskey=${DOCKER_CERT_HOME}/key.pem --tlscert=${DOCKER_CERT_HOME}/cert.pem token://$swarm_cluster_id

--- a/admin/installer/setup_swarm_node.sh
+++ b/admin/installer/setup_swarm_node.sh
@@ -10,5 +10,5 @@ DOCKER_CERT_HOME='/root/.docker'
 swarm_cluster_id=$(s3cmd_wrapper get --config=/root/.s3cfg s3://${s3_bucket}/swarm-config/swarm_cluster_id -)
 
 # Start the Swarm node.
-docker pull swarm:1.2.3
-docker run -d -v ${DOCKER_CERT_HOME}:${DOCKER_CERT_HOME} swarm:1.2.3 join --addr=$(/usr/bin/ec2metadata --public-ipv4):2375 token://$swarm_cluster_id
+docker pull swarm:1.2.5
+docker run -d -v ${DOCKER_CERT_HOME}:${DOCKER_CERT_HOME} swarm:1.2.5 join --addr=$(/usr/bin/ec2metadata --public-ipv4):2375 token://$swarm_cluster_id

--- a/admin/test/test_installer.py
+++ b/admin/test/test_installer.py
@@ -35,7 +35,7 @@ POSTGRESQL_PORT = 5432
 POSTGRESQL_USERNAME = 'flocker'
 POSTGRESQL_PASSWORD = 'flocker'
 
-CLOUDFORMATION_TEMPLATE_URL = "https://s3.amazonaws.com/installer.downloads.clusterhq.com/flocker-cluster.cloudformation.json"  # noqa
+CLOUDFORMATION_TEMPLATE_URL = "https://s3.amazonaws.com/installer.downloads.clusterhq.com/flocker-cluster.cloudformation.1.15.0.json"  # noqa
 
 
 def remote_command(client_ip, command):


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4486

I've wrapped the apt-get commands with a retry function.

I rebuilt new cloudformation AMIs with Flocker 1.15.0 pre-installed and the latest versions of Docker and Swarm.
According to "Update the CloudFormation installer template." in https://flocker-docs.clusterhq.com/en/latest/gettinginvolved/infrastructure/release-process.html#release

```
(1.15.0) richard@richardw-pet-ubuntu1604:~/flocker$ jq < ami_map_docker.json 
{
  "us-east-1": "ami-b8f6c4af",
  "ap-northeast-1": "ami-d4e553b5",
  "ap-southeast-2": "ami-de97a9bd",
  "sa-east-1": "ami-a58618c9",
  "ap-southeast-1": "ami-7d11b31e",
  "ap-northeast-2": "ami-25c1164b",
  "us-west-2": "ami-8d248bed",
  "us-west-1": "ami-1482d674",
  "eu-central-1": "ami-b74480d8",
  "eu-west-1": "ami-f7085784"
}
(1.15.0) richard@richardw-pet-ubuntu1604:~/flocker$ jq < ami_map_flocker.json 
{
  "us-east-1": "ami-68f7c57f",
  "ap-northeast-1": "ami-6bef590a",
  "ap-southeast-2": "ami-3b92ac58",
  "sa-east-1": "ami-2950ce45",
  "ap-southeast-1": "ami-e311b380",
  "ap-northeast-2": "ami-c9cf18a7",
  "us-west-2": "ami-bd228ddd",
  "us-west-1": "ami-a583d7c5",
  "eu-central-1": "ami-4f418520",
  "eu-west-1": "ami-0a0a5579"
}

```

Then rebuilt the cloudformation template from this branch:
 * https://s3.amazonaws.com/installer.downloads.clusterhq.com/flocker-cluster.cloudformation.1.15.0.json