### PR TITLE
[FLOC-4548] SQL configuration store

### DIFF
--- a/flocker/apiclient/test/test_client.py
+++ b/flocker/apiclient/test/test_client.py
@@ -717,7 +717,8 @@ class FlockerClientTests(make_clientv1_tests()):
         clock = Clock()
         _, self.port = find_free_port()
         self.persistence_service = ConfigurationPersistenceService(
-            clock, FilePath(self.mktemp()))
+            reactor=clock,
+        )
         self.persistence_service.startService()
         self.cluster_state_service = ClusterStateService(reactor)
         self.cluster_state_service.startService()

--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -595,13 +595,17 @@ class ConfigurationPersistenceService(MultiService):
     """
     logger = Logger()
 
-    def __init__(self, reactor, store, deployment=None):
+    def __init__(self, reactor, store=None, deployment=None):
         """
         :param reactor: Reactor to use for thread pool.
         :param IConfigurationStore store: An already initialized
-            IConfigurationStore implementer.
+            IConfigurationStore implementer. Defaults to an in memory store.
+        :param Deployment deployment: The initial deployment.
         """
         MultiService.__init__(self)
+        if store is None:
+            from .configuration_store.testtools import MemoryConfigurationStore
+            store = MemoryConfigurationStore()
         self._store = store
         if deployment is None:
             deployment = Deployment()

--- a/flocker/control/_persistence.py
+++ b/flocker/control/_persistence.py
@@ -13,6 +13,7 @@ from uuid import UUID
 from collections import Set, Mapping, Iterable
 
 from eliot import Logger, write_traceback, MessageType, Field, ActionType
+from eliot.twisted import DeferredContext
 
 from pyrsistent import PRecord, PVector, PMap, PSet, pmap, PClass
 
@@ -594,96 +595,73 @@ class ConfigurationPersistenceService(MultiService):
     """
     logger = Logger()
 
-    def __init__(self, reactor, path):
+    def __init__(self, reactor, store, deployment=None):
         """
         :param reactor: Reactor to use for thread pool.
-        :param FilePath path: Directory where desired deployment will be
-            persisted.
+        :param IConfigurationStore store: An already initialized
+            IConfigurationStore implementer.
         """
         MultiService.__init__(self)
-        self._path = path
-        self._config_path = self._path.child(b"current_configuration.json")
+        self._store = store
+        if deployment is None:
+            deployment = Deployment()
+        self._deployment = deployment
+        self._hash = self._hash_deployment_data(
+            self._encode_deployment(deployment)
+        )
         self._change_callbacks = []
         LeaseService(reactor, self).setServiceParent(self)
 
+    @classmethod
+    def from_store(cls, store, reactor):
+        """
+        Load the persisted configuration, upgrading the configuration format
+        if an older version is detected.
+        """
+        d = store.initialize()
+
+        def load_config(ignored):
+            return store.get_content()
+        d = d.addCallback(load_config)
+
+        def maybe_upgrade_config(config_json):
+            if config_json == b'':
+                deployment = Deployment()
+            else:
+                config_dict = loads(config_json)
+                config_version = config_dict.get('version', 1)
+                if config_version < _CONFIG_VERSION:
+                    with _LOG_UPGRADE(configuration=config_json,
+                                      source_version=config_version,
+                                      target_version=_CONFIG_VERSION):
+                        config_json = migrate_configuration(
+                            config_version, _CONFIG_VERSION,
+                            config_json, ConfigurationMigration)
+                config = wire_decode(config_json)
+                deployment = config.deployment
+            return deployment
+        d = d.addCallback(maybe_upgrade_config)
+
+        def create_persistence_service(deployment):
+            o = cls(
+                reactor=reactor,
+                store=store,
+            )
+            d = o.save(deployment)
+            d = d.addCallback(lambda ignored: o)
+            return d
+        d = d.addCallback(create_persistence_service)
+        return d
+
     def startService(self):
-        if not self._path.exists():
-            self._path.makedirs()
-        self.load_configuration()
         MultiService.startService(self)
         _LOG_STARTUP(configuration=self.get()).write(self.logger)
-
-    def _process_v1_config(self, file_name, archive_name):
-        """
-        Check if a v1 configuration file exists and upgrade it if necessary.
-        After upgrade, the v1 configuration file is retained with an archived
-        file name, which ensures the data is not lost but we do not override
-        a newer configuration version next time the service starts.
-
-        :param bytes file_name: The expected file name of a version 1
-            configuration.
-        :param bytes archive_name: The file name to which a version 1
-            configuration should be moved after it has been processed.
-        """
-        v1_config_path = self._path.child(file_name)
-        v1_archived_path = self._path.child(archive_name)
-        # Check for a v1 config and upgrade to latest if found.
-        if v1_config_path.exists():
-            v1_json = v1_config_path.getContent()
-            with _LOG_UPGRADE(self.logger,
-                              configuration=v1_json,
-                              source_version=1,
-                              target_version=_CONFIG_VERSION):
-                updated_json = migrate_configuration(
-                    1, _CONFIG_VERSION, v1_json,
-                    ConfigurationMigration
-                )
-                self._config_path.setContent(updated_json)
-                v1_config_path.moveTo(v1_archived_path)
 
     def configuration_hash(self):
         """
         :return bytes: A hash of the configuration.
         """
         return self._hash
-
-    def load_configuration(self):
-        """
-        Load the persisted configuration, upgrading the configuration format
-        if an older version is detected.
-        """
-        # Version 1 configurations are a special case. They do not store
-        # any version information in the configuration data itself, rather they
-        # can only be identified by the use of the file name
-        # current_configuration.v1.json
-        # Therefore we check for a version 1 configuration file and if it is
-        # found, the config is upgraded, written to current_configuration.json
-        # and the old file archived as current_configuration.v1.old.json
-        self._process_v1_config(
-            file_name=b"current_configuration.v1.json",
-            archive_name=b"current_configuration.v1.old.json"
-        )
-
-        # We can now safely attempt to detect and process a >v1 configuration
-        # file as normal.
-        if self._config_path.exists():
-            config_json = self._config_path.getContent()
-            config_dict = loads(config_json)
-            config_version = config_dict['version']
-            if config_version < _CONFIG_VERSION:
-                with _LOG_UPGRADE(self.logger,
-                                  configuration=config_json,
-                                  source_version=config_version,
-                                  target_version=_CONFIG_VERSION):
-                    config_json = migrate_configuration(
-                        config_version, _CONFIG_VERSION,
-                        config_json, ConfigurationMigration)
-            config = wire_decode(config_json)
-            self._deployment = config.deployment
-            self._sync_save(config.deployment)
-        else:
-            self._deployment = Deployment()
-            self._sync_save(self._deployment)
 
     def register(self, change_callback):
         """
@@ -694,28 +672,38 @@ class ConfigurationPersistenceService(MultiService):
         """
         self._change_callbacks.append(change_callback)
 
-    def _sync_save(self, deployment):
-        """
-        Save and flush new configuration to disk synchronously.
-        """
-        config = Configuration(version=_CONFIG_VERSION, deployment=deployment)
-        data = wire_encode(config)
-        self._hash = b16encode(mmh3_hash_bytes(data)).lower()
-        self._config_path.setContent(data)
-
     def save(self, deployment):
         """
         Save and flush new deployment to disk.
 
         :return Deferred: Fires when write is finished.
         """
-        if deployment == self._deployment:
-            _LOG_UNCHANGED_DEPLOYMENT_NOT_SAVED().write(self.logger)
-            return succeed(None)
+        action = _LOG_SAVE(self.logger, configuration=deployment)
+        with action.context():
+            d = DeferredContext(succeed(None))
+            if deployment == self._deployment:
+                _LOG_UNCHANGED_DEPLOYMENT_NOT_SAVED().write()
+            else:
+                d.addCallback(
+                    lambda ignored: self._really_save(deployment)
+                )
+            d.addActionFinish()
+            return d.result
 
-        with _LOG_SAVE(self.logger, configuration=deployment):
-            self._sync_save(deployment)
+    def _encode_deployment(self, deployment):
+        config = Configuration(version=_CONFIG_VERSION, deployment=deployment)
+        return wire_encode(config)
+
+    def _hash_deployment_data(self, deployment_data):
+        return b16encode(mmh3_hash_bytes(deployment_data)).lower()
+
+    def _really_save(self, deployment):
+        data = self._encode_deployment(deployment)
+        d = self._store.set_content(data)
+
+        def set_deployment_and_run_callbacks(ignored):
             self._deployment = deployment
+            self._hash = self._hash_deployment_data(data)
             # At some future point this will likely involve talking to a
             # distributed system (e.g. ZooKeeper or etcd), so the API doesn't
             # guarantee immediate saving of the data.
@@ -726,7 +714,8 @@ class ConfigurationPersistenceService(MultiService):
                     # Second argument will be ignored in next Eliot release, so
                     # not bothering with particular value.
                     write_traceback(self.logger, u"")
-            return succeed(None)
+        d.addCallback(set_deployment_and_run_callbacks)
+        return d
 
     def get(self):
         """

--- a/flocker/control/configuration_store/__init__.py
+++ b/flocker/control/configuration_store/__init__.py
@@ -1,0 +1,4 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Flocker configuration storage plugins.
+"""

--- a/flocker/control/configuration_store/directory.py
+++ b/flocker/control/configuration_store/directory.py
@@ -64,7 +64,7 @@ class DirectoryConfigurationStore(PClass):
         return succeed(self.path.setContent(content))
 
 
-def directory_store_from_options(options):
+def directory_store_from_options(reactor, options):
     return DirectoryConfigurationStore(
         directory=options["data-path"]
     )

--- a/flocker/control/configuration_store/directory.py
+++ b/flocker/control/configuration_store/directory.py
@@ -1,0 +1,40 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Persistence of cluster configuration to local file.
+"""
+
+from pyrsistent import PClass, field
+from twisted.internet.defer import succeed
+from twisted.python.filepath import FilePath
+from zope.interface import implementer
+
+from .interface import IConfigurationStore
+
+
+@implementer(IConfigurationStore)
+class DirectoryConfigurationStore(PClass):
+    directory = field(mandatory=True, type={FilePath})
+
+    @property
+    def path(self):
+        return self.directory.child("current_configuration.json")
+
+    def initialize_sync(self):
+        if not self.directory.exists():
+            self.directory.makedirs()
+        if not self.path.exists():
+            self.path.touch()
+
+    def initialize(self):
+        self.initialize_sync()
+        return succeed(None)
+
+    def get_content_sync(self):
+        return self.path.getContent()
+
+    def get_content(self):
+        return succeed(self.get_content_sync())
+
+    def set_content(self, content):
+        return succeed(self.path.setContent(content))

--- a/flocker/control/configuration_store/interface.py
+++ b/flocker/control/configuration_store/interface.py
@@ -1,0 +1,36 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Interface for cluster configuration storage plugin.
+"""
+
+from zope.interface import Interface
+
+
+class IConfigurationStore(Interface):
+    """
+    An interface for initializing, getting and setting Flocker configuration.
+    """
+    def initialize():
+        """
+        Set up a configuration store.
+        The implementation must be idempotent.
+        Calling ``initialize`` on an already initialized store must not change
+        the stored configuration.
+
+        :returns: A ``Deferred`` that fires with ``None`` when the store has
+        been initialized or with a ``Failure`` if initialization fails.
+        """
+
+    def get_content():
+        """
+        :returns: A ``Deferred`` that fires with the current Flocker
+            configuration ``bytes``.
+        """
+
+    def set_content(content):
+        """
+        :param bytes content: New Flocker configuration ``bytes`` to be stored.
+        :returns: A ``Deferred`` that fires with ``None`` when the supplied
+            Flocker configuration ``bytes`` have been stored.
+        """

--- a/flocker/control/configuration_store/sql.py
+++ b/flocker/control/configuration_store/sql.py
@@ -5,18 +5,71 @@ Persistence of cluster configuration to a SQL database.
 """
 from .interface import IConfigurationStore
 
-from twisted.internet.defer import succeed
+from alchimia import TWISTED_STRATEGY
+
+from pyrsistent import PClass, field
+
+from sqlalchemy import (
+    create_engine, MetaData, Table, Column, Integer, String, LargeBinary
+)
+from sqlalchemy.schema import CreateTable
+
+from twisted.internet.defer import inlineCallbacks, succeed, returnValue
 
 from zope.interface import implementer
 
+METADATA = MetaData()
+CONFIGURATION_TABLE = Table(
+    "configuration",
+    METADATA,
+    Column("content", LargeBinary),
+)
+
 
 @implementer(IConfigurationStore)
-class SQLConfigurationStore(object):
+class SQLConfigurationStore(PClass):
+
+    connection_string = field(
+        type=(unicode,),
+        mandatory=True
+    )
+    reactor = field(mandatory=True)
+
+    def _engine(self):
+        return create_engine(
+            self.connection_string,
+            reactor=self.reactor,
+            strategy=TWISTED_STRATEGY,
+        )
+
+    @inlineCallbacks
     def initialize(self):
-        return succeed(None)
+        engine = self._engine()
+        table_names = yield engine.table_names()
+        if not set(METADATA.tables.keys()).issubset(table_names):
+            yield engine.execute(
+                CreateTable(CONFIGURATION_TABLE)
+            )
+            yield engine.execute(
+                CONFIGURATION_TABLE.insert().values(content=b"")
+            )
+        table_names = yield engine.table_names()
+        returnValue(None)
 
+    @inlineCallbacks
     def get_content(self):
-        return succeed(None)
+        engine = self._engine()
+        result = yield engine.execute(
+            CONFIGURATION_TABLE.select()
+        )
+        [content] = yield result.fetchall()
+        [content] = content
+        returnValue(content)
 
+    @inlineCallbacks
     def set_content(self, content):
-        return succeed(None)
+        engine = self._engine()
+        yield engine.execute(
+            CONFIGURATION_TABLE.update().values(content=content)
+        )
+        returnValue(None)

--- a/flocker/control/configuration_store/sql.py
+++ b/flocker/control/configuration_store/sql.py
@@ -38,9 +38,9 @@ class SQLConfigurationStore(PClass):
     engine = field(mandatory=True, type=(TwistedEngine,))
 
     @classmethod
-    def from_connection_string(cls, reactor, connection_string):
+    def from_database_url(cls, reactor, database_url):
         engine = create_engine(
-            connection_string,
+            database_url,
             reactor=reactor,
             strategy=TWISTED_STRATEGY,
         )
@@ -74,3 +74,16 @@ class SQLConfigurationStore(PClass):
             CONFIGURATION_TABLE.update().values(content=content)
         )
         returnValue(None)
+
+
+def sql_store_from_options(reactor, options):
+    """
+    :param reactor: The reactor supplied by the entry point function.
+    :param twisted.python.usage.Options options: The command line options
+        supplied to the entry point function.
+    :returns: An SQLConfigurationStore connected to the supplied database URL.
+    """
+    return SQLConfigurationStore.from_database_url(
+        reactor=reactor,
+        database_url=options["database-url"],
+    )

--- a/flocker/control/configuration_store/sql.py
+++ b/flocker/control/configuration_store/sql.py
@@ -1,0 +1,22 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+
+"""
+Persistence of cluster configuration to a SQL database.
+"""
+from .interface import IConfigurationStore
+
+from twisted.internet.defer import succeed
+
+from zope.interface import implementer
+
+
+@implementer(IConfigurationStore)
+class SQLConfigurationStore(object):
+    def initialize(self):
+        return succeed(None)
+
+    def get_content(self):
+        return succeed(None)
+
+    def set_content(self, content):
+        return succeed(None)

--- a/flocker/control/configuration_store/test/__init__.py
+++ b/flocker/control/configuration_store/test/__init__.py
@@ -1,0 +1,4 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Tests for ``flocker.control.configuration_store``.
+"""

--- a/flocker/control/configuration_store/test/test_directory.py
+++ b/flocker/control/configuration_store/test/test_directory.py
@@ -1,0 +1,20 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Tests for ``flocker.control.configuration_store.filepath``.
+"""
+from ....testtools import AsyncTestCase
+
+from ..directory import DirectoryConfigurationStore
+from ..testtools import IConfigurationStoreTestsMixin
+
+
+class DirectoryConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
+                                                AsyncTestCase):
+    """
+    Tests for ``DirectoryConfigurationStore``.
+    """
+    def setUp(self):
+        super(DirectoryConfigurationStoreInterfaceTests, self).setUp()
+        self.store = DirectoryConfigurationStore(
+            directory=self.make_temporary_directory()
+        )

--- a/flocker/control/configuration_store/test/test_sql.py
+++ b/flocker/control/configuration_store/test/test_sql.py
@@ -9,6 +9,7 @@ from ..testtools import IConfigurationStoreTestsMixin
 
 from twisted.internet import reactor
 
+
 class SQLConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
                                           AsyncTestCase):
     """
@@ -16,7 +17,7 @@ class SQLConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
     """
     def setUp(self):
         super(SQLConfigurationStoreInterfaceTests, self).setUp()
-        self.store = SQLConfigurationStore(
-            connection_string=u"sqlite:///{}".format(self.make_temporary_file().path),
+        self.store = SQLConfigurationStore.from_connection_string(
             reactor=reactor,
+            connection_string=u"sqlite://",
         )

--- a/flocker/control/configuration_store/test/test_sql.py
+++ b/flocker/control/configuration_store/test/test_sql.py
@@ -1,0 +1,18 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Tests for ``flocker.control.configuration_store.sql``.
+"""
+from ....testtools import AsyncTestCase
+
+from ..sql import SQLConfigurationStore
+from ..testtools import IConfigurationStoreTestsMixin
+
+
+class SQLConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
+                                          AsyncTestCase):
+    """
+    Tests for ``SQLConfigurationStore``.
+    """
+    def setUp(self):
+        super(SQLConfigurationStoreInterfaceTests, self).setUp()
+        self.store = SQLConfigurationStore()

--- a/flocker/control/configuration_store/test/test_sql.py
+++ b/flocker/control/configuration_store/test/test_sql.py
@@ -17,7 +17,7 @@ class SQLConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
     """
     def setUp(self):
         super(SQLConfigurationStoreInterfaceTests, self).setUp()
-        self.store = SQLConfigurationStore.from_connection_string(
+        self.store = SQLConfigurationStore.from_database_url(
             reactor=reactor,
-            connection_string=u"sqlite://",
+            database_url=u"sqlite://",
         )

--- a/flocker/control/configuration_store/test/test_sql.py
+++ b/flocker/control/configuration_store/test/test_sql.py
@@ -7,6 +7,7 @@ from ....testtools import AsyncTestCase
 from ..sql import SQLConfigurationStore
 from ..testtools import IConfigurationStoreTestsMixin
 
+from twisted.internet import reactor
 
 class SQLConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
                                           AsyncTestCase):
@@ -15,4 +16,7 @@ class SQLConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
     """
     def setUp(self):
         super(SQLConfigurationStoreInterfaceTests, self).setUp()
-        self.store = SQLConfigurationStore()
+        self.store = SQLConfigurationStore(
+            connection_string=u"sqlite:///{}".format(self.make_temporary_file().path),
+            reactor=reactor,
+        )

--- a/flocker/control/configuration_store/test/test_testtools.py
+++ b/flocker/control/configuration_store/test/test_testtools.py
@@ -1,0 +1,17 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Tests for ``flocker.control.configuration_store.filepath``.
+"""
+from ....testtools import AsyncTestCase
+
+from ..testtools import IConfigurationStoreTestsMixin, MemoryConfigurationStore
+
+
+class MemoryConfigurationStoreInterfaceTests(IConfigurationStoreTestsMixin,
+                                             AsyncTestCase):
+    """
+    Tests for ``MemoryConfigurationStore``.
+    """
+    def setUp(self):
+        super(MemoryConfigurationStoreInterfaceTests, self).setUp()
+        self.store = MemoryConfigurationStore()

--- a/flocker/control/configuration_store/testtools.py
+++ b/flocker/control/configuration_store/testtools.py
@@ -1,0 +1,61 @@
+# Copyright ClusterHQ Inc.  See LICENSE file for details.
+"""
+Tests for ``flocker.control.configuration_storage``.
+"""
+from zope.interface.verify import verifyObject
+
+from ...testtools import random_name
+from .interface import IConfigurationStore
+
+
+class IConfigurationStoreTestsMixin(object):
+    """
+    Tests for implementers of ``IConfigurationStore``.
+    """
+    def test_interface(self):
+        """
+        ``self.store`` provides ``IConfigurationStore``.
+        """
+        self.assertTrue(verifyObject(IConfigurationStore, self.store))
+
+    def test_initialize_returns_none(self):
+        """
+        ``initialize`` returns ``None``.
+        """
+        d = self.store.initialize()
+        d.addCallback(self.assertIs, None)
+        return d
+
+    def test_initialize_empty(self):
+        """
+        ``initialize`` creates the key with an empty value.
+        """
+        d = self.store.initialize()
+        d.addCallback(lambda ignored: self.store.get_content())
+        d.addCallback(self.assertEqual, b"")
+        return d
+
+    def test_set_and_get(self):
+        """
+        ``set_content`` sets the value and the value can be retrieved by
+        ``get_content``.
+        """
+        expected_value = random_name(self).encode('utf8')
+        d = self.store.initialize()
+        d.addCallback(lambda ignored: self.store.set_content(expected_value))
+        d.addCallback(lambda ignored: self.store.get_content())
+        d.addCallback(self.assertEqual, expected_value)
+        return d
+
+    def test_initialize_non_empty(self):
+        """
+        ``initialize`` does not overwrite an existing value.
+        """
+        expected_value = random_name(self).encode('utf8')
+        d = self.store.initialize()
+        d.addCallback(lambda ignored: self.store.set_content(expected_value))
+        # Second initialize does not overwrite the expected_value above.
+        d.addCallback(lambda ignored: self.store.initialize())
+        d.addCallback(lambda ignored: self.store.get_content())
+        d.addCallback(self.assertEqual, expected_value)
+        return d

--- a/flocker/control/configuration_store/testtools.py
+++ b/flocker/control/configuration_store/testtools.py
@@ -2,10 +2,30 @@
 """
 Tests for ``flocker.control.configuration_storage``.
 """
+from twisted.internet.defer import succeed
+
+from zope.interface import implementer
 from zope.interface.verify import verifyObject
 
 from ...testtools import random_name
 from .interface import IConfigurationStore
+
+
+@implementer(IConfigurationStore)
+class MemoryConfigurationStore(object):
+    _content = None
+
+    def initialize(self):
+        if self._content is None:
+            self._content = b''
+        return succeed(None)
+
+    def get_content(self):
+        return succeed(self._content)
+
+    def set_content(self, content):
+        self._content = content
+        return succeed(None)
 
 
 class IConfigurationStoreTestsMixin(object):

--- a/flocker/control/script.py
+++ b/flocker/control/script.py
@@ -75,10 +75,13 @@ CONFIGURATION_STORE_PLUGINS = [
         name=u"sql",
         factory=sql_store_from_options,
         options=[[
-            "database-url", None, "", (
+            "database-url",
+            None,
+            "sqlite:////var/lib/flocker/current_configuration.sqlite",
+            (
                 "An SQLAlchemy database URL. "
-                "See http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls"  # noqa
-                )
+                "Only valid when using --configuration-store-plugin=sql. "
+            ),
         ]],
     ),
 ]

--- a/flocker/control/test/test_httpapi.py
+++ b/flocker/control/test/test_httpapi.py
@@ -77,7 +77,8 @@ class APITestsMixin(APIAssertionsMixin):
         Create initial objects for the ``ConfigurationAPIUserV1``.
         """
         self.persistence_service = ConfigurationPersistenceService(
-            reactor, FilePath(self.mktemp()))
+            reactor
+        )
         self.persistence_service.startService()
         self.cluster_state_service = ClusterStateService(Clock())
         self.cluster_state_service.startService()
@@ -2600,7 +2601,7 @@ class CreateAPIServiceTests(TestCase):
         reactor = MemoryReactor()
         endpoint = TCP4ServerEndpoint(reactor, 6789)
         verifyObject(IService, create_api_service(
-            ConfigurationPersistenceService(reactor, FilePath(self.mktemp())),
+            ConfigurationPersistenceService(reactor),
             ClusterStateService(reactor), endpoint, ClientContextFactory()))
 
 

--- a/flocker/control/test/test_script.py
+++ b/flocker/control/test/test_script.py
@@ -1,6 +1,7 @@
 # Copyright ClusterHQ Inc.  See LICENSE file for details.
 
 from twisted.python.filepath import FilePath
+from twisted.python.usage import UsageError
 
 from ..script import ControlOptions, ControlScript
 from ...testtools import (
@@ -34,6 +35,29 @@ class ControlOptionsTests(make_standard_options_test(ControlOptions)):
         options = ControlOptions()
         options.parseOptions([b"--port", b"tcp:1234"])
         self.assertEqual(options["port"], b"tcp:1234")
+
+    def test_configuration_store_plugin_default(self):
+        """
+        The default --configuration-store-plugin is ``directory``.
+        """
+        options = ControlOptions()
+        options.parseOptions([])
+        self.assertEqual(
+            "directory",
+            options["configuration-store-plugin"].name
+        )
+
+    def test_configuration_store_plugin_unknown(self):
+        """
+        ``--configuration-store-plugin`` raises ``UsageError`` if the supplied
+          plugin name is not recognized.
+        """
+        options = ControlOptions()
+        self.assertRaises(
+            UsageError,
+            options.parseOptions,
+            ["--configuration-store-plugin=bad-plugin-name"]
+        )
 
     def test_default_path(self):
         """

--- a/flocker/control/testtools.py
+++ b/flocker/control/testtools.py
@@ -137,7 +137,7 @@ def build_control_amp_service(test_case, reactor=None):
     cluster_state.startService()
     test_case.addCleanup(cluster_state.stopService)
     persistence_service = ConfigurationPersistenceService(
-        reactor, test_case.make_temporary_directory())
+        reactor)
     persistence_service.startService()
     test_case.addCleanup(persistence_service.stopService)
     return ControlAMPService(

--- a/requirements/flocker.txt
+++ b/requirements/flocker.txt
@@ -1,3 +1,4 @@
+alchimia==0.7.0
 # Libcloud is not detected by snakefood
 apache-libcloud==1.4.0
 bitmath==1.3.1.2
@@ -102,6 +103,7 @@ s3transfer==0.1.9
 service-identity==16.0.0
 simplejson==3.10.0
 snowballstemmer==1.2.1
+SQLAlchemy==1.1.4
 stevedore==1.19.1
 toolz==0.8.1
 traceback2==1.4.0

--- a/requirements/flocker.txt.in
+++ b/requirements/flocker.txt.in
@@ -1,3 +1,4 @@
+alchimia
 # Libcloud is not detected by snakefood
 apache-libcloud
 bitmath


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4548

Stacked on #2968 (https://github.com/ClusterHQ/flocker/compare/configuration-plugins-FLOC-4547...FLOC-4548-sql-configuration) 

This allows the configuration to be stored in a SQLite database.

Next I'll create a branch with tests for MySQL and PostgreSQL storage.
And try and devise a failover test.