### PR TITLE
Harden flocker-cluster-id EBS parsing

### DIFF
--- a/flocker/node/agents/ebs.py
+++ b/flocker/node/agents/ebs.py
@@ -821,9 +821,15 @@ def _is_cluster_volume(cluster_id, ebs_volume):
             if tag['Key'] == CLUSTER_ID_LABEL
         ]
         if actual_cluster_id:
-            actual_cluster_id = UUID(actual_cluster_id.pop())
-            if actual_cluster_id == cluster_id:
-                return True
+            try:
+                actual_cluster_id = UUID(actual_cluster_id.pop())
+                if actual_cluster_id == cluster_id:
+                    return True
+            except ValueError:
+                # If we can't parse the cluster id value as a UUID, assume
+                # that it's not part of our cluster instead of stopping the
+                # iteration
+                pass
     return False
 
 


### PR DESCRIPTION
If there is a volume in EBS with a tag key of `flocker-cluster-id` but
the value is not a valid UUID, any Flocker agent connected to that
account will throw an exception during iteration and will be unusable.

The change here catches bad values and makes them process as just
another volume that's not part of the asking cluster rather than
throwing the mentioned exceptions.