### PR TITLE
[FLOC-4550] Fix Sphinx warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
 
 matrix:
   allow_failures:
-  - env: FLOCKER_BUILDER=docs-lint
   - env: FLOCKER_BUILDER=docs-linkcheck
 
 script:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 extensions = [
     'sphinx.ext.extlinks',
     'sphinx.ext.ifconfig',
+    'sphinx.ext.intersphinx',
     'flocker.provision._sphinx',
     'flocker.docs.version_extensions',
     'sphinx-prompt',
@@ -151,8 +152,6 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The HTMLTranslator class
-html_translator_class = 'flocker.docs.bootstrap.HTMLWriter'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'clusterhq'
@@ -337,6 +336,25 @@ linkcheck_ignore = [
     r'https://docs.staging.clusterhq.com/',
     r'https://docs.docker.com/\S*',
 ]
+
+# XXX We use a Sphinx extension called autoklein which generates REST API docs
+# that include `:http:obj:` references.
+# Maybe these should link to http://www.json.org/ but for now I'll just ignore
+# them.
+nitpick_ignore = [
+    ("http:obj", "string"),
+    ("http:obj", "boolean"),
+    ("http:obj", "integer|null"),
+    ("http:obj", "object"),
+    ("http:obj", "number|null"),
+]
+
+# Allows `:py:mod:` references to work.
+# Copied from https://twistedmatrix.com/trac/ticket/4582
+intersphinx_mapping = {
+    'py2': ('http://docs.python.org/2.7', None),
+    'py3': ('http://docs.python.org/3.3', None),
+}
 
 
 def setup(app):

--- a/docs/gettinginvolved/infrastructure/packaging.rst
+++ b/docs/gettinginvolved/infrastructure/packaging.rst
@@ -187,7 +187,7 @@ To run the ``flocker-control`` container:
         clusterhqci/flocker-control:master
 
 flocker-docker-plugin
---------------------
+---------------------
 
 The ``flocker-docker-plugin`` Docker image is built using the same ``docker build ...`` command line as for ``flocker-dataset-agent`` but substituting the ``docker-plugin``.
 
@@ -202,5 +202,3 @@ To run the ``flocker-docker-plugin`` container:
         --detach \
         clusterhqci/flocker-docker-plugin:master \
         --rest-api-port=4523
-
-


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4550

Rendered docs: http://clusterhq-staging-docs.s3-website-us-east-1.amazonaws.com/FLOC-4550-fix-sphinx-warnings/

See: 
 * http://clusterhq-staging-docs.s3-website-us-east-1.amazonaws.com/FLOC-4550-fix-sphinx-warnings/administering/debugging.html#flocker-control-service

...for an example of the working intersphinx links for python module references.