### PR TITLE
[FLOC-4546] Run all the flocker unit tests on a single build slave

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -759,22 +759,7 @@ common_cli:
 run_trial_modules: &run_trial_modules
   - admin
   - benchmark
-  - flocker.acceptance.test
-  - flocker.apiclient
-  - flocker.ca.functional
-  - flocker.ca.test
-  - flocker.cli
-  - flocker.common
-  - flocker.control
-  - flocker.docs
-  - flocker.dockerplugin
-  - flocker.node.test
-  - flocker.node.functional.test_script
-  - flocker.node.functional.test_deploy
-  - flocker.provision
-  - flocker.restapi
-  - flocker.test
-  - flocker.testtools
+  - flocker
 run_trial_as_root_modules: &run_trial_as_root_modules
   # journald access requires root
   - flocker.common.functional

--- a/flocker/volume/test/test_filesystems_zfs.py
+++ b/flocker/volume/test/test_filesystems_zfs.py
@@ -19,7 +19,7 @@ from eliot.testing import (
 
 from ...testtools import (
     FakeProcessReactor, assert_equal_comparison, assert_not_equal_comparison,
-    TestCase,
+    TestCase, if_root
 )
 
 from ..filesystems.zfs import (
@@ -191,6 +191,9 @@ class SyncCommandTests(TestCase):
     """
     Tests for ``_sync_command_error_squashed``.
     """
+    # On Centos-7, and if run as a non-root the error message is "permission
+    # denied" rather than "no such file"
+    @if_root
     @validateLogging(no_such_executable_logged)
     def test_no_such_executable(self, logger):
         """


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4546

This makes all the flocker unit tests run in a single VM for each of our supported platforms.
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/fewer-build-slaves-FLOC-4546/view/CentOS_7/job/run_trial_on_AWS_CentOS_7_flocker/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/fewer-build-slaves-FLOC-4546/view/Ubuntu_Xenial_16_04/job/run_trial_on_AWS_Ubuntu_Xenial_flocker/
 * http://ci-live.clusterhq.com:8080/job/ClusterHQ-flocker/job/fewer-build-slaves-FLOC-4546/view/Ubuntu_Trusty_14_04_LTS/job/run_trial_on_AWS_Ubuntu_Trusty_flocker/

The unittest builds now take 18-22 minutes but that's still much less than the loopback acceptance tests so it doesn't change the overall build time.

The advantage is that fewer build slaves have to be created (which is slow) and the build results are less cluttered and hopefully with fewer build slaves to manage, Jenkins will manage the remaining build slaves more reliably i.e fewer "slave went offline" errors.