### PR TITLE
[FLOC-4542] Convert --rest-api-port to integrer in the flocker-docker-plugin 

### DIFF
--- a/flocker/dockerplugin/_script.py
+++ b/flocker/dockerplugin/_script.py
@@ -31,7 +31,7 @@ class DockerPluginOptions(Options):
     """
     optParameters = [
         ["rest-api-port", "p", REST_API_PORT,
-         "Port to connect to for control service REST API."],
+         "Port to connect to for control service REST API.", int],
         ["agent-config", "c", "/etc/flocker/agent.yml",
          "The configuration file for the local agent."],
     ]

--- a/flocker/dockerplugin/test/test_script.py
+++ b/flocker/dockerplugin/test/test_script.py
@@ -7,7 +7,21 @@ Unit tests for the Docker plugin script.
 from twisted.python.filepath import FilePath
 
 from ...testtools import TestCase
-from .._script import DockerPluginScript
+from .._script import DockerPluginScript, DockerPluginOptions
+
+
+class DockerPluginOptionsTests(TestCase):
+    """
+    Tests for ``DockerPluginOptions``.
+    """
+    def test_rest_api_port(self):
+        """
+        --rest-api-port is coerced to integer.
+        """
+        expected_port = 1234
+        options = DockerPluginOptions()
+        options.parseOptions([b"--rest-api-port=%s" % (expected_port,)])
+        self.assertEquals(expected_port, options["rest-api-port"])
 
 
 class DockerPluginScriptTests(TestCase):


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4542